### PR TITLE
[monitorlib] Use uas_standards for F3411 constants

### DIFF
--- a/monitoring/atproxy/routes_rid_observation.py
+++ b/monitoring/atproxy/routes_rid_observation.py
@@ -2,8 +2,8 @@ import logging
 from typing import Tuple
 
 import flask
+from uas_standards.astm.f3411.v19.constants import Scope
 
-from monitoring.monitorlib import rid_v2
 from . import handling
 from .app import webapp
 from .oauth import requires_scope
@@ -16,14 +16,14 @@ _logger.setLevel(logging.DEBUG)
 
 
 @webapp.route('/riddp/observation/display_data', methods=['GET'])
-@requires_scope([rid_v2.SCOPE_DP])
+@requires_scope([Scope.Read])
 def rid_observation_display_data() -> Tuple[str, int]:
     """Implements retrieval of current display data per automated testing API."""
     return handling.fulfill_query(RIDObservationGetDisplayDataRequest(view=flask.request.args['view']), _logger)
 
 
 @webapp.route('/riddp/observation/display_data/<flight_id>', methods=['GET'])
-@requires_scope([rid_v2.SCOPE_DP])
+@requires_scope([Scope.Read])
 def rid_observation_flight_details(flight_id: str) -> Tuple[str, int]:
     """Implements get flight details endpoint per automated testing API."""
     return handling.fulfill_query(RIDObservationGetDetailsRequest(id=flight_id), _logger)

--- a/monitoring/loadtest/locust_files/client.py
+++ b/monitoring/loadtest/locust_files/client.py
@@ -5,6 +5,8 @@ import time
 import typing
 from locust import User
 from monitoring.monitorlib import auth, infrastructure, rid_v1
+from uas_standards.astm.f3411.v19.constants import Scope
+
 
 class DSSClient(infrastructure.UTMClientSession):
     _locust_environment = None
@@ -68,4 +70,4 @@ class USS(User):
             raise e
         # This is a load tester its acceptable to have all the scopes required to operate anything.
         # We are not testing if the scope is incorrect. We are testing if it can handle the load.
-        self.client.default_scopes = [rid_v1.SCOPE_WRITE, rid_v1.SCOPE_READ]
+        self.client.default_scopes = [Scope.Write, Scope.Read]

--- a/monitoring/mock_uss/riddp/routes_observation.py
+++ b/monitoring/mock_uss/riddp/routes_observation.py
@@ -2,13 +2,18 @@ from typing import Dict, List, Optional, Tuple
 
 import arrow
 import flask
+from implicitdict import ImplicitDict
 import s2sphere
-
 from uas_standards.astm.f3411.v19.api import ErrorResponse, RIDFlight
+from uas_standards.astm.f3411.v19.constants import (
+    Scope,
+    NetMaxDisplayAreaDiagonalKm,
+    NetDetailsMaxDisplayAreaDiagonalKm,
+)
+
 from monitoring.monitorlib import geo, rid_v1
 from monitoring.monitorlib.fetch import rid as fetch
 from monitoring.monitorlib.rid_automated_testing import observation_api
-from implicitdict import ImplicitDict
 from monitoring.mock_uss import resources, webapp
 from monitoring.mock_uss.auth import requires_scope
 from . import clustering, database
@@ -64,7 +69,7 @@ def _make_flight_observation(
 
 
 @webapp.route("/riddp/observation/display_data", methods=["GET"])
-@requires_scope([rid_v1.SCOPE_READ])
+@requires_scope([Scope.Read])
 def riddp_display_data() -> Tuple[str, int]:
     """Implements retrieval of current display data per automated testing API."""
 
@@ -83,7 +88,7 @@ def riddp_display_data() -> Tuple[str, int]:
 
     # Determine what kind of response to produce
     diagonal = geo.get_latlngrect_diagonal_km(view)
-    if diagonal > rid_v1.NetMaxDisplayAreaDiagonal:
+    if diagonal > NetMaxDisplayAreaDiagonalKm:
         return (
             flask.jsonify(ErrorResponse(message="Requested diagonal was too large")),
             413,
@@ -136,7 +141,7 @@ def riddp_display_data() -> Tuple[str, int]:
     if behavior.always_omit_recent_paths:
         for f in flights:
             f.recent_paths = None
-    if diagonal <= rid_v1.NetDetailsMaxDisplayAreaDiagonal:
+    if diagonal <= NetDetailsMaxDisplayAreaDiagonalKm:
         # Construct detailed flights response
         response = observation_api.GetDisplayDataResponse(flights=flights)
     else:
@@ -147,7 +152,7 @@ def riddp_display_data() -> Tuple[str, int]:
 
 
 @webapp.route("/riddp/observation/display_data/<flight_id>", methods=["GET"])
-@requires_scope([rid_v1.SCOPE_READ])
+@requires_scope([Scope.Read])
 def riddp_flight_details(flight_id: str) -> Tuple[str, int]:
     """Implements get flight details endpoint per automated testing API."""
 

--- a/monitoring/mock_uss/ridsp/routes_ridsp_v19.py
+++ b/monitoring/mock_uss/ridsp/routes_ridsp_v19.py
@@ -1,5 +1,6 @@
 import arrow
 import datetime
+from datetime import timedelta
 from typing import List, Optional
 
 import flask
@@ -37,7 +38,9 @@ def _get_report(
         return None
 
     recent_states = flight.select_relevant_states(
-        view, t_request - NetMaxNearRealTimeDataPeriodSeconds, t_request
+        view,
+        t_request - timedelta(seconds=NetMaxNearRealTimeDataPeriodSeconds),
+        t_request,
     )
     if not recent_states:
         # No recent telemetry applicable to view

--- a/monitoring/monitorlib/fetch/rid.py
+++ b/monitoring/monitorlib/fetch/rid.py
@@ -1,11 +1,12 @@
 import datetime
 from typing import Dict, List, Optional
 
+from implicitdict import ImplicitDict
 import s2sphere
+from uas_standards.astm.f3411.v19.constants import Scope
 import yaml
 from yaml.representer import Representer
 
-from implicitdict import ImplicitDict
 from monitoring.monitorlib import fetch, infrastructure, rid_v1
 
 
@@ -83,7 +84,7 @@ def isas(
         end_time.strftime(rid_v1.DATE_FORMAT),
     )
     return FetchedISAs(
-        fetch.query_and_describe(utm_client, "GET", url, scope=rid_v1.SCOPE_READ)
+        fetch.query_and_describe(utm_client, "GET", url, scope=Scope.Read)
     )
 
 
@@ -129,7 +130,7 @@ def flights(
             ),
             "include_recent_positions": "true" if include_recent_positions else "false",
         },
-        scope=rid_v1.SCOPE_READ,
+        scope=Scope.Read,
     )
     return FetchedUSSFlights(result)
 
@@ -167,9 +168,9 @@ def flight_details(
 ) -> FetchedUSSFlightDetails:
     suffix = "?enhanced=true" if enhanced_details else ""
     scope = (
-        " ".join([rid_v1.SCOPE_READ, rid_v1.UPP2_SCOPE_ENHANCED_DETAILS])
+        " ".join([Scope.Read, rid_v1.UPP2_SCOPE_ENHANCED_DETAILS])
         if enhanced_details
-        else rid_v1.SCOPE_READ
+        else Scope.Read
     )
     result = FetchedUSSFlightDetails(
         fetch.query_and_describe(
@@ -274,5 +275,5 @@ def subscription(
     utm_client: infrastructure.UTMClientSession, subscription_id: str
 ) -> FetchedSubscription:
     url = "/v1/dss/subscriptions/{}".format(subscription_id)
-    result = fetch.query_and_describe(utm_client, "GET", url, scope=rid_v1.SCOPE_READ)
+    result = fetch.query_and_describe(utm_client, "GET", url, scope=Scope.Read)
     return FetchedSubscription(result)

--- a/monitoring/monitorlib/mutate/rid.py
+++ b/monitoring/monitorlib/mutate/rid.py
@@ -1,16 +1,17 @@
 import datetime
 from typing import Dict, List, Optional
 
-import s2sphere
-import yaml
-from yaml.representer import Representer
-
-from monitoring.monitorlib import fetch, infrastructure, rid_v1
 from implicitdict import ImplicitDict
+import s2sphere
 from uas_standards.astm.f3411.v19.api import (
     IdentificationServiceArea,
     SubscriberToNotify,
 )
+from uas_standards.astm.f3411.v19.constants import Scope
+import yaml
+from yaml.representer import Representer
+
+from monitoring.monitorlib import fetch, infrastructure, rid_v1
 
 
 class MutatedSubscription(fetch.Query):
@@ -75,9 +76,7 @@ def put_subscription(
             subscription_id, subscription_version
         )
     result = MutatedSubscription(
-        fetch.query_and_describe(
-            utm_client, "PUT", url, json=body, scope=rid_v1.SCOPE_READ
-        )
+        fetch.query_and_describe(utm_client, "PUT", url, json=body, scope=Scope.Read)
     )
     result.mutation = "create" if subscription_version is None else "update"
     return result
@@ -90,7 +89,7 @@ def delete_subscription(
 ) -> MutatedSubscription:
     url = "/v1/dss/subscriptions/{}/{}".format(subscription_id, subscription_version)
     result = MutatedSubscription(
-        fetch.query_and_describe(utm_client, "DELETE", url, scope=rid_v1.SCOPE_READ)
+        fetch.query_and_describe(utm_client, "DELETE", url, scope=Scope.Read)
     )
     result.mutation = "delete"
     return result
@@ -174,9 +173,7 @@ def put_isa(
             entity_id, isa_version
         )
     dss_response = MutatedISAResponse(
-        fetch.query_and_describe(
-            utm_client, "PUT", url, json=body, scope=rid_v1.SCOPE_WRITE
-        )
+        fetch.query_and_describe(utm_client, "PUT", url, json=body, scope=Scope.Write)
     )
     dss_response["mutation"] = "create" if isa_version is None else "update"
 
@@ -196,7 +193,7 @@ def put_isa(
         }
         url = "{}/{}".format(subscriber.url, entity_id)
         notifications[subscriber.url] = fetch.query_and_describe(
-            utm_client, "POST", url, json=body, scope=rid_v1.SCOPE_WRITE
+            utm_client, "POST", url, json=body, scope=Scope.Write
         )
 
     return MutatedISA(dss_response=dss_response, notifications=notifications)
@@ -207,7 +204,7 @@ def delete_isa(
 ) -> MutatedISA:
     url = "/v1/dss/identification_service_areas/{}/{}".format(entity_id, isa_version)
     dss_response = MutatedISAResponse(
-        fetch.query_and_describe(utm_client, "DELETE", url, scope=rid_v1.SCOPE_WRITE)
+        fetch.query_and_describe(utm_client, "DELETE", url, scope=Scope.Write)
     )
     dss_response["mutation"] = "delete"
 
@@ -221,7 +218,7 @@ def delete_isa(
         body = {"subscriptions": subscriber.subscriptions}
         url = "{}/{}".format(subscriber.url, entity_id)
         notifications[subscriber.url] = fetch.query_and_describe(
-            utm_client, "POST", url, json=body, scope=rid_v1.SCOPE_WRITE
+            utm_client, "POST", url, json=body, scope=Scope.Write
         )
 
     return MutatedISA(dss_response=dss_response, notifications=notifications)

--- a/monitoring/monitorlib/rid.py
+++ b/monitoring/monitorlib/rid.py
@@ -1,10 +1,9 @@
 from datetime import timedelta
 from enum import Enum
 
-from monitoring.monitorlib import rid_v1
-from monitoring.monitorlib import rid_v2
-
-# TODO(BenjaminPelletier): Rename this file to `rid.py`
+from uas_standards.astm.f3411 import v19, v22a
+import uas_standards.astm.f3411.v19.constants
+import uas_standards.astm.f3411.v22a.constants
 
 
 class RIDVersion(str, Enum):
@@ -17,35 +16,35 @@ class RIDVersion(str, Enum):
     @property
     def read_scope(self) -> str:
         if self == RIDVersion.f3411_19:
-            return rid_v1.SCOPE_READ
+            return v19.constants.Scope.Read
         elif self == RIDVersion.f3411_22a:
-            return rid_v2.SCOPE_DP
+            return v22a.constants.Scope.DisplayProvider
         else:
             raise ValueError("Unsupported RID version '{}'".format(self))
 
     @property
     def realtime_period(self) -> timedelta:
         if self == RIDVersion.f3411_19:
-            return rid_v1.NetMaxNearRealTimeDataPeriod
+            return v19.constants.NetMaxNearRealTimeDataPeriodSeconds
         elif self == RIDVersion.f3411_22a:
-            return rid_v2.NetMaxNearRealTimeDataPeriod
+            return v22a.constants.NetMaxNearRealTimeDataPeriodSeconds
         else:
             raise ValueError("Unsupported RID version '{}'".format(self))
 
     @property
     def max_diagonal_km(self) -> float:
         if self == RIDVersion.f3411_19:
-            return rid_v1.NetMaxDisplayAreaDiagonal
+            return v19.constants.NetMaxDisplayAreaDiagonalKm
         elif self == RIDVersion.f3411_22a:
-            return rid_v2.NetMaxDisplayAreaDiagonal
+            return v22a.constants.NetMaxDisplayAreaDiagonalKm
         else:
             raise ValueError("Unsupported RID version '{}'".format(self))
 
     @property
     def max_details_diagonal_km(self) -> float:
         if self == RIDVersion.f3411_19:
-            return rid_v1.NetDetailsMaxDisplayAreaDiagonal
+            return v19.constants.NetDetailsMaxDisplayAreaDiagonalKm
         elif self == RIDVersion.f3411_22a:
-            return rid_v2.NetDetailsMaxDisplayAreaDiagonal
+            return v22a.constants.NetDetailsMaxDisplayAreaDiagonalKm
         else:
             raise ValueError("Unsupported RID version '{}'".format(self))

--- a/monitoring/monitorlib/rid.py
+++ b/monitoring/monitorlib/rid.py
@@ -25,9 +25,9 @@ class RIDVersion(str, Enum):
     @property
     def realtime_period(self) -> timedelta:
         if self == RIDVersion.f3411_19:
-            return v19.constants.NetMaxNearRealTimeDataPeriodSeconds
+            return timedelta(seconds=v19.constants.NetMaxNearRealTimeDataPeriodSeconds)
         elif self == RIDVersion.f3411_22a:
-            return v22a.constants.NetMaxNearRealTimeDataPeriodSeconds
+            return timedelta(seconds=v22a.constants.NetMaxNearRealTimeDataPeriodSeconds)
         else:
             raise ValueError("Unsupported RID version '{}'".format(self))
 

--- a/monitoring/monitorlib/rid_v1.py
+++ b/monitoring/monitorlib/rid_v1.py
@@ -1,20 +1,7 @@
-import datetime
 from typing import Dict, List, Optional
 import s2sphere
 
-MAX_SUB_PER_AREA = 10
-
-MAX_SUB_TIME_HRS = 24
-
 DATE_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
-
-ISA_PATH = "/v1/dss/identification_service_areas"
-SUBSCRIPTION_PATH = "/v1/dss/subscriptions"
-SCOPE_READ = "dss.read.identification_service_areas"
-SCOPE_WRITE = "dss.write.identification_service_areas"
-NetMaxNearRealTimeDataPeriod = datetime.timedelta(seconds=60)
-NetMaxDisplayAreaDiagonal = 3.6  # km
-NetDetailsMaxDisplayAreaDiagonal = 1.0  # km
 
 # This scope is used only for experimentation during UPP2
 UPP2_SCOPE_ENHANCED_DETAILS = "rid.read.enhanced_details"

--- a/monitoring/monitorlib/rid_v2.py
+++ b/monitoring/monitorlib/rid_v2.py
@@ -1,13 +1,8 @@
 import datetime
 
 from uas_standards.astm.f3411.v22a.api import Time, Altitude
+
 from . import rid_v1 as rid_v1
-
-
-ISA_PATH = "/dss/identification_service_areas"
-SUBSCRIPTION_PATH = "/dss/subscriptions"
-SCOPE_DP = "rid.display_provider"
-SCOPE_SP = "rid.service_provider"
 
 
 def make_time(t: datetime.datetime) -> Time:
@@ -18,10 +13,5 @@ def make_altitude(altitude_meters: float) -> Altitude:
     return Altitude(reference="W84", units="M", value=altitude_meters)
 
 
-MAX_SUB_PER_AREA = rid_v1.MAX_SUB_PER_AREA
-MAX_SUB_TIME_HRS = rid_v1.MAX_SUB_TIME_HRS
 DATE_FORMAT = rid_v1.DATE_FORMAT
-NetMaxNearRealTimeDataPeriod = rid_v1.NetMaxNearRealTimeDataPeriod
-NetMaxDisplayAreaDiagonal = 7  # km
-NetDetailsMaxDisplayAreaDiagonal = 2  # km
 geo_polygon_string = rid_v1.geo_polygon_string

--- a/monitoring/prober/aux_/test_token_validation.py
+++ b/monitoring/prober/aux_/test_token_validation.py
@@ -1,25 +1,23 @@
 """Test aux features"""
 
-import pytest
+from uas_standards.astm.f3411.v19.constants import Scope
 
 from monitoring.monitorlib.infrastructure import default_scope
-from monitoring.monitorlib import rid_v1
-from monitoring.monitorlib.auth import DummyOAuth
 
 
-@default_scope(rid_v1.SCOPE_READ)
+@default_scope(Scope.Read)
 def test_validate(aux_session):
   resp = aux_session.get('/validate_oauth')
   assert resp.status_code == 200
 
 
-@default_scope(rid_v1.SCOPE_READ)
+@default_scope(Scope.Read)
 def test_validate_token_good_user(aux_session, subscriber):
   resp = aux_session.get('/validate_oauth?owner={}'.format(subscriber))
   assert resp.status_code == 200
 
 
-@default_scope(rid_v1.SCOPE_READ)
+@default_scope(Scope.Read)
 def test_validate_token_bad_user(aux_session):
   resp = aux_session.get('/validate_oauth?owner=bad_user')
   assert resp.status_code == 403

--- a/monitoring/prober/conftest.py
+++ b/monitoring/prober/conftest.py
@@ -1,6 +1,11 @@
 import argparse
 from typing import Callable, Optional
 
+from uas_standards.astm import f3411, f3548
+import uas_standards.astm.f3411.v19.constants
+import uas_standards.astm.f3411.v22a.constants
+import uas_standards.astm.f3548.v21.constants
+
 from monitoring.monitorlib.infrastructure import UTMClientSession, AsyncUTMTestSession
 from monitoring.monitorlib import auth, rid_v1, scd
 from monitoring.prober.infrastructure import add_test_result, IDFactory, ResourceType, VersionString
@@ -178,19 +183,19 @@ def subscriber(pytestconfig) -> Optional[str]:
   """Subscriber of USS making UTM API calls"""
   if pytestconfig.getoption(OPT_RID_AUTH):
     session = make_session(pytestconfig, BASE_URL_RID, OPT_RID_AUTH)
-    session.get('/healthy', scope=rid_v1.SCOPE_READ)
+    session.get('/healthy', scope=f3411.v19.constants.Scope.Read)
     rid_sub = session.auth_adapter.get_sub()
     if rid_sub:
       return rid_sub
   if pytestconfig.getoption(OPT_SCD_AUTH1):
     scd_session = make_session(pytestconfig, BASE_URL_SCD, OPT_SCD_AUTH1)
-    scd_session.get('/healthy', scope=scd.SCOPE_SC)
+    scd_session.get('/healthy', scope=f3548.v21.constants.Scope.StrategicCoordination)
     scd_sub = scd_session.auth_adapter.get_sub()
     if scd_sub:
       return scd_sub
   if pytestconfig.getoption(OPT_SCD_AUTH2):
     scd_session2 = make_session(pytestconfig, BASE_URL_SCD, OPT_SCD_AUTH2)
-    scd_session2.get('/healthy', scope=scd.SCOPE_SC)
+    scd_session2.get('/healthy', scope=f3548.v21.constants.Scope.StrategicCoordination)
     scd2_sub = scd_session2.auth_adapter.get_sub()
     if scd2_sub:
       return scd2_sub

--- a/monitoring/prober/rid/v1/test_isa_expiry.py
+++ b/monitoring/prober/rid/v1/test_isa_expiry.py
@@ -5,19 +5,21 @@ import time
 
 from monitoring.monitorlib.infrastructure import default_scope
 from monitoring.monitorlib import rid_v1
-from monitoring.monitorlib.rid_v1 import SCOPE_READ, SCOPE_WRITE, ISA_PATH
 from monitoring.prober.infrastructure import register_resource_type
 from . import common
 
+from uas_standards.astm.f3411.v19.api import OperationID, OPERATIONS
+from uas_standards.astm.f3411.v19.constants import Scope
 
+ISA_PATH = OPERATIONS[OperationID.SearchIdentificationServiceAreas].path
 ISA_TYPE = register_resource_type(222, 'ISA')
 
 
 def test_ensure_clean_workspace(ids, session_ridv1):
-  resp = session_ridv1.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)), scope=SCOPE_READ)
+  resp = session_ridv1.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)), scope=Scope.Read)
   if resp.status_code == 200:
     version = resp.json()['service_area']['version']
