### PR TITLE
[uss_qualifier] Improve query error handling

### DIFF
--- a/monitoring/monitorlib/clients/scd.py
+++ b/monitoring/monitorlib/clients/scd.py
@@ -13,24 +13,33 @@ from implicitdict import ImplicitDict
 def query_operational_intent_references(
     utm_client: UTMClientSession, area_of_interest: scd.Volume4D
 ) -> List[scd.OperationalIntentReference]:
+    url = "/dss/v1/operational_intent_references/query"
+    subject = f"queryOperationalIntentReferences from {url}"
     req = scd.QueryOperationalIntentReferenceParameters(
         area_of_interest=area_of_interest
     )
-    initiated_at = datetime.utcnow()
-    resp = utm_client.post(
-        "/dss/v1/operational_intent_references/query", json=req, scope=scd.SCOPE_SC
+    query = fetch.query_and_describe(
+        utm_client, "POST", url, json=req, scope=scd.SCOPE_SC
     )
-    query = fetch.describe_query(resp, initiated_at)
-    if resp.status_code != 200:
+    if query.status_code != 200:
         raise QueryError(
-            msg="queryOperationalIntentReferences failed {}:\n{}".format(
-                resp.status_code, resp.content.decode("utf-8")
+            msg="{} failed {}:\n{}".format(
+                subject, query.status_code, query.response.get("content", "")
             ),
             queries=[query],
         )
-    resp_body = ImplicitDict.parse(
-        resp.json(), scd.QueryOperationalIntentReferenceResponse
-    )
+    try:
+        resp_body = ImplicitDict.parse(
+            query.response["json"], scd.QueryOperationalIntentReferenceResponse
+        )
+    except KeyError:
+        raise QueryError(
+            msg=f"{subject} response did not contain JSON body", queries=[query]
+        )
+    except ValueError as e:
+        raise QueryError(
+            msg=f"{subject} response contained invalid JSON: {str(e)}", queries=[query]
+        )
     return resp_body.operational_intent_references
 
 
@@ -40,17 +49,29 @@ def create_operational_intent_reference(
     req: scd.PutOperationalIntentReferenceParameters,
 ) -> scd.ChangeOperationalIntentReferenceResponse:
     url = "/dss/v1/operational_intent_references/{}".format(id)
-    initiated_at = datetime.utcnow()
-    resp = utm_client.put(url, json=req, scope=scd.SCOPE_SC)
-    query = fetch.describe_query(resp, initiated_at)
-    if resp.status_code != 200 and resp.status_code != 201:
+    subject = f"createOperationalIntentReference to {url}"
+    query = fetch.query_and_describe(
+        utm_client, "PUT", url, json=req, scope=scd.SCOPE_SC
+    )
+    if query.status_code != 200 and query.status_code != 201:
         raise QueryError(
-            msg="createOperationalIntentReference failed {} to {}:\n{}".format(
-                resp.status_code, url, resp.content.decode("utf-8")
+            msg="{} failed {}:\n{}".format(
+                subject, query.status_code, query.response.get("content", "")
             ),
             queries=[query],
         )
-    return ImplicitDict.parse(resp.json(), scd.ChangeOperationalIntentReferenceResponse)
+    try:
+        return ImplicitDict.parse(
+            query.response["json"], scd.ChangeOperationalIntentReferenceResponse
+        )
+    except KeyError:
+        raise QueryError(
+            msg=f"{subject} response did not contain JSON body", queries=[query]
+        )
+    except ValueError as e:
+        raise QueryError(
+            msg=f"{subject} response contained invalid JSON: {str(e)}", queries=[query]
+        )
 
 
 def update_operational_intent_reference(
@@ -60,36 +81,56 @@ def update_operational_intent_reference(
     req: scd.PutOperationalIntentReferenceParameters,
 ) -> scd.ChangeOperationalIntentReferenceResponse:
     url = "/dss/v1/operational_intent_references/{}/{}".format(id, ovn)
-    initiated_at = datetime.utcnow()
-    resp = utm_client.put(url, json=req, scope=scd.SCOPE_SC)
-    query = fetch.describe_query(resp, initiated_at)
-    if resp.status_code != 200 and resp.status_code != 201:
+    subject = f"updateOperationalIntentReference to {url}"
+    query = fetch.query_and_describe(
+        utm_client, "PUT", url, json=req, scope=scd.SCOPE_SC
+    )
+    if query.status_code != 200 and query.status_code != 201:
         raise QueryError(
-            msg="updateOperationalIntentReference failed {} to {}:\n{}".format(
-                resp.status_code, url, resp.content.decode("utf-8")
+            msg="{} failed {}:\n{}".format(
+                subject, query.status_code, query.response.get("content", "")
             ),
             queries=[query],
         )
-    return ImplicitDict.parse(resp.json(), scd.ChangeOperationalIntentReferenceResponse)
+    try:
+        return ImplicitDict.parse(
+            query.response["json"], scd.ChangeOperationalIntentReferenceResponse
+        )
+    except KeyError:
+        raise QueryError(
+            msg=f"{subject} response did not contain JSON body", queries=[query]
+        )
+    except ValueError as e:
+        raise QueryError(
+            msg=f"{subject} response contained invalid JSON: {str(e)}", queries=[query]
+        )
 
 
 def delete_operational_intent_reference(
     utm_client: UTMClientSession, id: str, ovn: str
 ) -> scd.ChangeOperationalIntentReferenceResponse:
-    initiated_at = datetime.utcnow()
-    resp = utm_client.delete(
-        "/dss/v1/operational_intent_references/{}/{}".format(id, ovn),
-        scope=scd.SCOPE_SC,
-    )
-    query = fetch.describe_query(resp, initiated_at)
-    if resp.status_code != 200:
+    url = f"/dss/v1/operational_intent_references/{id}/{ovn}"
+    subject = f"deleteOperationalIntentReference from {url}"
+    query = fetch.query_and_describe(utm_client, "DELETE", url, scope=scd.SCOPE_SC)
+    if query.status_code != 200:
         raise QueryError(
-            msg="deleteOperationalIntentReference failed {}:\n{}".format(
-                resp.status_code, resp.content.decode("utf-8")
+            msg="{} failed {}:\n{}".format(
+                subject, query.status_code, query.response.get("content", "")
             ),
             queries=[query],
         )
-    return ImplicitDict.parse(resp.json(), scd.ChangeOperationalIntentReferenceResponse)
+    try:
+        return ImplicitDict.parse(
+            query.response["json"], scd.ChangeOperationalIntentReferenceResponse
+        )
+    except KeyError:
+        raise QueryError(
+            msg=f"{subject} response did not contain JSON body", queries=[query]
+        )
+    except ValueError as e:
+        raise QueryError(
+            msg=f"{subject} response contained invalid JSON: {str(e)}", queries=[query]
+        )
 
 
 # === USS operations defined in the ASTM API ===
@@ -98,19 +139,28 @@ def delete_operational_intent_reference(
 def get_operational_intent_details(
     utm_client: UTMClientSession, uss_base_url: str, id: str
 ) -> scd.OperationalIntent:
-    initiated_at = datetime.utcnow()
-    resp = utm_client.get(
-        "{}/uss/v1/operational_intents/{}".format(uss_base_url, id), scope=scd.SCOPE_SC
-    )
-    query = fetch.describe_query(resp, initiated_at)
-    if resp.status_code != 200:
+    url = f"{uss_base_url}/uss/v1/operational_intents/{id}"
+    subject = f"getOperationalIntentDetails from {url}"
+    query = fetch.query_and_describe(utm_client, "GET", url, scope=scd.SCOPE_SC)
+    if query.status_code != 200:
         raise QueryError(
-            msg="getOperationalIntentDetails failed {}:\n{}".format(
-                resp.status_code, resp.content.decode("utf-8")
+            msg="{} failed {}:\n{}".format(
+                subject, query.status_code, query.response.get("content", "")
             ),
             queries=[query],
         )
-    resp_body = ImplicitDict.parse(resp.json(), scd.GetOperationalIntentDetailsResponse)
+    try:
+        resp_body = ImplicitDict.parse(
+            query.response["json"], scd.GetOperationalIntentDetailsResponse
+        )
+    except KeyError:
+        raise QueryError(
+            msg=f"{subject} response did not contain JSON body", queries=[query]
+        )
+    except ValueError as e:
+        raise QueryError(
+            msg=f"{subject} response contained invalid JSON: {str(e)}", queries=[query]
+        )
     return resp_body.operational_intent
 
 
@@ -119,17 +169,15 @@ def notify_operational_intent_details_changed(
     uss_base_url: str,
     update: scd.PutOperationalIntentDetailsParameters,
 ) -> None:
-    initiated_at = datetime.utcnow()
-    resp = utm_client.post(
-        "{}/uss/v1/operational_intents".format(uss_base_url),
-        json=update,
-        scope=scd.SCOPE_SC,
+    url = f"{uss_base_url}/uss/v1/operational_intents"
+    subject = f"notifyOperationalIntentDetailsChanged to {url}"
+    query = fetch.query_and_describe(
+        utm_client, "POST", url, json=update, scope=scd.SCOPE_SC
     )
-    query = fetch.describe_query(resp, initiated_at)
-    if resp.status_code != 204 and resp.status_code != 200:
+    if query.status_code != 204 and query.status_code != 200:
         raise QueryError(
-            msg="notifyOperationalIntentDetailsChanged failed {} to {}:\n{}".format(
-                resp.status_code, resp.request.url, resp.content.decode("utf-8")
+            msg="{} failed {}:\n{}".format(
+                subject, query.status_code, query.response.get("content", "")
             ),
             queries=[query],
         )

--- a/monitoring/monitorlib/fetch/__init__.py
+++ b/monitoring/monitorlib/fetch/__init__.py
@@ -6,6 +6,7 @@ from typing import Dict, Optional, List
 import arrow
 import flask
 import requests
+import urllib3
 import yaml
 from yaml.representer import Representer
 
@@ -162,7 +163,7 @@ def query_and_describe(
     t0 = datetime.datetime.utcnow()
     try:
         return describe_query(client.request(method, url, **req_kwargs), t0)
-    except requests.RequestException as e:
+    except (requests.RequestException, urllib3.exceptions.ReadTimeoutError) as e:
         msg = "{}: {}".format(type(e).__name__, str(e))
     t1 = datetime.datetime.utcnow()
 

--- a/monitoring/uss_qualifier/resources/astm/f3548/v21/dss.py
+++ b/monitoring/uss_qualifier/resources/astm/f3548/v21/dss.py
@@ -52,31 +52,29 @@ class DSSInstance(object):
     ) -> Tuple[List[OperationalIntentReference], fetch.Query]:
         url = "/dss/v1/operational_intent_references/query"
         req = QueryOperationalIntentReferenceParameters(area_of_interest=extent)
-
-        initiated_at = datetime.utcnow()
-        resp = self.client.post(url, scope=SCOPE_SC, json=req)
-        if resp.status_code != 200:
+        query = fetch.query_and_describe(
+            self.client, "POST", url, scope=SCOPE_SC, json=req
+        )
+        if query.status_code != 200:
             result = None
         else:
             result = ImplicitDict.parse(
-                resp.json(), QueryOperationalIntentReferenceResponse
+                query.response["json"], QueryOperationalIntentReferenceResponse
             ).operational_intent_references
-        return result, fetch.describe_query(resp, initiated_at)
+        return result, query
 
     def get_full_op_intent(
         self, op_intent_ref: OperationalIntentReference
     ) -> Tuple[OperationalIntent, fetch.Query]:
         url = f"{op_intent_ref.uss_base_url}/uss/v1/operational_intents/{op_intent_ref.id}"
-
-        initiated_at = datetime.utcnow()
-        resp = self.client.get(url, scope=SCOPE_SC)
-        if resp.status_code != 200:
+        query = fetch.query_and_describe(self.client, "GET", url, scope=SCOPE_SC)
+        if query.status_code != 200:
             result = None
         else:
             result = ImplicitDict.parse(
-                resp.json(), GetOperationalIntentDetailsResponse
+                query.response["json"], GetOperationalIntentDetailsResponse
             ).operational_intent
-        return result, fetch.describe_query(resp, initiated_at)
+        return result, query
 
 
 class DSSInstanceResource(Resource[DSSInstanceSpecification]):

--- a/monitoring/uss_qualifier/resources/interuss/mock_uss.py
+++ b/monitoring/uss_qualifier/resources/interuss/mock_uss.py
@@ -24,9 +24,9 @@ class MockUSSClient(object):
         self.participant_id = participant_id
 
     def get_status(self) -> fetch.Query:
-        initiated_at = arrow.utcnow().datetime
-        resp = self.session.get("/scdsc/v1/status", scope=SCOPE_SCD_QUALIFIER_INJECT)
-        return fetch.describe_query(resp, initiated_at)
+        return fetch.query_and_describe(
+            self.session, "GET", "/scdsc/v1/status", scope=SCOPE_SCD_QUALIFIER_INJECT
+        )
 
     # TODO: Add other methods to interact with the mock USS in other ways (like starting/stopping message signing data collection)
 
@@ -34,7 +34,7 @@ class MockUSSClient(object):
 class MockUSSSpecification(ImplicitDict):
     mock_uss_base_url: str
     """The base URL for the mock USS.
-    
+
     If the mock USS had scdsc enabled, for instance, then these URLs would be
     valid:
       * <mock_uss_base_url>/mock/scd/uss/v1/reports

--- a/monitoring/uss_qualifier/resources/netrid/service_providers.py
+++ b/monitoring/uss_qualifier/resources/netrid/service_providers.py
@@ -49,22 +49,21 @@ class NetRIDServiceProvider(object):
         self.client = infrastructure.UTMClientSession(base_url, auth_adapter)
 
     def submit_test(self, request: CreateTestParameters, test_id: str) -> fetch.Query:
-        injection_path = "/tests/{}".format(test_id)
-
-        initiated_at = datetime.datetime.utcnow()
-        response = self.client.put(
-            url=injection_path, json=request, scope=SCOPE_RID_QUALIFIER_INJECT
+        return fetch.query_and_describe(
+            self.client,
+            "PUT",
+            url=f"/tests/{test_id}",
+            json=request,
+            scope=SCOPE_RID_QUALIFIER_INJECT,
         )
-        return fetch.describe_query(response, initiated_at)
 
     def delete_test(self, test_id: str) -> fetch.Query:
-        deletion_path = "/tests/{}".format(test_id)
-
-        initiated_at = datetime.datetime.utcnow()
-        response = self.client.delete(
-            url=deletion_path, scope=SCOPE_RID_QUALIFIER_INJECT
+        return fetch.query_and_describe(
+            self.client,
+            "DELETE",
+            url=f"/tests/{test_id}",
+            scope=SCOPE_RID_QUALIFIER_INJECT,
         )
-        return fetch.describe_query(response, initiated_at)
 
 
 class NetRIDServiceProviders(Resource[NetRIDServiceProvidersSpecification]):


### PR DESCRIPTION
Currently, failure to query a flight planner that results in an exception (e.g., a timeout exception) will not report information about the attempted query because the exception will jump immediately up to the scenario exception handler.  This means #28 is hard to diagnose as information about the query that times out is not available anywhere.  This PR addresses that issue by performing the flight planner queries with `fetch.query_and_describe` which captures exceptions, now including timeouts, gracefully so that the query information can be included in the report.

This replacement of query-then-describe_query with query_and_describe is repeated in most other places to provide the same resiliency to query errors in other locations as well.

Finally, some additional logging is added to the atproxy client daemon code as it is a prime suspect in the root timeout issue of #28.