### PR TITLE
[atproxy] Improve atproxy logging and reduce atproxy_client daemon failures

### DIFF
--- a/monitoring/atproxy/app/__init__.py
+++ b/monitoring/atproxy/app/__init__.py
@@ -1,7 +1,3 @@
-import logging
-_logger = logging.getLogger('atproxy.context')
-_logger.setLevel(logging.DEBUG)
-
 import flask
 from flask_httpauth import HTTPBasicAuth
 

--- a/monitoring/atproxy/routes.py
+++ b/monitoring/atproxy/routes.py
@@ -1,17 +1,12 @@
-import logging
 from typing import Tuple
 
 import flask
+from loguru import logger
 from werkzeug.exceptions import HTTPException
 from werkzeug.security import check_password_hash
 
 from monitoring.monitorlib import auth_validation, versioning
 from .app import webapp, basic_auth, users
-
-
-logging.basicConfig()
-_logger = logging.getLogger('atproxy.notifications')
-_logger.setLevel(logging.DEBUG)
 
 
 @webapp.route('/')
@@ -32,6 +27,7 @@ def status():
 
 @webapp.errorhandler(Exception)
 def handle_exception(e):
+    logger.error("Reporting exception {}: {}", type(e).__name__, str(e))
     if isinstance(e, HTTPException):
         return e
     elif isinstance(e, auth_validation.InvalidScopeError):

--- a/monitoring/atproxy/routes_handler.py
+++ b/monitoring/atproxy/routes_handler.py
@@ -1,18 +1,15 @@
+import os
 from datetime import datetime, timedelta
-import logging
 import time
 from typing import Tuple
 
 import flask
+from loguru import logger
 
 from implicitdict import ImplicitDict
 from .app import webapp, basic_auth
 from .database import db, Query, QueryState
 from .handling import ListQueriesResponse, PendingRequest, PutQueryRequest
-
-logging.basicConfig()
-_logger = logging.getLogger('atproxy.handler')
-_logger.setLevel(logging.DEBUG)
 
 
 @webapp.route('/handler/queries', methods=['GET'])
@@ -23,7 +20,7 @@ def list_queries() -> Tuple[str, int]:
     See ListQueriesResponse for response body schema.
     """
     t_start = datetime.utcnow()
-    _logger.debug('Handler requesting queries')
+    logger.debug('Handler requesting queries from worker {}', os.getpid())
     max_timeout = timedelta(seconds=5)
     while datetime.utcnow() < t_start + max_timeout:
         with db as tx:
@@ -32,10 +29,10 @@ def list_queries() -> Tuple[str, int]:
                 for id, q in tx.queries.items()
                 if q.state == QueryState.Queued])
             if response.requests:
-                _logger.debug('Provided handler {} queries'.format(len(response.requests)))
+                logger.debug('Provided handler {} queries'.format(len(response.requests)))
                 return flask.jsonify(response)
         time.sleep(0.1)
-    _logger.debug('No queries available for handler')
+    logger.debug('No queries available for handler from worker {}', os.getpid())
     return flask.jsonify(ListQueriesResponse(requests=[]))
 
 
@@ -46,16 +43,22 @@ def put_query_result(id: str) -> Tuple[str, int]:
 
     See PutQueryRequest for request body schema.
     """
+    logger.debug('Handler instructed to fulfill request {} from worker {}', id, os.getpid())
     try:
         request: PutQueryRequest = ImplicitDict.parse(flask.request.json, PutQueryRequest)
     except ValueError as e:
-        return flask.jsonify({'message': 'Could not parse PutQueryRequest: {}'.format(e)}), 400
+        msg = f'Could not parse PutQueryRequest due to {type(e).__name__} on worker {os.getpid()}: {str(e)}'
+        logger.error(msg)
+        return flask.jsonify({'message': msg}), 400
     with db as tx:
         if id not in tx.queries:
-            return flask.jsonify({'message': 'No outstanding request with ID {} exists'.format(id)}), 400
+            msg = f'No outstanding request with ID {id} exists on worker {os.getpid()}'
+            logger.error(msg)
+            return flask.jsonify({'message': msg}), 400
         query: Query = tx.queries[id]
-        _logger.debug('{} query {} handled with code {}'.format(query.type, id, request.return_code))
+        logger.debug('{} query {} handled with code {}', query.type, id, request.return_code)
         query.return_code = request.return_code
         query.response = request.response
         query.state = QueryState.Complete
+    logger.debug('Handler fulfilled request {} from worker {}', id, os.getpid())
     return '', 204

--- a/monitoring/atproxy/routes_rid_injection.py
+++ b/monitoring/atproxy/routes_rid_injection.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Tuple
 
 import flask
@@ -9,11 +8,6 @@ from .oauth import requires_scope
 from .requests import RIDInjectionCreateTestRequest, RIDInjectionDeleteTestRequest
 from monitoring.monitorlib.rid_automated_testing import injection_api
 from implicitdict import ImplicitDict