-    resp = session_ridv1.delete('{}/{}/{}'.format(ISA_PATH, ids(ISA_TYPE), version), scope=SCOPE_WRITE)
+    resp = session_ridv1.delete('{}/{}/{}'.format(ISA_PATH, ids(ISA_TYPE), version), scope=Scope.Write)
     assert resp.status_code == 200, resp.content
   elif resp.status_code == 404:
     # As expected.
@@ -26,7 +28,7 @@ def test_ensure_clean_workspace(ids, session_ridv1):
     assert False, resp.content
 
 
-@default_scope(SCOPE_WRITE)
+@default_scope(Scope.Write)
 def test_create(ids, session_ridv1):
   time_start = datetime.datetime.utcnow()
   time_end = time_start + datetime.timedelta(seconds=5)
@@ -50,7 +52,7 @@ def test_create(ids, session_ridv1):
   assert resp.status_code == 200, resp.content
 
 
-@default_scope(SCOPE_READ)
+@default_scope(Scope.Read)
 def test_valid_immediately(ids, session_ridv1):
   # The ISA is still valid immediately after we create it.
   resp = session_ridv1.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)))
@@ -62,14 +64,14 @@ def test_sleep_5_seconds():
   time.sleep(5)
 
 
-@default_scope(SCOPE_READ)
+@default_scope(Scope.Read)
 def test_returned_by_id(ids, session_ridv1):
   # We can get it explicitly by ID
   resp = session_ridv1.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)))
   assert resp.status_code == 200, resp.content
 
 
-@default_scope(SCOPE_READ)
+@default_scope(Scope.Read)
 def test_not_returned_by_search(ids, session_ridv1):
   # ...but it's not included in a search.
   resp = session_ridv1.get('{}?area={}'.format(
@@ -78,10 +80,10 @@ def test_not_returned_by_search(ids, session_ridv1):
   assert ids(ISA_TYPE) not in [x['id'] for x in resp.json()['service_areas']]
 
 
-@default_scope(SCOPE_READ)
+@default_scope(Scope.Read)
 def test_delete(ids, session_ridv1):
-  resp = session_ridv1.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)), scope=SCOPE_READ)
+  resp = session_ridv1.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)), scope=Scope.Read)
   assert resp.status_code == 200
   version = resp.json()['service_area']['version']
-  resp = session_ridv1.delete('{}/{}/{}'.format(ISA_PATH, ids(ISA_TYPE), version), scope=SCOPE_WRITE)
+  resp = session_ridv1.delete('{}/{}/{}'.format(ISA_PATH, ids(ISA_TYPE), version), scope=Scope.Write)
   assert resp.status_code == 200, resp.content

--- a/monitoring/prober/rid/v1/test_isa_simple.py
+++ b/monitoring/prober/rid/v1/test_isa_simple.py
@@ -11,20 +11,22 @@ import re
 
 from monitoring.monitorlib.infrastructure import default_scope
 from monitoring.monitorlib import rid_v1
-from monitoring.monitorlib.rid_v1 import SCOPE_READ, SCOPE_WRITE, ISA_PATH
 from monitoring.monitorlib.testing import assert_datetimes_are_equal
 from monitoring.prober.infrastructure import register_resource_type
 from . import common
 
+from uas_standards.astm.f3411.v19.api import OPERATIONS, OperationID
+from uas_standards.astm.f3411.v19.constants import Scope
 
+ISA_PATH = OPERATIONS[OperationID.SearchIdentificationServiceAreas].path
 ISA_TYPE = register_resource_type(223, 'ISA')
 
 
 def test_ensure_clean_workspace(ids, session_ridv1):
-  resp = session_ridv1.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)), scope=SCOPE_READ)
+  resp = session_ridv1.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)), scope=Scope.Read)
   if resp.status_code == 200:
     version = resp.json()['service_area']['version']
