### PR TITLE
[monitorlib] Convert fetch objects to ImplicitDicts

### DIFF
--- a/monitoring/mock_uss/tracer/context.py
+++ b/monitoring/mock_uss/tracer/context.py
@@ -1,16 +1,15 @@
-import argparse
 import atexit
 import datetime
 import os
-import shlex
 import signal
 import sys
-import threading
-import time
 from multiprocessing import Process
 from typing import Optional
 
+from implicitdict import StringBasedDateTime
 from loguru import logger
+import yaml
+from yaml.representer import Representer
 
 from monitoring.monitorlib import ids, versioning
 from monitoring.monitorlib import fetch
@@ -24,6 +23,8 @@ from monitoring.mock_uss.tracer import tracer_poll
 from monitoring.mock_uss.tracer.resources import ResourceSet, get_options
 from monitoring.mock_uss.tracer.database import db
 
+
+yaml.add_representer(StringBasedDateTime, Representer.represent_str)
 
 RID_SUBSCRIPTION_ID_CODE = "tracer RID Subscription"
 SCD_SUBSCRIPTION_ID_CODE = "tracer SCD Subscription"

--- a/monitoring/mock_uss/tracer/routes.py
+++ b/monitoring/mock_uss/tracer/routes.py
@@ -8,6 +8,7 @@ from loguru import logger
 from termcolor import colored
 import yaml
 
+from implicitdict import ImplicitDict
 from monitoring.monitorlib import fetch, formatting, geo, infrastructure, versioning
 from monitoring.monitorlib.fetch import summarize
 import monitoring.monitorlib.fetch.rid
@@ -248,17 +249,21 @@ def tracer_logs(log):
     object_type = obj.get("object_type", None)
     if object_type == fetch.rid.FetchedISAs.__name__:
         obj = {
-            "summary": summarize.isas(fetch.rid.FetchedISAs(obj)),
+            "summary": summarize.isas(ImplicitDict.parse(obj, fetch.rid.FetchedISAs)),
             "details": obj,
         }
     elif object_type == fetch.scd.FetchedEntities.__name__:
         obj = {
-            "summary": summarize.entities(fetch.scd.FetchedEntities(obj)),
+            "summary": summarize.entities(
+                ImplicitDict.parse(obj, fetch.scd.FetchedEntities)
+            ),
             "details": obj,
         }
     elif object_type == fetch.rid.FetchedFlights.__name__:
         obj = {
-            "summary": summarize.flights(fetch.rid.FetchedFlights(obj)),
+            "summary": summarize.flights(
+                ImplicitDict.parse(obj, fetch.rid.FetchedFlights)
+            ),
             "details": obj,
         }
 

