### PR TITLE
[mock_uss] Add F3411-22a support to mock_uss

### DIFF
--- a/monitoring/mock_uss/riddp/__init__.py
+++ b/monitoring/mock_uss/riddp/__init__.py
@@ -1,0 +1,26 @@
+from . import config
+from monitoring.mock_uss import webapp, require_config_value
+from monitoring.mock_uss.config import KEY_DSS_URL, KEY_AUTH_SPEC
+from monitoring.mock_uss.riddp.config import KEY_RID_VERSION
+from monitoring.monitorlib import auth
+from monitoring.monitorlib.infrastructure import UTMClientSession
+from monitoring.monitorlib.rid import RIDVersion
+
+
+require_config_value(KEY_DSS_URL)
+require_config_value(KEY_AUTH_SPEC)
+require_config_value(KEY_RID_VERSION)
+
+if webapp.config[KEY_RID_VERSION] == RIDVersion.f3411_19:
+    _dss_base_url = webapp.config[KEY_DSS_URL]
+elif webapp.config[KEY_RID_VERSION] == RIDVersion.f3411_22a:
+    _dss_base_url = webapp.config[KEY_DSS_URL] + "/rid/v2"
+else:
+    raise NotImplementedError(
+        f"Cannot construct DSS base URL using RID version {webapp.config[KEY_RID_VERSION]}"
+    )
+
+utm_client = UTMClientSession(
+    _dss_base_url,
+    auth.make_auth_adapter(webapp.config[KEY_AUTH_SPEC]),
+)

--- a/monitoring/mock_uss/riddp/config.py
+++ b/monitoring/mock_uss/riddp/config.py
@@ -1,0 +1,10 @@
+from monitoring.mock_uss import import_environment_variable
+from monitoring.monitorlib.rid import RIDVersion
+
+KEY_RID_VERSION = "MOCK_USS_RID_VERSION"
+
+import_environment_variable(
+    KEY_RID_VERSION,
+    default=RIDVersion.f3411_19,
+    mutator=lambda s: RIDVersion(s),
+)

--- a/monitoring/mock_uss/riddp/routes_observation.py
+++ b/monitoring/mock_uss/riddp/routes_observation.py
@@ -12,9 +12,9 @@ from monitoring.monitorlib.fetch import rid as fetch
 from monitoring.monitorlib.fetch.rid import Flight, FetchedISAs
 from monitoring.monitorlib.rid import RIDVersion
 from monitoring.monitorlib.rid_automated_testing import observation_api
-from monitoring.mock_uss import resources, webapp
+from monitoring.mock_uss import webapp
 from monitoring.mock_uss.auth import requires_scope
-from . import clustering, database
+from . import clustering, database, utm_client
 from .behavior import DisplayProviderBehavior
 from .config import KEY_RID_VERSION
 from .database import db
@@ -92,7 +92,7 @@ def riddp_display_data() -> Tuple[str, int]:
 
     # Get ISAs in the DSS
     t = arrow.utcnow().datetime
-    isa_list: FetchedISAs = fetch.isas(view, t, t, rid_version, resources.utm_client)
+    isa_list: FetchedISAs = fetch.isas(view, t, t, rid_version, utm_client)
     if not isa_list.success:
         msg = f"Error fetching ISAs from DSS: {isa_list.error}"
         logger.error(msg)