-    resp = session_ridv1.delete('{}/{}/{}'.format(ISA_PATH, ids(ISA_TYPE), version), scope=SCOPE_WRITE)
+    resp = session_ridv1.delete('{}/{}/{}'.format(ISA_PATH, ids(ISA_TYPE), version), scope=Scope.Write)
     assert resp.status_code == 200, resp.content
   elif resp.status_code == 404:
     # As expected.
@@ -33,7 +35,7 @@ def test_ensure_clean_workspace(ids, session_ridv1):
     assert False, resp.content
 
 
-@default_scope(SCOPE_WRITE)
+@default_scope(Scope.Write)
 def test_create_isa(ids, session_ridv1):
   """ASTM Compliance Test: DSS0030_A_PUT_ISA."""
   time_start = datetime.datetime.utcnow()
@@ -67,7 +69,7 @@ def test_create_isa(ids, session_ridv1):
   assert 'subscribers' in data
 
 
-@default_scope(SCOPE_READ)
+@default_scope(Scope.Read)
 def test_get_isa_by_id(ids, session_ridv1):
   resp = session_ridv1.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)))
   assert resp.status_code == 200, resp.content
@@ -77,9 +79,9 @@ def test_get_isa_by_id(ids, session_ridv1):
   assert data['service_area']['flights_url'] == 'https://example.com/dss'
 
 
-@default_scope(SCOPE_WRITE)
+@default_scope(Scope.Write)
 def test_update_isa(ids, session_ridv1):
-  resp = session_ridv1.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)), scope=SCOPE_READ)
+  resp = session_ridv1.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)), scope=Scope.Read)
   version = resp.json()['service_area']['version']
 
   resp = session_ridv1.put(
@@ -105,7 +107,7 @@ def test_update_isa(ids, session_ridv1):
   assert 'subscribers' in data
 
 
-@default_scope(SCOPE_READ)
+@default_scope(Scope.Read)
 def test_get_isa_by_id_after_update(ids, session_ridv1):
   resp = session_ridv1.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)))
   assert resp.status_code == 200, resp.content
@@ -115,13 +117,13 @@ def test_get_isa_by_id_after_update(ids, session_ridv1):
   assert data['service_area']['flights_url'] == 'https://example.com/dss/v2'
 
 
-@default_scope(SCOPE_READ)
+@default_scope(Scope.Read)
 def test_get_isa_by_search_missing_params(session_ridv1):
   resp = session_ridv1.get(ISA_PATH)
   assert resp.status_code == 400, resp.content
 
 
-@default_scope(SCOPE_READ)
+@default_scope(Scope.Read)
 def test_get_isa_by_search(ids, session_ridv1):
   resp = session_ridv1.get('{}?area={}'.format(
       ISA_PATH, common.GEO_POLYGON_STRING))
@@ -129,7 +131,7 @@ def test_get_isa_by_search(ids, session_ridv1):
   assert ids(ISA_TYPE) in [x['id'] for x in resp.json()['service_areas']]
 
 
-@default_scope(SCOPE_READ)
+@default_scope(Scope.Read)
 def test_get_isa_by_search_earliest_time_included(ids, session_ridv1):
   earliest_time = datetime.datetime.utcnow() + datetime.timedelta(minutes=59)
   resp = session_ridv1.get('{}?area={}&earliest_time={}'.format(
@@ -139,7 +141,7 @@ def test_get_isa_by_search_earliest_time_included(ids, session_ridv1):
   assert ids(ISA_TYPE) in [x['id'] for x in resp.json()['service_areas']]
 
 
-@default_scope(SCOPE_READ)
+@default_scope(Scope.Read)
 def test_get_isa_by_search_earliest_time_excluded(ids, session_ridv1):
   earliest_time = datetime.datetime.utcnow() + datetime.timedelta(minutes=61)
   resp = session_ridv1.get('{}?area={}&earliest_time={}'.format(
@@ -149,7 +151,7 @@ def test_get_isa_by_search_earliest_time_excluded(ids, session_ridv1):
   assert ids(ISA_TYPE) not in [x['id'] for x in resp.json()['service_areas']]
 
 
-@default_scope(SCOPE_READ)
+@default_scope(Scope.Read)
 def test_get_isa_by_search_latest_time_included(ids, session_ridv1):
   latest_time = datetime.datetime.utcnow() + datetime.timedelta(minutes=1)
   resp = session_ridv1.get('{}?area={}&latest_time={}'.format(
@@ -159,7 +161,7 @@ def test_get_isa_by_search_latest_time_included(ids, session_ridv1):
   assert ids(ISA_TYPE) in [x['id'] for x in resp.json()['service_areas']]
 
 
-@default_scope(SCOPE_READ)
+@default_scope(Scope.Read)
 def test_get_isa_by_search_latest_time_excluded(ids, session_ridv1):
   latest_time = datetime.datetime.utcnow() - datetime.timedelta(minutes=1)
   resp = session_ridv1.get('{}?area={}&latest_time={}'.format(
@@ -169,26 +171,26 @@ def test_get_isa_by_search_latest_time_excluded(ids, session_ridv1):
   assert ids(ISA_TYPE) not in [x['id'] for x in resp.json()['service_areas']]
 
 
-@default_scope(SCOPE_READ)
+@default_scope(Scope.Read)
 def test_get_isa_by_search_area_only(ids, session_ridv1):
   resp = session_ridv1.get('{}?area={}'.format(ISA_PATH, common.GEO_POLYGON_STRING))
   assert resp.status_code == 200, resp.content
   assert ids(ISA_TYPE) in [x['id'] for x in resp.json()['service_areas']]
 
 
-@default_scope(SCOPE_READ)
+@default_scope(Scope.Read)
 def test_get_isa_by_search_huge_area(session_ridv1):
   resp = session_ridv1.get('{}?area={}'.format(ISA_PATH, common.HUGE_GEO_POLYGON_STRING))
   assert resp.status_code == 413, resp.content
 
 
-@default_scope(SCOPE_WRITE)
+@default_scope(Scope.Write)
 def test_delete_isa_wrong_version(ids, session_ridv1):
   resp = session_ridv1.delete('{}/{}/fake_version'.format(ISA_PATH, ids(ISA_TYPE)))
   assert resp.status_code == 400, resp.content
 
 
-@default_scope(SCOPE_WRITE)
+@default_scope(Scope.Write)
 def test_delete_isa_empty_version(ids, session_ridv1):
   resp = session_ridv1.delete('{}/{}/'.format(ISA_PATH, ids(ISA_TYPE)))
   assert resp.status_code == 400, resp.content
@@ -197,29 +199,29 @@ def test_delete_isa_empty_version(ids, session_ridv1):
 def test_delete_isa(ids, session_ridv1):
   """ASTM Compliance Test: DSS0030_B_DELETE_ISA."""
   # GET the ISA first to find its version.
-  resp = session_ridv1.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)), scope=SCOPE_READ)
+  resp = session_ridv1.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)), scope=Scope.Read)
   assert resp.status_code == 200, resp.content
   version = resp.json()['service_area']['version']
 
   # Then delete it.
-  resp = session_ridv1.delete('{}/{}/{}'.format(ISA_PATH, ids(ISA_TYPE), version), scope=SCOPE_WRITE)
+  resp = session_ridv1.delete('{}/{}/{}'.format(ISA_PATH, ids(ISA_TYPE), version), scope=Scope.Write)
   assert resp.status_code == 200, resp.content
 
 
-@default_scope(SCOPE_READ)
+@default_scope(Scope.Read)
 def test_get_deleted_isa_by_id(ids, session_ridv1):
   resp = session_ridv1.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)))
   assert resp.status_code == 404, resp.content
 
 
-@default_scope(SCOPE_READ)
+@default_scope(Scope.Read)
 def test_get_deleted_isa_by_search(ids, session_ridv1):
   resp = session_ridv1.get('{}?area={}'.format(ISA_PATH, common.GEO_POLYGON_STRING))
   assert resp.status_code == 200, resp.content
   assert ids(ISA_TYPE) not in [x['id'] for x in resp.json()['service_areas']]
 
 
-@default_scope(SCOPE_READ)
+@default_scope(Scope.Read)
 def test_get_isa_search_area_with_loop(session_ridv1):
   resp = session_ridv1.get('{}?area={}'.format(ISA_PATH, common.LOOP_GEO_POLYGON_STRING))
   assert resp.status_code == 400, resp.content

--- a/monitoring/prober/rid/v1/test_isa_simple_heavy_traffic_concurrent.py
+++ b/monitoring/prober/rid/v1/test_isa_simple_heavy_traffic_concurrent.py
@@ -12,14 +12,16 @@ import re
 
 from monitoring.monitorlib import rid_v1
 from monitoring.monitorlib.infrastructure import default_scope
-from monitoring.monitorlib.rid_v1 import SCOPE_READ, SCOPE_WRITE, ISA_PATH
 from monitoring.monitorlib.testing import assert_datetimes_are_equal
 from monitoring.prober.infrastructure import register_resource_type
 from . import common
 
+from uas_standards.astm.f3411.v19.api import OPERATIONS, OperationID
+from uas_standards.astm.f3411.v19.constants import Scope
 
 THREAD_COUNT = 10
 FLIGHTS_URL = 'https://example.com/dss'
+ISA_PATH = OPERATIONS[OperationID.SearchIdentificationServiceAreas].path
 ISA_TYPES = [register_resource_type(224 + i, 'Operational intent {}'.format(i)) for i in range(100)]
 # Semaphore is added to limit the number of simultaneous requests,
 # default is 100.
@@ -49,25 +51,25 @@ def _make_isa_request(time_start, time_end):
 
 async def _put_isa(isa_id, req, session_ridv1):
   async with SEMAPHORE:
-    return isa_id, await session_ridv1.put('{}/{}'.format(ISA_PATH, isa_id), json=req, scope=SCOPE_WRITE)
+    return isa_id, await session_ridv1.put('{}/{}'.format(ISA_PATH, isa_id), json=req, scope=Scope.Write)
 
 async def _get_isa(isa_id, session_ridv1):
   async with SEMAPHORE:
-    return isa_id, await session_ridv1.get('{}/{}'.format(ISA_PATH, isa_id), scope=SCOPE_READ)
+    return isa_id, await session_ridv1.get('{}/{}'.format(ISA_PATH, isa_id), scope=Scope.Read)
 
 
 async def _delete_isa(isa_id, version, session_ridv1):
   async with SEMAPHORE:
-    return isa_id, await session_ridv1.delete('{}/{}/{}'.format(ISA_PATH, isa_id, version), scope=SCOPE_WRITE)
+    return isa_id, await session_ridv1.delete('{}/{}/{}'.format(ISA_PATH, isa_id, version), scope=Scope.Write)
 
 
 
 def test_ensure_clean_workspace(ids, session_ridv1):
   for isa_id in map(ids, ISA_TYPES):
-    resp = session_ridv1.get('{}/{}'.format(ISA_PATH, isa_id), scope=SCOPE_READ)
+    resp = session_ridv1.get('{}/{}'.format(ISA_PATH, isa_id), scope=Scope.Read)
     if resp.status_code == 200:
       version = resp.json()['service_area']['version']
-      resp = session_ridv1.delete('{}/{}/{}'.format(ISA_PATH, isa_id, version), scope=SCOPE_WRITE)
+      resp = session_ridv1.delete('{}/{}/{}'.format(ISA_PATH, isa_id, version), scope=Scope.Write)
       assert resp.status_code == 200, resp.content
     elif resp.status_code == 404:
       # As expected.
@@ -76,7 +78,7 @@ def test_ensure_clean_workspace(ids, session_ridv1):
       assert False, resp.content
 
 
-@default_scope(SCOPE_WRITE)
+@default_scope(Scope.Write)
 def test_create_isa_concurrent(ids, session_ridv1_async):
   time_start = datetime.datetime.utcnow()
   time_end = time_start + datetime.timedelta(minutes=60)
@@ -98,7 +100,7 @@ def test_create_isa_concurrent(ids, session_ridv1_async):
     assert 'subscribers' in data
 
 
-@default_scope(SCOPE_READ)
+@default_scope(Scope.Read)
 def test_get_isa_by_ids_concurrent(ids, session_ridv1_async):
   resp_map = {}
 
@@ -114,7 +116,7 @@ def test_get_isa_by_ids_concurrent(ids, session_ridv1_async):
     assert data['service_area']['flights_url'] == FLIGHTS_URL
 
 