-
-
-logging.basicConfig()
-_logger = logging.getLogger('atproxy.rid_injection')
-_logger.setLevel(logging.DEBUG)
 
 
 @webapp.route('/ridsp/injection/tests/<test_id>', methods=['PUT'])
@@ -29,11 +23,11 @@ def rid_injection_create_test(test_id: str) -> Tuple[str, int]:
         msg = 'Create test {} unable to parse JSON: {}'.format(test_id, e)
         return msg, 400
 
-    return handling.fulfill_query(RIDInjectionCreateTestRequest(test_id=test_id, request_body=req_body), _logger)
+    return handling.fulfill_query(RIDInjectionCreateTestRequest(test_id=test_id, request_body=req_body))
 
 
 @webapp.route('/ridsp/injection/tests/<test_id>/<version>', methods=['DELETE'])
 @requires_scope([injection_api.SCOPE_RID_QUALIFIER_INJECT])
 def rid_injection_delete_test(test_id: str, version: str) -> Tuple[str, int]:
     """Implements test deletion in RID automated testing injection API."""
-    return handling.fulfill_query(RIDInjectionDeleteTestRequest(test_id=test_id, version=version), _logger)
+    return handling.fulfill_query(RIDInjectionDeleteTestRequest(test_id=test_id, version=version))

--- a/monitoring/atproxy/routes_rid_observation.py
+++ b/monitoring/atproxy/routes_rid_observation.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Tuple
 
 import flask
@@ -10,20 +9,15 @@ from .oauth import requires_scope
 from .requests import RIDObservationGetDisplayDataRequest, RIDObservationGetDetailsRequest
 
 
-logging.basicConfig()
-_logger = logging.getLogger('atproxy.rid_observation')
-_logger.setLevel(logging.DEBUG)
-
-
 @webapp.route('/riddp/observation/display_data', methods=['GET'])
 @requires_scope([rid_v2.SCOPE_DP])
 def rid_observation_display_data() -> Tuple[str, int]:
     """Implements retrieval of current display data per automated testing API."""
-    return handling.fulfill_query(RIDObservationGetDisplayDataRequest(view=flask.request.args['view']), _logger)
+    return handling.fulfill_query(RIDObservationGetDisplayDataRequest(view=flask.request.args['view']))
 
 
 @webapp.route('/riddp/observation/display_data/<flight_id>', methods=['GET'])
 @requires_scope([rid_v2.SCOPE_DP])
 def rid_observation_flight_details(flight_id: str) -> Tuple[str, int]:
     """Implements get flight details endpoint per automated testing API."""
-    return handling.fulfill_query(RIDObservationGetDetailsRequest(id=flight_id), _logger)
+    return handling.fulfill_query(RIDObservationGetDetailsRequest(id=flight_id))

--- a/monitoring/atproxy/routes_scd.py
+++ b/monitoring/atproxy/routes_scd.py
@@ -1,10 +1,10 @@
-import logging
 from typing import Tuple
 
 import flask
-
+from implicitdict import ImplicitDict
 from uas_standards.interuss.automated_testing.flight_planning.v1.api import \
     InjectFlightRequest, ClearAreaRequest
+
 from . import handling
 from .app import webapp
 from .oauth import requires_scope
@@ -12,26 +12,20 @@ from .requests import SCDInjectionStatusRequest, \
     SCDInjectionCapabilitiesRequest, SCDInjectionPutFlightRequest, \
     SCDInjectionDeleteFlightRequest, SCDInjectionClearAreaRequest
 from monitoring.monitorlib.scd_automated_testing.scd_injection_api import SCOPE_SCD_QUALIFIER_INJECT
-from implicitdict import ImplicitDict
-
-
-logging.basicConfig()
-_logger = logging.getLogger('atproxy.rid_injection')
-_logger.setLevel(logging.DEBUG)
 
 
 @webapp.route('/scd/v1/status', methods=['GET'])
 @requires_scope([SCOPE_SCD_QUALIFIER_INJECT])
 def scd_injection_status() -> Tuple[str, int]:
     """Implements status in SCD automated testing injection API."""
-    return handling.fulfill_query(SCDInjectionStatusRequest(), _logger)
+    return handling.fulfill_query(SCDInjectionStatusRequest())
 
 
 @webapp.route('/scd/v1/capabilities', methods=['GET'])
 @requires_scope([SCOPE_SCD_QUALIFIER_INJECT])
 def scd_injection_capabilities() -> Tuple[str, int]:
     """Implements capabilities in SCD automated testing injection API."""
-    return handling.fulfill_query(SCDInjectionCapabilitiesRequest(), _logger)
+    return handling.fulfill_query(SCDInjectionCapabilitiesRequest())
 
 
 @webapp.route('/scd/v1/flights/<flight_id>', methods=['PUT'])
