### PR TITLE
[uss_qualifier] Directly query Service Providers in RID nominal behavior test

### DIFF
--- a/monitoring/uss_qualifier/configurations/dev/faa/uft/uft.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/faa/uft/uft.yaml
@@ -64,6 +64,15 @@ v1:
                 evaluation_configuration:
                     resource_type: resources.netrid.EvaluationConfigurationResource
                     specification: { }
+                rid_dss_pool:
+                    resource_type: resources.astm.f3411.DSSInstancesResource
+                    dependencies:
+                        auth_adapter: utm_auth
+                    specification:
+                        dss_instances:
+                            - participant_id: uss8082
+                              rid_version: F3411-19
+                              base_url: http://host.docker.internal:8082
 
         action:
             test_suite:
@@ -79,6 +88,7 @@ v1:
                     service_providers: service_providers
                     observers: observers
                     evaluation_configuration: evaluation_configuration
+                    rid_dss_pool: rid_dss_pool
 
                 suite_definition:  # In-configuration definition of what tests to run
                     name: UFT automated test suite
@@ -96,6 +106,7 @@ v1:
                         service_providers: resources.netrid.NetRIDServiceProviders
                         observers: resources.netrid.NetRIDObserversResource
                         evaluation_configuration: resources.netrid.EvaluationConfigurationResource
+                        rid_dss_pool: resources.astm.f3411.DSSInstancesResource?
                     actions:
                         - test_suite:
                               suite_type: suites.astm.utm.f3548_21
@@ -112,6 +123,7 @@ v1:
                                   service_providers: service_providers
                                   observers: observers
                                   evaluation_configuration: evaluation_configuration
+                                  dss_pool: rid_dss_pool
                               on_failure: Continue
 
     artifacts:

--- a/monitoring/uss_qualifier/reports/report.py
+++ b/monitoring/uss_qualifier/reports/report.py
@@ -81,8 +81,11 @@ class TestStepReport(ImplicitDict):
     end_time: Optional[StringBasedDateTime]
     """Time at which the test step completed or encountered an error"""
 
-    def has_critical_problem(self):
+    def has_critical_problem(self) -> bool:
         return any(fc.severity == Severity.Critical for fc in self.failed_checks)
+
+    def successful(self) -> bool:
+        return False if self.failed_checks else True
 
 
 class TestCaseReport(ImplicitDict):

--- a/monitoring/uss_qualifier/resources/astm/f3411/dss.py
+++ b/monitoring/uss_qualifier/resources/astm/f3411/dss.py
@@ -49,7 +49,7 @@ class DSSInstancesSpecification(ImplicitDict):
     dss_instances: List[DSSInstanceSpecification]
 
 
-class DSSInstancesResource(Resource[DSSInstanceSpecification]):
+class DSSInstancesResource(Resource[DSSInstancesSpecification]):
     dss_instances: List[DSSInstance]
 
     def __init__(

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/display_data_evaluator.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/display_data_evaluator.py
@@ -411,25 +411,24 @@ class RIDObservationEvaluator(object):
         dp_observation: FetchedFlights,
         rect: s2sphere.LatLngRect,
     ) -> None:
