### PR TITLE
[prober] Fix missing migrated variable

### DIFF
--- a/monitoring/prober/aux_/test_version.py
+++ b/monitoring/prober/aux_/test_version.py
@@ -1,9 +1,10 @@
 """Test version can be queried."""
 
 from monitoring.monitorlib import rid_v1
+from uas_standards.astm.f3411 import v19
 
 def test_version(aux_session):
-  resp = aux_session.get('/version', scope=rid_v1.SCOPE_READ)
+  resp = aux_session.get('/version', scope=v19.constants.Scope.Read)
   assert resp.status_code == 200
   version = resp.json()['version']
   assert version


### PR DESCRIPTION
`rid_v1.SCOPE_READ` has been previously migrated to a new package. This PR fixes this missing variable to address a prober failing test.

This PR is the first of an effort to bring the prober to the same quality level as the uss_qualifier.