-@default_scope(SCOPE_READ)
+@default_scope(Scope.Read)
 def test_get_isa_by_search(ids, session_ridv1):
   resp = session_ridv1.get('{}?area={}'.format(ISA_PATH, common.GEO_POLYGON_STRING))
 

--- a/monitoring/prober/rid/v1/test_isa_validation.py
+++ b/monitoring/prober/rid/v1/test_isa_validation.py
@@ -10,19 +10,21 @@ import datetime
 
 from monitoring.monitorlib.infrastructure import default_scope
 from monitoring.monitorlib import rid_v1
-from monitoring.monitorlib.rid_v1 import SCOPE_READ, SCOPE_WRITE, ISA_PATH
 from monitoring.prober.infrastructure import register_resource_type
 from . import common
 
+from uas_standards.astm.f3411.v19.api import OPERATIONS, OperationID
+from uas_standards.astm.f3411.v19.constants import Scope
 
+ISA_PATH = OPERATIONS[OperationID.SearchIdentificationServiceAreas].path
 ISA_TYPE = register_resource_type(324, 'ISA')
 
 
 def test_ensure_clean_workspace(ids, session_ridv1):
-  resp = session_ridv1.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)), scope=SCOPE_READ)
+  resp = session_ridv1.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)), scope=Scope.Read)
   if resp.status_code == 200:
     version = resp.json()["service_area"]['version']
-    resp = session_ridv1.delete('{}/{}/{}'.format(ISA_PATH, ids(ISA_TYPE), version), scope=SCOPE_WRITE)
+    resp = session_ridv1.delete('{}/{}/{}'.format(ISA_PATH, ids(ISA_TYPE), version), scope=Scope.Write)
     assert resp.status_code == 200, resp.content
   elif resp.status_code == 404:
     # As expected.
@@ -31,7 +33,7 @@ def test_ensure_clean_workspace(ids, session_ridv1):
     assert False, resp.content
 
 
-@default_scope(SCOPE_WRITE)
+@default_scope(Scope.Write)
 def test_isa_huge_area(ids, session_ridv1):
   time_start = datetime.datetime.utcnow()
   time_end = time_start + datetime.timedelta(minutes=60)
@@ -56,7 +58,7 @@ def test_isa_huge_area(ids, session_ridv1):
   assert 'too large' in resp.json()['message']
 
 
-@default_scope(SCOPE_WRITE)
+@default_scope(Scope.Write)
 def test_isa_empty_vertices(ids, session_ridv1):
   time_start = datetime.datetime.utcnow()
   time_end = time_start + datetime.timedelta(minutes=60)
@@ -81,7 +83,7 @@ def test_isa_empty_vertices(ids, session_ridv1):
   assert 'Missing or malformed required extents' in resp.json()['message']
 
 
-@default_scope(SCOPE_WRITE)
+@default_scope(Scope.Write)
 def test_isa_missing_footprint(ids, session_ridv1):
   time_start = datetime.datetime.utcnow()
   time_end = time_start + datetime.timedelta(minutes=60)
@@ -103,7 +105,7 @@ def test_isa_missing_footprint(ids, session_ridv1):
   assert 'Missing or malformed required extents' in resp.json()['message']
 
 
-@default_scope(SCOPE_WRITE)
+@default_scope(Scope.Write)
 def test_isa_missing_spatial_volume(ids, session_ridv1):
   time_start = datetime.datetime.utcnow()
   time_end = time_start + datetime.timedelta(minutes=60)
@@ -121,7 +123,7 @@ def test_isa_missing_spatial_volume(ids, session_ridv1):
   assert 'Missing or malformed required extents' in resp.json()['message']
 
 
-@default_scope(SCOPE_WRITE)
+@default_scope(Scope.Write)
 def test_isa_missing_extents(ids, session_ridv1):
   resp = session_ridv1.put(
       '{}/{}'.format(ISA_PATH, ids(ISA_TYPE)),
@@ -132,7 +134,7 @@ def test_isa_missing_extents(ids, session_ridv1):
   assert 'Missing or malformed required extents' in resp.json()['message']
 
 
-@default_scope(SCOPE_WRITE)
+@default_scope(Scope.Write)
 def test_isa_start_time_in_past(ids, session_ridv1):
   time_start = datetime.datetime.utcnow() - datetime.timedelta(minutes=10)
   time_end = time_start + datetime.timedelta(minutes=60)
@@ -157,7 +159,7 @@ def test_isa_start_time_in_past(ids, session_ridv1):
   assert 'IdentificationServiceArea time_start must not be in the past' in resp.json()['message']
 
 
-@default_scope(SCOPE_WRITE)
+@default_scope(Scope.Write)
 def test_isa_start_time_after_time_end(ids, session_ridv1):
   time_start = datetime.datetime.utcnow() + datetime.timedelta(minutes=10)
   time_end = time_start - datetime.timedelta(minutes=5)
@@ -182,7 +184,7 @@ def test_isa_start_time_after_time_end(ids, session_ridv1):
   assert 'IdentificationServiceArea time_end must be after time_start' in resp.json()['message']
 
 
-@default_scope(SCOPE_WRITE)
+@default_scope(Scope.Write)
 def test_isa_not_on_earth(ids, session_ridv1):
   time_start = datetime.datetime.utcnow()
   time_end = time_start + datetime.timedelta(minutes=60)

--- a/monitoring/prober/rid/v1/test_subscription_isa_interactions.py
+++ b/monitoring/prober/rid/v1/test_subscription_isa_interactions.py
@@ -11,20 +11,23 @@ import datetime
 
 from monitoring.monitorlib.infrastructure import default_scope
 from monitoring.monitorlib import rid_v1
-from monitoring.monitorlib.rid_v1 import SCOPE_READ, SCOPE_WRITE, ISA_PATH, SUBSCRIPTION_PATH
 from monitoring.prober.infrastructure import register_resource_type
 from . import common
 
+from uas_standards.astm.f3411.v19.api import OPERATIONS, OperationID
+from uas_standards.astm.f3411.v19.constants import Scope
 
+ISA_PATH = OPERATIONS[OperationID.SearchIdentificationServiceAreas].path
+SUBSCRIPTION_PATH = OPERATIONS[OperationID.SearchSubscriptions].path
 ISA_TYPE = register_resource_type(325, 'ISA')
 SUB_TYPE = register_resource_type(326, 'Subscription')
 
 
 def test_ensure_clean_workspace(ids, session_ridv1):
-  resp = session_ridv1.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)), scope=SCOPE_READ)
+  resp = session_ridv1.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)), scope=Scope.Read)
   if resp.status_code == 200:
     version = resp.json()['service_area']['version']
-    resp = session_ridv1.delete('{}/{}/{}'.format(ISA_PATH, ids(ISA_TYPE), version), scope=SCOPE_WRITE)
+    resp = session_ridv1.delete('{}/{}/{}'.format(ISA_PATH, ids(ISA_TYPE), version), scope=Scope.Write)
     assert resp.status_code == 200, resp.content
   elif resp.status_code == 404:
     # As expected.
@@ -32,10 +35,10 @@ def test_ensure_clean_workspace(ids, session_ridv1):
   else:
     assert False, resp.content
 
-  resp = session_ridv1.get('{}/{}'.format(SUBSCRIPTION_PATH, ids(SUB_TYPE)), scope=SCOPE_READ)
+  resp = session_ridv1.get('{}/{}'.format(SUBSCRIPTION_PATH, ids(SUB_TYPE)), scope=Scope.Read)
   if resp.status_code == 200:
     version = resp.json()['subscription']['version']
-    resp = session_ridv1.delete('{}/{}/{}'.format(SUBSCRIPTION_PATH, ids(SUB_TYPE), version), scope=SCOPE_READ)
+    resp = session_ridv1.delete('{}/{}/{}'.format(SUBSCRIPTION_PATH, ids(SUB_TYPE), version), scope=Scope.Read)
     assert resp.status_code == 200, resp.content
   elif resp.status_code == 404:
     # As expected
@@ -44,7 +47,7 @@ def test_ensure_clean_workspace(ids, session_ridv1):
     assert False, resp.content
 
 
-@default_scope(SCOPE_WRITE)
+@default_scope(Scope.Write)
 def test_create_isa(ids, session_ridv1):
   time_start = datetime.datetime.utcnow()
   time_end = time_start + datetime.timedelta(minutes=60)
@@ -68,7 +71,7 @@ def test_create_isa(ids, session_ridv1):
   assert resp.status_code == 200, resp.content
 
 
-@default_scope(SCOPE_READ)
+@default_scope(Scope.Read)
 def test_create_subscription(ids, session_ridv1):
   time_start = datetime.datetime.utcnow()
   time_end = time_start + datetime.timedelta(minutes=60)
@@ -101,7 +104,7 @@ def test_create_subscription(ids, session_ridv1):
 
 def test_modify_isa(ids, session_ridv1):
   # GET the ISA first to find its version.
-  resp = session_ridv1.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)), scope=SCOPE_READ)
+  resp = session_ridv1.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)), scope=Scope.Read)
   assert resp.status_code == 200, resp.content
   version = resp.json()['service_area']['version']
 
@@ -122,7 +125,7 @@ def test_modify_isa(ids, session_ridv1):
               'time_end': time_end.strftime(rid_v1.DATE_FORMAT),
           },
           'flights_url': 'https://example.com/dss',
-      }, scope=SCOPE_WRITE)
+      }, scope=Scope.Write)
   assert resp.status_code == 200, resp.content
 
   # The response should include our subscription.
@@ -139,13 +142,13 @@ def test_modify_isa(ids, session_ridv1):
 
 def test_delete_isa(ids, session_ridv1):
   # GET the ISA first to find its version.
-  resp = session_ridv1.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)), scope=SCOPE_READ)
+  resp = session_ridv1.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)), scope=Scope.Read)
   assert resp.status_code == 200, resp.content
   version = resp.json()['service_area']['version']
 
   # Then delete it.
   resp = session_ridv1.delete('{}/{}/{}'.format(
-      ISA_PATH, ids(ISA_TYPE), version), scope=SCOPE_WRITE)
+      ISA_PATH, ids(ISA_TYPE), version), scope=Scope.Write)
   assert resp.status_code == 200, resp.content
 
   # The response should include our subscription.
@@ -160,7 +163,7 @@ def test_delete_isa(ids, session_ridv1):
   } in data['subscribers']
 
 
-@default_scope(SCOPE_READ)
+@default_scope(Scope.Read)
 def test_delete_subscription(ids, session_ridv1):
   # GET the sub first to find its version.
   resp = session_ridv1.get('{}/{}'.format(SUBSCRIPTION_PATH, ids(SUB_TYPE)))

--- a/monitoring/prober/rid/v1/test_subscription_isa_slightly_overlapping.py
+++ b/monitoring/prober/rid/v1/test_subscription_isa_slightly_overlapping.py
@@ -10,20 +10,23 @@ import datetime
 
 from monitoring.monitorlib.infrastructure import default_scope
 from monitoring.monitorlib import rid_v1
-from monitoring.monitorlib.rid_v1 import SCOPE_READ, SCOPE_WRITE, ISA_PATH, SUBSCRIPTION_PATH
 from monitoring.prober.infrastructure import register_resource_type
 from . import common
 
+from uas_standards.astm.f3411.v19.api import OPERATIONS, OperationID
+from uas_standards.astm.f3411.v19.constants import Scope
 
+ISA_PATH = OPERATIONS[OperationID.SearchIdentificationServiceAreas].path
+SUBSCRIPTION_PATH = OPERATIONS[OperationID.SearchSubscriptions].path
 ISA_TYPE = register_resource_type(427, 'ISA')
 SUB_TYPE = register_resource_type(428, 'Subscription')
 
 
 def test_ensure_clean_workspace(ids, session_ridv1):
-  resp = session_ridv1.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)), scope=SCOPE_READ)
+  resp = session_ridv1.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)), scope=Scope.Read)
   if resp.status_code == 200:
     version = resp.json()['service_area']['version']
-    resp = session_ridv1.delete('{}/{}/{}'.format(ISA_PATH, ids(ISA_TYPE), version), scope=SCOPE_WRITE)
+    resp = session_ridv1.delete('{}/{}/{}'.format(ISA_PATH, ids(ISA_TYPE), version), scope=Scope.Write)
     assert resp.status_code == 200, resp.content
   elif resp.status_code == 404:
     # As expected.
@@ -31,10 +34,10 @@ def test_ensure_clean_workspace(ids, session_ridv1):
   else:
     assert False, resp.content
 
