### PR TITLE
[mock_uss] SCD flight injection: return ReadyToFly result when OpIntent is Activated

### DIFF
--- a/monitoring/mock_uss/scdsc/routes_injection.py
+++ b/monitoring/mock_uss/scdsc/routes_injection.py
@@ -8,7 +8,9 @@ import flask
 from loguru import logger
 import requests.exceptions
 
-from uas_standards.interuss.automated_testing.flight_planning.v1.api import OperationalIntentState
+from uas_standards.interuss.automated_testing.flight_planning.v1.api import (
+    OperationalIntentState,
+)
 from monitoring.monitorlib import scd, versioning, fetch
 from monitoring.monitorlib.clients import scd as scd_client
 from monitoring.monitorlib.fetch import QueryError
@@ -288,14 +290,15 @@ def inject_flight(flight_id: str, req_body: InjectFlightRequest) -> Tuple[dict, 
         step_name = "returning final successful result"
         logger.debug(f"[inject_flight:{flight_id}] Complete.")
 
-        if result.operational_intent_reference.state == OperationalIntentState.Activated:
+        if (
+            result.operational_intent_reference.state
+            == OperationalIntentState.Activated
+        ):
             injection_result = InjectFlightResult.ReadyToFly
         else:
             injection_result = InjectFlightResult.Planned
         return (
-            InjectFlightResponse(
-                result=injection_result, operational_intent_id=id
-            ),
+            InjectFlightResponse(result=injection_result, operational_intent_id=id),
             200,
         )
     except (ValueError, ConnectionError) as e:

--- a/monitoring/mock_uss/scdsc/routes_injection.py
+++ b/monitoring/mock_uss/scdsc/routes_injection.py
@@ -8,6 +8,7 @@ import flask
 from loguru import logger
 import requests.exceptions
 
+from uas_standards.interuss.automated_testing.flight_planning.v1.api import OperationalIntentState
 from monitoring.monitorlib import scd, versioning, fetch
 from monitoring.monitorlib.clients import scd as scd_client
 from monitoring.monitorlib.fetch import QueryError
@@ -286,9 +287,14 @@ def inject_flight(flight_id: str, req_body: InjectFlightRequest) -> Tuple[dict, 
 
         step_name = "returning final successful result"
         logger.debug(f"[inject_flight:{flight_id}] Complete.")
+
+        if result.operational_intent_reference.state == OperationalIntentState.Activated:
+            injection_result = InjectFlightResult.ReadyToFly
+        else:
+            injection_result = InjectFlightResult.Planned
         return (
             InjectFlightResponse(
-                result=InjectFlightResult.Planned, operational_intent_id=id
+                result=injection_result, operational_intent_id=id
             ),
             200,
         )

--- a/monitoring/monitorlib/scd_automated_testing/scd_injection_api.py
+++ b/monitoring/monitorlib/scd_automated_testing/scd_injection_api.py
@@ -76,6 +76,7 @@ class InjectFlightRequest(ImplicitDict):
 
 class InjectFlightResult(str, Enum):
     Planned = "Planned"
+    ReadyToFly = "ReadyToFly"
     Rejected = "Rejected"
     ConflictWithFlight = "ConflictWithFlight"
     Failed = "Failed"


### PR DESCRIPTION
Based on my understanding of the SCD injection API, 
The implementation of the SCD injection API in the mock USS seems to be lacking a result type: `ReadyToFly`.
If my understanding is correct, this result must be returned when the operational intent is in the state `Activated`.

This PR adds the injection result type to the enum and returns it when the operational intent is in the `Activated`.

PS: I'm not yet quite used to the testing codebase (nor Python), so there is high probability that for my first PRs I do things ignoring some context, so please don't hesitate with the feedback.