### PR TITLE
[uss_qualifier] Add Kentland Farms flight intents

### DIFF
--- a/monitoring/uss_qualifier/configurations/dev/f3548.json
+++ b/monitoring/uss_qualifier/configurations/dev/f3548.json
@@ -3,7 +3,7 @@
     "test_run": {
       "resources": {
         "resource_declarations": {
-          "$ref": "resources.yaml#/f3548"
+          "$ref": "resources.yaml#/f3548_che"
         }
       },
       "action": {

--- a/monitoring/uss_qualifier/configurations/dev/faa/uft/f3548.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/faa/uft/f3548.yaml
@@ -1,0 +1,23 @@
+v1:
+  test_run:
+    resources:
+      resource_declarations:
+        "$ref": ../../resources.yaml#/f3548_kentland
+    action:
+      test_suite:
+        suite_type: suites.astm.utm.f3548_21
+        resources:
+          flight_planners: flight_planners
+          conflicting_flights: conflicting_flights
+          priority_preemption_flights: priority_preemption_flights
+          dss: dss
+  artifacts:
+    tested_roles:
+      report_path: tested_requirements.html
+      roles:
+      - name: Strategic Coordination role
+        requirement_set: astm.f3548.v21.scd
+        participants:
+        - uss1
+        - uss2
+    "$ref": ../../artifacts.yaml#/relative

--- a/monitoring/uss_qualifier/configurations/dev/non_docker/resources.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/non_docker/resources.yaml
@@ -50,7 +50,7 @@ net_rid_sims:
       flight_record_collection_path: "./test_data/usa/netrid/dcdemo_flights.json"
 
 flight_auth:
-  $ref: '#/f3548'
+  $ref: '#/f3548_che'
   invalid_flight_auth_flights:
     resource_type: resources.flight_planning.FlightIntentsResource
     specification:

--- a/monitoring/uss_qualifier/configurations/dev/resources.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/resources.yaml
@@ -62,12 +62,46 @@ net_rid_sims:
       flight_record_collection_path: "./test_data/usa/netrid/dcdemo_flights.json"
 
 flight_auth:
-  $ref: '#/f3548'
+  $ref: '#/f3548_che'
   invalid_flight_auth_flights:
     resource_type: resources.flight_planning.FlightIntentsResource
     specification:
       planning_time: '0:05:00'
       file_source: file://./test_data/che/flight_intents/invalid_flight_auths.json
+
+che_flight_intents:
+  conflicting_flights:
+    resource_type: resources.flight_planning.FlightIntentsResource
+    specification:
+      planning_time: '0:05:00'
+      file_source: file://./test_data/che/flight_intents/conflicting_flights.json
+  priority_preemption_flights:
+    resource_type: resources.flight_planning.FlightIntentsResource
+    specification:
+      planning_time: '0:05:00'
+      file_source: test_data.che.flight_intents.priority_preemption
+
+kentland_flight_intents:
+  conflicting_flights:
+    resource_type: resources.flight_planning.FlightIntentsResource
+    specification:
+      planning_time: '0:05:00'
+      file_source: file://./test_data/usa/kentland/flight_intents/conflicting_flights.yaml
+  priority_preemption_flights:
+    resource_type: resources.flight_planning.FlightIntentsResource
+    specification:
+      planning_time: '0:05:00'
+      file_source: test_data.usa.kentland.flight_intents.priority_preemption
+
+f3548_che:
+  allOf:
+    - $ref: '#/f3548'
+    - $ref: '#/che_flight_intents'
+
+f3548_kentland:
+  allOf:
+  - $ref: '#/f3548'
+  - $ref: '#/kentland_flight_intents'
 
 f3548:
   $ref: '#/common'
@@ -83,16 +117,6 @@ f3548:
       # uss2 uses atproxy, with requests being fulfilled by mock_uss with atproxy_client functionality enabled
       - participant_id: uss2
         injection_base_url: http://host.docker.internal:8075/scd
-  conflicting_flights:
-    resource_type: resources.flight_planning.FlightIntentsResource
-    specification:
-      planning_time: '0:05:00'
-      file_source: file://./test_data/che/flight_intents/conflicting_flights.json
-  priority_preemption_flights:
-    resource_type: resources.flight_planning.FlightIntentsResource
-    specification:
-      planning_time: '0:05:00'
-      file_source: test_data.che.flight_intents.priority_preemption
   dss:
     resource_type: resources.astm.f3548.v21.DSSInstanceResource
     dependencies:
@@ -102,7 +126,7 @@ f3548:
       base_url: http://host.docker.internal:8082
 
 f3548_single_scenario:
-  $ref: '#/f3548'
+  $ref: '#/f3548_che'
   uss1:
     resource_type: resources.flight_planning.FlightPlannerResource
     dependencies:

--- a/monitoring/uss_qualifier/test_data/usa/kentland/flight_intents/conflicting_flights.yaml
+++ b/monitoring/uss_qualifier/test_data/usa/kentland/flight_intents/conflicting_flights.yaml
@@ -1,0 +1,109 @@
+intents:
+- reference_time: '2023-01-01T00:00:00+00:00'
+  request:
+    operational_intent:
+      volumes:
+      - volume:
+          outline_polygon:
+            vertices:
+            - lat: 37.19330428406196
+              lng: -80.59314014213832
+            - lat: 37.19026757574101
+              lng: -80.59428502333573
+            - lat: 37.18526788213324
+              lng: -80.59005346211121
+            - lat: 37.1837232669677
+              lng: -80.58471856692397
+            - lat: 37.18696946882951
+              lng: -80.58072507989046
+            - lat: 37.19117638063535
+              lng: -80.57796221630451
+            - lat: 37.19735957232225
+              lng: -80.56931360695863
+            - lat: 37.19892943598067
+              lng: -80.57104154088566
+            - lat: 37.19763628976819
+              lng: -80.57674276197271
+            - lat: 37.19465764212709
+              lng: -80.58235632399915
+            - lat: 37.19637327692024
+              lng: -80.58569665094863
+          altitude_lower:
+            value: 474
+            reference: W84
+            units: M
+          altitude_upper:
+            value: 560
+            reference: W84
+            units: M
+        time_start:
+          value: '2023-01-01T00:03:00+00:00'
+          format: RFC3339
+        time_end:
+          value: '2023-01-01T00:08:00+00:00'
+          format: RFC3339
+      state: Accepted
+      off_nominal_volumes: []
+      priority: 0
+    # TODO: Remove flight_authorisation section when it is optional
+    flight_authorisation:
+      uas_serial_number: 1AF49UL5CC5J6K
+      operation_category: Open
+      operation_mode: Bvlos
+      uas_class: C0
+      identification_technologies: ['N/A']
+      connectivity_methods: ['N/A']
+      endurance_minutes: 30
+      emergency_procedure_url: https://example.uav.com/emergency
+      operator_id: CHEo5kut30e0mt01-qwe
+      uas_id: ''
+      uas_type_certificate: ''
+- reference_time: '2023-01-01T00:00:00+00:00'
+  request:
+    operational_intent:
+      volumes:
+      - volume:
+          outline_polygon:
+            vertices:
+            - lat: 37.19060214692082
+              lng: -80.57754923361475
+            - lat: 37.1954872363992
+              lng: -80.57106342715623
+            - lat: 37.19906626886441
+              lng: -80.56532842695125
+            - lat: 37.19958021621874
+              lng: -80.56597582177831
+            - lat: 37.19672366937564
+              lng: -80.57147209739449
+            - lat: 37.19115600938851
+              lng: -80.57855594239999
+          altitude_lower:
+            value: 480
+            reference: W84
+            units: M
+          altitude_upper:
+            value: 540
+            reference: W84
+            units: M
+        time_start:
+          value: '2023-01-01T00:05:20+00:00'
+          format: RFC3339
+        time_end:
+          value: '2023-01-01T00:10:40+00:00'
+          format: RFC3339
+      state: Accepted
+      off_nominal_volumes: []
+      priority: 0
+    # TODO: Remove flight_authorisation section when it is optional
+    flight_authorisation:
+      uas_serial_number: 1AF49UL5CC5J6K
+      operation_category: Open
+      operation_mode: Bvlos
+      uas_class: C0
+      identification_technologies: ['N/A']
+      connectivity_methods: ['N/A']
+      endurance_minutes: 30
+      emergency_procedure_url: https://example.uav.com/emergency
+      operator_id: CHEo5kut30e0mt01-qwe
+      uas_id: ''
+      uas_type_certificate: ''

--- a/monitoring/uss_qualifier/test_data/usa/kentland/flight_intents/priority_preemption.yaml
+++ b/monitoring/uss_qualifier/test_data/usa/kentland/flight_intents/priority_preemption.yaml
@@ -1,0 +1,109 @@
+intents:
+- reference_time: '2023-01-01T00:00:00+00:00'
+  request:
+    operational_intent:
+      volumes:
+      - volume:
+          outline_polygon:
+            vertices:
+            - lat: 37.19330428406196
+              lng: -80.59314014213832
+            - lat: 37.19026757574101
+              lng: -80.59428502333573
+            - lat: 37.18526788213324
+              lng: -80.59005346211121
+            - lat: 37.1837232669677
+              lng: -80.58471856692397
+            - lat: 37.18696946882951
+              lng: -80.58072507989046
+            - lat: 37.19117638063535
+              lng: -80.57796221630451
+            - lat: 37.19735957232225
+              lng: -80.56931360695863
+            - lat: 37.19892943598067
+              lng: -80.57104154088566
+            - lat: 37.19763628976819
+              lng: -80.57674276197271
+            - lat: 37.19465764212709
+              lng: -80.58235632399915
+            - lat: 37.19637327692024
+              lng: -80.58569665094863
+          altitude_lower:
+            value: 474
+            reference: W84
+            units: M
+          altitude_upper:
+            value: 560
+            reference: W84
+            units: M
+        time_start:
+          value: '2023-01-01T00:03:00+00:00'
+          format: RFC3339
+        time_end:
+          value: '2023-01-01T00:08:00+00:00'
+          format: RFC3339
+      state: Accepted
+      off_nominal_volumes: []
+      priority: 0
+    # TODO: Remove flight_authorisation section when it is optional
+    flight_authorisation:
+      uas_serial_number: 1AF49UL5CC5J6K
+      operation_category: Open
+      operation_mode: Bvlos
+      uas_class: C0
+      identification_technologies: ['N/A']
+      connectivity_methods: ['N/A']
+      endurance_minutes: 30
+      emergency_procedure_url: https://example.uav.com/emergency
+      operator_id: CHEo5kut30e0mt01-qwe
+      uas_id: ''
+      uas_type_certificate: ''
+- reference_time: '2023-01-01T00:00:00+00:00'
+  request:
+    operational_intent:
+      volumes:
+      - volume:
+          outline_polygon:
+            vertices:
+            - lat: 37.19389846157564
+              lng: -80.57843722762006
+            - lat: 37.19542873284961
+              lng: -80.57744077506473
+            - lat: 37.19621141165609
+              lng: -80.578531141435
+            - lat: 37.19610765396546
+              lng: -80.57910946528506
+            - lat: 37.19626017503177
+              lng: -80.57953226320937
+            - lat: 37.19516471659203
+              lng: -80.58067042878767
+          altitude_lower:
+            value: 483
+            reference: W84
+            units: M
+          altitude_upper:
+            value: 519
+            reference: W84
+            units: M
+        time_start:
+          value: '2023-01-01T00:02:00+00:00'
+          format: RFC3339
+        time_end:
+          value: '2023-01-01T00:12:15+00:00'
+          format: RFC3339
+      state: Accepted
+      off_nominal_volumes: []
+      priority: 100
+    # TODO: Remove flight_authorisation section when it is optional
+    flight_authorisation:
+      uas_serial_number: 1AF49UL5CC5J6K
+      operation_category: Open
+      operation_mode: Bvlos
+      uas_class: C0
+      identification_technologies: ['N/A']
+      connectivity_methods: ['N/A']
+      endurance_minutes: 30
+      emergency_procedure_url: https://example.uav.com/emergency
+      operator_id: CHEo5kut30e0mt01-qwe
+      uas_id: ''
+      uas_type_certificate: ''


### PR DESCRIPTION
Currently, we only have one dataset used for testing functionality related to flight planning -- it is labeled "CHE", but actually has operational intents in Ethiopia due to a reversal of latitude and longitude.  In preparation for use of InterUSS in FAA's UTM Field Trials (UFT), this PR adds an additional set of flight intents reflective of the Mid-Atlantic Aviation Partnership (MAAP) involvement in this activity.  The two primary files added by this PR are monitoring/uss_qualifier/test_data/usa/kentland/flight_intents/*.yaml, plus a configuration file to use these flight intents at monitoring/uss_qualifier/configurations/dev/faa/uft/f3548.yaml.

The configurations.dev.resources.yaml file is also restructured to differentiate between F3548 resources for CHE versus USA, which uncovered a bug in dict-file parsing that is also addressed in this PR.