### PR TITLE
[CI] Collect local logs and upload them as CI run artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,11 +59,13 @@ jobs:
         cd monitoring/uss_qualifier
         make test
     - name: Save logs of containers as artifacts
+      if: always()
       uses: actions/upload-artifact@v3
       with:
         name: monitoring-tests-containers-logs
         path: logs
     - name: Save logs of tracer as artifacts
+      if: always()
       uses: actions/upload-artifact@v3
       with:
         name: monitoring-tests-tracer-logs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,11 @@ jobs:
       run: |
         cd monitoring/uss_qualifier
         make test
+    - uses: actions/upload-artifact@v3
+      with:
+        name: monitoring-tests-logs
+        path: logs
+    - uses: actions/upload-artifact@v3
+      with:
+        name: monitoring-tests-tracer-logs
+        path: monitoring/mock_uss/tracer/logs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,11 +58,13 @@ jobs:
       run: |
         cd monitoring/uss_qualifier
         make test
-    - uses: actions/upload-artifact@v3
+    - name: Save logs of containers as artifacts
+      uses: actions/upload-artifact@v3
       with:
-        name: monitoring-tests-logs
+        name: monitoring-tests-containers-logs
         path: logs
-    - uses: actions/upload-artifact@v3
+    - name: Save logs of tracer as artifacts
+      uses: actions/upload-artifact@v3
       with:
         name: monitoring-tests-tracer-logs
         path: monitoring/mock_uss/tracer/logs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,15 +58,20 @@ jobs:
       run: |
         cd monitoring/uss_qualifier
         make test
-    - name: Save logs of containers as artifacts
+    - name: Save containers and tracer logs as artifact
       if: always()
       uses: actions/upload-artifact@v3
       with:
-        name: monitoring-tests-containers-logs
-        path: logs
-    - name: Save logs of tracer as artifacts
+        name: monitoring-tests-logs
+        path: |
+          logs
+          monitoring/mock_uss/tracer/logs
+    - name: Save USS qualifier report as artifact
       if: always()
       uses: actions/upload-artifact@v3
       with:
-        name: monitoring-tests-tracer-logs
-        path: monitoring/mock_uss/tracer/logs
+        name: monitoring-tests-report
+        path: |
+          monitoring/uss_qualifier/report.gv
+          monitoring/uss_qualifier/report.json
+          monitoring/uss_qualifier/tested_requirements.html

--- a/Makefile
+++ b/Makefile
@@ -66,9 +66,17 @@ stop-uss-mocks:
 	monitoring/mock_uss/stop_all_local_mocks.sh
 	docker container rm -f atproxy
 
+# The prepended dash ignores errors. This allows collecting logs even if some containers are missing.
 .PHONY: collect-local-logs
 collect-local-logs:
-	docker logs dss_sandbox_local-dss-core-service_1 2> core-service-for-testing.log
+	mkdir -p logs
+	-sh -c "build/dev/run_locally.sh logs --timestamps" > logs/dss_sandbox_local.log 2>&1
+	-docker logs atproxy > logs/atproxy.log 2>&1
+	-docker logs mock_uss_scdsc > logs/mock_uss_scdsc.log 2>&1
+	-docker logs mock_uss_ridsp > logs/mock_uss_ridsp.log 2>&1
+	-docker logs mock_uss_riddp > logs/mock_uss_riddp.log 2>&1
+	-docker logs mock_uss_geoawareness > logs/mock_uss_geoawareness.log 2>&1
+	-docker logs mock_uss_tracer > logs/mock_uss_tracer.log 2>&1
 
 .PHONY: stop-locally
 stop-locally:

--- a/monitoring/uss_qualifier/scripts/test_docker_fully_mocked.sh
+++ b/monitoring/uss_qualifier/scripts/test_docker_fully_mocked.sh
@@ -18,6 +18,12 @@ echo "============="
 make down-locally
 make stop-uss-mocks
 
+function collect_logs() {
+  echo "Collect local logs"
+  echo "============="
+  make collect-local-logs
+}
+
 function cleanup() {
   echo "Clean up"
   echo "============="
@@ -26,10 +32,12 @@ function cleanup() {
 }
 
 function on_exit() {
+    collect_logs
 	cleanup
 }
 
 function on_sigint() {
+    collect_logs
 	cleanup
 	exit
 }


### PR DESCRIPTION
This PR enhances the CI by saving as artifacts the logs of the containers and of the tracer.
This will be useful for debugging issues, e.g. the timeout issue that sometimes happen in the CI.

[See for example this run](https://github.com/interuss/monitoring/actions/runs/4084261787):
![Screenshot from 2023-02-03 13-59-39](https://user-images.githubusercontent.com/5486788/216609816-ae077d95-5e6a-4057-9a5a-3572a566a354.png)