@@ -110,7 +110,7 @@ def riddp_display_data() -> Tuple[str, int]:
         if uss in behavior.do_not_display_flights_from:
             continue
         flights_response = fetch.uss_flights(
-            flights_url, view, True, rid_version, resources.utm_client
+            flights_url, view, True, rid_version, utm_client
         )
         if not flights_response.success:
             msg = (

--- a/monitoring/mock_uss/riddp/routes_observation.py
+++ b/monitoring/mock_uss/riddp/routes_observation.py
@@ -4,26 +4,24 @@ import arrow
 import flask
 from loguru import logger
 import s2sphere
-from uas_standards.astm.f3411.v19.api import ErrorResponse, RIDFlight
-from uas_standards.astm.f3411.v19.constants import (
-    Scope,
-    NetMaxDisplayAreaDiagonalKm,
-    NetDetailsMaxDisplayAreaDiagonalKm,
-)
+from uas_standards.astm.f3411.v19.api import ErrorResponse
+from uas_standards.astm.f3411.v19.constants import Scope
 
 from monitoring.monitorlib import geo
 from monitoring.monitorlib.fetch import rid as fetch
+from monitoring.monitorlib.fetch.rid import Flight, FetchedISAs
+from monitoring.monitorlib.rid import RIDVersion
 from monitoring.monitorlib.rid_automated_testing import observation_api
 from monitoring.mock_uss import resources, webapp
 from monitoring.mock_uss.auth import requires_scope
 from . import clustering, database
 from .behavior import DisplayProviderBehavior
+from .config import KEY_RID_VERSION
 from .database import db
-from ...monitorlib.rid import RIDVersion
 
 
 def _make_flight_observation(
-    flight: RIDFlight, view: s2sphere.LatLngRect
+    flight: Flight, view: s2sphere.LatLngRect
 ) -> observation_api.Flight:
     paths: List[List[observation_api.Position]] = []
     current_path: List[observation_api.Position] = []
@@ -36,11 +34,9 @@ def _make_flight_observation(
 
     # Decompose recent positions into a list of contiguous paths
     for p in flight.recent_positions:
-        lat = p.position.lat
-        lng = p.position.lng
-        position_report = observation_api.Position(lat=lat, lng=lng, alt=p.position.alt)
+        position_report = observation_api.Position(lat=p.lat, lng=p.lng, alt=p.alt)
 
-        inside_view = lat_min <= lat <= lat_max and lng_min <= lng <= lng_max
+        inside_view = lat_min <= p.lat <= lat_max and lng_min <= p.lng <= lng_max
         if inside_view:
             # This point is inside the view
             if not current_path and previous_position:
@@ -58,13 +54,10 @@ def _make_flight_observation(
     if current_path:
         paths.append(current_path)
 
+    p = flight.most_recent_position
     return observation_api.Flight(
         id=flight.id,
-        most_recent_position=observation_api.Position(
-            lat=flight.current_state.position.lat,
-            lng=flight.current_state.position.lng,
-            alt=flight.current_state.position.alt,
-        ),
+        most_recent_position=observation_api.Position(lat=p.lat, lng=p.lng, alt=p.alt),
         recent_paths=[observation_api.Path(positions=path) for path in paths],
     )
 
@@ -87,9 +80,11 @@ def riddp_display_data() -> Tuple[str, int]:
             400,
         )
 
+    rid_version: RIDVersion = webapp.config[KEY_RID_VERSION]
+
     # Determine what kind of response to produce
     diagonal = geo.get_latlngrect_diagonal_km(view)
-    if diagonal > NetMaxDisplayAreaDiagonalKm:
+    if diagonal > rid_version.max_diagonal_km:
         return (
             flask.jsonify(ErrorResponse(message="Requested diagonal was too large")),
             413,
@@ -97,9 +92,7 @@ def riddp_display_data() -> Tuple[str, int]:
 
     # Get ISAs in the DSS
     t = arrow.utcnow().datetime
-    isa_list: fetch.FetchedISAs = fetch.isas(
-        view, t, t, RIDVersion.f3411_19, resources.utm_client
-    )
+    isa_list: FetchedISAs = fetch.isas(view, t, t, rid_version, resources.utm_client)
     if not isa_list.success:
         msg = f"Error fetching ISAs from DSS: {isa_list.error}"
         logger.error(msg)
@@ -108,7 +101,7 @@ def riddp_display_data() -> Tuple[str, int]:
         return flask.jsonify(response), 412
 
     # Fetch flights from each unique flights URL
-    validated_flights: List[RIDFlight] = []
+    validated_flights: List[Flight] = []
     tx = db.value
     flight_info: Dict[str, database.FlightInfo] = {k: v for k, v in tx.flights.items()}
     behavior: DisplayProviderBehavior = tx.behavior
@@ -117,7 +110,7 @@ def riddp_display_data() -> Tuple[str, int]:
         if uss in behavior.do_not_display_flights_from:
             continue
         flights_response = fetch.uss_flights(
-            flights_url, view, True, RIDVersion.f3411_19, resources.utm_client
+            flights_url, view, True, rid_version, resources.utm_client
         )
         if not flights_response.success:
             msg = (
@@ -128,7 +121,7 @@ def riddp_display_data() -> Tuple[str, int]:
             response["errors"] = [flights_response]
             return flask.jsonify(response), 412
         for flight in flights_response.flights:
-            validated_flights.append(flight.as_v19())
+            validated_flights.append(flight)
             flight_info[flight.id] = database.FlightInfo(flights_url=flights_url)
 
     # Update links between flight IDs and flight URLs
@@ -141,7 +134,7 @@ def riddp_display_data() -> Tuple[str, int]:
     if behavior.always_omit_recent_paths:
         for f in flights:
             f.recent_paths = None
-    if diagonal <= NetDetailsMaxDisplayAreaDiagonalKm:
+    if diagonal <= rid_version.max_details_diagonal_km:
         # Construct detailed flights response
         response = observation_api.GetDisplayDataResponse(flights=flights)
     else:

--- a/monitoring/mock_uss/ridsp/__init__.py
+++ b/monitoring/mock_uss/ridsp/__init__.py
@@ -1,1 +1,25 @@
-from . import config
+from monitoring.mock_uss import webapp, require_config_value
+from monitoring.mock_uss.config import KEY_DSS_URL, KEY_AUTH_SPEC
+from monitoring.mock_uss.riddp.config import KEY_RID_VERSION
+from monitoring.monitorlib import auth
+from monitoring.monitorlib.infrastructure import UTMClientSession
+from monitoring.monitorlib.rid import RIDVersion
+
+
+require_config_value(KEY_DSS_URL)
+require_config_value(KEY_AUTH_SPEC)
+require_config_value(KEY_RID_VERSION)
+
+if webapp.config[KEY_RID_VERSION] == RIDVersion.f3411_19:
+    _dss_base_url = webapp.config[KEY_DSS_URL]
+elif webapp.config[KEY_RID_VERSION] == RIDVersion.f3411_22a:
+    _dss_base_url = webapp.config[KEY_DSS_URL] + "/rid/v2"
+else:
+    raise NotImplementedError(
+        f"Cannot construct DSS base URL using RID version {webapp.config[KEY_RID_VERSION]}"
+    )
+
+utm_client = UTMClientSession(
+    _dss_base_url,
+    auth.make_auth_adapter(webapp.config[KEY_AUTH_SPEC]),
+)

--- a/monitoring/mock_uss/ridsp/config.py
+++ b/monitoring/mock_uss/ridsp/config.py
@@ -1,4 +1,6 @@
 from monitoring.mock_uss import require_config_value
 from monitoring.mock_uss.config import KEY_BASE_URL
+from monitoring.mock_uss.riddp.config import KEY_RID_VERSION
 
 require_config_value(KEY_BASE_URL)
+require_config_value(KEY_RID_VERSION)

--- a/monitoring/mock_uss/ridsp/config.py
+++ b/monitoring/mock_uss/ridsp/config.py
@@ -1,6 +1,0 @@
-from monitoring.mock_uss import require_config_value
-from monitoring.mock_uss.config import KEY_BASE_URL
-from monitoring.mock_uss.riddp.config import KEY_RID_VERSION
-
-require_config_value(KEY_BASE_URL)
-require_config_value(KEY_RID_VERSION)

--- a/monitoring/mock_uss/ridsp/routes.py
+++ b/monitoring/mock_uss/ridsp/routes.py
@@ -1,11 +1,22 @@
 from monitoring.mock_uss import webapp
+from monitoring.mock_uss.riddp.config import KEY_RID_VERSION
+from monitoring.monitorlib.rid import RIDVersion
+
+
+rid_version: RIDVersion = webapp.config[KEY_RID_VERSION]
 
 
 @webapp.route("/ridsp/status")
 def ridsp_status():
-    return "Mock RID Service Provider ok"
+    return f"Mock RID Service Provider ok; RID version {rid_version}"
 
 
-from . import routes_ridsp_v19
+if rid_version == RIDVersion.f3411_19:
+    from . import routes_ridsp_v19
+else:
+    raise NotImplementedError(
+        f"Mock USS does not yet support RID version {rid_version}"
+    )
+
 from . import routes_injection
 from . import routes_behavior

--- a/monitoring/mock_uss/ridsp/routes.py
+++ b/monitoring/mock_uss/ridsp/routes.py
@@ -13,6 +13,8 @@ def ridsp_status():
 
 if rid_version == RIDVersion.f3411_19:
     from . import routes_ridsp_v19
+elif rid_version == RIDVersion.f3411_22a:
+    from . import routes_ridsp_v22a
 else:
     raise NotImplementedError(
         f"Mock USS does not yet support RID version {rid_version}"

--- a/monitoring/mock_uss/ridsp/routes_injection.py
+++ b/monitoring/mock_uss/ridsp/routes_injection.py
@@ -5,8 +5,8 @@ import uuid
 import flask
 from loguru import logger
 
-from uas_standards.astm.f3411.v19.api import ErrorResponse
 from monitoring.monitorlib.mutate import rid as mutate
+from monitoring.monitorlib.rid import RIDVersion
 from monitoring.monitorlib.rid_automated_testing import injection_api
 from implicitdict import ImplicitDict
 from monitoring.mock_uss import webapp
@@ -19,9 +19,11 @@ from .database import db
 
 # Time after the last position report during which the created ISA will still
 # exist.  This value must be at least 60 seconds per NET0610.
-from ...monitorlib.rid import RIDVersion
-
 RECENT_POSITIONS_BUFFER = datetime.timedelta(seconds=60.2)
+
+
+class ErrorResponse(ImplicitDict):
+    message: str
 
 
 @webapp.route("/ridsp/injection/tests/<test_id>", methods=["PUT"])

--- a/monitoring/mock_uss/ridsp/routes_injection.py
+++ b/monitoring/mock_uss/ridsp/routes_injection.py
@@ -3,19 +3,24 @@ from typing import Tuple
 import uuid
 
 import flask
+from implicitdict import ImplicitDict
 from loguru import logger
+from uas_standards.interuss.automated_testing.rid.v1.injection import ChangeTestResponse
 
 from monitoring.monitorlib.mutate import rid as mutate
 from monitoring.monitorlib.rid import RIDVersion
 from monitoring.monitorlib.rid_automated_testing import injection_api
-from implicitdict import ImplicitDict
-from monitoring.mock_uss import webapp
+from monitoring.mock_uss import webapp, require_config_value
 from monitoring.mock_uss.auth import requires_scope
-from monitoring.mock_uss import config, resources
-from uas_standards.interuss.automated_testing.rid.v1.injection import ChangeTestResponse
+from monitoring.mock_uss.config import KEY_BASE_URL
+from monitoring.mock_uss.riddp.config import KEY_RID_VERSION
+from monitoring.mock_uss.ridsp import utm_client
 from . import database
 from .database import db
 
+
+require_config_value(KEY_BASE_URL)
+require_config_value(KEY_RID_VERSION)
 
 # Time after the last position report during which the created ISA will still
 # exist.  This value must be at least 60 seconds per NET0610.
@@ -31,6 +36,7 @@ class ErrorResponse(ImplicitDict):
 def ridsp_create_test(test_id: str) -> Tuple[str, int]:
     """Implements test creation in RID automated testing injection API."""
     logger.info(f"Create test {test_id}")
+    rid_version = webapp.config[KEY_RID_VERSION]
     try:
         json = flask.request.json
         if json is None:
@@ -49,15 +55,22 @@ def ridsp_create_test(test_id: str) -> Tuple[str, int]:
     (t0, t1) = req_body.get_span()
     t1 += RECENT_POSITIONS_BUFFER
     rect = req_body.get_rect()
-    uss_base_url = "{}/mock/ridsp".format(webapp.config.get(config.KEY_BASE_URL))
+    if rid_version == RIDVersion.f3411_19:
+        uss_base_url = f"{webapp.config[KEY_BASE_URL]}/mock/ridsp"
+    elif rid_version == RIDVersion.f3411_22a:
+        uss_base_url = f"{webapp.config[KEY_BASE_URL]}/mock/ridsp/v2"
+    else:
+        raise NotImplementedError(
+            f"Unable to determine base URL for RID version {rid_version}"
+        )
     mutated_isa = mutate.put_isa(
         area=rect,
         start_time=t0,
         end_time=t1,
         uss_base_url=uss_base_url,
         isa_id=record.version,
-        rid_version=RIDVersion.f3411_19,
-        utm_client=resources.utm_client,
+        rid_version=rid_version,
+        utm_client=utm_client,
     )
     if not mutated_isa.dss_query.success:
         errors = "\n".join(mutated_isa.dss_query.errors)
@@ -98,6 +111,7 @@ def ridsp_create_test(test_id: str) -> Tuple[str, int]:
 def ridsp_delete_test(test_id: str) -> Tuple[str, int]:
     """Implements test deletion in RID automated testing injection API."""
     logger.info(f"Delete test {test_id}")
+    rid_version = webapp.config[KEY_RID_VERSION]
     record = db.value.tests.get(test_id, None)
 
     if record is None:
@@ -107,13 +121,14 @@ def ridsp_delete_test(test_id: str) -> Tuple[str, int]:
     deleted_isa = mutate.delete_isa(
         isa_id=record.version,
         isa_version=record.isa_version,
-        rid_version=RIDVersion.f3411_19,
-        utm_client=resources.utm_client,
+        rid_version=rid_version,
+        utm_client=utm_client,
     )
     if not deleted_isa.dss_query.success:
         logger.error(f"Unable to delete ISA {record.version} from DSS")
         response = ErrorResponse(message="Unable to delete ISA from DSS")
         response["errors"] = deleted_isa.dss_query.errors
+        response["query"] = deleted_isa.dss_query
         return flask.jsonify(response), 412
     logger.info(f"Created ISA {deleted_isa.dss_query.isa.id}")
     result = ChangeTestResponse(version=record.version, injected_flights=record.flights)

--- a/monitoring/mock_uss/ridsp/routes_ridsp_v19.py
+++ b/monitoring/mock_uss/ridsp/routes_ridsp_v19.py
@@ -12,19 +12,40 @@ from uas_standards.astm.f3411.v19.api import (
     RIDFlight,
     GetFlightDetailsResponse,
     GetFlightsResponse,
+    OperationID,
+    OPERATIONS,
+    RIDAircraftPosition,
+    RIDAircraftState,
+    RIDFlightDetails,
 )
 from uas_standards.astm.f3411.v19.constants import (
     Scope,
     NetMaxNearRealTimeDataPeriodSeconds,
     NetMaxDisplayAreaDiagonalKm,
 )
+from uas_standards.interuss.automated_testing.rid.v1 import injection
 
-from monitoring.monitorlib import geo, rid_v1
+from monitoring.monitorlib import geo
 from monitoring.monitorlib.rid_automated_testing.injection_api import TestFlight
 from monitoring.mock_uss import webapp
 from monitoring.mock_uss.auth import requires_scope
 from . import behavior
 from .database import db
+
+
+def _make_state(p: injection.RIDAircraftState) -> RIDAircraftState:
+    """Convert injection RIDAircraftState to F3411-19"""
+    return RIDAircraftState(p)
+
+
+def _make_position(p: injection.RIDAircraftPosition) -> RIDAircraftPosition:
+    """Convert injection RIDAircraftPosition to F3411-19"""
+    return RIDAircraftPosition(p)
+
+
+def _make_details(p: injection.RIDFlightDetails) -> RIDFlightDetails:
+    """Convert injection RIDFlightDetails to F3411-19"""
+    return RIDFlightDetails(p)
 
 
 def _get_report(
@@ -50,7 +71,7 @@ def _get_report(
     result = RIDFlight(
         id=details.id,
         aircraft_type="NotDeclared",  # TODO: Include aircraft_type in TestFlight API
-        current_state=recent_states[-1],
+        current_state=_make_state(recent_states[-1]),
         simulated=True,
     )
     if include_recent_positions:
@@ -58,16 +79,23 @@ def _get_report(
         for recent_state in recent_states:
             recent_positions.append(
                 RIDRecentAircraftPosition(
-                    time=recent_state.timestamp, position=recent_state.position
+                    time=recent_state.timestamp,
+                    position=_make_position(recent_state.position),
                 )
             )
         result.recent_positions = recent_positions
     return result
 
 
-@webapp.route("/mock/ridsp/v1/uss/identification_service_areas/<id>", methods=["POST"])
+def rid_v19_operation(op_id: OperationID):
+    op = OPERATIONS[op_id]
+    path = op.path.replace("{", "<").replace("}", ">")
+    return webapp.route("/mock/ridsp" + path, methods=[op.verb])
+
+
+@rid_v19_operation(OperationID.PostIdentificationServiceArea)
 @requires_scope([Scope.Write])
-def ridsp_notify_isa(id: str):
+def ridsp_notify_isa_v19(id: str):
     return (
         flask.jsonify(
             {"message": "mock_ridsp never solicits subscription notifications"}
@@ -76,9 +104,9 @@ def ridsp_notify_isa(id: str):
     )
 
 
-@webapp.route("/mock/ridsp/v1/uss/flights", methods=["GET"])
+@rid_v19_operation(OperationID.SearchFlights)
 @requires_scope([Scope.Read])
-def ridsp_flights():
+def ridsp_flights_v19():
     if "view" not in flask.request.args:
         return (
             flask.jsonify(ErrorResponse(message='Missing required "view" parameter')),
@@ -124,16 +152,21 @@ def ridsp_flights():
     )
 
 
-@webapp.route("/mock/ridsp/v1/uss/flights/<id>/details", methods=["GET"])
+@rid_v19_operation(OperationID.GetFlightDetails)
 @requires_scope([Scope.Read])
-def ridsp_flight_details(id: str):
+def ridsp_flight_details_v19(id: str):
     now = arrow.utcnow().datetime
     tx = db.value
     for test_id, record in tx.tests.items():
         for flight in record.flights:
             details = flight.get_details(now)
             if details and details.id == id:
-                return flask.jsonify(GetFlightDetailsResponse(details=details)), 200
+                return (
+                    flask.jsonify(
+                        GetFlightDetailsResponse(details=_make_details(details))
+                    ),
+                    200,
+                )
     return (
         flask.jsonify(ErrorResponse(message="Flight {} not found".format(id))),
         404,

--- a/monitoring/mock_uss/ridsp/routes_ridsp_v22a.py
+++ b/monitoring/mock_uss/ridsp/routes_ridsp_v22a.py
@@ -1,0 +1,230 @@
+import arrow
+import datetime
+from datetime import timedelta
+from typing import List, Optional
+
+import flask
+from implicitdict import StringBasedDateTime
+import s2sphere
+from uas_standards.astm.f3411.v22a.api import (
+    ErrorResponse,
+    RIDRecentAircraftPosition,
+    RIDFlight,
+    GetFlightDetailsResponse,
+    GetFlightsResponse,
+    OperationID,
+    OPERATIONS,
+    RIDAircraftPosition,
+    RIDAircraftState,
+    RIDFlightDetails,
+    OperatorLocation,
+    LatLngPoint,
+    UASID,
+    Altitude,
+)
+from uas_standards.astm.f3411.v22a.constants import (
+    Scope,
+    NetMaxNearRealTimeDataPeriodSeconds,
+    NetMaxDisplayAreaDiagonalKm,
+)
+from uas_standards.interuss.automated_testing.rid.v1 import injection
+
+from monitoring.monitorlib import geo
+from monitoring.monitorlib.rid_automated_testing.injection_api import TestFlight
+from monitoring.mock_uss import webapp
+from monitoring.mock_uss.auth import requires_scope
+from . import behavior
+from .database import db
+from ...monitorlib.rid_v2 import make_time
+
+
+def _make_position(p: injection.RIDAircraftPosition) -> RIDAircraftPosition:
+    """Convert injection RIDAircraftPosition to F3411-22a"""
+    return RIDAircraftPosition(p)
+
+
+def _make_state(s: injection.RIDAircraftState) -> RIDAircraftState:
+    """Convert injection RIDAircraftState to F3411-22a"""
+    return RIDAircraftState(
+        timestamp=make_time(s.timestamp.datetime),
+        timestamp_accuracy=s.timestamp_accuracy,
+        operational_status=s.operational_status,
+        position=_make_position(s.position),
+        track=s.track,
+        speed=s.speed,
+        speed_accuracy=s.speed_accuracy,
+        vertical_speed=s.vertical_speed,
+    )
+
+
+def _make_operator_location(
+    position: injection.LatLngPoint, altitude: injection.OperatorAltitude
+) -> OperatorLocation:
+    """Convert injection information to F3411-22a OperatorLocation"""
+    return OperatorLocation(
+        position=LatLngPoint(position),
+        altitude=Altitude(value=altitude.altitude),
+        altitude_type=altitude.altitude_type,
+    )
+
+
+def _make_details(p: injection.RIDFlightDetails) -> RIDFlightDetails:
+    """Convert injection RIDFlightDetails to F3411-22a"""
+    serial_number = p.serial_number if "serial_number" in p and p.serial_number else ""
+    registration_number = (
+        p.registration_number
+        if "registration_number" in p and p.registration_number
+        else ""
+    )
+    uas_id = (
+        p.uas_id
+        if "uas_id" in p and p.uas_id
+        else UASID(
+            serial_number=serial_number,
+            registration_number=registration_number,
+            utm_id=p.id,
+        )
+    )
+    kwargs = {"id": p.id, "uas_id": uas_id}
+    for field in (
+        "operator_id",
+        "operation_description",
+        "auth_data",
+        "eu_classification",
+    ):
+        if field in p:
+            kwargs[field] = p[field]
+    if (
+        "operator_location" in p
+        and p.operator_location
+        and "operator_altitude" in p
+        and p.operator_altitude
+    ):
+        kwargs["operator_location"] = _make_operator_location(
+            p.operator_location, p.operator_altitude
+        )
+    return RIDFlightDetails(**kwargs)
+
+
+def _get_report(
+    flight: TestFlight,
+    t_request: datetime.datetime,
+    view: s2sphere.LatLngRect,
+    include_recent_positions: bool,
+) -> Optional[RIDFlight]:
+    details = flight.get_details(t_request)
+    if not details:
+        return None
+
+    recent_states = flight.select_relevant_states(
+        view,
+        t_request - timedelta(seconds=NetMaxNearRealTimeDataPeriodSeconds),
+        t_request,
+    )
+    if not recent_states:
+        # No recent telemetry applicable to view
+        return None
+
+    recent_states.sort(key=lambda p: p.timestamp)
+    result = RIDFlight(
+        id=details.id,
+        aircraft_type="NotDeclared",  # TODO: Include aircraft_type in TestFlight API
+        current_state=_make_state(recent_states[-1]),
+        simulated=True,
+    )
+    if include_recent_positions:
+        recent_positions: List[RIDRecentAircraftPosition] = []
+        for recent_state in recent_states:
+            recent_positions.append(
+                RIDRecentAircraftPosition(
+                    time=make_time(recent_state.timestamp.datetime),
+                    position=_make_position(recent_state.position),
+                )
+            )
+        result.recent_positions = recent_positions
+    return result
+
+
+def rid_v22a_operation(op_id: OperationID):
+    op = OPERATIONS[op_id]
+    path = op.path.replace("{", "<").replace("}", ">")
+    return webapp.route("/mock/ridsp/v2" + path, methods=[op.verb])
+
+
+@rid_v22a_operation(OperationID.PostIdentificationServiceArea)
+@requires_scope([Scope.ServiceProvider])
+def ridsp_notify_isa_v22a(id: str):
+    return (
+        flask.jsonify(
+            {"message": "mock_ridsp never solicits subscription notifications"}
+        ),
+        400,
+    )
+
+
+@rid_v22a_operation(OperationID.SearchFlights)
+@requires_scope([Scope.DisplayProvider])
+def ridsp_flights_v22a():
+    if "view" not in flask.request.args:
+        return (
+            flask.jsonify(ErrorResponse(message='Missing required "view" parameter')),
+            400,
+        )
+    try:
+        view = geo.make_latlng_rect(flask.request.args["view"])
+    except ValueError as e:
+        return (
+            flask.jsonify(ErrorResponse(message="Error parsing view: {}".format(e))),
+            400,
+        )
+
+    include_recent_positions = (
+        flask.request.args.get("include_recent_positions", "False").lower() == "true"
+    )
+
+    diagonal = (
+        view.lo().get_distance(view.hi()).degrees * geo.EARTH_CIRCUMFERENCE_KM / 360
+    )
+    if diagonal > NetMaxDisplayAreaDiagonalKm:
+        msg = "Requested diagonal of {} km exceeds limit of {} km".format(
+            diagonal, NetMaxDisplayAreaDiagonalKm
+        )
+        return flask.jsonify(ErrorResponse(message=msg)), 413
+
+    now = arrow.utcnow().datetime
+    flights = []
+    tx = db.value
+    for test_id, record in tx.tests.items():
+        for flight in record.flights:
+            reported_flight = _get_report(flight, now, view, include_recent_positions)
+            if reported_flight is not None:
+                # TODO: Implement Service Provider behaviors for F3411-22a
+                # reported_flight = behavior.adjust_reported_flight(
+                #     flight, reported_flight, tx.behavior
+                # )
+                flights.append(reported_flight)
+    return (
+        flask.jsonify(GetFlightsResponse(timestamp=make_time(now), flights=flights)),
+        200,
+    )
+
+
+@rid_v22a_operation(OperationID.GetFlightDetails)
+@requires_scope([Scope.DisplayProvider])
+def ridsp_flight_details_v22a(id: str):
+    now = arrow.utcnow().datetime
+    tx = db.value
+    for test_id, record in tx.tests.items():
+        for flight in record.flights:
+            details = flight.get_details(now)
+            if details and details.id == id:
+                return (
+                    flask.jsonify(
+                        GetFlightDetailsResponse(details=_make_details(details))
+                    ),
+                    200,
+                )
+    return (
+        flask.jsonify(ErrorResponse(message="Flight {} not found".format(id))),
+        404,
+    )

--- a/monitoring/mock_uss/scdsc/__init__.py
+++ b/monitoring/mock_uss/scdsc/__init__.py
@@ -1,1 +1,13 @@
-from . import config
+from monitoring.mock_uss import require_config_value, webapp
+from monitoring.mock_uss.config import KEY_DSS_URL, KEY_AUTH_SPEC
+from monitoring.monitorlib import auth
+from monitoring.monitorlib.infrastructure import UTMClientSession
+
+
+require_config_value(KEY_DSS_URL)
+require_config_value(KEY_AUTH_SPEC)
+
+utm_client = UTMClientSession(
+    webapp.config[KEY_DSS_URL],
+    auth.make_auth_adapter(webapp.config[KEY_AUTH_SPEC]),
+)

--- a/monitoring/mock_uss/scdsc/config.py
+++ b/monitoring/mock_uss/scdsc/config.py
@@ -1,6 +1,0 @@
-from monitoring.mock_uss import require_config_value
-from monitoring.mock_uss.config import KEY_BASE_URL, KEY_BEHAVIOR_LOCALITY
-
-
-require_config_value(KEY_BASE_URL)
-require_config_value(KEY_BEHAVIOR_LOCALITY)

--- a/monitoring/monitorlib/fetch/rid.py
+++ b/monitoring/monitorlib/fetch/rid.py
@@ -106,6 +106,27 @@ class ISA(ImplicitDict):
         )
 
 
+class Position(ImplicitDict):
+    """Version-independent representation of a 3D position."""
+
+    lat: float
+    """Degrees north of equator."""
+
+    lng: float
+    """Degrees east of prime meridian."""
+
+    alt: float
+    """Meters above the WGS84 reference ellipsoid."""
+
+    @staticmethod
+    def from_v19_rid_aircraft_position(p: v19.api.RIDAircraftPosition) -> Position:
+        return Position(lat=p.lat, lng=p.lng, alt=p.alt)
+
+    @staticmethod
+    def from_v22a_rid_aircraft_position(p: v22a.api.RIDAircraftPosition) -> Position:
+        return Position(lat=p.lat, lng=p.lng, alt=p.alt)
+
+
 class Flight(ImplicitDict):
     """Version-independent representation of a F3411 flight."""
 
@@ -141,19 +162,38 @@ class Flight(ImplicitDict):
     @property
     def most_recent_position(
         self,
-    ) -> Optional[Union[v19.api.RIDAircraftPosition, v22a.api.RIDAircraftPosition]]:
-        return (
-            self.raw.current_state.position
-            if "current_state" in self.raw and self.raw.current_state
-            else None
-        )
+    ) -> Optional[Position]:
+        if "current_state" in self.raw and self.raw.current_state:
+            if self.rid_version == RIDVersion.f3411_19:
+                return Position.from_v19_rid_aircraft_position(
+                    self.v19_value.current_state.position
+                )
+            elif self.rid_version == RIDVersion.f3411_22a:
+                return Position.from_v22a_rid_aircraft_position(
+                    self.v22a_value.current_state.position
+                )
+            else:
+                raise NotImplementedError(
+                    f"Cannot retrieve most recent position using RID version {self.rid_version}"
+                )
+        else:
+            return None
 
-    def as_v19(self) -> v19.api.RIDFlight:
-        if self.v19_value is not None:
-            return self.v19_value
+    @property
+    def recent_positions(self) -> List[Position]:
+        if self.rid_version == RIDVersion.f3411_19:
+            return [
+                Position.from_v19_rid_aircraft_position(p.position)
+                for p in self.v19_value.recent_positions
+            ]
+        elif self.rid_version == RIDVersion.f3411_22a:
+            return [
+                Position.from_v22a_rid_aircraft_position(p.position)
+                for p in self.v22a_value.recent_positions
+            ]
         else:
             raise NotImplementedError(
-                f"Conversion to F3411-19 RIDFlight has not yet been implemented for RID version {self.rid_version}"
+                f"Cannot retrieve recent positions using RID version {self.rid_version}"
             )
 
 

--- a/monitoring/monitorlib/fetch/rid.py
+++ b/monitoring/monitorlib/fetch/rid.py
@@ -627,16 +627,11 @@ def flight_details(
             )
         else:
             kwargs["scope"] = v19.constants.Scope.Read
-        query = fetch.query_and_describe(
-            session,
-            "GET",
-            url,
-            **kwargs,
-        )
+        query = fetch.query_and_describe(session, "GET", url, **kwargs)
         return FetchedUSSFlightDetails(v19_query=query)
     elif rid_version == RIDVersion.f3411_22a:
         query = fetch.query_and_describe(
-            session, "GET", flights_url, scope=v22a.constants.Scope.DisplayProvider
+            session, "GET", url, scope=v22a.constants.Scope.DisplayProvider
         )
         return FetchedUSSFlightDetails(v22a_query=query)
     else:

--- a/monitoring/monitorlib/mutate/rid.py
+++ b/monitoring/monitorlib/mutate/rid.py
@@ -425,10 +425,14 @@ def put_isa(
             "uss_base_url": uss_base_url,
         }
         if isa_version is None:
-            op = v22a.api.OPERATIONS[v22a.api.OperationID.CreateSubscription]
+            op = v22a.api.OPERATIONS[
+                v22a.api.OperationID.CreateIdentificationServiceArea
+            ]
             url = op.path.format(id=isa_id)
         else:
-            op = v22a.api.OPERATIONS[v22a.api.OperationID.UpdateSubscription]
+            op = v22a.api.OPERATIONS[
+                v22a.api.OperationID.UpdateIdentificationServiceArea
+            ]
             url = op.path.format(id=isa_id, version=isa_version)
         dss_response = ChangedISA(
             mutation=mutation,
@@ -471,7 +475,7 @@ def delete_isa(
             ),
         )
     elif rid_version == RIDVersion.f3411_22a:
-        op = v22a.api.OPERATIONS[v22a.api.OperationID.UpdateSubscription]
+        op = v22a.api.OPERATIONS[v22a.api.OperationID.DeleteIdentificationServiceArea]
         url = op.path.format(id=isa_id, version=isa_version)
         dss_response = ChangedISA(
             mutation="delete",

--- a/monitoring/monitorlib/rid_automated_testing/injection_api.py
+++ b/monitoring/monitorlib/rid_automated_testing/injection_api.py
@@ -4,11 +4,12 @@ from typing import List, Optional, Tuple
 import arrow
 import s2sphere
 
-from monitoring.monitorlib import geo, rid_v1
-from uas_standards.astm.f3411.v19.api import RIDFlightDetails, RIDAircraftState
-
+from monitoring.monitorlib import geo
 from uas_standards.interuss.automated_testing.rid.v1 import injection
-
+from uas_standards.interuss.automated_testing.rid.v1.injection import (
+    RIDFlightDetails,
+    RIDAircraftState,
+)
 
 SCOPE_RID_QUALIFIER_INJECT = "rid.inject_test_data"
 

--- a/monitoring/uss_qualifier/configurations/dev/local_test.json
+++ b/monitoring/uss_qualifier/configurations/dev/local_test.json
@@ -22,7 +22,7 @@
             "priority_preemption_flights": "priority_preemption_flights",
             "invalid_flight_auth_flights": "invalid_flight_auth_flights",
             "dss": "dss",
-            "netrid_dss_instances": "netrid_dss_instances"
+            "netrid_dss_instances_v19": "netrid_dss_instances_v19"
           }
         }
       }

--- a/monitoring/uss_qualifier/configurations/dev/netrid.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/netrid.yaml
@@ -1,0 +1,52 @@
+v1:
+    test_run:
+        resources:
+            resource_declarations:
+                utm_auth:
+                    resource_type: resources.communications.AuthAdapterResource
+                    specification:
+                        environment_variable_containing_auth_spec: AUTH_SPEC
+                kentland_flights_data:
+                    resource_type: resources.netrid.FlightDataResource
+                    specification:
+                        kml_source:
+                            kml_location: file://./test_data/usa/kentland/rid.kml
+                service_providers:
+                    resource_type: resources.netrid.NetRIDServiceProviders
+                    dependencies:
+                        auth_adapter: utm_auth
+                    specification:
+                        service_providers:
+                            - participant_id: uss1
+                              injection_base_url: http://host.docker.internal:8071/ridsp/injection
+                observers:
+                    resource_type: resources.netrid.NetRIDObserversResource
+                    dependencies:
+                        auth_adapter: utm_auth
+                    specification:
+                        observers:
+                            - participant_id: uss2
+                              observation_base_url: http://host.docker.internal:8073/riddp/observation
+                observation_evaluation_configuration:
+                    resource_type: resources.netrid.EvaluationConfigurationResource
+                    specification: {}
+                dss_pool:
+                    resource_type: resources.astm.f3411.DSSInstancesResource
+                    dependencies:
+                        auth_adapter: utm_auth
+                    specification:
+                        dss_instances:
+                            - participant_id: uss1
+                              rid_version: F3411-22a
+                              base_url: http://host.docker.internal:8082/rid/v2
+        action:
+            test_suite:
+                suite_type: suites.astm.netrid.f3411_22a
+                resources:
+                    flights_data: kentland_flights_data
+                    service_providers: service_providers
+                    observers: observers
+                    evaluation_configuration: observation_evaluation_configuration
+                    dss_instances: dss_pool
+    artifacts:
+        "$ref": artifacts.yaml#/relative

--- a/monitoring/uss_qualifier/configurations/dev/non_docker/local_test.json
+++ b/monitoring/uss_qualifier/configurations/dev/non_docker/local_test.json
@@ -22,7 +22,7 @@
             "priority_preemption_flights": "priority_preemption_flights",
             "invalid_flight_auth_flights": "invalid_flight_auth_flights",
             "dss": "dss",
-            "netrid_dss_instances": "netrid_dss_instances"
+            "netrid_dss_instances_v19": "netrid_dss_instances_v19"
           }
         }
       }

--- a/monitoring/uss_qualifier/configurations/dev/non_docker/resources.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/non_docker/resources.yaml
@@ -29,7 +29,7 @@ net_rid:
   netrid_observation_evaluation_configuration:
     resource_type: resources.netrid.EvaluationConfigurationResource
     specification: {}
-  netrid_dss_instances:
+  netrid_dss_instances_v19:
       resource_type: resources.astm.f3411.DSSInstancesResource
       dependencies:
           auth_adapter: utm_auth

--- a/monitoring/uss_qualifier/configurations/dev/resources.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/resources.yaml
@@ -29,7 +29,7 @@ net_rid:
   netrid_observation_evaluation_configuration:
     resource_type: resources.netrid.EvaluationConfigurationResource
     specification: {}
-  netrid_dss_instances:
+  netrid_dss_instances_v19:
     resource_type: resources.astm.f3411.DSSInstancesResource
     dependencies:
       auth_adapter: utm_auth

--- a/monitoring/uss_qualifier/resources/netrid/flight_data_resources.py
+++ b/monitoring/uss_qualifier/resources/netrid/flight_data_resources.py
@@ -4,8 +4,10 @@ import uuid
 
 import arrow
 from implicitdict import ImplicitDict, StringBasedDateTime
-from uas_standards.astm.f3411.v19.api import RIDAircraftState
-from uas_standards.interuss.automated_testing.rid.v1.injection import TestFlightDetails
+from uas_standards.interuss.automated_testing.rid.v1.injection import (
+    TestFlightDetails,
+    RIDAircraftState,
+)
 
 from monitoring.monitorlib.rid_automated_testing.injection_api import (
     TestFlight,

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/display_data_evaluator.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/display_data_evaluator.py
@@ -86,6 +86,10 @@ class DPObservedFlight(object):
     flight: int
 
     @property
+    def id(self) -> str:
+        return self.query.flights[self.flight].id
+
+    @property
     def most_recent_position(self):
         return self.query.flights[self.flight].most_recent_position
 
@@ -169,6 +173,10 @@ class RIDObservationEvaluator(object):
         self._config = config
         self._rid_version = rid_version
         self._dss = dss
+        if dss and dss.rid_version != rid_version:
+            raise ValueError(
+                f"Cannot evaluate a system using RID version {rid_version} with a DSS using RID version {dss.rid_version}"
+            )
 
     def evaluate_system_instantaneously(
         self,
@@ -467,8 +475,8 @@ class RIDObservationEvaluator(object):
         for mapping in mappings.values():
             details_queries = [
                 q
-                for q in dp_observation.uss_flight_details_queries.values()
-                if q.flights_url == mapping.observed_flight.query.flights_url
+                for flight_id, q in dp_observation.uss_flight_details_queries.items()
+                if flight_id == mapping.observed_flight.id
             ]
             if len(details_queries) != 1:
                 raise RuntimeError(

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/display_data_evaluator.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/display_data_evaluator.py
@@ -4,14 +4,14 @@ from typing import List, Optional, Dict, Union
 import arrow
 import s2sphere
 
-from monitoring.monitorlib.fetch import rid, Query
+from monitoring.monitorlib.fetch import Query
 from monitoring.monitorlib.fetch.rid import (
     all_flights,
     FetchedFlights,
     FetchedUSSFlights,
 )
 from monitoring.uss_qualifier.resources.astm.f3411.dss import DSSInstance
-from uas_standards.astm.f3411.v19.api import RIDAircraftState
+from uas_standards.interuss.automated_testing.rid.v1.injection import RIDAircraftState
 from uas_standards.interuss.automated_testing.rid.v1.observation import (
     Flight,
     GetDisplayDataResponse,

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/nominal_behavior.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/nominal_behavior.py
@@ -55,6 +55,14 @@ class NominalBehavior(TestScenario):
         self._injected_flights = []
         self._dss_pool = dss_pool
 
+    @property
+    def _rid_version(self) -> RIDVersion:
+        return (
+            self._dss_pool.dss_instances[0].rid_version
+            if self._dss_pool
+            else RIDVersion.f3411_19
+        )
+
     def run(self):
         self.begin_test_scenario()
         self.begin_test_case("Nominal flight")
@@ -146,13 +154,11 @@ class NominalBehavior(TestScenario):
                 raise RuntimeError("High-severity issue did not abort test scenario")
 
         config = self._evaluation_configuration.configuration
-        # TODO: Replace hardcoded value
-        rid_version = RIDVersion.f3411_19
         self._virtual_observer = VirtualObserver(
             injected_flights=InjectedFlightCollection(self._injected_flights),
             repeat_query_rect_period=config.repeat_query_rect_period,
             min_query_diagonal_m=config.min_query_diagonal,
-            relevant_past_data_period=rid_version.realtime_period
+            relevant_past_data_period=self._rid_version.realtime_period
             + config.max_propagation_latency.timedelta,
         )
 
@@ -162,8 +168,7 @@ class NominalBehavior(TestScenario):
             self,
             self._injected_flights,
             self._evaluation_configuration.configuration,
-            # TODO: Replace hardcoded value
-            RIDVersion.f3411_19,
+            self._rid_version,
             self._dss_pool.dss_instances[0] if self._dss_pool else None,
         )
 

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a.yaml
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a.yaml
@@ -1,0 +1,17 @@
+name: ASTM F3411-22a
+resources:
+  flights_data: resources.netrid.FlightDataResource
+  service_providers: resources.netrid.NetRIDServiceProviders
+  observers: resources.netrid.NetRIDObserversResource
+  evaluation_configuration: resources.netrid.EvaluationConfigurationResource
+  dss_instances: resources.astm.f3411.DSSInstancesResource
+actions:
+  - test_scenario:
+      scenario_type: scenarios.astm.netrid.NominalBehavior
+      resources:
+        flights_data: flights_data
+        service_providers: service_providers
+        observers: observers
+        evaluation_configuration: evaluation_configuration
+        dss_pool: dss_instances
+    on_failure: Continue

--- a/monitoring/uss_qualifier/suites/dev/local_test.yaml
+++ b/monitoring/uss_qualifier/suites/dev/local_test.yaml
@@ -14,7 +14,7 @@ resources:
   invalid_flight_auth_flights: resources.flight_planning.FlightIntentsResource
   dss: resources.astm.f3548.v21.DSSInstanceResource
 
-  netrid_dss_instances: resources.astm.f3411.DSSInstancesResource
+  netrid_dss_instances_v19: resources.astm.f3411.DSSInstancesResource
 actions:
 - test_suite:
     suite_type: suites.interuss.generate_test_data
@@ -37,5 +37,5 @@ actions:
       service_providers: service_providers
       observers: observers
       evaluation_configuration: evaluation_configuration
-      netrid_dss_instances: netrid_dss_instances
+      netrid_dss_instances: netrid_dss_instances_v19
   on_failure: Continue

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,5 +37,5 @@ s2sphere==0.2.5
 shapely==1.7.1
 structlog==21.5.0  # deployment_manager
 termcolor==1.1.0
-uas_standards==1.2.0
+uas_standards==1.3.0
 Werkzeug==2.0.3 # See https://github.com/interuss/dss/issues/753


### PR DESCRIPTION
This PR adds full F3411-22a support to mock_uss.  The configurations.dev.netrid configuration runs successfully when the default RID version in mock_uss/riddp/config.py is set to 22a, but this test is not incorporated into this PR as doing so would require substantially more changes in an already-large PR (including tracer behavior, more mock_uss instances, etc).