--- a/monitoring/monitorlib/clients/scd.py
+++ b/monitoring/monitorlib/clients/scd.py
@@ -30,7 +30,7 @@ def query_operational_intent_references(
         )
     try:
         resp_body = ImplicitDict.parse(
-            query.response["json"], scd.QueryOperationalIntentReferenceResponse
+            query.response.json, scd.QueryOperationalIntentReferenceResponse
         )
     except KeyError:
         raise QueryError(
@@ -62,7 +62,7 @@ def create_operational_intent_reference(
         )
     try:
         return ImplicitDict.parse(
-            query.response["json"], scd.ChangeOperationalIntentReferenceResponse
+            query.response.json, scd.ChangeOperationalIntentReferenceResponse
         )
     except KeyError:
         raise QueryError(
@@ -94,7 +94,7 @@ def update_operational_intent_reference(
         )
     try:
         return ImplicitDict.parse(
-            query.response["json"], scd.ChangeOperationalIntentReferenceResponse
+            query.response.json, scd.ChangeOperationalIntentReferenceResponse
         )
     except KeyError:
         raise QueryError(
@@ -121,7 +121,7 @@ def delete_operational_intent_reference(
         )
     try:
         return ImplicitDict.parse(
-            query.response["json"], scd.ChangeOperationalIntentReferenceResponse
+            query.response.json, scd.ChangeOperationalIntentReferenceResponse
         )
     except KeyError:
         raise QueryError(
@@ -151,7 +151,7 @@ def get_operational_intent_details(
         )
     try:
         resp_body = ImplicitDict.parse(
-            query.response["json"], scd.GetOperationalIntentDetailsResponse
+            query.response.json, scd.GetOperationalIntentDetailsResponse
         )
     except KeyError:
         raise QueryError(

--- a/monitoring/monitorlib/fetch/__init__.py
+++ b/monitoring/monitorlib/fetch/__init__.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import traceback
+from types import MappingProxyType
 from typing import Dict, Optional, List
 
 import flask
@@ -19,7 +20,8 @@ TIMEOUTS = (5, 25)  # Timeouts of `connect` and `read` in seconds
 class RequestDescription(ImplicitDict):
     method: str
     url: str
-    headers: dict
+    # Note: MappingProxyType effectively creates a read-only dict.
+    headers: dict = MappingProxyType({})
     json: Optional[dict] = None
     body: Optional[str] = None
 

--- a/monitoring/monitorlib/fetch/__init__.py
+++ b/monitoring/monitorlib/fetch/__init__.py
@@ -3,39 +3,41 @@ import json
 import traceback
 from typing import Dict, Optional, List
 
-import arrow
 import flask
 import requests
 import urllib3
 import yaml
 from yaml.representer import Representer
 
+from implicitdict import ImplicitDict, StringBasedDateTime
 from monitoring.monitorlib import infrastructure
 
 
 TIMEOUTS = (5, 25)  # Timeouts of `connect` and `read` in seconds
 
 
-def coerce(obj: Dict, desired_type: type):
-    if isinstance(obj, desired_type):
-        return obj
-    else:
-        return desired_type(obj)
+class RequestDescription(ImplicitDict):
+    method: str
+    url: str
+    headers: dict
+    json: Optional[dict] = None
+    body: Optional[str] = None
 
+    initiated_at: Optional[StringBasedDateTime]
+    received_at: Optional[StringBasedDateTime]
 
-class RequestDescription(dict):
     @property
     def token(self) -> Dict:
-        return infrastructure.get_token_claims(self.get("headers", {}))
+        return infrastructure.get_token_claims(self.headers)
 
     @property
     def timestamp(self) -> datetime.datetime:
         if "initiated_at" in self:
             # This was an outgoing request
-            return arrow.get(self["initiated_at"]).datetime
+            return self.initiated_at.datetime
         elif "received_at" in self:
             # This was an incoming request
-            return arrow.get(self["received_at"]).datetime
+            return self.received_at.datetime
         else:
             raise KeyError(
                 "RequestDescription missing both initiated_at and received_at"
@@ -47,48 +49,52 @@ yaml.add_representer(RequestDescription, Representer.represent_dict)
 
 def describe_flask_request(request: flask.Request) -> RequestDescription:
     headers = {k: v for k, v in request.headers}
-    info = {
+    kwargs = {
         "method": request.method,
         "url": request.url,
-        "received_at": datetime.datetime.utcnow().isoformat(),
+        "received_at": StringBasedDateTime(datetime.datetime.utcnow()),
         "headers": headers,
     }
     try:
-        info["json"] = request.json
+        kwargs["json"] = request.json
     except ValueError:
-        info["body"] = request.data.encode("utf-8")
-    return RequestDescription(info)
+        kwargs["body"] = request.data.decode("utf-8")
+    return RequestDescription(**kwargs)
 
 
 def describe_request(
     req: requests.PreparedRequest, initiated_at: datetime.datetime
 ) -> RequestDescription:
     headers = {k: v for k, v in req.headers.items()}
-    info = {
+    kwargs = {
         "method": req.method,
         "url": req.url,
-        "initiated_at": initiated_at.isoformat(),
+        "initiated_at": StringBasedDateTime(initiated_at),
         "headers": headers,
     }
     body = req.body.decode("utf-8") if req.body else None
     try:
         if body:
-            info["json"] = json.loads(body)
+            kwargs["json"] = json.loads(body)
         else:
-            info["body"] = body
+            kwargs["body"] = body
     except ValueError:
-        info["body"] = body
-    return RequestDescription(info)
+        kwargs["body"] = body
+    return RequestDescription(**kwargs)
 
 
-class ResponseDescription(dict):
+class ResponseDescription(ImplicitDict):
+    code: Optional[int] = None
+    failure: Optional[str]
+    headers: dict
+    elapsed_s: float
+    reported: StringBasedDateTime
+    json: Optional[dict] = None
+    body: Optional[str] = None
+
     @property
     def status_code(self) -> int:
-        return self["code"] if self.get("code") is not None else 999
-
-    @property
-    def reported(self) -> datetime.datetime:
-        return arrow.get(self["reported"]).datetime
+        return self.code or 999
 
 
 yaml.add_representer(ResponseDescription, Representer.represent_dict)
@@ -96,27 +102,22 @@ yaml.add_representer(ResponseDescription, Representer.represent_dict)
 
 def describe_response(resp: requests.Response) -> ResponseDescription:
     headers = {k: v for k, v in resp.headers.items()}
-    info = {
+    kwargs = {
         "code": resp.status_code,
         "headers": headers,
         "elapsed_s": resp.elapsed.total_seconds(),
-        "reported": datetime.datetime.utcnow().isoformat(),
+        "reported": StringBasedDateTime(datetime.datetime.utcnow()),
     }
     try:
-        info["json"] = resp.json()
+        kwargs["json"] = resp.json()
     except ValueError:
-        info["body"] = resp.content.decode("utf-8")
-    return ResponseDescription(info)
+        kwargs["body"] = resp.content.decode("utf-8")
+    return ResponseDescription(**kwargs)
 
 
-class Query(dict):
-    @property
-    def request(self) -> RequestDescription:
-        return coerce(self["request"], RequestDescription)
-
-    @property
-    def response(self) -> ResponseDescription:
-        return coerce(self["response"], ResponseDescription)
+class Query(ImplicitDict):
+    request: RequestDescription
+    response: ResponseDescription
 
     @property
     def status_code(self) -> int:
@@ -124,7 +125,7 @@ class Query(dict):
 
     @property
     def json_result(self) -> Optional[Dict]:
-        return self.response.get("json", None)
+        return self.response.json
 
 
 class QueryError(RuntimeError):
@@ -148,10 +149,8 @@ yaml.add_representer(Query, Representer.represent_dict)
 
 def describe_query(resp: requests.Response, initiated_at: datetime.datetime) -> Query:
     return Query(
-        {
-            "request": describe_request(resp.request, initiated_at),
-            "response": describe_response(resp),
-        }
+        request=describe_request(resp.request, initiated_at),
+        response=describe_response(resp),
     )
 
 
@@ -174,15 +173,11 @@ def query_and_describe(
     req = requests.Request(method, url, **req_kwargs)
     prepped_req = client.prepare_request(req)
     return Query(
-        {
-            "request": describe_request(prepped_req, t0),
-            "response": ResponseDescription(
-                {
-                    "code": None,
-                    "failure": msg,
-                    "elapsed_s": (t1 - t0).total_seconds(),
-                    "reported": t1,
-                }
-            ),
-        }
+        request=describe_request(prepped_req, t0),
+        response=ResponseDescription(
+            code=None,
+            failure=msg,
+            elapsed_s=(t1 - t0).total_seconds(),
+            reported=StringBasedDateTime(t1),
+        ),
     )

--- a/monitoring/monitorlib/fetch/rid.py
+++ b/monitoring/monitorlib/fetch/rid.py
@@ -1,11 +1,11 @@
 import datetime
 from typing import Dict, List, Optional
 
-import requests
 import s2sphere
 import yaml
 from yaml.representer import Representer
 
+from implicitdict import ImplicitDict
 from monitoring.monitorlib import fetch, infrastructure, rid
 
 
@@ -86,6 +86,8 @@ def isas(
 
 
 class FetchedUSSFlights(fetch.Query):
+    """Wrapper to interpret a USS flights query as a list of flights."""
+
     @property
     def success(self) -> bool:
         return not self.errors
@@ -131,6 +133,8 @@ def flights(
 
 
 class FetchedUSSFlightDetails(fetch.Query):
+    """Wrapper to interpret a USS flight details query as details for a flight."""
+
     @property
     def success(self) -> bool:
         return not self.errors
@@ -156,7 +160,7 @@ yaml.add_representer(FetchedUSSFlightDetails, Representer.represent_dict)
 def flight_details(
     utm_client: infrastructure.UTMClientSession,
     flights_url: str,
-    id: str,
+    flight_id: str,
     enhanced_details: bool = False,
 ) -> FetchedUSSFlightDetails:
     suffix = "?enhanced=true" if enhanced_details else ""
@@ -169,15 +173,19 @@ def flight_details(
         fetch.query_and_describe(
             utm_client,
             "GET",
-            flights_url + "/{}/details{}".format(id, suffix),
+            flights_url + "/{}/details{}".format(flight_id, suffix),
             scope=scope,
         )
     )
-    result["requested_id"] = id
+    result["requested_id"] = flight_id
     return result
 
 
-class FetchedFlights(fetch.Query):
+class FetchedFlights(ImplicitDict):
+    dss_isa_query: FetchedISAs
+    uss_flight_queries: Dict[str, FetchedUSSFlights]
+    uss_flight_details_queries: Dict[str, FetchedUSSFlightDetails]
+
     @property
     def success(self):
         return not self.errors
@@ -187,24 +195,6 @@ class FetchedFlights(fetch.Query):
         if not self.dss_isa_query.success:
             return ["Failed to obtain ISAs: " + self.dss_isa_query.error]
         return []
-
-    @property
-    def dss_isa_query(self) -> FetchedISAs:
-        return fetch.coerce(self["dss_isa_query"], FetchedISAs)
-
-    @property
-    def uss_flight_queries(self) -> Dict[str, FetchedUSSFlights]:
-        return {
-            k: fetch.coerce(v, FetchedUSSFlights)
-            for k, v in self.get("uss_flight_queries", {}).items()
-        }
-
-    @property
-    def uss_flight_details_queries(self) -> Dict[str, FetchedUSSFlightDetails]:
-        return {
-            k: fetch.coerce(v, FetchedUSSFlightDetails)
-            for k, v in self.get("uss_flight_details_queries", {}).items()
-        }
 
 
 yaml.add_representer(FetchedFlights, Representer.represent_dict)
@@ -238,15 +228,15 @@ def all_flights(
                     uss_flight_details_queries[flight.id] = details
 
     return FetchedFlights(
-        {
-            "dss_isa_query": isa_query,
-            "uss_flight_queries": uss_flight_queries,
-            "uss_flight_details_queries": uss_flight_details_queries,
-        }
+        dss_isa_query=isa_query,
+        uss_flight_queries=uss_flight_queries,
+        uss_flight_details_querie=uss_flight_details_queries,
     )
 
 
 class FetchedSubscription(fetch.Query):
+    """Wrapper to interpret a DSS Subscription query as a Subscription."""
+
     @property
     def success(self) -> bool:
         return not self.errors

--- a/monitoring/monitorlib/mutate/rid.py
+++ b/monitoring/monitorlib/mutate/rid.py
@@ -10,6 +10,8 @@ from implicitdict import ImplicitDict
 
 
 class MutatedSubscription(fetch.Query):
+    mutation: Optional[str] = None
+
     @property
     def success(self) -> bool:
         return not self.errors
@@ -36,10 +38,6 @@ class MutatedSubscription(fetch.Query):
         if not sub:
             return None
         return rid.Subscription(sub)
-
-    @property
-    def mutation(self) -> str:
-        return self["mutation"]
 
 
 yaml.add_representer(MutatedSubscription, Representer.represent_dict)
@@ -77,7 +75,7 @@ def put_subscription(
             utm_client, "PUT", url, json=body, scope=rid.SCOPE_READ
         )
     )
-    result["mutation"] = "create" if subscription_version is None else "update"
+    result.mutation = "create" if subscription_version is None else "update"
     return result
 
 
@@ -90,12 +88,14 @@ def delete_subscription(
     result = MutatedSubscription(
         fetch.query_and_describe(utm_client, "DELETE", url, scope=rid.SCOPE_READ)
     )
-    result["mutation"] = "delete"
+    result.mutation = "delete"
     return result
 
 
 class MutatedISAResponse(fetch.Query):
     """Response to a call to the DSS to mutate an ISA"""
+
+    mutation: Optional[str] = None
 
     @property
     def success(self) -> bool:
@@ -129,10 +129,6 @@ class MutatedISAResponse(fetch.Query):
         if not subs:
             return []
         return [rid.SubscriberToNotify(sub) for sub in subs]
-
-    @property
-    def mutation(self) -> str:
-        return self["mutation"]
 
 
 yaml.add_representer(MutatedISAResponse, Representer.represent_dict)

--- a/monitoring/monitorlib/mutate/scd.py
+++ b/monitoring/monitorlib/mutate/scd.py
@@ -10,6 +10,8 @@ from monitoring.monitorlib import fetch
 
 
 class MutatedSubscription(fetch.Query):
+    mutation: Optional[str] = None
+
     @property
     def success(self) -> bool:
         return not self.errors
@@ -36,10 +38,6 @@ class MutatedSubscription(fetch.Query):
         if not sub:
             return None
         return scd.Subscription(sub)
-
-    @property
-    def mutation(self) -> str:
-        return self["mutation"]
 
 
 yaml.add_representer(MutatedSubscription, Representer.represent_dict)
@@ -74,7 +72,7 @@ def put_subscription(
     result = MutatedSubscription(
         fetch.query_and_describe(utm_client, "PUT", url, json=body, scope=scd.SCOPE_SC)
     )
-    result["mutation"] = "update" if version else "create"
+    result.mutation = "update" if version else "create"
     return result
 
 
@@ -85,5 +83,5 @@ def delete_subscription(
     result = MutatedSubscription(
         fetch.query_and_describe(utm_client, "DELETE", url, scope=scd.SCOPE_SC)
     )
-    result["mutation"] = "delete"
+    result.mutation = "delete"
     return result

--- a/monitoring/uss_qualifier/resources/astm/f3548/v21/dss.py
+++ b/monitoring/uss_qualifier/resources/astm/f3548/v21/dss.py
@@ -59,7 +59,7 @@ class DSSInstance(object):
             result = None
         else:
             result = ImplicitDict.parse(
-                query.response["json"], QueryOperationalIntentReferenceResponse
+                query.response.json, QueryOperationalIntentReferenceResponse
             ).operational_intent_references
         return result, query
 
@@ -72,7 +72,7 @@ class DSSInstance(object):
             result = None
         else:
             result = ImplicitDict.parse(
-                query.response["json"], GetOperationalIntentDetailsResponse
+                query.response.json, GetOperationalIntentDetailsResponse
             ).operational_intent
         return result, query
 

--- a/monitoring/uss_qualifier/resources/netrid/observers.py
+++ b/monitoring/uss_qualifier/resources/netrid/observers.py
@@ -40,7 +40,7 @@ class RIDSystemObserver(object):
         try:
             result = (
                 ImplicitDict.parse(
-                    query.response["json"], observation_api.GetDisplayDataResponse
+                    query.response.json, observation_api.GetDisplayDataResponse
                 )
                 if query.status_code == 200
                 else None
@@ -59,7 +59,7 @@ class RIDSystemObserver(object):
         try:
             result = (
                 ImplicitDict.parse(
-                    query.response["json"], observation_api.GetDetailsResponse
+                    query.response.json, observation_api.GetDetailsResponse
                 )
                 if query.status_code == 200
                 else None

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/display_data_evaluator.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/display_data_evaluator.py
@@ -125,7 +125,7 @@ class RIDObservationEvaluator(object):
 
         for expected_flight in self._injected_flights:
             t_initiated = query.request.timestamp
-            t_response = query.response.reported
+            t_response = query.response.reported.datetime
             timestamps = [
                 arrow.get(t.timestamp) for t in expected_flight.flight.telemetry
             ]

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/nominal_behavior.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/nominal_behavior.py
@@ -106,7 +106,7 @@ class NominalBehavior(TestScenario):
                 if "json" not in query.response:
                     raise ValueError(f"Response did not contain a JSON body")
                 changed_test: ChangeTestResponse = ImplicitDict.parse(
-                    query.response["json"], ChangeTestResponse
+                    query.response.json, ChangeTestResponse
                 )
                 injections = changed_test.injected_flights
                 check.record_passed()

--- a/monitoring/uss_qualifier/test_data/che/netrid/circular_flights.json
+++ b/monitoring/uss_qualifier/test_data/che/netrid/circular_flights.json
@@ -1,10 +1,10 @@
 {
   "flights": [
     {
-      "reference_time": "2022-01-01T00:00:00.000000Z",
+      "reference_time": "2022-01-01T00:00:00+00:00",
       "states": [
         {
-          "timestamp": "2022-01-01T00:00:01.000000Z",
+          "timestamp": "2022-01-01T00:00:01+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.9754225199202,
@@ -25,7 +25,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:02.000000Z",
+          "timestamp": "2022-01-01T00:00:02+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97537839156561,
@@ -46,7 +46,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:03.000000Z",
+          "timestamp": "2022-01-01T00:00:03+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97533460388938,
@@ -67,7 +67,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:04.000000Z",
+          "timestamp": "2022-01-01T00:00:04+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97529157858963,
@@ -88,7 +88,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:05.000000Z",
+          "timestamp": "2022-01-01T00:00:05+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97524973002137,
@@ -109,7 +109,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:06.000000Z",
+          "timestamp": "2022-01-01T00:00:06+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.975209461206134,
@@ -130,7 +130,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:07.000000Z",
+          "timestamp": "2022-01-01T00:00:07+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97517115995081,
@@ -151,7 +151,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:08.000000Z",
+          "timestamp": "2022-01-01T00:00:08+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97513519511295,
@@ -172,7 +172,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:09.000000Z",
+          "timestamp": "2022-01-01T00:00:09+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97510191304869,
@@ -193,7 +193,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:10.000000Z",
+          "timestamp": "2022-01-01T00:00:10+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.9750716342773,
@@ -214,7 +214,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:11.000000Z",
+          "timestamp": "2022-01-01T00:00:11+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97504465039461,
@@ -235,7 +235,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:12.000000Z",
+          "timestamp": "2022-01-01T00:00:12+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97502122126502,
@@ -256,7 +256,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:13.000000Z",
+          "timestamp": "2022-01-01T00:00:13+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97500157251901,
@@ -277,7 +277,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:14.000000Z",
+          "timestamp": "2022-01-01T00:00:14+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.974985893380456,
@@ -298,7 +298,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:15.000000Z",
+          "timestamp": "2022-01-01T00:00:15+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.974974334844354,
@@ -319,7 +319,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:16.000000Z",
+          "timestamp": "2022-01-01T00:00:16+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97496700822293,
@@ -340,7 +340,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:17.000000Z",
+          "timestamp": "2022-01-01T00:00:17+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97496398407367,
@@ -361,7 +361,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:18.000000Z",
+          "timestamp": "2022-01-01T00:00:18+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97496529151983,
@@ -382,7 +382,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:19.000000Z",
+          "timestamp": "2022-01-01T00:00:19+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.974970917970175,
@@ -403,7 +403,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:20.000000Z",
+          "timestamp": "2022-01-01T00:00:20+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97498080924005,
@@ -424,7 +424,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:21.000000Z",
+          "timestamp": "2022-01-01T00:00:21+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97499487007325,
@@ -445,7 +445,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:22.000000Z",
+          "timestamp": "2022-01-01T00:00:22+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97501296505933,
@@ -466,7 +466,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:23.000000Z",
+          "timestamp": "2022-01-01T00:00:23+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.9750349199375,
@@ -487,7 +487,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:24.000000Z",
+          "timestamp": "2022-01-01T00:00:24+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.975060523274735,
@@ -508,7 +508,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:25.000000Z",
+          "timestamp": "2022-01-01T00:00:25+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.975089528501826,
@@ -529,7 +529,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:26.000000Z",
+          "timestamp": "2022-01-01T00:00:26+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.975121656287804,
@@ -550,7 +550,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:27.000000Z",
+          "timestamp": "2022-01-01T00:00:27+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.9751565972298,
@@ -571,7 +571,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:28.000000Z",
+          "timestamp": "2022-01-01T00:00:28+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97519401483258,
@@ -592,7 +592,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:29.000000Z",
+          "timestamp": "2022-01-01T00:00:29+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.975233548749024,
@@ -613,7 +613,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:30.000000Z",
+          "timestamp": "2022-01-01T00:00:30+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.975274818250206,
@@ -648,10 +648,10 @@
       "aircraft_type": "Helicopter"
     },
     {
-      "reference_time": "2022-01-01T00:00:00.000000Z",
+      "reference_time": "2022-01-01T00:00:00+00:00",
       "states": [
         {
-          "timestamp": "2022-01-01T00:00:01.000000Z",
+          "timestamp": "2022-01-01T00:00:01+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97690122350781,
@@ -672,7 +672,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:02.000000Z",
+          "timestamp": "2022-01-01T00:00:02+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976857095163645,
@@ -693,7 +693,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:03.000000Z",
+          "timestamp": "2022-01-01T00:00:03+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97681330749575,
@@ -714,7 +714,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:04.000000Z",
+          "timestamp": "2022-01-01T00:00:04+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976770282202125,
@@ -735,7 +735,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:05.000000Z",
+          "timestamp": "2022-01-01T00:00:05+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97672843363776,
@@ -756,7 +756,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:06.000000Z",
+          "timestamp": "2022-01-01T00:00:06+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976688164824125,
@@ -777,7 +777,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:07.000000Z",
+          "timestamp": "2022-01-01T00:00:07+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.9766498635681,
@@ -798,7 +798,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:08.000000Z",
+          "timestamp": "2022-01-01T00:00:08+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97661389872726,
@@ -819,7 +819,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:09.000000Z",
+          "timestamp": "2022-01-01T00:00:09+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97658061665774,
@@ -840,7 +840,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:10.000000Z",
+          "timestamp": "2022-01-01T00:00:10+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97655033787888,
@@ -861,7 +861,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:11.000000Z",
+          "timestamp": "2022-01-01T00:00:11+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97652335398656,
@@ -882,7 +882,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:12.000000Z",
+          "timestamp": "2022-01-01T00:00:12+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97649992484531,
@@ -903,7 +903,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:13.000000Z",
+          "timestamp": "2022-01-01T00:00:13+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976480276085674,
@@ -924,7 +924,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:14.000000Z",
+          "timestamp": "2022-01-01T00:00:14+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976464596931706,
@@ -945,7 +945,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:15.000000Z",
+          "timestamp": "2022-01-01T00:00:15+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97645303837853,
@@ -966,7 +966,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:16.000000Z",
+          "timestamp": "2022-01-01T00:00:16+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97644571173855,
@@ -987,7 +987,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:17.000000Z",
+          "timestamp": "2022-01-01T00:00:17+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976442687569374,
@@ -1008,7 +1008,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:18.000000Z",
+          "timestamp": "2022-01-01T00:00:18+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97644399499454,
@@ -1029,7 +1029,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:19.000000Z",
+          "timestamp": "2022-01-01T00:00:19+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97644962142294,
@@ -1050,7 +1050,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:20.000000Z",
+          "timestamp": "2022-01-01T00:00:20+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97645951267017,
@@ -1071,7 +1071,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:21.000000Z",
+          "timestamp": "2022-01-01T00:00:21+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97647357348022,
@@ -1092,7 +1092,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:22.000000Z",
+          "timestamp": "2022-01-01T00:00:22+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97649166844289,
@@ -1113,7 +1113,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:23.000000Z",
+          "timestamp": "2022-01-01T00:00:23+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976513623297585,
@@ -1134,7 +1134,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:24.000000Z",
+          "timestamp": "2022-01-01T00:00:24+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97653922661156,
@@ -1155,7 +1155,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:25.000000Z",
+          "timestamp": "2022-01-01T00:00:25+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976568231815776,
@@ -1176,7 +1176,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:26.000000Z",
+          "timestamp": "2022-01-01T00:00:26+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976600359579514,
@@ -1197,7 +1197,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:27.000000Z",
+          "timestamp": "2022-01-01T00:00:27+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.9766353005001,
@@ -1218,7 +1218,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:28.000000Z",
+          "timestamp": "2022-01-01T00:00:28+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97667271808253,
@@ -1239,7 +1239,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:29.000000Z",
+          "timestamp": "2022-01-01T00:00:29+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976712251979855,
@@ -1260,7 +1260,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:30.000000Z",
+          "timestamp": "2022-01-01T00:00:30+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976753521463344,
@@ -1295,10 +1295,10 @@
       "aircraft_type": "Helicopter"
     },
     {
-      "reference_time": "2022-01-01T00:00:00.000000Z",
+      "reference_time": "2022-01-01T00:00:00+00:00",
       "states": [
         {
-          "timestamp": "2022-01-01T00:00:01.000000Z",
+          "timestamp": "2022-01-01T00:00:01+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97542251027387,
@@ -1319,7 +1319,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:02.000000Z",
+          "timestamp": "2022-01-01T00:00:02+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97537838193127,
@@ -1340,7 +1340,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:03.000000Z",
+          "timestamp": "2022-01-01T00:00:03+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.975334594359815,
@@ -1361,7 +1361,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:04.000000Z",
+          "timestamp": "2022-01-01T00:00:04+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97529156925661,
@@ -1382,7 +1382,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:05.000000Z",
+          "timestamp": "2022-01-01T00:00:05+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97524972097478,
@@ -1403,7 +1403,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:06.000000Z",
+          "timestamp": "2022-01-01T00:00:06+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97520945253309,
@@ -1424,7 +1424,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:07.000000Z",
+          "timestamp": "2022-01-01T00:00:07+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.975171151734834,
@@ -1445,7 +1445,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:08.000000Z",
+          "timestamp": "2022-01-01T00:00:08+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.975135187433175,
@@ -1466,7 +1466,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:09.000000Z",
+          "timestamp": "2022-01-01T00:00:09+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97510190597907,
@@ -1487,7 +1487,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:10.000000Z",
+          "timestamp": "2022-01-01T00:00:10+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.975071627885924,
@@ -1508,7 +1508,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:11.000000Z",
+          "timestamp": "2022-01-01T00:00:11+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.975044644743015,
@@ -1529,7 +1529,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:12.000000Z",
+          "timestamp": "2022-01-01T00:00:12+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97502121640763,
@@ -1550,7 +1550,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:13.000000Z",
+          "timestamp": "2022-01-01T00:00:13+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97500156850261,
@@ -1571,7 +1571,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:14.000000Z",
+          "timestamp": "2022-01-01T00:00:14+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97498589024373,
@@ -1592,7 +1592,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:15.000000Z",
+          "timestamp": "2022-01-01T00:00:15+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.974974332617506,
@@ -1613,7 +1613,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:16.000000Z",
+          "timestamp": "2022-01-01T00:00:16+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.974967006927415,
@@ -1634,7 +1634,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:17.000000Z",
+          "timestamp": "2022-01-01T00:00:17+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97496398372193,
@@ -1655,7 +1655,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:18.000000Z",
+          "timestamp": "2022-01-01T00:00:18+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97496529211529,
@@ -1676,7 +1676,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:19.000000Z",
+          "timestamp": "2022-01-01T00:00:19+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97497091950708,
@@ -1697,7 +1697,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:20.000000Z",
+          "timestamp": "2022-01-01T00:00:20+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97498081170361,
@@ -1718,7 +1718,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:21.000000Z",
+          "timestamp": "2022-01-01T00:00:21+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.974994873439734,
@@ -1739,7 +1739,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:22.000000Z",
+          "timestamp": "2022-01-01T00:00:22+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.9750129692963,
@@ -1760,7 +1760,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:23.000000Z",
+          "timestamp": "2022-01-01T00:00:23+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.975034925004174,
@@ -1781,7 +1781,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:24.000000Z",
+          "timestamp": "2022-01-01T00:00:24+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.975060529122324,
@@ -1802,7 +1802,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:25.000000Z",
+          "timestamp": "2022-01-01T00:00:25+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.975089535074005,
@@ -1823,7 +1823,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:26.000000Z",
+          "timestamp": "2022-01-01T00:00:26+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.9751216635213,
@@ -1844,7 +1844,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:27.000000Z",
+          "timestamp": "2022-01-01T00:00:27+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97515660505494,
@@ -1865,7 +1865,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:28.000000Z",
+          "timestamp": "2022-01-01T00:00:28+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97519402317401,
@@ -1886,7 +1886,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:29.000000Z",
+          "timestamp": "2022-01-01T00:00:29+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97523355752641,
@@ -1907,7 +1907,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:30.000000Z",
+          "timestamp": "2022-01-01T00:00:30+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97527482737902,
@@ -1942,10 +1942,10 @@
       "aircraft_type": "Helicopter"
     },
     {
-      "reference_time": "2022-01-01T00:00:00.000000Z",
+      "reference_time": "2022-01-01T00:00:00+00:00",
       "states": [
         {
-          "timestamp": "2022-01-01T00:00:01.000000Z",
+          "timestamp": "2022-01-01T00:00:01+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97690121386124,
@@ -1966,7 +1966,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:02.000000Z",
+          "timestamp": "2022-01-01T00:00:02+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976857085529076,
@@ -1987,7 +1987,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:03.000000Z",
+          "timestamp": "2022-01-01T00:00:03+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97681329796595,
@@ -2008,7 +2008,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:04.000000Z",
+          "timestamp": "2022-01-01T00:00:04+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976770272868876,
@@ -2029,7 +2029,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:05.000000Z",
+          "timestamp": "2022-01-01T00:00:05+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976728424590945,
@@ -2050,7 +2050,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:06.000000Z",
+          "timestamp": "2022-01-01T00:00:06+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97668815615087,
@@ -2071,7 +2071,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:07.000000Z",
+          "timestamp": "2022-01-01T00:00:07+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97664985535192,
@@ -2092,7 +2092,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:08.000000Z",
+          "timestamp": "2022-01-01T00:00:08+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97661389104729,
@@ -2113,7 +2113,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:09.000000Z",
+          "timestamp": "2022-01-01T00:00:09+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97658060958795,
@@ -2134,7 +2134,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:10.000000Z",
+          "timestamp": "2022-01-01T00:00:10+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97655033148734,
@@ -2155,7 +2155,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:11.000000Z",
+          "timestamp": "2022-01-01T00:00:11+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97652334833483,
@@ -2176,7 +2176,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:12.000000Z",
+          "timestamp": "2022-01-01T00:00:12+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.9764999199878,
@@ -2197,7 +2197,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:13.000000Z",
+          "timestamp": "2022-01-01T00:00:13+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97648027206919,
@@ -2218,7 +2218,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:14.000000Z",
+          "timestamp": "2022-01-01T00:00:14+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.9764645937949,
@@ -2239,7 +2239,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:15.000000Z",
+          "timestamp": "2022-01-01T00:00:15+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97645303615162,
@@ -2260,7 +2260,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:16.000000Z",
+          "timestamp": "2022-01-01T00:00:16+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97644571044297,
@@ -2281,7 +2281,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:17.000000Z",
+          "timestamp": "2022-01-01T00:00:17+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976442687217634,
@@ -2302,7 +2302,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:18.000000Z",
+          "timestamp": "2022-01-01T00:00:18+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976443995589996,
@@ -2323,7 +2323,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:19.000000Z",
+          "timestamp": "2022-01-01T00:00:19+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976449622959876,
@@ -2344,7 +2344,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:20.000000Z",
+          "timestamp": "2022-01-01T00:00:20+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976459515133776,
@@ -2365,7 +2365,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:21.000000Z",
+          "timestamp": "2022-01-01T00:00:21+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97647357684678,
@@ -2386,7 +2386,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:22.000000Z",
+          "timestamp": "2022-01-01T00:00:22+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97649167267996,
@@ -2407,7 +2407,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:23.000000Z",
+          "timestamp": "2022-01-01T00:00:23+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976513628364394,
@@ -2428,7 +2428,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:24.000000Z",
+          "timestamp": "2022-01-01T00:00:24+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97653923245929,
@@ -2449,7 +2449,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:25.000000Z",
+          "timestamp": "2022-01-01T00:00:25+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97656823838812,
@@ -2470,7 +2470,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:26.000000Z",
+          "timestamp": "2022-01-01T00:00:26+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976600366813166,
@@ -2491,7 +2491,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:27.000000Z",
+          "timestamp": "2022-01-01T00:00:27+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97663530832542,
@@ -2512,7 +2512,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:28.000000Z",
+          "timestamp": "2022-01-01T00:00:28+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97667272642415,
@@ -2533,7 +2533,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:29.000000Z",
+          "timestamp": "2022-01-01T00:00:29+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976712260757445,
@@ -2554,7 +2554,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:30.000000Z",
+          "timestamp": "2022-01-01T00:00:30+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97675353059237,
@@ -2589,10 +2589,10 @@
       "aircraft_type": "Helicopter"
     },
     {
-      "reference_time": "2022-01-01T00:00:00.000000Z",
+      "reference_time": "2022-01-01T00:00:00+00:00",
       "states": [
         {
-          "timestamp": "2022-01-01T00:00:01.000000Z",
+          "timestamp": "2022-01-01T00:00:01+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97542250062755,
@@ -2613,7 +2613,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:02.000000Z",
+          "timestamp": "2022-01-01T00:00:02+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97537837229697,
@@ -2634,7 +2634,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:03.000000Z",
+          "timestamp": "2022-01-01T00:00:03+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97533458483033,
@@ -2655,7 +2655,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:04.000000Z",
+          "timestamp": "2022-01-01T00:00:04+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97529155992369,
@@ -2676,7 +2676,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:05.000000Z",
+          "timestamp": "2022-01-01T00:00:05+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97524971192833,
@@ -2697,7 +2697,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:06.000000Z",
+          "timestamp": "2022-01-01T00:00:06+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97520944386022,
@@ -2718,7 +2718,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:07.000000Z",
+          "timestamp": "2022-01-01T00:00:07+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.975171143519084,
@@ -2739,7 +2739,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:08.000000Z",
+          "timestamp": "2022-01-01T00:00:08+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97513517975364,
@@ -2760,7 +2760,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:09.000000Z",
+          "timestamp": "2022-01-01T00:00:09+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.975101898909735,
@@ -2781,7 +2781,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:10.000000Z",
+          "timestamp": "2022-01-01T00:00:10+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97507162149484,
@@ -2802,7 +2802,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:11.000000Z",
+          "timestamp": "2022-01-01T00:00:11+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97504463909175,
@@ -2823,7 +2823,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:12.000000Z",
+          "timestamp": "2022-01-01T00:00:12+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97502121155059,
@@ -2844,7 +2844,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:13.000000Z",
+          "timestamp": "2022-01-01T00:00:13+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.975001564486575,
@@ -2865,7 +2865,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:14.000000Z",
+          "timestamp": "2022-01-01T00:00:14+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97498588710737,
@@ -2886,7 +2886,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:15.000000Z",
+          "timestamp": "2022-01-01T00:00:15+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.974974330391035,
@@ -2907,7 +2907,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:16.000000Z",
+          "timestamp": "2022-01-01T00:00:16+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.974967005632266,
@@ -2928,7 +2928,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:17.000000Z",
+          "timestamp": "2022-01-01T00:00:17+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.974963983370586,
@@ -2949,7 +2949,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:18.000000Z",
+          "timestamp": "2022-01-01T00:00:18+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.974965292711126,
@@ -2970,7 +2970,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:19.000000Z",
+          "timestamp": "2022-01-01T00:00:19+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97497092104437,
@@ -2991,7 +2991,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:20.000000Z",
+          "timestamp": "2022-01-01T00:00:20+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97498081416754,
@@ -3012,7 +3012,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:21.000000Z",
+          "timestamp": "2022-01-01T00:00:21+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97499487680657,
@@ -3033,7 +3033,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:22.000000Z",
+          "timestamp": "2022-01-01T00:00:22+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97501297353365,
@@ -3054,7 +3054,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:23.000000Z",
+          "timestamp": "2022-01-01T00:00:23+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97503493007119,
@@ -3075,7 +3075,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:24.000000Z",
+          "timestamp": "2022-01-01T00:00:24+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.975060534970225,
@@ -3096,7 +3096,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:25.000000Z",
+          "timestamp": "2022-01-01T00:00:25+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97508954164649,
@@ -3117,7 +3117,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:26.000000Z",
+          "timestamp": "2022-01-01T00:00:26+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.975121670755044,
@@ -3138,7 +3138,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:27.000000Z",
+          "timestamp": "2022-01-01T00:00:27+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97515661288031,
@@ -3159,7 +3159,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:28.000000Z",
+          "timestamp": "2022-01-01T00:00:28+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97519403151563,
@@ -3180,7 +3180,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:29.000000Z",
+          "timestamp": "2022-01-01T00:00:29+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.975233566303956,
@@ -3201,7 +3201,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:30.000000Z",
+          "timestamp": "2022-01-01T00:00:30+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.975274836507936,
@@ -3236,10 +3236,10 @@
       "aircraft_type": "Helicopter"
     },
     {
-      "reference_time": "2022-01-01T00:00:00.000000Z",
+      "reference_time": "2022-01-01T00:00:00+00:00",
       "states": [
         {
-          "timestamp": "2022-01-01T00:00:01.000000Z",
+          "timestamp": "2022-01-01T00:00:01+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97690120421468,
@@ -3260,7 +3260,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:02.000000Z",
+          "timestamp": "2022-01-01T00:00:02+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976857075894536,
@@ -3281,7 +3281,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:03.000000Z",
+          "timestamp": "2022-01-01T00:00:03+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976813288436226,
@@ -3302,7 +3302,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:04.000000Z",
+          "timestamp": "2022-01-01T00:00:04+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976770263535755,
@@ -3323,7 +3323,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:05.000000Z",
+          "timestamp": "2022-01-01T00:00:05+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97672841554428,
@@ -3344,7 +3344,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:06.000000Z",
+          "timestamp": "2022-01-01T00:00:06+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.9766881474778,
@@ -3365,7 +3365,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:07.000000Z",
+          "timestamp": "2022-01-01T00:00:07+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97664984713598,
@@ -3386,7 +3386,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:08.000000Z",
+          "timestamp": "2022-01-01T00:00:08+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97661388336759,
@@ -3407,7 +3407,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:09.000000Z",
+          "timestamp": "2022-01-01T00:00:09+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976580602518446,
@@ -3428,7 +3428,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:10.000000Z",
+          "timestamp": "2022-01-01T00:00:10+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.9765503250961,
@@ -3449,7 +3449,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:11.000000Z",
+          "timestamp": "2022-01-01T00:00:11+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976523342683436,
@@ -3470,7 +3470,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:12.000000Z",
+          "timestamp": "2022-01-01T00:00:12+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97649991513066,
@@ -3491,7 +3491,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:13.000000Z",
+          "timestamp": "2022-01-01T00:00:13+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97648026805306,
@@ -3512,7 +3512,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:14.000000Z",
+          "timestamp": "2022-01-01T00:00:14+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97646459065849,
@@ -3533,7 +3533,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:15.000000Z",
+          "timestamp": "2022-01-01T00:00:15+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97645303392511,
@@ -3554,7 +3554,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:16.000000Z",
+          "timestamp": "2022-01-01T00:00:16+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97644570914782,
@@ -3575,7 +3575,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:17.000000Z",
+          "timestamp": "2022-01-01T00:00:17+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976442686866285,
@@ -3596,7 +3596,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:18.000000Z",
+          "timestamp": "2022-01-01T00:00:18+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976443996185864,
@@ -3617,7 +3617,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:19.000000Z",
+          "timestamp": "2022-01-01T00:00:19+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97644962449721,
@@ -3638,7 +3638,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:20.000000Z",
+          "timestamp": "2022-01-01T00:00:20+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97645951759776,
@@ -3659,7 +3659,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:21.000000Z",
+          "timestamp": "2022-01-01T00:00:21+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97647358021371,
@@ -3680,7 +3680,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:22.000000Z",
+          "timestamp": "2022-01-01T00:00:22+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97649167691741,
@@ -3701,7 +3701,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:23.000000Z",
+          "timestamp": "2022-01-01T00:00:23+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97651363343155,
@@ -3722,7 +3722,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:24.000000Z",
+          "timestamp": "2022-01-01T00:00:24+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976539238307325,
@@ -3743,7 +3743,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:25.000000Z",
+          "timestamp": "2022-01-01T00:00:25+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97656824496077,
@@ -3764,7 +3764,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:26.000000Z",
+          "timestamp": "2022-01-01T00:00:26+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.9766003740471,
@@ -3785,7 +3785,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:27.000000Z",
+          "timestamp": "2022-01-01T00:00:27+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97663531615098,
@@ -3806,7 +3806,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:28.000000Z",
+          "timestamp": "2022-01-01T00:00:28+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97667273476598,
@@ -3827,7 +3827,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:29.000000Z",
+          "timestamp": "2022-01-01T00:00:29+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97671226953519,
@@ -3848,7 +3848,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-01-01T00:00:30.000000Z",
+          "timestamp": "2022-01-01T00:00:30+00:00",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97675353972152,

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ geojson===2.5.0  # uss_qualifier
 google-auth==1.6.3
 graphviz==0.20.1  # uss_qualifier
 gunicorn==20.0.4
-implicitdict==1.1.1
+implicitdict==2.1.0
 itsdangerous==2.0.1 # Version 2.1.0 is not compatible with flask 1.1.2.
 Jinja2==3.0.3 # See https://github.com/interuss/dss/issues/745
 jsonpath-ng==1.5.3  # uss_qualifier


### PR DESCRIPTION
When the "fetch" mechanisms in monitorlib were written a long time ago, the implicitdict tool was not yet available.  To provide semantic interpretation and expectations around dict content, "fetch" objects simply inherit dict and provide methods to interact with that data.  This PR improves on that older paradigm by migrating "fetch" objects to ImplicitDicts so that the expected data contract can be validated and field usage easily traced in an IDE.  The "coerce" method is replaced by ImplicitDict.parse, which includes validation logic.

An implicitdict update supports consistent StringBasedDateTime datetime representations (naive vs timezone-aware) and causes the circular_flights.json generated file to be updated.