### PR TITLE
[prober] Ensure probing indicates error on failure

### DIFF
--- a/monitoring/prober/run_locally.sh
+++ b/monitoring/prober/run_locally.sh
@@ -57,4 +57,8 @@ if ! docker run --link "$OAUTH_CONTAINER":oauth \
         echo "Dumping core-service logs"
         docker logs "$CORE_SERVICE_CONTAINER"
     fi
+    echo "Prober did not succeed."
+    exit 1
+else
+    echo "Prober succeeded."
 fi


### PR DESCRIPTION
Discovered in [this `dss` PR](https://github.com/interuss/dss/pull/938), prober's run_locally.sh would actually succeed (exit with code 0) when the probing itself failed.  This PR fixes that problem in this repository.