### PR TITLE
[prober] Add lint and format targets to prober

### DIFF
--- a/monitoring/Makefile
+++ b/monitoring/Makefile
@@ -3,23 +3,27 @@ lint:
 	cd uss_qualifier && make lint
 	cd mock_uss && make lint
 	cd monitorlib && make lint
+	cd prober && make lint
 
 .PHONY: python-lint
 python-lint:
 	cd uss_qualifier && make python-lint
 	cd mock_uss && make python-lint
 	cd monitorlib && make python-lint
+	cd prober && make python-lint
 
 .PHONY: shell-lint
 shell-lint:
 	cd uss_qualifier && make shell-lint
 	cd mock_uss && make shell-lint
+	cd prober && make shell-lint
 
 .PHONY: format
 format:
 	cd uss_qualifier && make format
 	cd mock_uss && make format
 	cd monitorlib && make format
+	cd prober && make format
 
 .PHONY: build
 build:

--- a/monitoring/prober/Makefile
+++ b/monitoring/prober/Makefile
@@ -1,0 +1,15 @@
+.PHONY: lint
+lint: python-lint shell-lint
+
+.PHONY: python-lint
+python-lint:
+	docker run --rm -v "$(CURDIR):/code" -w /code pyfound/black:22.10.0 black --check . || (echo "Linter didn't succeed. You can use the following command to fix python linter issues: make format" && exit 1)
+
+.PHONY: shell-lint
+shell-lint:
+	find . -name '*.sh' | xargs docker run --rm -v "$(CURDIR):/code" -w /code koalaman/shellcheck
+
+.PHONY: format
+format:
+	docker run --rm -v "$(CURDIR):/code" -w /code pyfound/black:22.10.0 black .
+


### PR DESCRIPTION
This PR adds lint and format targets to the prober project.
Note, that the first commit updates the Makefiles and the second commit contains the result 
of the format command.