-        if not dp_observation.dss_isa_query.success:
-            # Note: This step currently uses the DSS endpoint to perform a one-time query for ISAs, but this
-            # endpoint is not strictly required.  The PUT Subscription endpoint, followed immediately by the
-            # DELETE Subscription would produce the same result, but because uss_qualifier does not expose any
-            # endpoints (and therefore cannot provide a callback/base URL), calling the one-time query endpoint
-            # is currently much cleaner.  If this test is applied to a DSS that does not implement the one-time
-            # ISA query endpoint, this check can be adapted.
-            with self._test_scenario.check("ISA query") as check:
-                if not dp_observation.dss_isa_query.success:
-                    check.record_failed(
-                        summary="Could not query ISAs from DSS",
-                        severity=Severity.Medium,
-                        details=f"Query to {self._dss.participant_id}'s DSS at {dp_observation.dss_isa_query.query.request.url} failed {dp_observation.dss_isa_query.query.status_code}",
-                        participants=[self._dss.participant_id],
-                        query_timestamps=[
-                            dp_observation.dss_isa_query.query.request.initiated_at.datetime
-                        ],
-                    )
-            return
+        # Note: This step currently uses the DSS endpoint to perform a one-time query for ISAs, but this
+        # endpoint is not strictly required.  The PUT Subscription endpoint, followed immediately by the
+        # DELETE Subscription would produce the same result, but because uss_qualifier does not expose any
+        # endpoints (and therefore cannot provide a callback/base URL), calling the one-time query endpoint
+        # is currently much cleaner.  If this test is applied to a DSS that does not implement the one-time
+        # ISA query endpoint, this check can be adapted.
+        with self._test_scenario.check("ISA query") as check:
+            if not dp_observation.dss_isa_query.success:
+                check.record_failed(
+                    summary="Could not query ISAs from DSS",
+                    severity=Severity.Medium,
+                    details=f"Query to {self._dss.participant_id}'s DSS at {dp_observation.dss_isa_query.query.request.url} failed {dp_observation.dss_isa_query.query.status_code}",
+                    participants=[self._dss.participant_id],
+                    query_timestamps=[
+                        dp_observation.dss_isa_query.query.request.initiated_at.datetime
+                    ],
+                )
+                return
 
         observed_flights = []
         for uss_query in dp_observation.uss_flight_queries.values():

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/nominal_behavior.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/nominal_behavior.md
@@ -59,7 +59,7 @@ The timestamps of the injected telemetry usually start in the future.  If a flig
 
 #### Missing flight check
 
-**[astm.f3411.v19.NET0610](../../../requirements/astm/f3411/v19.md)** require that SPs make all UAS operations discoverable over the duration of the flight plus *NetMaxNearRealTimeDataPeriod*, so each injected flight should be observable during this time.  If a flight is not observed during its appropriate time period, this check will fail.
+**[astm.f3411.v19.NET0610](../../../requirements/astm/f3411/v19.md)** requires that SPs make all UAS operations discoverable over the duration of the flight plus *NetMaxNearRealTimeDataPeriod*, so each injected flight should be observable during this time.  If a flight is not observed during its appropriate time period, this check will fail.
 
 **[astm.f3411.v19.NET0710](../../../requirements/astm/f3411/v19.md)** requires a Service Provider to implement the GET flights endpoint.  This check will also fail if uss_qualifier cannot query that endpoint (specified in the ISA present in the DSS) successfully.
 
@@ -73,7 +73,7 @@ The timestamps of the injected telemetry usually start in the future.  If a flig
 
 #### Area too large check
 
-**[astm.f3411.v19.NET0430](../../../requirements/astm/f3411/v19.md)** require that a NetRID Display Provider reject a request for a very large view area with a diagonal greater than *NetMaxDisplayAreaDiagonal*.  If such a large view is requested and a 413 error code is not received, then this check will fail.
+**[astm.f3411.v19.NET0430](../../../requirements/astm/f3411/v19.md)** requires that a NetRID Display Provider rejects a request for a very large view area with a diagonal greater than *NetMaxDisplayAreaDiagonal*.  If such a large view is requested and a 413 error code is not received, then this check will fail.
 
 ### Observer polling test step
 

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_19.yaml
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_19.yaml
@@ -18,4 +18,5 @@ actions:
         service_providers: service_providers
         observers: observers
         evaluation_configuration: evaluation_configuration
+        dss_pool: dss_instances
     on_failure: Continue


### PR DESCRIPTION
Currently, the RID nominal behavior test is completely independent of which RID standard is used because it only tests whether injections cause observations.  The down side of this approach is that the responsible party (between the Service Provider and Display Provider) cannot easily be assigned.  This PR adds an optional feature to that scenario that will cause uss_qualifier to directly query the DSS and Service Provider when DSS information is provided.  The responses to these queries are checked first before the end-to-end observation is performed.