### PR TITLE
[uss_qualifier] Add in-configuration suite definitions

### DIFF
--- a/monitoring/monitorlib/kml.py
+++ b/monitoring/monitorlib/kml.py
@@ -1,6 +1,3 @@
-# Module to parse KML file.
-
-import logging
 from pykml import parser
 import re
 
@@ -96,9 +93,13 @@ def get_folder_description(folder_elem):
         folder_elem: Folder element from KML.
     """
     description = folder_elem.description
-    return dict(
-        [tuple(j.strip() for j in i.split(":")) for i in str(description).split("\n")]
-    )
+    lines = [line for line in str(description).split("\n") if ":" in line]
+    values = {}
+    for line in lines:
+        cols = [col.strip() for col in line.split(":")]
+        if len(cols) == 2:
+            values[cols[0]] = cols[1]
+    return values
 
 
 def get_kml_content(kml_file, from_string=False):

--- a/monitoring/uss_qualifier/configurations/dev/faa/uft/uft.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/faa/uft/uft.yaml
@@ -1,0 +1,126 @@
+v1:
+    test_run:
+        resources:
+            resource_declarations:
+                # ===== Common resources =====
+                utm_auth:
+                    resource_type: resources.communications.AuthAdapterResource
+                    specification:
+                        environment_variable_containing_auth_spec: AUTH_SPEC
+
+                # ===== F3548 resources =====
+                flight_planners:
+                    resource_type: resources.flight_planning.FlightPlannersResource
+                    dependencies:
+                        auth_adapter: utm_auth
+                    specification:
+                        flight_planners:
+                            # uss1 is the mock_uss directly exposing scdsc functionality
+                            - participant_id: uss8074
+                              injection_base_url: http://host.docker.internal:8074/scdsc
+                            # uss2 uses atproxy, with requests being fulfilled by mock_uss with atproxy_client functionality enabled
+                            - participant_id: uss8075
+                              injection_base_url: http://host.docker.internal:8075/scd
+                scd_dss:
+                    resource_type: resources.astm.f3548.v21.DSSInstanceResource
+                    dependencies:
+                        auth_adapter: utm_auth
+                    specification:
+                        participant_id: uss8082
+                        base_url: http://host.docker.internal:8082
+                conflicting_flights:
+                    resource_type: resources.flight_planning.FlightIntentsResource
+                    specification:
+                        planning_time: '0:05:00'
+                        file_source: file://./test_data/usa/kentland/flight_intents/conflicting_flights.yaml
+                priority_preemption_flights:
+                    resource_type: resources.flight_planning.FlightIntentsResource
+                    specification:
+                        planning_time: '0:05:00'
+                        file_source: test_data.usa.kentland.flight_intents.priority_preemption
+
+                # ===== NetRID resources =====
+                flights_data:
+                    resource_type: resources.netrid.FlightDataResource
+                    specification:
+                        kml_source:
+                            kml_location: file://./test_data/usa/kentland/rid.kml
+                service_providers:
+                    resource_type: resources.netrid.NetRIDServiceProviders
+                    dependencies:
+                        auth_adapter: utm_auth
+                    specification:
+                        service_providers:
+                            -   participant_id: uss8071
+                                injection_base_url: http://host.docker.internal:8071/ridsp/injection
+                observers:
+                    resource_type: resources.netrid.NetRIDObserversResource
+                    dependencies:
+                        auth_adapter: utm_auth
+                    specification:
+                        observers:
+                            -   participant_id: uss8073
+                                observation_base_url: http://host.docker.internal:8073/riddp/observation
+                evaluation_configuration:
+                    resource_type: resources.netrid.EvaluationConfigurationResource
+                    specification: { }
+
+        action:
+            test_suite:
+                resources:  # Resources provided to suite from resource pool (UFT suite resource name: pool resource name)
+                    # SCD
+                    flight_planners: flight_planners
+                    conflicting_flights: conflicting_flights
+                    priority_preemption_flights: priority_preemption_flights
+                    scd_dss: scd_dss
+
+                    # NetRID
+                    flights_data: flights_data
+                    service_providers: service_providers
+                    observers: observers
+                    evaluation_configuration: evaluation_configuration
+
+                suite_definition:  # In-configuration definition of what tests to run
+                    name: UFT automated test suite
+                    resources:  # Resources needed by suite
+                        # SCD
+                        flight_planners: resources.flight_planning.FlightPlannersResource
+                        scd_dss: resources.astm.f3548.v21.DSSInstanceResource
+                        conflicting_flights: resources.flight_planning.FlightIntentsResource
+                        priority_preemption_flights: resources.flight_planning.FlightIntentsResource
+                        nominal_planning_selector: resources.flight_planning.FlightPlannerCombinationSelectorResource?
+                        priority_planning_selector: resources.flight_planning.FlightPlannerCombinationSelectorResource?
+
+                        # NetRID
+                        flights_data: resources.netrid.FlightDataResource
+                        service_providers: resources.netrid.NetRIDServiceProviders
+                        observers: resources.netrid.NetRIDObserversResource
+                        evaluation_configuration: resources.netrid.EvaluationConfigurationResource
+                    actions:
+                        - test_suite:
+                              suite_type: suites.astm.utm.f3548_21
+                              resources:  # Resources needed by F3548-21 suite (F3548 suite resource name: UFT suite resource name)
+                                  conflicting_flights: conflicting_flights
+                                  priority_preemption_flights: priority_preemption_flights
+                                  flight_planners: flight_planners
+                                  dss: scd_dss
+                              on_failure: Continue
+                        - test_scenario:
+                              scenario_type: scenarios.astm.netrid.NominalBehavior
+                              resources:  # Resources needed by RID Nominal Behavior scenario (RID scenario resource name: UFT suite resource name)
+                                  flights_data: flights_data
+                                  service_providers: service_providers
+                                  observers: observers
+                                  evaluation_configuration: evaluation_configuration
+                              on_failure: Continue
+
+    artifacts:
+        tested_roles:
+            report_path: tested_requirements.html
+            roles:
+                - name: Strategic Coordination role
+                  requirement_set: astm.f3548.v21.scd
+                  participants:
+                      - uss1
+                      - uss2
+        "$ref": ../../artifacts.yaml#/relative

--- a/monitoring/uss_qualifier/reports/graphs.py
+++ b/monitoring/uss_qualifier/reports/graphs.py
@@ -132,7 +132,7 @@ def _make_test_suite_nodes(
     new_nodes = None
     nodes: List[Node] = []
     children: List[NodeName] = []
-    definition = TestSuiteDefinition.load(declaration.suite_type)
+    definition = TestSuiteDefinition.load_from_declaration(declaration)
     for action_report, action in zip(report.actions, definition.actions):
         action_nodes = _translate_ids(nodes_by_id, action.get_resource_links())
         if "test_suite" in action_report:

--- a/monitoring/uss_qualifier/resources/netrid/simulation/kml_flights.py
+++ b/monitoring/uss_qualifier/resources/netrid/simulation/kml_flights.py
@@ -8,6 +8,8 @@ import s2sphere
 import uuid
 from datetime import timedelta
 from shapely.geometry import LineString, Point, Polygon
+
+from implicitdict import StringBasedDateTime
 from monitoring.monitorlib.geo import flatten, unflatten
 from monitoring.monitorlib import kml
 from monitoring.uss_qualifier.resources.netrid.flight_data import (
@@ -205,7 +207,7 @@ def generate_flight_record(
         )
         aircraft_height = None
         rid_aircraft_state = RIDAircraftState(
-            timestamp=timestamp_isoformat,
+            timestamp=StringBasedDateTime(timestamp_isoformat),
             operational_status="Airborne",
             position=aircraft_position,
             height=aircraft_height,
@@ -214,7 +216,7 @@ def generate_flight_record(
             timestamp_accuracy=float(
                 flight_description.get("timestamp_accuracy", "0.0")
             ),
-            speed_accuracy=flight_description.get("speed_accuracy", ""),
+            speed_accuracy=flight_description["speed_accuracy"],
             vertical_speed=0.0,
         )
         flight_telemetry.append(rid_aircraft_state)
@@ -234,7 +236,7 @@ def generate_flight_record(
     )
 
     return FullFlightRecord(
-        reference_time=now_isoformat,
+        reference_time=StringBasedDateTime(now_isoformat),
         states=flight_telemetry,
         flight_details=rid_details,
         aircraft_type=flight_description.get("aircraft_type"),

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/nominal_behavior.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/nominal_behavior.py
@@ -115,6 +115,7 @@ class NominalBehavior(TestScenario):
                     summary="Error injecting test flight",
                     severity=Severity.High,
                     details=f"Attempting to inject a test flight into {target.participant_id}, encountered status code {query.status_code}: {str(e)}",
+                    query_timestamps=[query.request.timestamp],
                 )
                 return False
             # TODO: Validate injected flights, especially to make sure they contain the specified injection IDs

--- a/monitoring/uss_qualifier/suites/suite.py
+++ b/monitoring/uss_qualifier/suites/suite.py
@@ -146,7 +146,7 @@ class TestSuite(object):
         resources: Dict[ResourceID, ResourceType],
     ):
         self.declaration = declaration
-        self.definition = TestSuiteDefinition.load(declaration.suite_type)
+        self.definition = TestSuiteDefinition.load_from_declaration(declaration)
         local_resources = {
             local_resource_id: resources[parent_resource_id]
             for local_resource_id, parent_resource_id in declaration.resources.items()
@@ -173,7 +173,7 @@ class TestSuite(object):
     def run(self) -> TestSuiteReport:
         report = TestSuiteReport(
             name=self.definition.name,
-            suite_type=self.declaration.suite_type,
+            suite_type=self.declaration.type_name,
             documentation_url="",  # TODO: Populate correctly
             start_time=StringBasedDateTime(datetime.utcnow()),
             actions=[],

--- a/monitoring/uss_qualifier/test_data/usa/kentland/rid.kml
+++ b/monitoring/uss_qualifier/test_data/usa/kentland/rid.kml
@@ -1,0 +1,347 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:kml="http://www.opengis.net/kml/2.2" xmlns:atom="http://www.w3.org/2005/Atom">
+<Document>
+	<name>rid.kml</name>
+	<StyleMap id="m_ylw-pushpin">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#s_ylw-pushpin</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#s_ylw-pushpin_hl0</styleUrl>
+		</Pair>
+	</StyleMap>
+	<StyleMap id="m_ylw-pushpin0">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#s_ylw-pushpin0</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#s_ylw-pushpin_hl</styleUrl>
+		</Pair>
+	</StyleMap>
+	<StyleMap id="msn_ylw-pushpin">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#sn_ylw-pushpin</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#sh_ylw-pushpin</styleUrl>
+		</Pair>
+	</StyleMap>
+	<StyleMap id="msn_ylw-pushpin0">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#sn_ylw-pushpin0</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#sh_ylw-pushpin2</styleUrl>
+		</Pair>
+	</StyleMap>
+	<StyleMap id="msn_ylw-pushpin1">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#sn_ylw-pushpin1</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#sh_ylw-pushpin1</styleUrl>
+		</Pair>
+	</StyleMap>
+	<StyleMap id="msn_ylw-pushpin2">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#sn_ylw-pushpin2</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#sh_ylw-pushpin0</styleUrl>
+		</Pair>
+	</StyleMap>
+	<Style id="s_ylw-pushpin">
+		<IconStyle>
+			<scale>1.1</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+	</Style>
+	<Style id="s_ylw-pushpin0">
+		<IconStyle>
+			<scale>1.1</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<PolyStyle>
+			<fill>0</fill>
+		</PolyStyle>
+	</Style>
+	<Style id="s_ylw-pushpin_hl">
+		<IconStyle>
+			<scale>1.3</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<PolyStyle>
+			<fill>0</fill>
+		</PolyStyle>
+	</Style>
+	<Style id="s_ylw-pushpin_hl0">
+		<IconStyle>
+			<scale>1.3</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+	</Style>
+	<Style id="sh_ylw-pushpin">
+		<IconStyle>
+			<scale>1.3</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<BalloonStyle>
+		</BalloonStyle>
+		<PolyStyle>
+			<fill>0</fill>
+		</PolyStyle>
+	</Style>
+	<Style id="sh_ylw-pushpin0">
+		<IconStyle>
+			<scale>1.3</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<BalloonStyle>
+		</BalloonStyle>
+		<LineStyle>
+			<color>ff0880fd</color>
+		</LineStyle>
+		<PolyStyle>
+			<fill>0</fill>
+		</PolyStyle>
+	</Style>
+	<Style id="sh_ylw-pushpin1">
+		<IconStyle>
+			<scale>1.3</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<BalloonStyle>
+		</BalloonStyle>
+		<LineStyle>
+			<color>ffffff20</color>
+		</LineStyle>
+	</Style>
+	<Style id="sh_ylw-pushpin2">
+		<IconStyle>
+			<scale>1.3</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<BalloonStyle>
+		</BalloonStyle>
+		<PolyStyle>
+			<fill>0</fill>
+		</PolyStyle>
+	</Style>
+	<Style id="sn_ylw-pushpin">
+		<IconStyle>
+			<scale>1.1</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<BalloonStyle>
+		</BalloonStyle>
+		<PolyStyle>
+			<fill>0</fill>
+		</PolyStyle>
+	</Style>
+	<Style id="sn_ylw-pushpin0">
+		<IconStyle>
+			<scale>1.1</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<BalloonStyle>
+		</BalloonStyle>
+		<PolyStyle>
+			<fill>0</fill>
+		</PolyStyle>
+	</Style>
+	<Style id="sn_ylw-pushpin1">
+		<IconStyle>
+			<scale>1.1</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<BalloonStyle>
+		</BalloonStyle>
+		<LineStyle>
+			<color>ffffff20</color>
+		</LineStyle>
+	</Style>
+	<Style id="sn_ylw-pushpin2">
+		<IconStyle>
+			<scale>1.1</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<BalloonStyle>
+		</BalloonStyle>
+		<LineStyle>
+			<color>ff0880fd</color>
+		</LineStyle>
+		<PolyStyle>
+			<fill>0</fill>
+		</PolyStyle>
+	</Style>
+	<Folder>
+		<name>kentland</name>
+		<open>1</open>
+		<Folder>
+			<name>flight: dairy circle</name>
+			<open>1</open>
+			<description>serial_number: EXAMPLE_SERIAL1
+operation_description: Circle around dairy complex
+operator_id: EXAMPLE_OPERATOR1
+registration_number: EXAMPLE_REGISTRATION1
+aircraft_type: Helicopter
+operator_name: UFT Participant 1
+timestamp_accuracy: 1.0
+speed_accuracy: SA3mps
+sample_rate: 1.0
+accuracy_h: HAUnknown
+accuracy_v: VAUnknown</description>
+			<Placemark>
+				<name>Dairy south</name>
+				<styleUrl>#msn_ylw-pushpin1</styleUrl>
+				<LineString>
+					<tessellate>1</tessellate>
+					<coordinates>
+						-80.5778764450798,37.19720908658443,0 -80.5777768286344,37.19728133750581,0 -80.57773082850338,37.19731267525504,0 -80.57768438827864,37.19734407176483,0 -80.5776495089373,37.19737060757612,0 -80.57758729162289,37.19739859846299,0 -80.57752505433055,37.19742659822762,0 -80.57745907863931,37.19746716669243,0 -80.57738688748377,37.19749977218039,0 -80.5773139829071,37.19753251518929,0 -80.57726189529737,37.19755590765877,0 -80.57720073033923,37.19758377509351,0 -80.57713952986137,37.19761165052821,0 -80.5770922006789,37.19762232156152,0 -80.57704572028027,37.1976328294542,0 -80.57699605790832,37.19765589226827,0 -80.57692976063167,37.19767568841888,0 -80.57686693474291,37.19768293841224,0 -80.57680950096041,37.19769812988639,0 -80.57675716062005,37.19772167169791,0 -80.57669780014476,37.19773727173713,0 -80.57665589744273,37.19775608507496,0 -80.57660747428443,37.19776690799308,0 -80.57653408426039,37.19779981779911,0 -80.57648545595988,37.19781061083629,0 -80.57643294743279,37.19783418642947,0 -80.57638081542508,37.19785767634002,0 -80.57631758690576,37.19788593026246,0 -80.57627652382901,37.19792560919144,0 -80.57624477218545,37.19793976249941,0 -80.57619201744512,37.19796331616435,0 -80.57613926555615,37.19798686815086,0 -80.57609722344614,37.19800569769228,0 -80.57602377092753,37.19803864208959,0 -80.57598179034363,37.19805747107653,0 -80.57593980330259,37.1980763025139,0 -80.57589362689288,37.19810791057883,0 -80.57584750897499,37.19813955138073,0 -80.57579449383257,37.19816309781955,0 -80.57574778047588,37.1981947510941,0 -80.57570102501548,37.19822641180827,0 -80.57565984068103,37.19826618049159,0 -80.57561265049266,37.19829785713759,0 -80.57558669615106,37.19832010335504,0 -80.57553979783128,37.19835174193695,0 -80.57550381963671,37.19837875090242,0 -80.57544704049415,37.19841521011799,0 -80.57541174025101,37.19844227621081,0 -80.57536622157269,37.19847412545869,0 -80.57532587181626,37.19851408521055,0 -80.57530652519603,37.1985446173658,0 -80.57527657845981,37.19857990405448,0 -80.57524660535501,37.19861522132099,0 -80.57520632514922,37.1986553299863,0 -80.57517656532367,37.19869077694575,0 -80.57514676122008,37.19872626592397,0 -80.57510632627809,37.19876652055684,0 -80.57507015330373,37.19879377980233,0 -80.57504015016816,37.19882931344202,0 -80.57499917572656,37.19886954985638,0 -80.5749568693238,37.19890939748394,0 -80.57492559163907,37.19894458937578,0 -80.57489432344305,37.19897977243097,0 -80.57487389110439,37.19901029538762,0 -80.57483734825645,37.19905814447889,0 -80.57481206288159,37.19910155549907,0 -80.5747870692686,37.19914510567172,0 -80.57475637213105,37.19918053299198,0 -80.57473151814611,37.19922419211069,0 -80.57472330783241,37.19927145027812,0 -80.57470912404166,37.19931045163637,0 -80.57467827068737,37.19934588320876,0 -80.57466436991389,37.19938512954617,0 -80.57463388039599,37.19942087328005,0 -80.57458798171328,37.19947440516556,0 -80.57455263979614,37.19952323433175,0 -80.57452219907877,37.19955917243859,0 -80.5744976811034,37.19960349727569,0 -80.57447777755191,37.19963467500811,0 -80.57443657548973,37.19967548014522,0 -80.57440107466564,37.19972447346963,0 -80.57437033784461,37.19976039117743,0 -80.57433359917643,37.19978792014409,0 -80.57430263971628,37.19982362876906,0 -80.57425497291501,37.19985565013072,0 -80.57422426067119,37.19989179537554,0 -80.57418764753194,37.19991960064916,0 -80.57414632126304,37.19996074653258,0 -80.57411542863196,37.19999679585158,0 -80.57409522866878,37.20002810477575,0 -80.57405359318189,37.20006898237141,0 -80.57401194486573,37.20010989867604,0 -80.57398097740159,37.20014604845946,0 -80.57393938818348,37.20018723920186,0 -80.5739085389429,37.20022379824662,0 -80.57387749463898,37.20026005450408,0 -80.57384659916293,37.20029656055951,0 -80.57382620362222,37.20032810833365,0 -80.57380581629218,37.2003595970273,0 -80.57376985205539,37.2004092411357,0 -80.57373977695701,37.20046749254768,0 -80.57372532895349,37.2005077842383,0 -80.57371090677958,37.20054831390769,0 -80.57368572073288,37.20059377599405,0 -80.57366050333133,37.20063929534206,0 -80.57365677693902,37.20067511289658,0 -80.57364118208753,37.20069356998238,0 -80.57360724394887,37.20078863712937,0 -80.57358665783921,37.20082030520007,0 -80.57357197536018,37.20086067712546,0 -80.57355246581429,37.20091499399152,0 -80.57354374748427,37.20096457999171,0 -80.57352420402184,37.20101912964533,0 -80.57351061854799,37.20108272384585,0 -80.57350674484402,37.20111880464864,0 -80.57349794414419,37.20116857015283,0 -80.57350590918077,37.20122224254838,0 -80.57348619188703,37.20127663148679,0 -80.57348818394421,37.20132134922118,0 -80.57348424167023,37.20135734785288,0 -80.57349217534835,37.2014109324365,0 -80.57350008710428,37.20146430188367,0 -80.57350200496631,37.20150863070424,0 -80.57351483536593,37.20154821626734,0 -80.57351676032992,37.20159260923267,0 -80.57353059117055,37.20165458126355,0 -80.57353754149592,37.20168589080885,0 -80.57354553983663,37.20173982576041,0 -80.57354748885547,37.20178491494669,0 -80.57353869245951,37.20183526742923,0 -80.57353583592621,37.201894864754,0 -80.57353188390458,37.20193127129742,0 -80.57352280452324,37.2019804037467,0 -80.57351472389033,37.20205220190878,0 
+					</coordinates>
+				</LineString>
+			</Placemark>
+			<Placemark>
+				<name>alt: Runway</name>
+				<styleUrl>#m_ylw-pushpin0</styleUrl>
+				<Polygon>
+					<tessellate>1</tessellate>
+					<altitudeMode>absolute</altitudeMode>
+					<outerBoundaryIs>
+						<LinearRing>
+							<coordinates>
+								-80.57850709375344,37.19696983131671,529 -80.57836943742444,37.1968206451378,529 -80.57757910966818,37.19730804793311,529 -80.57771657931552,37.197467166625,529 -80.57850709375344,37.19696983131671,529 
+							</coordinates>
+						</LinearRing>
+					</outerBoundaryIs>
+				</Polygon>
+			</Placemark>
+			<Placemark>
+				<name>alt: High</name>
+				<styleUrl>#msn_ylw-pushpin</styleUrl>
+				<Polygon>
+					<extrude>1</extrude>
+					<tessellate>1</tessellate>
+					<altitudeMode>absolute</altitudeMode>
+					<outerBoundaryIs>
+						<LinearRing>
+							<coordinates>
+								-80.57683884039908,37.19812412967849,655 -80.57612876354007,37.19744757353455,655 -80.57279268045139,37.19884365512596,655 -80.57458740723276,37.20085102219347,655 -80.57683884039908,37.19812412967849,655 
+							</coordinates>
+						</LinearRing>
+					</outerBoundaryIs>
+				</Polygon>
+			</Placemark>
+			<Placemark>
+				<name>alt: Low</name>
+				<styleUrl>#msn_ylw-pushpin0</styleUrl>
+				<Polygon>
+					<extrude>1</extrude>
+					<tessellate>1</tessellate>
+					<altitudeMode>absolute</altitudeMode>
+					<outerBoundaryIs>
+						<LinearRing>
+							<coordinates>
+								-80.57561732912529,37.20189206292986,570 -80.5743256811095,37.2044692971395,570 -80.57733777134109,37.20453751876916,570 -80.57865313153285,37.20209835906732,570 -80.57561732912529,37.20189206292986,570 
+							</coordinates>
+						</LinearRing>
+					</outerBoundaryIs>
+				</Polygon>
+			</Placemark>
+			<Placemark>
+				<name>speed: Departure (5)</name>
+				<styleUrl>#msn_ylw-pushpin2</styleUrl>
+				<Polygon>
+					<tessellate>1</tessellate>
+					<outerBoundaryIs>
+						<LinearRing>
+							<coordinates>
+								-80.57840012928878,37.19642068766655,0 -80.57725966321578,37.19688950425997,0 -80.57790987491153,37.197746184721,0 -80.57904101928465,37.19715307178074,0 -80.57840012928878,37.19642068766655,0 
+							</coordinates>
+						</LinearRing>
+					</outerBoundaryIs>
+				</Polygon>
+			</Placemark>
+			<Placemark>
+				<name>speed: Enroute (30)</name>
+				<styleUrl>#msn_ylw-pushpin2</styleUrl>
+				<Polygon>
+					<tessellate>1</tessellate>
+					<outerBoundaryIs>
+						<LinearRing>
+							<coordinates>
+								-80.57800768901809,37.19833708385374,0 -80.57295402573506,37.19978873922927,0 -80.57194576874815,37.20375460145004,0 -80.57651619071703,37.20461952158183,0 -80.58094687700341,37.20169420910003,0 -80.57800768901809,37.19833708385374,0 
+							</coordinates>
+						</LinearRing>
+					</outerBoundaryIs>
+				</Polygon>
+			</Placemark>
+			<Placemark>
+				<name>operator_location</name>
+				<LookAt>
+					<longitude>-80.57846286902858</longitude>
+					<latitude>37.19696299174171</latitude>
+					<altitude>0</altitude>
+					<heading>-40.47980710991282</heading>
+					<tilt>3.701659637926226</tilt>
+					<range>517.6832013653914</range>
+					<gx:altitudeMode>relativeToSeaFloor</gx:altitudeMode>
+				</LookAt>
+				<styleUrl>#m_ylw-pushpin</styleUrl>
+				<Point>
+					<gx:drawOrder>1</gx:drawOrder>
+					<coordinates>-80.57812675723362,37.19736628374068,0</coordinates>
+				</Point>
+			</Placemark>
+		</Folder>
+	</Folder>
+</Document>
+</kml>


### PR DESCRIPTION
Originally, uss_qualifier accepted just a test suite name in the configuration to define what to run.  This was later expanded to specification of a test suite action (a test suite, test scenario, or action generator) to support running a specific scenario rather than suite.  This PR takes this generalization one step further and enables full definition of a test suite within a configuration file -- this will allow full flexibility for how users define what tests they want to run.

An example configuration (uft.yaml) is added, along with a new injectable RID file (rid.kml), to demonstrate this capability (and also further UFT).

Some fixes were necessary in the KML -> NetRID test data conversion code.