-  resp = session_ridv1.get('{}/{}'.format(SUBSCRIPTION_PATH, ids(SUB_TYPE)), scope=SCOPE_READ)
+  resp = session_ridv1.get('{}/{}'.format(SUBSCRIPTION_PATH, ids(SUB_TYPE)), scope=Scope.Read)
   if resp.status_code == 200:
     version = resp.json()['subscription']['version']
-    resp = session_ridv1.delete('{}/{}/{}'.format(SUBSCRIPTION_PATH, ids(SUB_TYPE), version), scope=SCOPE_READ)
+    resp = session_ridv1.delete('{}/{}/{}'.format(SUBSCRIPTION_PATH, ids(SUB_TYPE), version), scope=Scope.Read)
     assert resp.status_code == 200, resp.content
   elif resp.status_code == 404:
     # As expected
@@ -43,7 +46,7 @@ def test_ensure_clean_workspace(ids, session_ridv1):
     assert False, resp.content
 
 
-@default_scope(SCOPE_WRITE)
+@default_scope(Scope.Write)
 def test_create_isa(ids, session_ridv1):
   time_start = datetime.datetime.utcnow()
   time_end = time_start + datetime.timedelta(minutes=60)
@@ -67,7 +70,7 @@ def test_create_isa(ids, session_ridv1):
   assert resp.status_code == 200, resp.content
 
 
-@default_scope(SCOPE_READ)
+@default_scope(Scope.Read)
 def test_create_subscription(ids, session_ridv1):
   time_start = datetime.datetime.utcnow()
   time_end = time_start + datetime.timedelta(minutes=60)
@@ -101,13 +104,13 @@ def test_create_subscription(ids, session_ridv1):
 
 def test_delete_isa(ids, session_ridv1):
   # GET the ISA first to find its version.
-  resp = session_ridv1.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)), scope=SCOPE_READ)
+  resp = session_ridv1.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)), scope=Scope.Read)
   assert resp.status_code == 200, resp.content
   version = resp.json()['service_area']['version']
 
   # Then delete it.
   resp = session_ridv1.delete('{}/{}/{}'.format(
-      ISA_PATH, ids(ISA_TYPE), version), scope=SCOPE_WRITE)
+      ISA_PATH, ids(ISA_TYPE), version), scope=Scope.Write)
   assert resp.status_code == 200, resp.content
 
   # The response should include our subscription.
@@ -122,7 +125,7 @@ def test_delete_isa(ids, session_ridv1):
   } in data['subscribers']
 
 
-@default_scope(SCOPE_READ)
+@default_scope(Scope.Read)
 def test_delete_subscription(ids, session_ridv1):
   # GET the sub first to find its version.
   resp = session_ridv1.get('{}/{}'.format(SUBSCRIPTION_PATH, ids(SUB_TYPE)))

--- a/monitoring/prober/rid/v1/test_subscription_validation.py
+++ b/monitoring/prober/rid/v1/test_subscription_validation.py
@@ -10,20 +10,23 @@ import datetime
 
 from monitoring.monitorlib.infrastructure import default_scope
 from monitoring.monitorlib import rid_v1
-from monitoring.monitorlib.rid_v1 import SCOPE_READ, SUBSCRIPTION_PATH
 from monitoring.prober.infrastructure import register_resource_type
 from . import common
 
+from uas_standards.astm.f3411.v19.api import OPERATIONS, OperationID
+from uas_standards.astm.f3411.v19.constants import Scope, NetDSSMaxSubscriptionPerArea, NetDSSMaxSubscriptionDurationHours
 
+
+SUBSCRIPTION_PATH = OPERATIONS[OperationID.SearchSubscriptions].path
 SUB_TYPE = register_resource_type(328, 'Subscription')
 MULTI_SUB_TYPES = [register_resource_type(329 + i, 'Subscription limit Subscription {}'.format(i)) for i in range(11)]
 
 
 def test_ensure_clean_workspace(ids, session_ridv1):
-  resp = session_ridv1.get('{}/{}'.format(SUBSCRIPTION_PATH, ids(SUB_TYPE)), scope=SCOPE_READ)
+  resp = session_ridv1.get('{}/{}'.format(SUBSCRIPTION_PATH, ids(SUB_TYPE)), scope=Scope.Read)
   if resp.status_code == 200:
     version = resp.json()['subscription']['version']
-    resp = session_ridv1.delete('{}/{}/{}'.format(SUBSCRIPTION_PATH, ids(SUB_TYPE), version), scope=SCOPE_READ)
+    resp = session_ridv1.delete('{}/{}/{}'.format(SUBSCRIPTION_PATH, ids(SUB_TYPE), version), scope=Scope.Read)
     assert resp.status_code == 200, resp.content
   elif resp.status_code == 404:
     # As expected.
@@ -32,7 +35,7 @@ def test_ensure_clean_workspace(ids, session_ridv1):
     assert False, resp.content
 
 
-@default_scope(SCOPE_READ)
+@default_scope(Scope.Read)
 def test_create_sub_empty_vertices(ids, session_ridv1):
   time_start = datetime.datetime.utcnow()
   time_end = time_start + datetime.timedelta(seconds=10)
@@ -58,7 +61,7 @@ def test_create_sub_empty_vertices(ids, session_ridv1):
   assert resp.status_code == 400, resp.content
 
 
-@default_scope(SCOPE_READ)
+@default_scope(Scope.Read)
 def test_create_sub_missing_footprint(ids, session_ridv1):
   time_start = datetime.datetime.utcnow()
   time_end = time_start + datetime.timedelta(seconds=10)
@@ -81,7 +84,7 @@ def test_create_sub_missing_footprint(ids, session_ridv1):
   assert resp.status_code == 400, resp.content
 
 
-@default_scope(SCOPE_READ)
+@default_scope(Scope.Read)
 def test_create_sub_with_huge_area(ids, session_ridv1):
   time_start = datetime.datetime.utcnow()
   time_end = time_start + datetime.timedelta(seconds=10)
@@ -107,7 +110,7 @@ def test_create_sub_with_huge_area(ids, session_ridv1):
   assert resp.status_code == 400, resp.content
 
 
-@default_scope(SCOPE_READ)
+@default_scope(Scope.Read)
 def test_create_too_many_subs(ids, session_ridv1):
   """ASTM Compliance Test: DSS0050_MAX_SUBS_PER_AREA."""
   time_start = datetime.datetime.utcnow()
@@ -115,7 +118,7 @@ def test_create_too_many_subs(ids, session_ridv1):
 
   # create 1 more than the max allowed Subscriptions per area
   versions = []
-  for index in range(rid_v1.MAX_SUB_PER_AREA + 1):
+  for index in range(NetDSSMaxSubscriptionPerArea + 1):
     resp = session_ridv1.put(
         '{}/{}'.format(SUBSCRIPTION_PATH, ids(MULTI_SUB_TYPES[index])),
         json={
@@ -151,7 +154,7 @@ def test_create_too_many_subs(ids, session_ridv1):
                 'identification_service_area_url': 'https://example.com/foo'
             },
         })
-    if index < rid_v1.MAX_SUB_PER_AREA:
+    if index < NetDSSMaxSubscriptionPerArea:
       assert resp.status_code == 200, resp.content
       resp_json = resp.json()
       assert 'subscription' in resp_json
@@ -161,16 +164,16 @@ def test_create_too_many_subs(ids, session_ridv1):
       assert resp.status_code == 429, resp.content
 
   # clean up Subscription-limit Subscriptions
-  for index in range(rid_v1.MAX_SUB_PER_AREA):
+  for index in range(NetDSSMaxSubscriptionPerArea):
     resp = session_ridv1.delete('{}/{}/{}'.format(SUBSCRIPTION_PATH, ids(MULTI_SUB_TYPES[index]), versions[index]))
     assert resp.status_code == 200
 
 
-@default_scope(SCOPE_READ)
+@default_scope(Scope.Read)
 def test_create_sub_with_too_long_end_time(ids, session_ridv1):
     """ASTM Compliance Test: DSS0060_MAX_SUBS_DURATION."""
     time_start = datetime.datetime.utcnow()
-    time_end = time_start + datetime.timedelta(hours=(rid_v1.MAX_SUB_TIME_HRS + 1))
+    time_end = time_start + datetime.timedelta(hours=(NetDSSMaxSubscriptionDurationHours + 1))
 
     resp = session_ridv1.put(
         "{}/{}".format(SUBSCRIPTION_PATH, ids(SUB_TYPE)),
@@ -190,7 +193,7 @@ def test_create_sub_with_too_long_end_time(ids, session_ridv1):
     assert resp.status_code == 400, resp.content
 
 
-@default_scope(SCOPE_READ)
+@default_scope(Scope.Read)
 def test_update_sub_with_too_long_end_time(ids, session_ridv1):
     """ASTM Compliance Test: DSS0060_MAX_SUBS_DURATION."""
     time_start = datetime.datetime.utcnow()
@@ -213,7 +216,7 @@ def test_update_sub_with_too_long_end_time(ids, session_ridv1):
     )
     assert resp.status_code == 200, resp.content
 
-    time_end = time_start + datetime.timedelta(hours=(rid_v1.MAX_SUB_TIME_HRS + 1))
+    time_end = time_start + datetime.timedelta(hours=(NetDSSMaxSubscriptionDurationHours + 1))
     resp = session_ridv1.put(
         '{}/{}'.format(SUBSCRIPTION_PATH, ids(SUB_TYPE)) + '/' + resp.json()["subscription"]["version"],
         json={
@@ -232,12 +235,12 @@ def test_update_sub_with_too_long_end_time(ids, session_ridv1):
     assert resp.status_code == 400, resp.content
 
 
-@default_scope(SCOPE_READ)
+@default_scope(Scope.Read)
 def test_delete(ids, session_ridv1):
-  resp = session_ridv1.get('{}/{}'.format(SUBSCRIPTION_PATH, ids(SUB_TYPE)), scope=SCOPE_READ)
+  resp = session_ridv1.get('{}/{}'.format(SUBSCRIPTION_PATH, ids(SUB_TYPE)), scope=Scope.Read)
   if resp.status_code == 200:
     version = resp.json()['subscription']['version']
-    resp = session_ridv1.delete('{}/{}/{}'.format(SUBSCRIPTION_PATH, ids(SUB_TYPE), version), scope=SCOPE_READ)
+    resp = session_ridv1.delete('{}/{}/{}'.format(SUBSCRIPTION_PATH, ids(SUB_TYPE), version), scope=Scope.Read)
     assert resp.status_code == 200, resp.content
   elif resp.status_code == 404:
     # As expected.

--- a/monitoring/prober/rid/v1/test_token_validation.py
+++ b/monitoring/prober/rid/v1/test_token_validation.py
@@ -11,19 +11,21 @@
 import datetime
 
 from monitoring.monitorlib import rid_v1
-from monitoring.monitorlib.rid_v1 import SCOPE_READ, SCOPE_WRITE, ISA_PATH
 from monitoring.prober.infrastructure import register_resource_type
 from . import common
 
+from uas_standards.astm.f3411.v19.api import OPERATIONS, OperationID
+from uas_standards.astm.f3411.v19.constants import Scope
 
+ISA_PATH = OPERATIONS[OperationID.SearchIdentificationServiceAreas].path
 ISA_TYPE = register_resource_type(340, 'ISA')
 
 
 def test_ensure_clean_workspace(ids, session_ridv1):
-  resp = session_ridv1.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)), scope=SCOPE_READ)
+  resp = session_ridv1.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)), scope=Scope.Read)
   if resp.status_code == 200:
     version = resp.json()["service_area"]['version']
-    resp = session_ridv1.delete('{}/{}/{}'.format(ISA_PATH, ids(ISA_TYPE), version), scope=SCOPE_WRITE)
+    resp = session_ridv1.delete('{}/{}/{}'.format(ISA_PATH, ids(ISA_TYPE), version), scope=Scope.Write)
     assert resp.status_code == 200, resp.content
   elif resp.status_code == 404:
     # As expected.
@@ -51,7 +53,7 @@ def test_put_isa_with_read_only_scope_token(ids, session_ridv1):
               'time_end': time_end.strftime(rid_v1.DATE_FORMAT),
           },
           'flights_url': 'https://example.com/dss',
-      }, scope=SCOPE_READ)
+      }, scope=Scope.Read)
   assert resp.status_code == 403, resp.content
 
 
@@ -74,7 +76,7 @@ def test_create_isa(ids, session_ridv1):
               'time_end': time_end.strftime(rid_v1.DATE_FORMAT),
           },
           'flights_url': 'https://example.com/dss',
