### PR TITLE
[uss_qualifier] Fix RID altitude check

### DIFF
--- a/monitoring/uss_qualifier/reports/report.py
+++ b/monitoring/uss_qualifier/reports/report.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 import traceback
-from typing import List, Optional, Dict, Tuple, Any, Union
+from typing import List, Optional, Dict, Tuple, Any, Union, Set
 
 from implicitdict import ImplicitDict, StringBasedDateTime
 
@@ -86,6 +86,13 @@ class TestStepReport(ImplicitDict):
 
     def successful(self) -> bool:
         return False if self.failed_checks else True
+
+    def participants_with_failed_checks(self) -> Set[str]:
+        participants = set()
+        for fc in self.failed_checks:
+            for p in fc.participants:
+                participants.add(p)
+        return participants
 
 
 class TestCaseReport(ImplicitDict):

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/display_data_evaluator.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/display_data_evaluator.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
-from typing import List, Optional, Dict, Union
+from typing import List, Optional, Dict, Union, Set
 
 import arrow
 from loguru import logger
+import math
 import s2sphere
 
 from monitoring.monitorlib.fetch import Query
@@ -124,7 +125,8 @@ def _make_flight_mapping(
     """
     mapping: Dict[str, TelemetryMapping] = {}
     for injected_flight in injected_flights:
-        found = False
+        smallest_distance = 1e9
+        best_match = None
         for observed_flight in observed_flights:
             if (
                 isinstance(observed_flight, Flight)
@@ -143,20 +145,32 @@ def _make_flight_mapping(
                 )
                 continue
             for t1, injected_telemetry in enumerate(injected_flight.flight.telemetry):
-                if (
-                    abs(p.lat - injected_telemetry.position.lat) < COORD_TOLERANCE_DEG
-                    and abs(p.lng - injected_telemetry.position.lng)
-                    < COORD_TOLERANCE_DEG
-                ):
-                    mapping[injected_flight.flight.injection_id] = TelemetryMapping(
-                        injected_flight=injected_flight,
-                        telemetry_index=t1,
-                        observed_flight=observed_flight,
-                    )
-                    found = True
-                    break
-            if found:
-                break
+                dlat = abs(p.lat - injected_telemetry.position.lat)
+                dlng = abs(p.lng - injected_telemetry.position.lng)
+                if dlat < COORD_TOLERANCE_DEG and dlng < COORD_TOLERANCE_DEG:
+                    new_distance = math.sqrt(math.pow(dlat, 2) + math.pow(dlng, 2))
+                    if new_distance < smallest_distance:
+                        best_match = TelemetryMapping(
+                            injected_flight=injected_flight,
+                            telemetry_index=t1,
+                            observed_flight=observed_flight,
+                        )
+                        smallest_distance = new_distance
+        if best_match is not None:
+            observed_p = best_match.observed_flight.most_recent_position
+            observed_lat = observed_p.lat if "lat" in observed_p else None
+            observed_lng = observed_p.lng if "lng" in observed_p else None
+            observed_alt = observed_p.alt if "alt" in observed_p else None
+            best_p = best_match.injected_flight.flight.telemetry[
+                best_match.telemetry_index
+            ].position
+            best_lat = best_p.lat if "lat" in best_p else None
+            best_lng = best_p.lng if "lng" in best_p else None
+            best_alt = best_p.alt if "alt" in best_p else None
+            logger.debug(
+                f"For injection ID {best_match.injected_flight.flight.injection_id}, matched observed flight {best_match.observed_flight.id} at ({observed_lat}, {observed_lng})+{observed_alt} to injected flight's telemetry index {best_match.telemetry_index} at ({best_lat}, {best_lng})+{best_alt}"
+            )
+            mapping[best_match.injected_flight.flight.injection_id] = best_match
     return mapping
 
 
@@ -203,22 +217,30 @@ class RIDObservationEvaluator(object):
         if self._dss:
             self._test_scenario.begin_test_step("Service Provider polling")
 
-            dp_observation = all_flights(
+            # Observe Service Provider with uss_qualifier acting as a Display Provider
+            sp_observation = all_flights(
                 rect,
                 include_recent_positions=True,
                 get_details=True,
                 rid_version=self._rid_version,
                 session=self._dss.client,
             )
-            for q in dp_observation.queries:
+            for q in sp_observation.queries:
                 self._test_scenario.record_query(q)
 
-            self._evaluate_dp_observation(dp_observation, rect)
+            self._evaluate_sp_observation(sp_observation, rect)
 
             step_report = self._test_scenario.end_test_step()
-            perform_observation = step_report.successful
+            perform_observation = step_report.successful()
+            verified_sps = {
+                obs.participant_id
+                for obs in observers
+                if obs.participant_id
+                not in step_report.participants_with_failed_checks()
+            }
         else:
             perform_observation = True
+            verified_sps = set()
 
         if perform_observation:
             for observer in observers:
@@ -230,6 +252,7 @@ class RIDObservationEvaluator(object):
                     rect,
                     observation,
                     query,
+                    verified_sps,
                 )
                 self._test_scenario.end_test_step()
 
@@ -242,6 +265,7 @@ class RIDObservationEvaluator(object):
         rect: s2sphere.LatLngRect,
         observation: Optional[GetDisplayDataResponse],
         query: fetch.Query,
+        verified_sps: Set[str],
     ) -> None:
         diagonal_km = (
             rect.lo().get_distance(rect.hi()).degrees * geo.EARTH_CIRCUMFERENCE_KM / 360
@@ -258,6 +282,7 @@ class RIDObservationEvaluator(object):
                 rect,
                 observation,
                 query,
+                verified_sps,
             )
 
     def _evaluate_normal_observation(
@@ -266,6 +291,7 @@ class RIDObservationEvaluator(object):
         rect: s2sphere.LatLngRect,
         observation: Optional[GetDisplayDataResponse],
         query: fetch.Query,
+        verified_sps: Set[str],
     ) -> None:
         with self._test_scenario.check(
             "Successful observation", [observer.participant_id]
@@ -304,8 +330,37 @@ class RIDObservationEvaluator(object):
         )
 
         self._evaluate_flight_presence(
-            observer.participant_id, [query], True, mapping_by_injection_id
+            observer.participant_id,
+            [query],
+            True,
+            mapping_by_injection_id,
+            verified_sps,
         )
+
+        # Check that altitudes match for any observed flights matching injected flights
+        for mapping in mapping_by_injection_id.values():
+            injected_telemetry = mapping.injected_flight.flight.telemetry[
+                mapping.telemetry_index
+            ]
+            observed_position = mapping.observed_flight.most_recent_position
+            injected_position = injected_telemetry.position
+            if "alt" in observed_position:
+                with self._test_scenario.check(
+                    "Observed altitude",
+                    [
+                        observer.participant_id,
+                        mapping.injected_flight.uss_participant_id,
+                    ],
+                ) as check:
+                    if (
+                        abs(observed_position.alt - injected_position.alt)
+                        > DISTANCE_TOLERANCE_M
+                    ):
+                        check.record_failed(
+                            "Observed altitude does not match injected altitude",
+                            Severity.Medium,
+                            details=f"{mapping.injected_flight.uss_participant_id}'s flight with injection ID {mapping.injected_flight.flight.injection_id} in test {mapping.injected_flight.test_id} had telemetry index {mapping.telemetry_index} at {injected_telemetry.timestamp} with lat={injected_telemetry.position.lat}, lng={injected_telemetry.position.lng}, alt={injected_telemetry.position.alt}, but {observer.participant_id} observed lat={observed_position.lat}, lng={observed_position.lng}, alt={observed_position.alt} at {query.request.initiated_at}",
+                        )
 
     def _evaluate_flight_presence(
         self,
@@ -313,6 +368,7 @@ class RIDObservationEvaluator(object):
         observation_queries: List[Query],
         observer_participant_is_relevant: bool,
         mapping_by_injection_id: Dict[str, TelemetryMapping],
+        verified_sps: Set[str],
     ):
         query_timestamps = [q.request.timestamp for q in observation_queries]
         observer_participants = (
@@ -349,9 +405,14 @@ class RIDObservationEvaluator(object):
                 + self._config.max_propagation_latency.timedelta
             ):
                 # This flight should not have been observed (it was too far in the past)
+                participants = observer_participants
+                if (
+                    expected_flight.uss_participant_id not in verified_sps
+                    or not participants
+                ):
+                    participants.append(expected_flight.uss_participant_id)
                 with self._test_scenario.check(
-                    "Lingering flight",
-                    observer_participants + [expected_flight.uss_participant_id],
+                    "Lingering flight", participants
                 ) as check:
                     if expected_flight.flight.injection_id in mapping_by_injection_id:
                         check.record_failed(
@@ -365,13 +426,18 @@ class RIDObservationEvaluator(object):
             elif (
                 t_min + self._config.max_propagation_latency.timedelta
                 < t_initiated
-                < t_max + self._rid_version.realtime_period
+                < t_max
+                + self._rid_version.realtime_period
+                - self._config.max_propagation_latency.timedelta
             ):
                 # This flight should definitely have been observed
-                with self._test_scenario.check(
-                    "Missing flight",
-                    observer_participants + [expected_flight.uss_participant_id],
-                ) as check:
+                participants = observer_participants
+                if (
+                    expected_flight.uss_participant_id not in verified_sps
+                    or not participants
+                ):
+                    participants.append(expected_flight.uss_participant_id)
+                with self._test_scenario.check("Missing flight", participants) as check:
                     if (
                         expected_flight.flight.injection_id
                         not in mapping_by_injection_id
@@ -388,27 +454,6 @@ class RIDObservationEvaluator(object):
             elif t_initiated > t_min:
                 # If this flight was not observed, there may be propagation latency
                 pass  # TODO: findings propagation latency
-
-            # Check that altitudes match
-            for mapping in mapping_by_injection_id.values():
-                expected_telemetry = expected_flight.flight.telemetry[
-                    mapping.telemetry_index
-                ]
-                observed_position = mapping.observed_flight.most_recent_position
-                expected_position = expected_telemetry.position
-                if (
-                    "alt" in observed_position
-                    and abs(observed_position.alt - expected_position.alt)
-                    > DISTANCE_TOLERANCE_M
-                ):
-                    self._test_scenario.check(
-                        "Altitude",
-                        observer_participants + [expected_flight.uss_participant_id],
-                    ).record_failed(
-                        "Observed altitude does not match injected altitude",
-                        Severity.Medium,
-                        details=f"{expected_flight.uss_participant_id}'s flight with injection ID {expected_flight.flight.injection_id} in test {expected_flight.test_id} had telemetry index {mapping.telemetry_index} at {expected_telemetry.timestamp} with lat={expected_telemetry.position.lat}, lng={expected_telemetry.position.lng}, alt={expected_telemetry.position.alt}, but {observer_participant_id} observed lat={observed_position.lat}, lng={observed_position.lng}, alt={observed_position.alt} at {t_response.isoformat()}",
-                    )
 
     def _evaluate_area_too_large_observation(
         self,
@@ -432,9 +477,9 @@ class RIDObservationEvaluator(object):
         # TODO: Check cluster sizing, aircraft counts, etc
         pass
 
-    def _evaluate_dp_observation(
+    def _evaluate_sp_observation(
         self,
-        dp_observation: FetchedFlights,
+        sp_observation: FetchedFlights,
         rect: s2sphere.LatLngRect,
     ) -> None:
         # Note: This step currently uses the DSS endpoint to perform a one-time query for ISAs, but this
@@ -444,20 +489,20 @@ class RIDObservationEvaluator(object):
         # is currently much cleaner.  If this test is applied to a DSS that does not implement the one-time
         # ISA query endpoint, this check can be adapted.
         with self._test_scenario.check("ISA query") as check:
-            if not dp_observation.dss_isa_query.success:
+            if not sp_observation.dss_isa_query.success:
                 check.record_failed(
                     summary="Could not query ISAs from DSS",
                     severity=Severity.Medium,
                     details=f"Query to {self._dss.participant_id}'s DSS at {dp_observation.dss_isa_query.query.request.url} failed {dp_observation.dss_isa_query.query.status_code}",
                     participants=[self._dss.participant_id],
                     query_timestamps=[
-                        dp_observation.dss_isa_query.query.request.initiated_at.datetime
+                        sp_observation.dss_isa_query.query.request.initiated_at.datetime
                     ],
                 )
                 return
 
         observed_flights = []
-        for uss_query in dp_observation.uss_flight_queries.values():
+        for uss_query in sp_observation.uss_flight_queries.values():
             for f in range(len(uss_query.flights)):
                 observed_flights.append(DPObservedFlight(query=uss_query, flight=f))
         mapping_by_injection_id = _make_flight_mapping(
@@ -468,32 +513,33 @@ class RIDObservationEvaluator(object):
             rect.lo().get_distance(rect.hi()).degrees * geo.EARTH_CIRCUMFERENCE_KM / 360
         )
         if diagonal_km > self._rid_version.max_diagonal_km:
-            self._evaluate_area_too_large_dp_observation(
+            self._evaluate_area_too_large_sp_observation(
                 mapping_by_injection_id, rect, diagonal_km
             )
         else:
-            self._evaluate_normal_dp_observation(
-                dp_observation, mapping_by_injection_id
+            self._evaluate_normal_sp_observation(
+                sp_observation, mapping_by_injection_id
             )
 
-    def _evaluate_normal_dp_observation(
+    def _evaluate_normal_sp_observation(
         self,
-        dp_observation: FetchedFlights,
+        sp_observation: FetchedFlights,
         mappings: Dict[str, TelemetryMapping],
     ) -> None:
 
         self._evaluate_flight_presence(
             "uss_qualifier, acting as Display Provider",
-            dp_observation.queries,
+            sp_observation.queries,
             False,
             mappings,
+            set(),
         )
 
         # Verify that flights queries returned correctly-formatted data
         for mapping in mappings.values():
             flights_queries = [
                 q
-                for flight_url, q in dp_observation.uss_flight_queries.items()
+                for flight_url, q in sp_observation.uss_flight_queries.items()
                 if mapping.observed_flight.id in {f.id for f in q.flights}
             ]
             if len(flights_queries) != 1:
@@ -521,11 +567,33 @@ class RIDObservationEvaluator(object):
                         query_timestamps=[flights_query.query.request.timestamp],
                     )
 
+        # Check that altitudes match for any observed flights matching injected flights
+        for mapping in mappings.values():
+            injected_telemetry = mapping.injected_flight.flight.telemetry[
+                mapping.telemetry_index
+            ]
+            observed_position = mapping.observed_flight.most_recent_position
+            injected_position = injected_telemetry.position
+            if "alt" in observed_position:
+                with self._test_scenario.check(
+                    "Service Provider altitude",
+                    [mapping.injected_flight.uss_participant_id],
+                ) as check:
+                    if (
+                        abs(observed_position.alt - injected_position.alt)
+                        > DISTANCE_TOLERANCE_M
+                    ):
+                        check.record_failed(
+                            "Altitude reported by Service Provider does not match injected altitude",
+                            Severity.Medium,
+                            details=f"{mapping.injected_flight.uss_participant_id}'s flight with injection ID {mapping.injected_flight.flight.injection_id} in test {mapping.injected_flight.test_id} had telemetry index {mapping.telemetry_index} at {injected_telemetry.timestamp} with lat={injected_telemetry.position.lat}, lng={injected_telemetry.position.lng}, alt={injected_telemetry.position.alt}, but Service Provider reported lat={observed_position.lat}, lng={observed_position.lng}, alt={observed_position.alt} at {mapping.observed_flight.query.query.request.initiated_at}",
+                        )
+
         # Verify that flight details queries succeeded and returned correctly-formatted data
         for mapping in mappings.values():
             details_queries = [
                 q
-                for flight_id, q in dp_observation.uss_flight_details_queries.items()
+                for flight_id, q in sp_observation.uss_flight_details_queries.items()
                 if flight_id == mapping.observed_flight.id
             ]
             if len(details_queries) != 1:
@@ -566,7 +634,7 @@ class RIDObservationEvaluator(object):
                         query_timestamps=[details_query.query.request.timestamp],
                     )
 
-    def _evaluate_area_too_large_dp_observation(
+    def _evaluate_area_too_large_sp_observation(
         self,
         mappings: Dict[str, TelemetryMapping],
         rect: s2sphere.LatLngRect,

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/display_data_evaluator.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/display_data_evaluator.py
@@ -243,8 +243,8 @@ class RIDObservationEvaluator(object):
             verified_sps = set()
 
         if perform_observation:
+            self._test_scenario.begin_test_step("Observer polling")
             for observer in observers:
-                self._test_scenario.begin_test_step("Observer polling")
                 (observation, query) = observer.observe_system(rect)
                 self._test_scenario.record_query(query)
                 self._evaluate_observation(
@@ -254,10 +254,10 @@ class RIDObservationEvaluator(object):
                     query,
                     verified_sps,
                 )
-                self._test_scenario.end_test_step()
 
                 # TODO: If bounding rect is smaller than cluster threshold, expand slightly above cluster threshold and re-observe
                 # TODO: If bounding rect is smaller than area-too-large threshold, expand slightly above area-too-large threshold and re-observe
+            self._test_scenario.end_test_step()
 
     def _evaluate_observation(
         self,

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/nominal_behavior.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/nominal_behavior.md
@@ -67,6 +67,10 @@ The timestamps of the injected telemetry usually start in the future.  If a flig
 
 **[astm.f3411.v19.NET0710](../../../requirements/astm/f3411/v19.md)** requires a Service Provider to implement the GET flights endpoint.  This check will also fail if uss_qualifier cannot query that endpoint (specified in the ISA present in the DSS) successfully.
 
+#### Service Provider altitude check
+
+**[astm.f3411.v19.NET0260](../../../requirements/astm/f3411/v19.md)** requires that relevant Remote ID data, consistent with the common data dictionary, be reported by the Service Provider.  Injected flight data had known altitudes, but the altitude reported by the Service Provider did not match those known altitudes.
+
 #### Successful flight details query check
 
 **[astm.f3411.v19.NET0710](../../../requirements/astm/f3411/v19.md)** requires a Service Provider to implement the GET flight details endpoint.  This check will fail if uss_qualifier cannot query that endpoint (specified in the ISA present in the DSS) successfully.
@@ -107,9 +111,9 @@ The timestamps of the injected telemetry usually start in the future.  If a flig
 
 **[astm.f3411.v19.NET0260](../../../requirements/astm/f3411/v19.md)** requires a SP to provide flights up to *NetMaxNearRealTimeDataPeriod* in the past, but an SP should preserve privacy and ensure relevancy by not sharing flights that are further in the past than this window.
 
-#### Altitude check
+#### Observed altitude check
 
-If the observed altitude of a flight does not match the altitude of the injected telemetry, this check will fail.
+**[astm.f3411.v19.NET0470](../../../requirements/astm/f3411/v19.md)** requires that a Display Provider provides any specified data fields in accordance with the common data dictionary when responding to a Display Application.  If the observed altitude of a flight does not match the altitude of the injected telemetry, this check will fail.
 
 #### Area too large check
 

--- a/monitoring/uss_qualifier/test_data/usa/kentland/rid.kml
+++ b/monitoring/uss_qualifier/test_data/usa/kentland/rid.kml
@@ -12,6 +12,16 @@
 			<styleUrl>#s_ylw-pushpin_hl0</styleUrl>
 		</Pair>
 	</StyleMap>
+	<StyleMap id="m_ylw-pushpin1">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#s_ylw-pushpin1</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#s_ylw-pushpin_hl00</styleUrl>
+		</Pair>
+	</StyleMap>
 	<StyleMap id="m_ylw-pushpin0">
 		<Pair>
 			<key>normal</key>
@@ -32,6 +42,16 @@
 			<styleUrl>#sh_ylw-pushpin</styleUrl>
 		</Pair>
 	</StyleMap>
+	<StyleMap id="msn_ylw-pushpin3">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#sn_ylw-pushpin3</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#sh_ylw-pushpin3</styleUrl>
+		</Pair>
+	</StyleMap>
 	<StyleMap id="msn_ylw-pushpin0">
 		<Pair>
 			<key>normal</key>
@@ -49,10 +69,30 @@
 		</Pair>
 		<Pair>
 			<key>highlight</key>
+			<styleUrl>#sh_ylw-pushpin10</styleUrl>
+		</Pair>
+	</StyleMap>
+	<StyleMap id="msn_ylw-pushpin10">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#sn_ylw-pushpin10</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
 			<styleUrl>#sh_ylw-pushpin1</styleUrl>
 		</Pair>
 	</StyleMap>
 	<StyleMap id="msn_ylw-pushpin2">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#sn_ylw-pushpin20</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#sh_ylw-pushpin00</styleUrl>
+		</Pair>
+	</StyleMap>
+	<StyleMap id="msn_ylw-pushpin20">
 		<Pair>
 			<key>normal</key>
 			<styleUrl>#sn_ylw-pushpin2</styleUrl>
@@ -63,6 +103,15 @@
 		</Pair>
 	</StyleMap>
 	<Style id="s_ylw-pushpin">
+		<IconStyle>
+			<scale>1.1</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+	</Style>
+	<Style id="s_ylw-pushpin1">
 		<IconStyle>
 			<scale>1.1</scale>
 			<Icon>
@@ -104,6 +153,15 @@
 			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
 		</IconStyle>
 	</Style>
+	<Style id="s_ylw-pushpin_hl00">
+		<IconStyle>
+			<scale>1.3</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+	</Style>
 	<Style id="sh_ylw-pushpin">
 		<IconStyle>
 			<scale>1.3</scale>
@@ -118,6 +176,18 @@
 			<fill>0</fill>
 		</PolyStyle>
 	</Style>
+	<Style id="sh_ylw-pushpin3">
+		<IconStyle>
+			<scale>1.3</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<PolyStyle>
+			<fill>0</fill>
+		</PolyStyle>
+	</Style>
 	<Style id="sh_ylw-pushpin0">
 		<IconStyle>
 			<scale>1.3</scale>
@@ -126,8 +196,21 @@
 			</Icon>
 			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
 		</IconStyle>
-		<BalloonStyle>
-		</BalloonStyle>
+		<LineStyle>
+			<color>ff0880fd</color>
+		</LineStyle>
+		<PolyStyle>
+			<fill>0</fill>
+		</PolyStyle>
+	</Style>
+	<Style id="sh_ylw-pushpin00">
+		<IconStyle>
+			<scale>1.3</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
 		<LineStyle>
 			<color>ff0880fd</color>
 		</LineStyle>
@@ -143,8 +226,18 @@
 			</Icon>
 			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
 		</IconStyle>
-		<BalloonStyle>
-		</BalloonStyle>
+		<LineStyle>
+			<color>ffffff20</color>
+		</LineStyle>
+	</Style>
+	<Style id="sh_ylw-pushpin10">
+		<IconStyle>
+			<scale>1.3</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
 		<LineStyle>
 			<color>ffffff20</color>
 		</LineStyle>
@@ -157,8 +250,6 @@
 			</Icon>
 			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
 		</IconStyle>
-		<BalloonStyle>
-		</BalloonStyle>
 		<PolyStyle>
 			<fill>0</fill>
 		</PolyStyle>
@@ -177,6 +268,18 @@
 			<fill>0</fill>
 		</PolyStyle>
 	</Style>
+	<Style id="sn_ylw-pushpin3">
+		<IconStyle>
+			<scale>1.1</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<PolyStyle>
+			<fill>0</fill>
+		</PolyStyle>
+	</Style>
 	<Style id="sn_ylw-pushpin0">
 		<IconStyle>
 			<scale>1.1</scale>
@@ -185,8 +288,6 @@
 			</Icon>
 			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
 		</IconStyle>
-		<BalloonStyle>
-		</BalloonStyle>
 		<PolyStyle>
 			<fill>0</fill>
 		</PolyStyle>
@@ -199,8 +300,18 @@
 			</Icon>
 			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
 		</IconStyle>
-		<BalloonStyle>
-		</BalloonStyle>
+		<LineStyle>
+			<color>ffffff20</color>
+		</LineStyle>
+	</Style>
+	<Style id="sn_ylw-pushpin10">
+		<IconStyle>
+			<scale>1.1</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
 		<LineStyle>
 			<color>ffffff20</color>
 		</LineStyle>
@@ -213,8 +324,21 @@
 			</Icon>
 			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
 		</IconStyle>
-		<BalloonStyle>
-		</BalloonStyle>
+		<LineStyle>
+			<color>ff0880fd</color>
+		</LineStyle>
+		<PolyStyle>
+			<fill>0</fill>
+		</PolyStyle>
+	</Style>
+	<Style id="sn_ylw-pushpin20">
+		<IconStyle>
+			<scale>1.1</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
 		<LineStyle>
 			<color>ff0880fd</color>
 		</LineStyle>
@@ -225,6 +349,123 @@
 	<Folder>
 		<name>kentland</name>
 		<open>1</open>
+		<Folder>
+			<name>flight: south u</name>
+			<open>1</open>
+			<description>serial_number: EXAMPLE_SERIAL2
+operation_description: U-turn south of takeoff
+operator_id: EXAMPLE_OPERATOR2
+registration_number: EXAMPLE_REGISTRATION2
+aircraft_type: HybridLift
+operator_name: UFT Participant 2
+timestamp_accuracy: 1.0
+speed_accuracy: SA3mps
+sample_rate: 1.0
+accuracy_h: HAUnknown
+accuracy_v: VAUnknown</description>
+			<Placemark>
+				<name>U turn south</name>
+				<styleUrl>#msn_ylw-pushpin10</styleUrl>
+				<LineString>
+					<tessellate>1</tessellate>
+					<coordinates>
+						-80.57802028980674,37.19714355363017,0 -80.57797675253043,37.19705074202537,0 -80.57800983801377,37.19694902808266,0 -80.5780474303987,37.19690109364706,0 -80.57811358652322,37.19681966148304,0 -80.5781216555155,37.19679655688515,0 -80.5781323958596,37.1967658046547,0 -80.57813945908244,37.1967298238938,0 -80.57814392771789,37.19670166260832,0 -80.57813862414081,37.19667084263494,0 -80.57812974002694,37.19663489860375,0 -80.57810822280315,37.19660386227894,0 -80.57808680009781,37.19657292090538,0 -80.57805287033446,37.19654689144921,0 -80.57801685035301,37.19652877181478,0 -80.57798437410553,37.19651578247868,0 -80.57795541973253,37.19650790849303,0 -80.57791416680433,37.19650499317999,0 -80.57786343304842,37.19649950359759,0 -80.57783204674391,37.19649932627075,0 -80.57777966065294,37.1965019468875,0 -80.5777370336082,37.19650728570836,0 -80.57771293899224,37.19651750378168,0 -80.57768565578642,37.19652277867118,0 -80.57763747114771,37.19654328332236,0 -80.57759211766535,37.19655630094977,0 -80.57754402039026,37.19657696153136,0 -80.57750589588102,37.19660059169945,0 -80.57747951786358,37.19661892142204,0 -80.5774474773521,37.19664014255395,0 -80.57741240795438,37.19665656163997,0 -80.57738253402972,37.19668224727236,0 -80.57733805633134,37.1967087346705,0 -80.57731144440999,37.19672723303452,0 -80.57728782013758,37.1967382213372,0 -80.5772670821306,37.19675403842484,0 -80.57722590371309,37.19677363092791,0 -80.57719021013257,37.19679007290647,0 -80.57715384893825,37.19680612894521,0 -80.57710325423781,37.19682580323256,0 -80.57705935794317,37.19684333921531,0 -80.57702785941196,37.19685573755429,0 -80.57697733713522,37.19687547603477,0 -80.5769268168293,37.19689521340487,0 -80.57689218727917,37.19691515641433,0 -80.57684576602931,37.19694092595839,0 -80.5768113755809,37.1969611651317,0 -80.57677111345579,37.19698442260341,0 -80.57672754086077,37.19701511985383,0 -80.57668035829094,37.19704028305533,0 -80.57664246609896,37.19705520615887,0 -80.57661090952831,37.19706766713748,0 -80.57655392485896,37.19708988530244,0 -80.57650314895285,37.19710943914248,0 -80.57645875475153,37.19712658106612,0 -80.57641467818948,37.19714419653998,0 -80.57637059695035,37.19716182061966,0 -80.57632651823518,37.19717947512723,0 -80.57627609999774,37.1971996033648,0 -80.57623470658326,37.19722160806288,0 -80.57619606993768,37.19723521126495,0 -80.57614524025075,37.19725449738874,0 -80.57610733442567,37.19726938807241,0 -80.57604102858684,37.19728911012695,0 -80.57600319582565,37.19730416478304,0 -80.57597149043076,37.19731629442016,0 -80.57593362783513,37.19733128797339,0 -80.57589889915046,37.19733851696943,0 -80.57586417772457,37.19734574427401,0 -80.57582315240158,37.1973554691392,0 -80.5757947630964,37.19736024915019,0 -80.57575688457634,37.19736210892274,0 -80.57571905420066,37.19736406691424,0 -80.57566842880406,37.19737032563788,0 -80.57561146439458,37.19736552363385,0 -80.57559881151388,37.19737029890231,0 -80.57557039842979,37.19736133206649,0 -80.57553885441419,37.19736016747333,0 -80.5755074502042,37.1973594799225,0 -80.57547299747129,37.19735368068493,0 -80.57541659119126,37.19734989051443,0 -80.5753571370973,37.19734062545451,0 -80.57531025161447,37.19733978931831,0 -80.57527290234596,37.19732881724949,0 -80.57523862724926,37.19732290358091,0 -80.57520132044687,37.19731159452292,0 -80.57516711123088,37.19730562136304,0 -80.57513616346247,37.19729188039913,0 -80.5750990109287,37.19728103413704,0 -80.57505563803612,37.19727221152231,0 -80.57502782892645,37.19726352227142,0 -80.57498780142572,37.19724666378211,0 -80.5749695654127,37.19722794184786,0 -80.57494213502011,37.19720637209506,0 -80.5749147583816,37.19718484445996,0 -80.57489365558244,37.19716097162902,0 -80.57487556084379,37.19714234764194,0 -80.57486073849576,37.19711619316517,0 -80.57485510309948,37.19709293181062,0 -80.57484651808807,37.19706458502421,0 -80.57483793488441,37.19703642304626,0 -80.57483231710563,37.19701342385019,0 -80.57483908697587,37.1969855863474,0 -80.57483670963236,37.19695509014836,0 -80.57483728812755,37.19692973339532,0 -80.57484109271809,37.19689694932215,0 -80.57485455008515,37.19684193878193,0 -80.57485510587279,37.19681685924259,0 -80.57487120275944,37.19677947910903,0 -80.57487470492359,37.19675926240063,0 -80.57488435582773,37.1967366609142,0 -80.57489747737328,37.1966939827177,0 -80.57491003378395,37.19667663144652,0 -80.57491696723982,37.19663656836807,0 -80.57494278450783,37.19656443073654,0 -80.57495896905118,37.19651475537266,0 -80.57496533956328,37.19649982348621,0 -80.5749812203474,37.19646239835231,0 -80.57500341110034,37.19641038509319,0 -80.57501019592259,37.1963706422341,0 -80.57503208199415,37.19633169287626,0 -80.57505414804908,37.19628027844096,0 -80.57506357384375,37.19625834616446,0 -80.57507616459698,37.19622916152061,0 -80.57509814989831,37.19617823663271,0 -80.57511362915179,37.19615412771148,0 -80.57512633842926,37.19611283286848,0 -80.57515092343139,37.19607883949087,0 -80.57516026828239,37.1960570099554,0 -80.57518807819817,37.19600379019301,0 -80.57520653329098,37.19597241202344,0 -80.57521890696329,37.19594344224873,0 -80.57524951446408,37.19589537944923,0 -80.57527097159294,37.19585701964773,0 -80.57528931623939,37.19582590556047,0 -80.57529854460773,37.19580436652097,0 -80.57531684937715,37.19577332379191,0 -80.57532911969601,37.19574467719581,0 -80.57534726543213,37.1957256591955,0 -80.575356445371,37.19570421576573,0 -80.57536561632516,37.19568279370441,0 -80.57538686810472,37.19564477153428,0 -80.57539913348404,37.19560438129218,0 -80.57541423138603,37.1955806653348,0 -80.57543238446472,37.1955380233246,0 -80.57544439280359,37.19552147444124,0 -80.57545959404297,37.19547427420357,0 -80.57546866576811,37.19545308935833,0 -80.57547477263343,37.19542720346918,0 -80.57548087195036,37.19540135142899,0 -80.57549292244842,37.19537320294821,0 -80.57550200848409,37.19534039916945,0 -80.57551105097414,37.1953193618027,0 -80.57552009590795,37.19529834183516,0 -80.5755380908282,37.19526802810682,0 -80.57554415457196,37.19524239245709,0 -80.57555912913728,37.19520746862251,0 -80.57557102733571,37.19519119263322,0 -80.57558594367956,37.19515634699608,0 -80.57559190303721,37.19514242515697,0 -80.57560380523063,37.19511460883445,0 -80.57560987197462,37.19508916181141,0 -80.57561286942858,37.19508222518156,0 
+					</coordinates>
+				</LineString>
+			</Placemark>
+			<Placemark>
+				<name>alt: Runway</name>
+				<styleUrl>#m_ylw-pushpin0</styleUrl>
+				<Polygon>
+					<tessellate>1</tessellate>
+					<altitudeMode>absolute</altitudeMode>
+					<outerBoundaryIs>
+						<LinearRing>
+							<coordinates>
+								-80.57850709375344,37.19696983131671,529 -80.57836943742444,37.1968206451378,529 -80.57757910966818,37.19730804793311,529 -80.57771657931552,37.197467166625,529 -80.57850709375344,37.19696983131671,529 
+							</coordinates>
+						</LinearRing>
+					</outerBoundaryIs>
+				</Polygon>
+			</Placemark>
+			<Placemark>
+				<name>alt: High</name>
+				<styleUrl>#msn_ylw-pushpin</styleUrl>
+				<Polygon>
+					<extrude>1</extrude>
+					<tessellate>1</tessellate>
+					<altitudeMode>absolute</altitudeMode>
+					<outerBoundaryIs>
+						<LinearRing>
+							<coordinates>
+								-80.57652650465256,37.19639064042909,630 -80.57551908137347,37.19673961497966,630 -80.57544473658429,37.19754032800347,630 -80.57690185992546,37.19712701759909,630 -80.57652650465256,37.19639064042909,630 
+							</coordinates>
+						</LinearRing>
+					</outerBoundaryIs>
+				</Polygon>
+			</Placemark>
+			<Placemark>
+				<name>alt: Low</name>
+				<styleUrl>#msn_ylw-pushpin</styleUrl>
+				<Polygon>
+					<extrude>1</extrude>
+					<tessellate>1</tessellate>
+					<altitudeMode>absolute</altitudeMode>
+					<outerBoundaryIs>
+						<LinearRing>
+							<coordinates>
+								-80.57425578863914,37.19421127095399,570 -80.57286981865417,37.19667992084468,570 -80.57548617423373,37.19643158135489,570 -80.57648484699767,37.19485509194953,570 -80.57425578863914,37.19421127095399,570 
+							</coordinates>
+						</LinearRing>
+					</outerBoundaryIs>
+				</Polygon>
+			</Placemark>
+			<Placemark>
+				<name>speed: Departure (5)</name>
+				<styleUrl>#msn_ylw-pushpin20</styleUrl>
+				<Polygon>
+					<tessellate>1</tessellate>
+					<outerBoundaryIs>
+						<LinearRing>
+							<coordinates>
+								-80.57847912230507,37.19668917192925,0 -80.57756486680796,37.19716402084653,0 -80.57796008822778,37.19760038633291,0 -80.57887087121067,37.19711298552166,0 -80.57847912230507,37.19668917192925,0 
+							</coordinates>
+						</LinearRing>
+					</outerBoundaryIs>
+				</Polygon>
+			</Placemark>
+			<Placemark>
+				<name>speed: Enroute (30)</name>
+				<styleUrl>#msn_ylw-pushpin20</styleUrl>
+				<Polygon>
+					<tessellate>1</tessellate>
+					<outerBoundaryIs>
+						<LinearRing>
+							<coordinates>
+								-80.57646779084327,37.19390309196537,0 -80.57318030114045,37.19649505923135,0 -80.5750628580529,37.19842004431668,0 -80.57808521816328,37.19590285668286,0 -80.57646779084327,37.19390309196537,0 
+							</coordinates>
+						</LinearRing>
+					</outerBoundaryIs>
+				</Polygon>
+			</Placemark>
+			<Placemark>
+				<name>operator_location</name>
+				<LookAt>
+					<longitude>-80.57815318711911</longitude>
+					<latitude>37.19718120157874</latitude>
+					<altitude>0</altitude>
+					<heading>-26.18362347326667</heading>
+					<tilt>12.31851320409981</tilt>
+					<range>144.5234695576378</range>
+					<gx:altitudeMode>relativeToSeaFloor</gx:altitudeMode>
+				</LookAt>
+				<styleUrl>#m_ylw-pushpin1</styleUrl>
+				<Point>
+					<gx:drawOrder>1</gx:drawOrder>
+					<coordinates>-80.57819770820173,37.19732333569079,0</coordinates>
+				</Point>
+			</Placemark>
+		</Folder>
 		<Folder>
 			<name>flight: dairy circle</name>
 			<open>1</open>
@@ -266,7 +507,7 @@ accuracy_v: VAUnknown</description>
 			</Placemark>
 			<Placemark>
 				<name>alt: High</name>
-				<styleUrl>#msn_ylw-pushpin</styleUrl>
+				<styleUrl>#msn_ylw-pushpin3</styleUrl>
 				<Polygon>
 					<extrude>1</extrude>
 					<tessellate>1</tessellate>


### PR DESCRIPTION
This PR fixes the altitude check in the RID nominal behavior scenario (checking that reported altitude matches injected altitude).  The previous implementation was wrong in a number of ways and this approach is substantively different.  The check is now performed separately for the uss_qualifier observation of the Service Provider under test and the observation from the Display Provider under test.

Service Providers that pass the checks for uss_qualifier's direct observation are also assumed to not be at fault for failed checks related to unexpected observations from a Display Provider under test.

Some terminology is clarified (dp_observation was originally meant to convey "observation made by uss_qualifier as the Display Provider", but that was hard to distinguish from "observation of the Display Provider [under test]").

The riddp F3411-22a functionality of mock_uss was found to not recognize the correct parameter to include recent positions; this is also fixed.

Finally, a second flight is added to the Kentland RID test data.