### PR TITLE
[uss_qualifier] Add option to redact access token signatures

### DIFF
--- a/monitoring/uss_qualifier/configurations/configuration.py
+++ b/monitoring/uss_qualifier/configurations/configuration.py
@@ -45,9 +45,17 @@ class GraphConfiguration(ImplicitDict):
     """Path of GraphViz (.gv) text file to contain a visualization of the test run"""
 
 
-class ArtifactsConfiguration(ImplicitDict):
-    report_path: Optional[str] = None
+class ReportConfiguration(ImplicitDict):
+    report_path: str
     """File name of the report to write (if test_config provided) or read (if test_config not provided)"""
+
+    redact_access_tokens: bool = False
+    """When True, look for instances of "Authorization" keys in the report with values starting "Bearer " and redact the siganture from those access tokens"""
+
+
+class ArtifactsConfiguration(ImplicitDict):
+    report: Optional[ReportConfiguration] = None
+    """Configuration for report generation"""
 
     graph: Optional[GraphConfiguration] = None
     """If specified, configuration describing a desired graph visualization summarizing the test run"""

--- a/monitoring/uss_qualifier/configurations/dev/artifacts.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/artifacts.yaml
@@ -1,6 +1,8 @@
 # These are configuration parameters for artifacts in a USSQualifierConfiguration
 # to be produced in the uss_qualifier folder.
 relative:
-  report_path: report.json
+  report:
+    report_path: report.json
+    redact_access_tokens: true
   graph:
     gv_path: report.gv

--- a/monitoring/uss_qualifier/configurations/dev/faa/uft/local_message_signing.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/faa/uft/local_message_signing.yaml
@@ -59,7 +59,8 @@ v1:
           dss: dss
 
   artifacts:
-    report_path: report.json
+    report:
+      report_path: report.json
     tested_roles:
       report_path: tested_requirements.html
       roles: []

--- a/monitoring/uss_qualifier/configurations/dev/geoawareness_cis.json
+++ b/monitoring/uss_qualifier/configurations/dev/geoawareness_cis.json
@@ -25,7 +25,9 @@
         "report_path": "tested_requirements.html",
         "roles": []
       },
-      "report_path": "report.json",
+      "report": {
+        "report_path": "report.json",
+      },
       "graph": {
         "gv_path": "report.gv"
       }

--- a/monitoring/uss_qualifier/configurations/dev/non_docker/local_test.json
+++ b/monitoring/uss_qualifier/configurations/dev/non_docker/local_test.json
@@ -21,7 +21,8 @@
             "conflicting_flights": "conflicting_flights",
             "priority_preemption_flights": "priority_preemption_flights",
             "invalid_flight_auth_flights": "invalid_flight_auth_flights",
-            "dss": "dss"
+            "dss": "dss",
+            "netrid_dss_instances": "netrid_dss_instances"
           }
         }
       }

--- a/monitoring/uss_qualifier/configurations/dev/non_docker/resources.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/non_docker/resources.yaml
@@ -29,6 +29,18 @@ net_rid:
   netrid_observation_evaluation_configuration:
     resource_type: resources.netrid.EvaluationConfigurationResource
     specification: {}
+  netrid_dss_instances:
+      resource_type: resources.astm.f3411.DSSInstancesResource
+      dependencies:
+          auth_adapter: utm_auth
+      specification:
+          dss_instances:
+              - participant_id: uss1
+                rid_version: F3411-19
+                base_url: http://localhost:8082
+              - participant_id: uss2
+                rid_version: F3411-19
+                base_url: http://localhost:8082
 
 net_rid_sims:
   adjacent_circular_flights_data:
@@ -50,7 +62,7 @@ net_rid_sims:
       flight_record_collection_path: "./test_data/usa/netrid/dcdemo_flights.json"
 
 flight_auth:
-  $ref: '#/f3548_che'
+  $ref: '#/f3548'
   invalid_flight_auth_flights:
     resource_type: resources.flight_planning.FlightIntentsResource
     specification:

--- a/monitoring/uss_qualifier/configurations/dev/self_contained_f3548.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/self_contained_f3548.yaml
@@ -71,8 +71,10 @@ v1:
   # relative to where uss_qualifier is executed from, and are located inside the
   # Docker container executing uss_qualifier.
   artifacts:
-    # Path to main report output
-    report_path: report.json
+    report:
+      # Path to main report output
+      report_path: report.json
+      redact_access_tokens: true
 
     # Information about a report including a list of roles tested and which participants are attempting to fill them
     tested_roles:

--- a/monitoring/uss_qualifier/fileio.py
+++ b/monitoring/uss_qualifier/fileio.py
@@ -243,7 +243,7 @@ def _replace_refs(
             ref_content = [m.value for m in ref_json_path.find(content)]
             if len(ref_content) != 1:
                 raise RuntimeError(
-                    f'Unexpectedly found {len(ref_content)} matches for local $ref path "{ref_path}"'
+                    f'Unexpectedly found {len(ref_content)} matches for local $ref path "{ref_path}" in {context_file_name}'
                 )
             ref_content = ref_content[0]
         for k, v in ref_content.items():


### PR DESCRIPTION
Currently, uss_qualifier reports contain every detail of interactions with other USSs including access tokens.  This makes the reports not suitable to share directly/immediately with others because the access tokens could be reused to impersonate the USS running uss_qualifier.  This PR addresses that issue by introducing an option to redact access token signatures from the test report.