-      }, scope=SCOPE_WRITE)
+      }, scope=Scope.Write)
   assert resp.status_code == 200, resp.content
 
 
@@ -92,10 +94,10 @@ def test_get_isa_with_fake_token(ids, no_auth_session_ridv1):
 
 
 def test_delete(ids, session_ridv1):
-  resp = session_ridv1.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)), scope=SCOPE_READ)
+  resp = session_ridv1.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)), scope=Scope.Read)
   if resp.status_code == 200:
     version = resp.json()["service_area"]['version']
-    resp = session_ridv1.delete('{}/{}/{}'.format(ISA_PATH, ids(ISA_TYPE), version), scope=SCOPE_WRITE)
+    resp = session_ridv1.delete('{}/{}/{}'.format(ISA_PATH, ids(ISA_TYPE), version), scope=Scope.Write)
     assert resp.status_code == 200, resp.content
   elif resp.status_code == 404:
     # As expected.

--- a/monitoring/prober/rid/v2/test_isa_validation.py
+++ b/monitoring/prober/rid/v2/test_isa_validation.py
@@ -8,22 +8,25 @@
 
 import datetime
 
+from uas_standards.astm.f3411.v22a.api import OPERATIONS, OperationID
+from uas_standards.astm.f3411.v22a.constants import Scope
+
 from monitoring.monitorlib.infrastructure import default_scope
 from monitoring.monitorlib import rid_v2
-from monitoring.monitorlib.rid_v2 import SCOPE_DP, SCOPE_SP, ISA_PATH
 from monitoring.prober.infrastructure import register_resource_type
 from . import common
 
 
+ISA_PATH = OPERATIONS[OperationID.SearchIdentificationServiceAreas].path
 ISA_TYPE = register_resource_type(366, 'ISA')
 BASE_URL = 'https://example.com/rid/v2'
 
 
 def test_ensure_clean_workspace(ids, session_ridv2):
-  resp = session_ridv2.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)), scope=SCOPE_DP)
+  resp = session_ridv2.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)), scope=Scope.DisplayProvider)
   if resp.status_code == 200:
     version = resp.json()["service_area"]['version']
-    resp = session_ridv2.delete('{}/{}/{}'.format(ISA_PATH, ids(ISA_TYPE), version), scope=SCOPE_SP)
+    resp = session_ridv2.delete('{}/{}/{}'.format(ISA_PATH, ids(ISA_TYPE), version), scope=Scope.ServiceProvider)
     assert resp.status_code == 200, resp.content
   elif resp.status_code == 404:
     # As expected.
@@ -32,7 +35,7 @@ def test_ensure_clean_workspace(ids, session_ridv2):
     assert False, resp.content
 
 
-@default_scope(SCOPE_SP)
+@default_scope(Scope.ServiceProvider)
 def test_isa_huge_area(ids, session_ridv2):
   time_start = datetime.datetime.utcnow()
   time_end = time_start + datetime.timedelta(minutes=60)
@@ -57,7 +60,7 @@ def test_isa_huge_area(ids, session_ridv2):
   assert 'too large' in resp.json()['message']
 
 
-@default_scope(SCOPE_SP)
+@default_scope(Scope.ServiceProvider)
 def test_isa_empty_vertices(ids, session_ridv2):
   time_start = datetime.datetime.utcnow()
   time_end = time_start + datetime.timedelta(minutes=60)
@@ -82,7 +85,7 @@ def test_isa_empty_vertices(ids, session_ridv2):
   assert 'Not enough points in polygon' in resp.json()['message']
 
 
-@default_scope(SCOPE_SP)
+@default_scope(Scope.ServiceProvider)
 def test_isa_missing_outline(ids, session_ridv2):
   time_start = datetime.datetime.utcnow()
   time_end = time_start + datetime.timedelta(minutes=60)
@@ -104,7 +107,7 @@ def test_isa_missing_outline(ids, session_ridv2):
   assert 'Error parsing Volume4D' in resp.json()['message']
 
 
-@default_scope(SCOPE_SP)
+@default_scope(Scope.ServiceProvider)
 def test_isa_missing_volume(ids, session_ridv2):
   time_start = datetime.datetime.utcnow()
   time_end = time_start + datetime.timedelta(minutes=60)
@@ -122,7 +125,7 @@ def test_isa_missing_volume(ids, session_ridv2):
   assert 'Error parsing Volume4D' in resp.json()['message']
 
 
