### PR TITLE
[ci][prober] Run prober in CI and capture report as artifact

### DIFF
--- a/.github/workflows/CI.md
+++ b/.github/workflows/CI.md
@@ -30,3 +30,5 @@ Steps:
 Steps:
 
 * test_docker_fully_mocked.sh
+
+### prober tests (`make test` in monitoring/prober)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,10 @@ jobs:
       run: |
         cd monitoring/uss_qualifier
         make test
+    - name: prober tests
+      run: |
+        cd monitoring/prober
+        make test
     - name: Save containers and tracer logs as artifact
       if: always()
       uses: actions/upload-artifact@v3
@@ -70,8 +74,9 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v3
       with:
-        name: monitoring-tests-report
+        name: monitoring-tests-reports
         path: |
           monitoring/uss_qualifier/report.gv
           monitoring/uss_qualifier/report.json
           monitoring/uss_qualifier/tested_requirements.html
+          monitoring/prober/prober_test_results.xml

--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,7 @@ coverage.xml
 *.cover
 .hypothesis/
 .pytest_cache/
-e2e_test_result
+prober_test_results.xml
 test_result
 
 # Translations
@@ -121,7 +121,7 @@ venv.bak/
 
 # mypy
 .mypy_cache/
-test/e2e_test_result
+
 
 # local go builds
 go

--- a/monitoring/Makefile
+++ b/monitoring/Makefile
@@ -34,3 +34,4 @@ test:
 	cd monitorlib && make test
 	cd mock_uss && make test
 	cd uss_qualifier && make test
+	cd prober && make test

--- a/monitoring/prober/Makefile
+++ b/monitoring/prober/Makefile
@@ -13,3 +13,6 @@ shell-lint:
 format:
 	docker run --rm -v "$(CURDIR):/code" -w /code pyfound/black:22.10.0 black .
 
+.PHONY: test
+test:
+	./scripts/test_docker_fully_mocked.sh

--- a/monitoring/prober/run_locally.sh
+++ b/monitoring/prober/run_locally.sh
@@ -30,8 +30,8 @@ for container_name in "${localhost_containers[@]}"; do
 	fi
 done
 
-echo "Re/Create e2e_test_result file"
-RESULTFILE="$(pwd)/e2e_test_result"
+echo "Re/Create prober_test_results.xml file"
+RESULTFILE="$(pwd)/monitoring/prober/prober_test_results.xml"
 touch "${RESULTFILE}"
 cat /dev/null > "${RESULTFILE}"
 

--- a/monitoring/prober/scripts/test_docker_fully_mocked.sh
+++ b/monitoring/prober/scripts/test_docker_fully_mocked.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+set -o xtrace
+
+# Find and change to repo root directory
+OS=$(uname)
+if [[ "$OS" == "Darwin" ]]; then
+  # OSX uses BSD readlink
+  BASEDIR="$(dirname "$0")"
+else
+  BASEDIR=$(readlink -e "$(dirname "$0")")
+fi
+cd "${BASEDIR}/../../.." || exit 1
+
+echo "Ensure the environment is clean"
+echo "============="
+make down-locally
+
+function collect_logs() {
+  mkdir -p logs/prober
+  build/dev/run_locally.sh logs --timestamps > logs/prober/dss_sandbox_local.log 2>&1
+}
+
+function cleanup() {
+  echo "Clean up"
+  echo "============="
+  make down-locally
+}
+
+function on_exit() {
+  collect_logs
+  cleanup
+}
+
+function on_sigint() {
+  collect_logs
+  cleanup
+  exit
+}
+
+trap on_exit   EXIT
+trap on_sigint SIGINT
+
+echo "Start mock system"
+echo "============="
+make start-locally
+
+echo "Run the standard local tests."
+echo "============="
+monitoring/prober/run_locally.sh


### PR DESCRIPTION
This PR adds the prober to the CI checks. I took the opportunity to rename the report so it clarifies the project it belongs to.
This requires an update of the DSS repository when published.

Note that the PR #63 will have to be merged first to successfully pass the check.