### PR TITLE
[uss_qualifier] Match RID flights by 2D position

### DIFF
--- a/monitoring/uss_qualifier/requirements/interuss/automated_testing/rid.md
+++ b/monitoring/uss_qualifier/requirements/interuss/automated_testing/rid.md
@@ -8,4 +8,3 @@ TODO: Describe overall approach, link to injection & observation
 
 TODO: Describe requirements
 
-### <tt>ObservationFlightID</tt>

--- a/monitoring/uss_qualifier/requirements/interuss/automated_testing/rid/observation.md
+++ b/monitoring/uss_qualifier/requirements/interuss/automated_testing/rid/observation.md
@@ -9,3 +9,5 @@ TODO: Link to API YAML and provide overview
 TODO: Describe requirements
 
 ### <tt>ObservationSuccess</tt>
+
+### <tt>UniqueFlights</tt>

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/nominal_behavior.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/nominal_behavior.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-In this scenario, a single nominal flight is injected into each NetRID Service Provider (SP) under test.  Each of the injected flights is expected to be visible to all the observers at appropriate times and for appropriate requests. 
+In this scenario, a single nominal flight is injected into each NetRID Service Provider (SP) under test.  Each of the injected flights is expected to be visible to all the observers at appropriate times and for appropriate requests.
 
 ## Resources
 
@@ -37,6 +37,10 @@ Per **[interuss.automated_testing.rid.injection.UpsertTestSuccess](../../../requ
 Per **[interuss.automated_testing.rid.injection.UpsertTestResult](../../../requirements/interuss/automated_testing/rid/injection.md)**, the NetRID Service Provider under test should only make valid modifications to the injected flights.  This includes:
 * A flight with the specified injection ID must be returned.
 
+#### Identifiable flights check
+
+This particular test requires each flight to be uniquely identifiable by its 2D telemetry position; the same (lat, lng) pair may not appear in two different telemetry points, even if the two points are in different injected flights.  This should generally be achieved by injecting appropriate data.
+
 ### Polling test step
 
 In this step, all observers are periodically queried for the flights they observe.  Based on the known flights that were injected into the SPs in the previous step, these observations are checked against expected behavior/data.  Observation rectangles are chosen to encompass the known flights when possible.
@@ -47,9 +51,7 @@ Per **[interuss.automated_testing.rid.observation.ObservationSuccess](../../../r
 
 #### Duplicate flights check
 
-An assumption (**[interuss.automated_testing.rid.ObservationFlightID](../../../requirements/interuss/automated_testing/rid.md)**) this test scenario currently makes is that the flight ID reported by the SP the flight was injected into is the same flight ID that each observer will report.  This is probably not a robust assumption and should be adjusted.
-
-This check will fail if an observation contains two flights with the same ID.
+Per **[interuss.automated_testing.rid.observation.UniqueFlights](../../../requirements/interuss/automated_testing/rid/observation.md)**, the same flight ID may not be reported by a Display Provider for two flights in the same observation.
 
 #### Premature flight check
 
@@ -62,6 +64,10 @@ The timestamps of the injected telemetry usually start in the future.  If a flig
 #### Missing flight check
 
 **[astm.f3411.v19.NET0610](../../../requirements/astm/f3411/v19.md)** require that SPs make all UAS operations discoverable over the duration of the flight plus *NetMaxNearRealTimeDataPeriod*, so each injected flight should be observable during this time.  If one of the flights is not observed during its appropriate time period, this check will fail.
+
+#### Altitude check
+
+If the observed altitude of a flight does not match the altitude of the injected telemetry, this check will fail.
 
 #### Area too large check
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/nominal_behavior.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/nominal_behavior.py
@@ -128,6 +128,22 @@ class NominalBehavior(TestScenario):
                     )
                 )
 
+        # Make sure the injected flights can be identified correctly by the test harness
+        with self.check("Identifiable flights") as check:
+            errors = display_data_evaluator.injected_flights_errors(
+                self._injected_flights
+            )
+            if errors:
+                check.record_failed(
+                    "Injected flights not suitable for test",
+                    Severity.High,
+                    details="When checking the suitability of the flights (as injected) for the test, found:\n"
+                    + "\n".join(errors),
+                    query_timestamps=[
+                        f.query_timestamp for f in self._injected_flights
+                    ],
+                )
+
         config = self._evaluation_configuration.configuration
         # TODO: Replace hardcoded value
         rid_version = RIDVersion.f3411_19


### PR DESCRIPTION
Currently, RID testing in uss_qualifier matches observed flights to expected/injected flights using the observed flight ID.  This is not a reliable method as Display Providers are free to identify flights to their Display Applications with any IDs they see fit, and these IDs do not need to match the IDs specified by the Service Provider.  This PR addresses that issue described in #4 by matching flights by precise 2D position rather than flight ID.  Since Service Providers report actual telemetry when available, latitudes and longitudes should match exactly with the injected telemetry.  To make identification easier, this PR also imposes the constraint that a (lat,lng) 2D position may not appear twice across all injected telemetry.

This PR should resolve #4 to the extent possible with the requirements we have to work with in F3411-19 and F3411-22a.