-@default_scope(SCOPE_SP)
+@default_scope(Scope.ServiceProvider)
 def test_isa_missing_extents(ids, session_ridv2):
   resp = session_ridv2.put(
       '{}/{}'.format(ISA_PATH, ids(ISA_TYPE)),
@@ -133,7 +136,7 @@ def test_isa_missing_extents(ids, session_ridv2):
   assert 'Error parsing Volume4D: Neither outline_polygon nor outline_circle were specified in volume' in resp.json()['message']
 
 
-@default_scope(SCOPE_SP)
+@default_scope(Scope.ServiceProvider)
 def test_isa_start_time_in_past(ids, session_ridv2):
   time_start = datetime.datetime.utcnow() - datetime.timedelta(minutes=10)
   time_end = time_start + datetime.timedelta(minutes=60)
@@ -158,7 +161,7 @@ def test_isa_start_time_in_past(ids, session_ridv2):
   assert 'IdentificationServiceArea time_start must not be in the past' in resp.json()['message']
 
 
-@default_scope(SCOPE_SP)
+@default_scope(Scope.ServiceProvider)
 def test_isa_start_time_after_time_end(ids, session_ridv2):
   time_start = datetime.datetime.utcnow() + datetime.timedelta(minutes=10)
   time_end = time_start - datetime.timedelta(minutes=5)
@@ -183,7 +186,7 @@ def test_isa_start_time_after_time_end(ids, session_ridv2):
   assert 'IdentificationServiceArea time_end must be after time_start' in resp.json()['message']
 
 
-@default_scope(SCOPE_SP)
+@default_scope(Scope.ServiceProvider)
 def test_isa_not_on_earth(ids, session_ridv2):
   time_start = datetime.datetime.utcnow()
   time_end = time_start + datetime.timedelta(minutes=60)

--- a/monitoring/prober/rid/v2/test_subscription_simple.py
+++ b/monitoring/prober/rid/v2/test_subscription_simple.py
@@ -9,23 +9,26 @@
 import datetime
 import re
 
+from uas_standards.astm.f3411.v22a.api import OPERATIONS, OperationID
+from uas_standards.astm.f3411.v22a.constants import Scope
+
 from monitoring.monitorlib.infrastructure import default_scope
 from monitoring.monitorlib import rid_v2
-from monitoring.monitorlib.rid_v2 import SCOPE_DP, SUBSCRIPTION_PATH
 from monitoring.monitorlib.testing import assert_datetimes_are_equal
 from monitoring.prober.infrastructure import register_resource_type
 from . import common
 
 
+SUBSCRIPTION_PATH = OPERATIONS[OperationID.SearchSubscriptions].path
 SUB_TYPE = register_resource_type(349, 'Subscription')
 BASE_URL = 'https://example.com/rid/v2'
 
 
 def test_ensure_clean_workspace(ids, session_ridv2):
-  resp = session_ridv2.get('{}/{}'.format(SUBSCRIPTION_PATH, ids(SUB_TYPE)), scope=SCOPE_DP)
+  resp = session_ridv2.get('{}/{}'.format(SUBSCRIPTION_PATH, ids(SUB_TYPE)), scope=Scope.DisplayProvider)
   if resp.status_code == 200:
     version = resp.json()['subscription']['version']
-    resp = session_ridv2.delete('{}/{}/{}'.format(SUBSCRIPTION_PATH, ids(SUB_TYPE), version), scope=SCOPE_DP)
+    resp = session_ridv2.delete('{}/{}/{}'.format(SUBSCRIPTION_PATH, ids(SUB_TYPE), version), scope=Scope.DisplayProvider)
     assert resp.status_code == 200, resp.content
   elif resp.status_code == 404:
     # As expected.
@@ -34,14 +37,14 @@ def test_ensure_clean_workspace(ids, session_ridv2):
     assert False, resp.content
 
 
-@default_scope(SCOPE_DP)
+@default_scope(Scope.DisplayProvider)
 def test_sub_does_not_exist(ids, session_ridv2):
   resp = session_ridv2.get('{}/{}'.format(SUBSCRIPTION_PATH, ids(SUB_TYPE)))
   assert resp.status_code == 404, resp.content
   assert 'Subscription {} not found'.format(ids(SUB_TYPE)) in resp.json()['message']
 
 
-@default_scope(SCOPE_DP)
+@default_scope(Scope.DisplayProvider)
 def test_create_sub(ids, session_ridv2):
   """ASTM Compliance Test: DSS0030_C_PUT_SUB."""
   time_start = datetime.datetime.utcnow()
@@ -76,7 +79,7 @@ def test_create_sub(ids, session_ridv2):
   assert 'service_areas' in data
 
 
-@default_scope(SCOPE_DP)
+@default_scope(Scope.DisplayProvider)
 def test_get_sub_by_id(ids, session_ridv2):
   """ASTM Compliance Test: DSS0030_E_GET_SUB_BY_ID."""
   resp = session_ridv2.get('{}/{}'.format(SUBSCRIPTION_PATH, ids(SUB_TYPE)))
@@ -88,7 +91,7 @@ def test_get_sub_by_id(ids, session_ridv2):
   assert data['subscription']['uss_base_url'] == BASE_URL
 
 
-@default_scope(SCOPE_DP)
+@default_scope(Scope.DisplayProvider)
 def test_get_sub_by_search(ids, session_ridv2):
   """ASTM Compliance Test: DSS0030_F_GET_SUBS_BY_AREA."""
   resp = session_ridv2.get('{}?area={}'.format(SUBSCRIPTION_PATH, common.GEO_POLYGON_STRING))
@@ -96,25 +99,25 @@ def test_get_sub_by_search(ids, session_ridv2):
   assert ids(SUB_TYPE) in [x['id'] for x in resp.json()['subscriptions']]
 
 
-@default_scope(SCOPE_DP)
+@default_scope(Scope.DisplayProvider)
 def test_get_sub_by_searching_huge_area(session_ridv2):
   resp = session_ridv2.get('{}?area={}'.format(SUBSCRIPTION_PATH, common.HUGE_GEO_POLYGON_STRING))
   assert resp.status_code == 413, resp.content
 
 
-@default_scope(SCOPE_DP)
+@default_scope(Scope.DisplayProvider)
 def test_delete_sub_empty_version(ids, session_ridv2):
   resp = session_ridv2.delete('{}/{}/'.format(SUBSCRIPTION_PATH, ids(SUB_TYPE)))
   assert resp.status_code == 400, resp.content
 
 
-@default_scope(SCOPE_DP)
+@default_scope(Scope.DisplayProvider)
 def test_delete_sub_wrong_version(ids, session_ridv2):
   resp = session_ridv2.delete('{}/{}/fake_version'.format(SUBSCRIPTION_PATH, ids(SUB_TYPE)))
   assert resp.status_code == 400, resp.content
 
 
-@default_scope(SCOPE_DP)
+@default_scope(Scope.DisplayProvider)
 def test_delete_sub(ids, session_ridv2):
   """ASTM Compliance Test: DSS0030_D_DELETE_SUB."""
   # GET the sub first to find its version.
@@ -127,20 +130,20 @@ def test_delete_sub(ids, session_ridv2):
   assert resp.status_code == 200, resp.content
 
 
-@default_scope(SCOPE_DP)
+@default_scope(Scope.DisplayProvider)
 def test_get_deleted_sub_by_id(ids, session_ridv2):
   resp = session_ridv2.get('{}/{}'.format(SUBSCRIPTION_PATH, ids(SUB_TYPE)))
   assert resp.status_code == 404, resp.content
 
 
-@default_scope(SCOPE_DP)
+@default_scope(Scope.DisplayProvider)
 def test_get_deleted_sub_by_search(ids, session_ridv2):
   resp = session_ridv2.get('{}?area={}'.format(SUBSCRIPTION_PATH, common.GEO_POLYGON_STRING))
   assert resp.status_code == 200, resp.content
   assert ids(SUB_TYPE) not in [x['id'] for x in resp.json()['subscriptions']]
 
 
-@default_scope(SCOPE_DP)
+@default_scope(Scope.DisplayProvider)
 def test_get_sub_with_loop_area(session_ridv2):
   resp = session_ridv2.get('{}?area={}'.format(SUBSCRIPTION_PATH, common.LOOP_GEO_POLYGON_STRING))
   assert resp.status_code == 400, resp.content

--- a/monitoring/prober/rid/v2/test_subscription_validation.py
+++ b/monitoring/prober/rid/v2/test_subscription_validation.py
@@ -8,23 +8,27 @@
 """
 import datetime
 
+from uas_standards.astm.f3411.v22a.api import OPERATIONS, OperationID
+from uas_standards.astm.f3411.v22a.constants import Scope, NetDSSMaxSubscriptionPerArea, NetDSSMaxSubscriptionDurationHours
+
+
 from monitoring.monitorlib.infrastructure import default_scope
 from monitoring.monitorlib import rid_v2
-from monitoring.monitorlib.rid_v2 import SCOPE_DP, SUBSCRIPTION_PATH
 from monitoring.prober.infrastructure import register_resource_type
 from . import common
 
 
+SUBSCRIPTION_PATH = OPERATIONS[OperationID.SearchSubscriptions].path
 SUB_TYPE = register_resource_type(350, 'Subscription')
 MULTI_SUB_TYPES = [register_resource_type(351 + i, 'Subscription limit Subscription {}'.format(i)) for i in range(11)]
 BASE_URL = 'https://example.com/rid/v2'
 
 
 def test_ensure_clean_workspace(ids, session_ridv2):
-  resp = session_ridv2.get('{}/{}'.format(SUBSCRIPTION_PATH, ids(SUB_TYPE)), scope=SCOPE_DP)
+  resp = session_ridv2.get('{}/{}'.format(SUBSCRIPTION_PATH, ids(SUB_TYPE)), scope=Scope.DisplayProvider)
   if resp.status_code == 200:
     version = resp.json()['subscription']['version']
-    resp = session_ridv2.delete('{}/{}/{}'.format(SUBSCRIPTION_PATH, ids(SUB_TYPE), version), scope=SCOPE_DP)
+    resp = session_ridv2.delete('{}/{}/{}'.format(SUBSCRIPTION_PATH, ids(SUB_TYPE), version), scope=Scope.DisplayProvider)
     assert resp.status_code == 200, resp.content
   elif resp.status_code == 404:
     # As expected.
@@ -33,7 +37,7 @@ def test_ensure_clean_workspace(ids, session_ridv2):
     assert False, resp.content
 
 
-@default_scope(SCOPE_DP)
+@default_scope(Scope.DisplayProvider)
 def test_create_sub_empty_vertices(ids, session_ridv2):
   time_start = datetime.datetime.utcnow()
   time_end = time_start + datetime.timedelta(seconds=10)
@@ -57,7 +61,7 @@ def test_create_sub_empty_vertices(ids, session_ridv2):
   assert resp.status_code == 400, resp.content
 
 
-@default_scope(SCOPE_DP)
+@default_scope(Scope.DisplayProvider)
 def test_create_sub_missing_outline_polygon(ids, session_ridv2):
   time_start = datetime.datetime.utcnow()
   time_end = time_start + datetime.timedelta(seconds=10)
@@ -78,7 +82,7 @@ def test_create_sub_missing_outline_polygon(ids, session_ridv2):
   assert resp.status_code == 400, resp.content
 
 
-@default_scope(SCOPE_DP)
+@default_scope(Scope.DisplayProvider)
 def test_create_sub_with_huge_area(ids, session_ridv2):
   time_start = datetime.datetime.utcnow()
   time_end = time_start + datetime.timedelta(seconds=10)
@@ -102,7 +106,7 @@ def test_create_sub_with_huge_area(ids, session_ridv2):
   assert resp.status_code == 400, resp.content
 
 
-@default_scope(SCOPE_DP)
+@default_scope(Scope.DisplayProvider)
 def test_create_too_many_subs(ids, session_ridv2):
   """ASTM Compliance Test: DSS0050_MAX_SUBS_PER_AREA."""
   time_start = datetime.datetime.utcnow()
@@ -110,7 +114,7 @@ def test_create_too_many_subs(ids, session_ridv2):
 
   # create 1 more than the max allowed Subscriptions per area
   versions = []
-  for index in range(rid_v2.MAX_SUB_PER_AREA + 1):
+  for index in range(NetDSSMaxSubscriptionPerArea + 1):
     resp = session_ridv2.put(
         '{}/{}'.format(SUBSCRIPTION_PATH, ids(MULTI_SUB_TYPES[index])),
         json={
@@ -144,7 +148,7 @@ def test_create_too_many_subs(ids, session_ridv2):
             },
             'uss_base_url': BASE_URL
         })
-    if index < rid_v2.MAX_SUB_PER_AREA:
+    if index < NetDSSMaxSubscriptionPerArea:
       assert resp.status_code == 200, resp.content
       resp_json = resp.json()
       assert 'subscription' in resp_json
@@ -154,16 +158,16 @@ def test_create_too_many_subs(ids, session_ridv2):
       assert resp.status_code == 429, resp.content
 
   # clean up Subscription-limit Subscriptions
-  for index in range(rid_v2.MAX_SUB_PER_AREA):
+  for index in range(NetDSSMaxSubscriptionPerArea):
     resp = session_ridv2.delete('{}/{}/{}'.format(SUBSCRIPTION_PATH, ids(MULTI_SUB_TYPES[index]), versions[index]))
     assert resp.status_code == 200
 
 
-@default_scope(SCOPE_DP)
+@default_scope(Scope.DisplayProvider)
 def test_create_sub_with_too_long_end_time(ids, session_ridv2):
     """ASTM Compliance Test: DSS0060_MAX_SUBS_DURATION."""
     time_start = datetime.datetime.utcnow()
-    time_end = time_start + datetime.timedelta(hours=(rid_v2.MAX_SUB_TIME_HRS + 1))
+    time_end = time_start + datetime.timedelta(hours=(NetDSSMaxSubscriptionDurationHours + 1))
 
     resp = session_ridv2.put(
         "{}/{}".format(SUBSCRIPTION_PATH, ids(SUB_TYPE)),
@@ -183,7 +187,7 @@ def test_create_sub_with_too_long_end_time(ids, session_ridv2):
     assert resp.status_code == 400, resp.content
 
 
-@default_scope(SCOPE_DP)
+@default_scope(Scope.DisplayProvider)
 def test_update_sub_with_too_long_end_time(ids, session_ridv2):
     """ASTM Compliance Test: DSS0060_MAX_SUBS_DURATION."""
     time_start = datetime.datetime.utcnow()
@@ -206,7 +210,7 @@ def test_update_sub_with_too_long_end_time(ids, session_ridv2):
     )
     assert resp.status_code == 200, resp.content
 
-    time_end = time_start + datetime.timedelta(hours=(rid_v2.MAX_SUB_TIME_HRS + 1))
+    time_end = time_start + datetime.timedelta(hours=(NetDSSMaxSubscriptionDurationHours + 1))
     resp = session_ridv2.put(
         '{}/{}'.format(SUBSCRIPTION_PATH, ids(SUB_TYPE)) + '/' + resp.json()["subscription"]["version"],
         json={
@@ -225,12 +229,12 @@ def test_update_sub_with_too_long_end_time(ids, session_ridv2):
     assert resp.status_code == 400, resp.content
 
 
-@default_scope(SCOPE_DP)
+@default_scope(Scope.DisplayProvider)
 def test_delete(ids, session_ridv2):
-  resp = session_ridv2.get('{}/{}'.format(SUBSCRIPTION_PATH, ids(SUB_TYPE)), scope=SCOPE_DP)
+  resp = session_ridv2.get('{}/{}'.format(SUBSCRIPTION_PATH, ids(SUB_TYPE)), scope=Scope.DisplayProvider)
   if resp.status_code == 200:
     version = resp.json()['subscription']['version']
-    resp = session_ridv2.delete('{}/{}/{}'.format(SUBSCRIPTION_PATH, ids(SUB_TYPE), version), scope=SCOPE_DP)
+    resp = session_ridv2.delete('{}/{}/{}'.format(SUBSCRIPTION_PATH, ids(SUB_TYPE), version), scope=Scope.DisplayProvider)
     assert resp.status_code == 200, resp.content
   elif resp.status_code == 404:
     # As expected.

--- a/monitoring/prober/rid/v2/test_token_validation.py
+++ b/monitoring/prober/rid/v2/test_token_validation.py
@@ -10,21 +10,24 @@
 
 import datetime
 
+from uas_standards.astm.f3411.v22a.api import OPERATIONS, OperationID
+from uas_standards.astm.f3411.v22a.constants import Scope
+
 from monitoring.monitorlib import rid_v2
-from monitoring.monitorlib.rid_v2 import SCOPE_DP, SCOPE_SP, ISA_PATH
 from monitoring.prober.infrastructure import register_resource_type
 from . import common
 
 
+ISA_PATH = OPERATIONS[OperationID.SearchIdentificationServiceAreas].path
 ISA_TYPE = register_resource_type(363, 'ISA')
 BASE_URL = 'https://example.com/rid/v2'
 
 
 def test_ensure_clean_workspace(ids, session_ridv2):
-  resp = session_ridv2.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)), scope=SCOPE_DP)
+  resp = session_ridv2.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)), scope=Scope.DisplayProvider)
   if resp.status_code == 200:
     version = resp.json()["service_area"]['version']
-    resp = session_ridv2.delete('{}/{}/{}'.format(ISA_PATH, ids(ISA_TYPE), version), scope=SCOPE_SP)
+    resp = session_ridv2.delete('{}/{}/{}'.format(ISA_PATH, ids(ISA_TYPE), version), scope=Scope.ServiceProvider)
     assert resp.status_code == 200, resp.content
   elif resp.status_code == 404:
     # As expected.
@@ -52,7 +55,7 @@ def test_put_isa_with_read_only_scope_token(ids, session_ridv2):
               'time_end': rid_v2.make_time(time_end),
           },
           'uss_base_url': BASE_URL,
-      }, scope=SCOPE_DP)
+      }, scope=Scope.DisplayProvider)
   assert resp.status_code == 403, resp.content
 
 
@@ -75,7 +78,7 @@ def test_create_isa(ids, session_ridv2):
               'time_end': rid_v2.make_time(time_end),
           },
           'uss_base_url': BASE_URL,
-      }, scope=SCOPE_SP)
+      }, scope=Scope.ServiceProvider)
   assert resp.status_code == 200, resp.content
 
 
@@ -93,10 +96,10 @@ def test_get_isa_with_fake_token(ids, no_auth_session_ridv2):
 
 
 def test_delete(ids, session_ridv2):
-  resp = session_ridv2.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)), scope=SCOPE_DP)
+  resp = session_ridv2.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)), scope=Scope.DisplayProvider)
   if resp.status_code == 200:
     version = resp.json()["service_area"]['version']
-    resp = session_ridv2.delete('{}/{}/{}'.format(ISA_PATH, ids(ISA_TYPE), version), scope=SCOPE_SP)
+    resp = session_ridv2.delete('{}/{}/{}'.format(ISA_PATH, ids(ISA_TYPE), version), scope=Scope.ServiceProvider)
     assert resp.status_code == 200, resp.content
   elif resp.status_code == 404:
     # As expected.

--- a/monitoring/uss_qualifier/resources/astm/f3411/dss.py
+++ b/monitoring/uss_qualifier/resources/astm/f3411/dss.py
@@ -4,7 +4,7 @@ from urllib.parse import urlparse
 from implicitdict import ImplicitDict
 
 from monitoring.monitorlib import infrastructure
-from monitoring.monitorlib.rid_common import RIDVersion
+from monitoring.monitorlib.rid import RIDVersion
 from monitoring.uss_qualifier.reports.report import ParticipantID
 from monitoring.uss_qualifier.resources.resource import Resource
 from monitoring.uss_qualifier.resources.communications import AuthAdapterResource

--- a/monitoring/uss_qualifier/resources/netrid/observers.py
+++ b/monitoring/uss_qualifier/resources/netrid/observers.py
@@ -1,4 +1,3 @@
-import datetime
 from typing import List, Optional, Tuple
 
 import s2sphere
@@ -6,7 +5,7 @@ from implicitdict import ImplicitDict
 
 from monitoring.monitorlib import fetch, infrastructure
 from monitoring.monitorlib.infrastructure import UTMClientSession
-from monitoring.monitorlib.rid_common import RIDVersion
+from monitoring.monitorlib.rid import RIDVersion
 from monitoring.monitorlib.rid_automated_testing import observation_api
 from monitoring.uss_qualifier.resources.resource import Resource
 from monitoring.uss_qualifier.resources.communications import AuthAdapterResource

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/display_data_evaluator.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/display_data_evaluator.py
@@ -1,12 +1,10 @@
-import datetime
-import time
 from typing import List, Optional
 
 import arrow
 import s2sphere
 
 from monitoring.monitorlib import fetch, geo
-from monitoring.monitorlib.rid_common import RIDVersion
+from monitoring.monitorlib.rid import RIDVersion
 from monitoring.uss_qualifier.common_data_definitions import Severity
 from monitoring.uss_qualifier.resources.netrid.evaluation import EvaluationConfiguration
 from monitoring.uss_qualifier.resources.netrid.observers import RIDSystemObserver

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/nominal_behavior.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/nominal_behavior.py
@@ -10,7 +10,7 @@ from requests.exceptions import RequestException
 from monitoring.monitorlib.rid_automated_testing.injection_api import (
     CreateTestParameters,
 )
-from monitoring.monitorlib.rid_common import RIDVersion
+from monitoring.monitorlib.rid import RIDVersion
 from monitoring.uss_qualifier.common_data_definitions import Severity
 from monitoring.uss_qualifier.resources.netrid import (
     FlightDataResource,

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss_interoperability.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss_interoperability.py
@@ -19,15 +19,14 @@ from uas_standards.astm.f3411.v19.api import (
 )
 
 from monitoring.monitorlib.infrastructure import UTMClientSession
-from monitoring.monitorlib.rid_v1 import SCOPE_READ, SCOPE_WRITE
-from monitoring.monitorlib.rid_common import RIDVersion
+from monitoring.monitorlib.rid import RIDVersion
 from monitoring.uss_qualifier.common_data_definitions import Severity
 from monitoring.uss_qualifier.reports.report import ParticipantID
 from monitoring.uss_qualifier.resources.astm.f3411.dss import (
     DSSInstancesResource,
 )
 from monitoring.uss_qualifier.scenarios.scenario import TestScenario
-
+from uas_standards.astm.f3411.v19.constants import Scope
 
 VERTICES = [
     LatLngPoint(lng=130.6205, lat=-23.6558),
@@ -159,7 +158,7 @@ class DSSInteroperability(TestScenario):
         resp = self._dss_map[self._primary_dss_instance].put(
             f"/v1/dss/identification_service_areas/{isa1.uuid}",
             json=_make_create_isa(time_end),
-            scope=SCOPE_WRITE,
+            scope=Scope.Write,
         )
         query = fetch.describe_query(resp, initiated_at)
         self.record_query(query)
@@ -191,7 +190,7 @@ class DSSInteroperability(TestScenario):
             resp = self._dss_map[dss].put(
                 f"/v1/dss/subscriptions/{sub_1_uuid}",
                 json=_make_create_subscription(time_end),
-                scope=SCOPE_READ,
+                scope=Scope.Read,
             )
             query = fetch.describe_query(resp, initiated_at)
             self.record_query(query)
@@ -231,7 +230,7 @@ class DSSInteroperability(TestScenario):
             initiated_at = datetime.datetime.utcnow()
             resp = self._dss_map[dss].get(
                 f"/v1/dss/subscriptions/{self._context['sub_1_0'].uuid}",
-                scope=SCOPE_READ,
+                scope=Scope.Read,
             )
             query = fetch.describe_query(resp, initiated_at)
             self.record_query(query)
@@ -266,7 +265,7 @@ class DSSInteroperability(TestScenario):
         for index, dss in enumerate(all_dss):
             initiated_at = datetime.datetime.utcnow()
             resp = self._dss_map[dss].get(
-                f"/v1/dss/subscriptions?area={GEO_POLYGON_STRING}", scope=SCOPE_READ
+                f"/v1/dss/subscriptions?area={GEO_POLYGON_STRING}", scope=Scope.Read
             )
             query = fetch.describe_query(resp, initiated_at)
             self.record_query(query)
@@ -298,7 +297,7 @@ class DSSInteroperability(TestScenario):
         isa_1 = self._context["isa_1"]
         initiated_at = datetime.datetime.utcnow()
         resp = self._dss_map[self._primary_dss_instance].get(
-            f"/v1/dss/identification_service_areas/{isa_1.uuid}", scope=SCOPE_READ
+            f"/v1/dss/identification_service_areas/{isa_1.uuid}", scope=Scope.Read
         )
         query = fetch.describe_query(resp, initiated_at)
         self.record_query(query)
@@ -323,7 +322,7 @@ class DSSInteroperability(TestScenario):
         put_resp = self._dss_map[self._primary_dss_instance].put(
             f"/v1/dss/identification_service_areas/{isa_1.uuid}/{isa_1.version}",
             json=isa_update,
-            scope=SCOPE_WRITE,
+            scope=Scope.Write,
         )
         query = fetch.describe_query(put_resp, initiated_at)
         self.record_query(query)
@@ -360,7 +359,7 @@ class DSSInteroperability(TestScenario):
                 initiated_at = datetime.datetime.utcnow()
                 resp = dss.delete(
                     f"/v1/dss/subscriptions/{entity.uuid}/{entity.version}",
-                    scope=SCOPE_READ,
+                    scope=Scope.Read,
                 )
                 query = fetch.describe_query(resp, initiated_at)
                 self.record_query(query)
@@ -384,7 +383,7 @@ class DSSInteroperability(TestScenario):
             dss = self._dss_map[dss_name]
             sub_uuid = self._context[f"sub_1_{index}"].uuid
             initiated_at = datetime.datetime.utcnow()
-            resp = dss.get(f"/v1/dss/subscriptions/{sub_uuid}", scope=SCOPE_READ)
+            resp = dss.get(f"/v1/dss/subscriptions/{sub_uuid}", scope=Scope.Read)
             query = fetch.describe_query(resp, initiated_at)
             self.record_query(query)
             with self.check("404 with proper response", [dss_name]) as check:
@@ -402,7 +401,7 @@ class DSSInteroperability(TestScenario):
         for dss in all_dss:
             initiated_at = datetime.datetime.utcnow()
             resp = self._dss_map[dss].get(
-                f"/v1/dss/subscriptions?area={GEO_POLYGON_STRING}", scope=SCOPE_READ
+                f"/v1/dss/subscriptions?area={GEO_POLYGON_STRING}", scope=Scope.Read
             )
             query = fetch.describe_query(resp, initiated_at)
             self.record_query(query)
@@ -450,7 +449,7 @@ class DSSInteroperability(TestScenario):
             resp = self._dss_map[dss].put(
                 f"/v1/dss/subscriptions/{sub_2_uuid}",
                 json=_make_create_subscription(time_end),
-                scope=SCOPE_READ,
+                scope=Scope.Read,
             )
             query = fetch.describe_query(resp, initiated_at)
             self.record_query(query)
@@ -488,7 +487,7 @@ class DSSInteroperability(TestScenario):
         resp = self._dss_map[self._primary_dss_instance].put(
             f"/v1/dss/identification_service_areas/{self._context['isa_2'].uuid}",
             json=_make_create_isa(time_end),
-            scope=SCOPE_WRITE,
+            scope=Scope.Write,
         )
         query = fetch.describe_query(resp, initiated_at)
         self.record_query(query)
@@ -532,7 +531,7 @@ class DSSInteroperability(TestScenario):
         initiated_at = datetime.datetime.utcnow()
         resp = self._dss_map[self._primary_dss_instance].delete(
             f"/v1/dss/identification_service_areas/{isa_2_uuid}/{version}",
-            scope=SCOPE_WRITE,
+            scope=Scope.Write,
         )
         query = fetch.describe_query(resp, initiated_at)
         self.record_query(query)
@@ -575,7 +574,7 @@ class DSSInteroperability(TestScenario):
         resp = self._dss_map[self._primary_dss_instance].put(
             f"/v1/dss/identification_service_areas/{self._context['isa_3'].uuid}",
             json=_make_create_isa(time_end),
-            scope=SCOPE_WRITE,
+            scope=Scope.Write,
         )
         query = fetch.describe_query(resp, initiated_at)
         self.record_query(query)
@@ -617,7 +616,7 @@ class DSSInteroperability(TestScenario):
         for index, dss in enumerate(all_dss):
             initiated_at = datetime.datetime.utcnow()
             resp = self._dss_map[dss].get(
-                f"/v1/dss/subscriptions?area={GEO_POLYGON_STRING}", scope=SCOPE_READ
+                f"/v1/dss/subscriptions?area={GEO_POLYGON_STRING}", scope=Scope.Read
             )
             query = fetch.describe_query(resp, initiated_at)
             self.record_query(query)
@@ -646,7 +645,7 @@ class DSSInteroperability(TestScenario):
             sub_2_uuid = self._context[f"sub_2_{index}"].uuid
             initiated_at = datetime.datetime.utcnow()
             resp = self._dss_map[dss].get(
-                f"/v1/dss/subscriptions/{sub_2_uuid}", scope=SCOPE_READ
+                f"/v1/dss/subscriptions/{sub_2_uuid}", scope=Scope.Read
             )
             query = fetch.describe_query(resp, initiated_at)
             self.record_query(query)
@@ -660,7 +659,7 @@ class DSSInteroperability(TestScenario):
         initiated_at = datetime.datetime.utcnow()
         resp = self._dss_map[self._primary_dss_instance].delete(
             f"/v1/dss/identification_service_areas/{isa_3_uuid}/{version}",
-            scope=SCOPE_WRITE,
+            scope=Scope.Write,
         )
         query = fetch.describe_query(resp, initiated_at)
         self.record_query(query)
@@ -702,7 +701,7 @@ class DSSInteroperability(TestScenario):
             resp = self._dss_map[dss].put(
                 f"/v1/dss/subscriptions/{sub_3_uuid}",
                 json=_make_create_subscription(time_end),
-                scope=SCOPE_READ,
+                scope=Scope.Read,
             )
             query = fetch.describe_query(resp, initiated_at)
             self.record_query(query)
@@ -738,7 +737,7 @@ class DSSInteroperability(TestScenario):
                 continue
             initiated_at = datetime.datetime.utcnow()
             resp = self._dss_map[self._primary_dss_instance].delete(
-                f"/v1/dss/subscriptions/{sub_3.uuid}/{sub_3.version}", scope=SCOPE_READ
+                f"/v1/dss/subscriptions/{sub_3.uuid}/{sub_3.version}", scope=Scope.Read
             )
             query = fetch.describe_query(resp, initiated_at)
             self.record_query(query)
@@ -763,7 +762,7 @@ class DSSInteroperability(TestScenario):
                 initiated_at = datetime.datetime.utcnow()
                 resp = dss.get(
                     f"/v1/dss/identification_service_areas/{entity.uuid}",
-                    scope=SCOPE_READ,
+                    scope=Scope.Read,
                 )
                 query = fetch.describe_query(resp, initiated_at)
                 self.record_query(query)
@@ -775,7 +774,7 @@ class DSSInteroperability(TestScenario):
                 initiated_at = datetime.datetime.utcnow()
                 resp = dss.delete(
                     f"/v1/dss/identification_service_areas/{entity.uuid}/{entity.version}",
-                    scope=SCOPE_WRITE,
+                    scope=Scope.Write,
                 )
                 query = fetch.describe_query(resp, initiated_at)
                 self.record_query(query)
@@ -794,7 +793,7 @@ class DSSInteroperability(TestScenario):
                 initiated_at = datetime.datetime.utcnow()
                 resp = dss.get(
                     f"/v1/dss/subscriptions/{entity.uuid}",
-                    scope=SCOPE_READ,
+                    scope=Scope.Read,
                 )
                 query = fetch.describe_query(resp, initiated_at)
                 self.record_query(query)
@@ -806,7 +805,7 @@ class DSSInteroperability(TestScenario):
                 initiated_at = datetime.datetime.utcnow()
                 resp = dss.delete(
                     f"/v1/dss/subscriptions/{entity.uuid}/{entity.version}",
-                    scope=SCOPE_READ,
+                    scope=Scope.Read,
                 )
                 query = fetch.describe_query(resp, initiated_at)
                 self.record_query(query)

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,5 +37,5 @@ s2sphere==0.2.5
 shapely==1.7.1
 structlog==21.5.0  # deployment_manager
 termcolor==1.1.0
-uas_standards==1.1.0
+uas_standards==1.2.0
 Werkzeug==2.0.3 # See https://github.com/interuss/dss/issues/753


### PR DESCRIPTION
This PR replaces ad-hoc F3411 constants defined in monitorlib with those defined in the uas_standard repository.  monitorlib's rid_common is also renamed to rid to satisfy a TODO.  No behavior change is intended by this PR, except that incorrect scope in atproxy's RID observation endpoints is corrected.