### PR TITLE
[uss_qualifier, mock_uss] Fix rid automated testing

### DIFF
--- a/monitoring/mock_uss/ridsp/routes_injection.py
+++ b/monitoring/mock_uss/ridsp/routes_injection.py
@@ -106,9 +106,9 @@ def ridsp_create_test(test_id: str) -> Tuple[str, int]:
     )
 
 
-@webapp.route("/ridsp/injection/tests/<test_id>", methods=["DELETE"])
+@webapp.route("/ridsp/injection/tests/<test_id>/<version>", methods=["DELETE"])
 @requires_scope([injection_api.SCOPE_RID_QUALIFIER_INJECT])
-def ridsp_delete_test(test_id: str) -> Tuple[str, int]:
+def ridsp_delete_test(test_id: str, version: str) -> Tuple[str, int]:
     """Implements test deletion in RID automated testing injection API."""
     logger.info(f"Delete test {test_id}")
     rid_version = webapp.config[KEY_RID_VERSION]
@@ -116,6 +116,12 @@ def ridsp_delete_test(test_id: str) -> Tuple[str, int]:
 
     if record is None:
         return 'Test "{}" not found'.format(test_id), 404
+
+    if record.version != version:
+        return (
+            f'Test "{test_id}" has version "{record.version}" rather than the specified version "{version}"',
+            404,
+        )
 
     # Delete ISA from DSS
     deleted_isa = mutate.delete_isa(

--- a/monitoring/monitorlib/fetch/rid.py
+++ b/monitoring/monitorlib/fetch/rid.py
@@ -231,7 +231,7 @@ class Flight(ImplicitDict):
                         ):
                             if (
                                 expected_field not in position
-                                or position["expected_field"] is None
+                                or position[expected_field] is None
                             ):
                                 result.append(
                                     f"`current_state.position.{expected_field}` is not specified"

--- a/monitoring/uss_qualifier/resources/netrid/service_providers.py
+++ b/monitoring/uss_qualifier/resources/netrid/service_providers.py
@@ -57,11 +57,11 @@ class NetRIDServiceProvider(object):
             scope=SCOPE_RID_QUALIFIER_INJECT,
         )
 
-    def delete_test(self, test_id: str) -> fetch.Query:
+    def delete_test(self, test_id: str, version: str) -> fetch.Query:
         return fetch.query_and_describe(
             self.client,
             "DELETE",
-            url=f"/tests/{test_id}",
+            url=f"/tests/{test_id}/{version}",
             scope=SCOPE_RID_QUALIFIER_INJECT,
         )
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/injection.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/injection.py
@@ -10,3 +10,9 @@ class InjectedFlight(ImplicitDict):
     test_id: str
     flight: TestFlight
     query_timestamp: datetime
+
+
+class InjectedTest(ImplicitDict):
+    participant_id: str
+    test_id: str
+    version: str


### PR DESCRIPTION
This PR addresses a number of issues encountered while conducting remote ID automated tests:

* Validates received Flight information before attempting to use it in mock_uss to produce clear error messages rather than internal errors
* Fixes DeleteTest endpoint in mock_uss to use missing version in path
* Fixes uss_qualifier to include version in path when calling DeleteTest endpoint
* Records injected test information rather than just injected flights in uss_qualifier
* Validates presence of position information before attempting to use it in uss_qualifier RID display data evaluator