@@ -46,14 +40,14 @@ def scd_injection_put_flight(flight_id: str) -> Tuple[str, int]:
     except ValueError as e:
         msg = 'Upsert flight {} unable to parse JSON: {}'.format(flight_id, e)
         return msg, 400
-    return handling.fulfill_query(SCDInjectionPutFlightRequest(flight_id=flight_id, request_body=req_body), _logger)
+    return handling.fulfill_query(SCDInjectionPutFlightRequest(flight_id=flight_id, request_body=req_body))
 
 
 @webapp.route('/scd/v1/flights/<flight_id>', methods=['DELETE'])
 @requires_scope([SCOPE_SCD_QUALIFIER_INJECT])
 def scd_injection_delete_flight(flight_id: str) -> Tuple[str, int]:
     """Implements flight deletion in SCD automated testing injection API."""
-    return handling.fulfill_query(SCDInjectionDeleteFlightRequest(flight_id=flight_id), _logger)
+    return handling.fulfill_query(SCDInjectionDeleteFlightRequest(flight_id=flight_id))
 
 
 @webapp.route('/scd/v1/clear_area_requests', methods=['POST'])
@@ -69,4 +63,4 @@ def scd_injection_clear_area() -> Tuple[str, int]:
         msg = 'Clear area request unable to parse JSON: {}'.format(e)
         return msg, 400
 
-    return handling.fulfill_query(SCDInjectionClearAreaRequest(request_body=req_body), _logger)
+    return handling.fulfill_query(SCDInjectionClearAreaRequest(request_body=req_body))

--- a/monitoring/monitorlib/fetch/__init__.py
+++ b/monitoring/monitorlib/fetch/__init__.py
@@ -20,13 +20,17 @@ TIMEOUTS = (5, 25)  # Timeouts of `connect` and `read` in seconds
 class RequestDescription(ImplicitDict):
     method: str
     url: str
-    # Note: MappingProxyType effectively creates a read-only dict.
-    headers: dict = MappingProxyType({})
+    headers: Optional[dict]
     json: Optional[dict] = None
     body: Optional[str] = None
 
     initiated_at: Optional[StringBasedDateTime]
     received_at: Optional[StringBasedDateTime]
+
+    def __init__(self, *args, **kwargs):
+        super(RequestDescription, self).__init__(*args, **kwargs)
+        if "headers" not in self:
+            self.headers = {}
 
     @property
     def token(self) -> Dict:
@@ -88,12 +92,16 @@ def describe_request(
 class ResponseDescription(ImplicitDict):
     code: Optional[int] = None
     failure: Optional[str]
-    # Note: MappingProxyType effectively creates a read-only dict.
-    headers: dict = MappingProxyType({})
+    headers: Optional[dict]
     elapsed_s: float
     reported: StringBasedDateTime
     json: Optional[dict] = None
     body: Optional[str] = None
+
+    def __init__(self, *args, **kwargs):
+        super(ResponseDescription, self).__init__(*args, **kwargs)
+        if "headers" not in self:
+            self.headers = {}
 
     @property
     def status_code(self) -> int:

--- a/monitoring/uss_qualifier/scenarios/definitions.py
+++ b/monitoring/uss_qualifier/scenarios/definitions.py
@@ -1,5 +1,5 @@
 from types import MappingProxyType
-from typing import Dict
+from typing import Dict, Optional
 
 from implicitdict import ImplicitDict
 from monitoring.uss_qualifier.fileio import FileReference
@@ -10,9 +10,13 @@ class TestScenarioDeclaration(ImplicitDict):
     scenario_type: FileReference
     """Type/location of test scenario.  Usually expressed as the class name of the scenario module-qualified relative to the `uss_qualifier` folder"""
 
-    # Note: MappingProxyType effectively creates a read-only dict.
-    resources: Dict[ResourceID, ResourceID] = MappingProxyType({})
+    resources: Optional[Dict[ResourceID, ResourceID]]
     """Mapping of the ID a resource in the test scenario -> the ID a resource is known by in the parent test suite.
-    
+
     The additional argument to concrete test scenario constructor <key> is supplied by the parent suite resource <value>.
     """
+
+    def __init__(self, *args, **kwargs):
+        super(TestScenarioDeclaration, self).__init__(*args, **kwargs)
+        if "resources" not in self:
+            self.resources = {}


### PR DESCRIPTION
This PR attempts to improve #28 by enhancing logging in atproxy and logging but not failing in atproxy_client's daemon when a query to atproxy fails.  This PR is not expected to resolve the problem as the root cause of atproxy_client's call to atproxy timing out has not been addressed (or identified).

Also, it turns out MappingProxyType was not a good substitute for an immutable dict as it is not serializable.  This PR also fixes that problem with an equivalent behavior.