### PR TITLE
[uss_qualifier] Add signatures to identify test baseline

### DIFF
--- a/monitoring/Dockerfile
+++ b/monitoring/Dockerfile
@@ -32,5 +32,7 @@ HEALTHCHECK CMD sh /app/health_check.sh
 
 ENV PYTHONPATH /app
 ARG version
+ARG commit_hash
 ENV MONITORING_VERSION=$version
+ENV GIT_COMMIT_HASH=$commit_hash
 ENTRYPOINT []

--- a/monitoring/build.sh
+++ b/monitoring/build.sh
@@ -14,9 +14,10 @@ cd "${BASEDIR}/.." || exit 1
 
 TAG="${1:-interuss/monitoring}"
 
-docker build \
+docker image build \
     -f monitoring/Dockerfile \
     -t "${TAG}" \
     --build-arg version="$(scripts/git/version.sh monitoring --long)" \
+    --build-arg commit_hash="$(git rev-parse HEAD)" \
     . \
   || exit 1

--- a/monitoring/monitorlib/versioning.py
+++ b/monitoring/monitorlib/versioning.py
@@ -2,13 +2,10 @@ import os
 import subprocess
 
 
-def get_code_version() -> str:
-    env_version = os.environ.get("MONITORING_VERSION", "")
-    if env_version:
-        return env_version
-    env_version = os.environ.get("CODE_VERSION", "")
-    if env_version:
-        return env_version
+def get_commit_hash() -> str:
+    env_hash = os.environ.get("GIT_COMMIT_HASH", "")
+    if env_hash:
+        return env_hash
 
     process = subprocess.Popen(
         ["git", "rev-parse", "--short", "HEAD"],
@@ -21,6 +18,18 @@ def get_code_version() -> str:
     commit = commit.strip()
     if "not a git repository" in commit:
         return "unknown"
+    return commit
+
+
+def get_code_version() -> str:
+    env_version = os.environ.get("MONITORING_VERSION", "")
+    if env_version:
+        return env_version
+    env_version = os.environ.get("CODE_VERSION", "")
+    if env_version:
+        return env_version
+
+    commit = get_commit_hash()
 
     process = subprocess.Popen(
         ["git", "status", "-s"], stdout=subprocess.PIPE, universal_newlines=True

--- a/monitoring/uss_qualifier/configurations/configuration.py
+++ b/monitoring/uss_qualifier/configurations/configuration.py
@@ -2,7 +2,7 @@ from typing import Optional, List
 
 from implicitdict import ImplicitDict
 
-from monitoring.uss_qualifier.fileio import load_dict_with_references
+from monitoring.uss_qualifier.fileio import load_dict_with_references, FileReference
 from monitoring.uss_qualifier.requirements.documentation import RequirementSetID
 from monitoring.uss_qualifier.resources.definitions import ResourceCollection
 from monitoring.uss_qualifier.suites.definitions import (
@@ -16,6 +16,9 @@ ParticipantID = str
 class TestConfiguration(ImplicitDict):
     action: TestSuiteActionDeclaration
     """The action this test configuration wants to run (usually a test suite)"""
+
+    non_baseline_inputs: Optional[List[FileReference]] = None
+    """List of file inputs that should not be considered when computing the test baseline signature (e.g., environmental definitions)."""
 
     resources: ResourceCollection
     """Declarations for resources used by the test suite"""

--- a/monitoring/uss_qualifier/configurations/dev/environment.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/environment.yaml
@@ -1,0 +1,76 @@
+# The resources in this file describe the system/environment under test and should not change the test being run.
+
+common:
+    utm_auth:
+        resource_type: resources.communications.AuthAdapterResource
+        specification:
+            environment_variable_containing_auth_spec: AUTH_SPEC
+
+net_rid:
+    netrid_service_providers:
+        resource_type: resources.netrid.NetRIDServiceProviders
+        dependencies:
+            auth_adapter: utm_auth
+        specification:
+            service_providers:
+                - participant_id: uss1
+                  injection_base_url: http://host.docker.internal:8071/ridsp/injection
+    netrid_observers:
+        resource_type: resources.netrid.NetRIDObserversResource
+        dependencies:
+            auth_adapter: utm_auth
+        specification:
+            observers:
+                - participant_id: uss2
+                  observation_base_url: http://host.docker.internal:8073/riddp/observation
+    netrid_dss_instances_v19:
+        resource_type: resources.astm.f3411.DSSInstancesResource
+        dependencies:
+            auth_adapter: utm_auth
+        specification:
+            dss_instances:
+                - participant_id: uss1
+                  rid_version: F3411-19
+                  base_url: http://host.docker.internal:8082
+                - participant_id: uss2
+                  rid_version: F3411-19
+                  base_url: http://host.docker.internal:8082
+
+f3548:
+    flight_planners:
+        resource_type: resources.flight_planning.FlightPlannersResource
+        dependencies:
+            auth_adapter: utm_auth
+        specification:
+            flight_planners:
+                # uss1 is the mock_uss directly exposing scdsc functionality
+                -   participant_id: uss1
+                    injection_base_url: http://host.docker.internal:8074/scdsc
+                # uss2 uses atproxy, with requests being fulfilled by mock_uss with atproxy_client functionality enabled
+                -   participant_id: uss2
+                    injection_base_url: http://host.docker.internal:8075/scd
+    dss:
+        resource_type: resources.astm.f3548.v21.DSSInstanceResource
+        dependencies:
+            auth_adapter: utm_auth
+        specification:
+            participant_id: uss1
+            base_url: http://host.docker.internal:8082
+
+f3548_single_scenario:
+    uss1:
+        resource_type: resources.flight_planning.FlightPlannerResource
+        dependencies:
+            auth_adapter: utm_auth
+        specification:
+            flight_planner:
+                participant_id: uss1
+                injection_base_url: http://host.docker.internal:8074/scdsc
+    uss2:
+        resource_type: resources.flight_planning.FlightPlannerResource
+        dependencies:
+            auth_adapter: utm_auth
+        specification:
+            flight_planner:
+                participant_id: uss2
+                injection_base_url: http://host.docker.internal:8074/scdsc

--- a/monitoring/uss_qualifier/configurations/dev/local_test.json
+++ b/monitoring/uss_qualifier/configurations/dev/local_test.json
@@ -1,6 +1,7 @@
 {
   "v1": {
     "test_run": {
+      "non_baseline_inputs": ["configurations.dev.environment"],
       "resources": {
         "resource_declarations": {
           "$ref": "resources.yaml#/all"

--- a/monitoring/uss_qualifier/configurations/dev/resources.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/resources.yaml
@@ -1,151 +1,91 @@
 all:
-  allOf:
-  - $ref: '#/uspace'
-  - $ref: '#/net_rid_sims'
+    allOf:
+        -   $ref: '#/uspace'
+        -   $ref: '#/net_rid_sims'
 
 uspace:
-  allOf:
-  - $ref: '#/net_rid'
-  - $ref: '#/flight_auth'
+    allOf:
+        -   $ref: '#/net_rid'
+        -   $ref: '#/flight_auth'
 
 net_rid:
-  $ref: '#/common'
-  netrid_service_providers:
-    resource_type: resources.netrid.NetRIDServiceProviders
-    dependencies:
-      auth_adapter: utm_auth
-    specification:
-      service_providers:
-      - participant_id: uss1
-        injection_base_url: http://host.docker.internal:8071/ridsp/injection
-  netrid_observers:
-    resource_type: resources.netrid.NetRIDObserversResource
-    dependencies:
-      auth_adapter: utm_auth
-    specification:
-      observers:
-      - participant_id: uss2
-        observation_base_url: http://host.docker.internal:8073/riddp/observation
-  netrid_observation_evaluation_configuration:
-    resource_type: resources.netrid.EvaluationConfigurationResource
-    specification: {}
-  netrid_dss_instances_v19:
-    resource_type: resources.astm.f3411.DSSInstancesResource
-    dependencies:
-      auth_adapter: utm_auth
-    specification:
-      dss_instances:
-        - participant_id: uss1
-          rid_version: F3411-19
-          base_url: http://host.docker.internal:8082
-        - participant_id: uss2
-          rid_version: F3411-19
-          base_url: http://host.docker.internal:8082
+    allOf:
+        -   $ref: '#/common'
+        -   $ref: 'environment.yaml#/net_rid'
+    netrid_observation_evaluation_configuration:
+        resource_type: resources.netrid.EvaluationConfigurationResource
+        specification: { }
 
 net_rid_sims:
-  adjacent_circular_flights_data:
-    resource_type: resources.netrid.FlightDataResource
-    specification:
-      adjacent_circular_flights_simulation_source: {}
-  adjacent_circular_storage_config:
-    resource_type: resources.netrid.FlightDataStorageResource
-    specification:
-      flight_record_collection_path: "./output/test_data.che.netrid.circular_flights.json"
-  kml_flights_data:
-    resource_type: resources.netrid.FlightDataResource
-    specification:
-      kml_source:
-        kml_location: file://./test_data/usa/netrid/dcdemo.kml
-  kml_storage_config:
-    resource_type: resources.netrid.FlightDataStorageResource
-    specification:
-      flight_record_collection_path: "./output/test_data.usa.netrid.dcdemo_flights.json"
+    adjacent_circular_flights_data:
+        resource_type: resources.netrid.FlightDataResource
+        specification:
+            adjacent_circular_flights_simulation_source: { }
+    adjacent_circular_storage_config:
+        resource_type: resources.netrid.FlightDataStorageResource
+        specification:
+            flight_record_collection_path: "./output/test_data.che.netrid.circular_flights.json"
+    kml_flights_data:
+        resource_type: resources.netrid.FlightDataResource
+        specification:
+            kml_source:
+                kml_location: file://./test_data/usa/netrid/dcdemo.kml
+    kml_storage_config:
+        resource_type: resources.netrid.FlightDataStorageResource
+        specification:
+            flight_record_collection_path: "./output/test_data.usa.netrid.dcdemo_flights.json"
 
 flight_auth:
-  $ref: '#/f3548_che'
-  invalid_flight_auth_flights:
-    resource_type: resources.flight_planning.FlightIntentsResource
-    specification:
-      planning_time: '0:05:00'
-      file_source: file://./test_data/che/flight_intents/invalid_flight_auths.json
+    $ref: '#/f3548_che'
+    invalid_flight_auth_flights:
+        resource_type: resources.flight_planning.FlightIntentsResource
+        specification:
+            planning_time: '0:05:00'
+            file_source: file://./test_data/che/flight_intents/invalid_flight_auths.json
 
 che_flight_intents:
-  conflicting_flights:
-    resource_type: resources.flight_planning.FlightIntentsResource
-    specification:
-      planning_time: '0:05:00'
-      file_source: file://./test_data/che/flight_intents/conflicting_flights.json
-  priority_preemption_flights:
-    resource_type: resources.flight_planning.FlightIntentsResource
-    specification:
-      planning_time: '0:05:00'
-      file_source: test_data.che.flight_intents.priority_preemption
+    conflicting_flights:
+        resource_type: resources.flight_planning.FlightIntentsResource
+        specification:
+            planning_time: '0:05:00'
+            file_source: file://./test_data/che/flight_intents/conflicting_flights.json
+    priority_preemption_flights:
+        resource_type: resources.flight_planning.FlightIntentsResource
+        specification:
+            planning_time: '0:05:00'
+            file_source: test_data.che.flight_intents.priority_preemption
 
 kentland_flight_intents:
-  conflicting_flights:
-    resource_type: resources.flight_planning.FlightIntentsResource
-    specification:
-      planning_time: '0:05:00'
-      file_source: file://./test_data/usa/kentland/flight_intents/conflicting_flights.yaml
-  priority_preemption_flights:
-    resource_type: resources.flight_planning.FlightIntentsResource
-    specification:
-      planning_time: '0:05:00'
-      file_source: test_data.usa.kentland.flight_intents.priority_preemption
+    conflicting_flights:
+        resource_type: resources.flight_planning.FlightIntentsResource
+        specification:
+            planning_time: '0:05:00'
+            file_source: file://./test_data/usa/kentland/flight_intents/conflicting_flights.yaml
+    priority_preemption_flights:
+        resource_type: resources.flight_planning.FlightIntentsResource
+        specification:
+            planning_time: '0:05:00'
+            file_source: test_data.usa.kentland.flight_intents.priority_preemption
 
 f3548_che:
-  allOf:
-    - $ref: '#/f3548'
-    - $ref: '#/che_flight_intents'
+    allOf:
+        -   $ref: '#/f3548'
+        -   $ref: '#/che_flight_intents'
 
 f3548_kentland:
-  allOf:
-  - $ref: '#/f3548'
-  - $ref: '#/kentland_flight_intents'
+    allOf:
+        -   $ref: '#/f3548'
+        -   $ref: '#/kentland_flight_intents'
 
 f3548:
-  $ref: '#/common'
-  flight_planners:
-    resource_type: resources.flight_planning.FlightPlannersResource
-    dependencies:
-      auth_adapter: utm_auth
-    specification:
-      flight_planners:
-      # uss1 is the mock_uss directly exposing scdsc functionality
-      - participant_id: uss1
-        injection_base_url: http://host.docker.internal:8074/scdsc
-      # uss2 uses atproxy, with requests being fulfilled by mock_uss with atproxy_client functionality enabled
-      - participant_id: uss2
-        injection_base_url: http://host.docker.internal:8075/scd
-  dss:
-    resource_type: resources.astm.f3548.v21.DSSInstanceResource
-    dependencies:
-      auth_adapter: utm_auth
-    specification:
-      participant_id: uss1
-      base_url: http://host.docker.internal:8082
+    allOf:
+        -   $ref: '#/common'
+        -   $ref: 'environment.yaml#/f3548'
 
 f3548_single_scenario:
-  $ref: '#/f3548_che'
-  uss1:
-    resource_type: resources.flight_planning.FlightPlannerResource
-    dependencies:
-      auth_adapter: utm_auth
-    specification:
-      flight_planner:
-        participant_id: uss1
-        injection_base_url: http://host.docker.internal:8074/scdsc
-  uss2:
-    resource_type: resources.flight_planning.FlightPlannerResource
-    dependencies:
-      auth_adapter: utm_auth
-    specification:
-      flight_planner:
-        participant_id: uss2
-        injection_base_url: http://host.docker.internal:8074/scdsc
+    allOf:
+        -   $ref: '#/f3548_che'
+        -   $ref: 'environment.yaml#/f3548_single_scenario'
 
 common:
-  utm_auth:
-    resource_type: resources.communications.AuthAdapterResource
-    specification:
-      environment_variable_containing_auth_spec: AUTH_SPEC
+    $ref: 'environment.yaml#/common'

--- a/monitoring/uss_qualifier/fileio.py
+++ b/monitoring/uss_qualifier/fileio.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import os
 from typing import Tuple, Optional, Dict, List, Union
@@ -25,6 +26,10 @@ Allowed extensions:
   * .yaml (dict, content)
   * .kml (content)
 """
+
+
+content_signatures: Dict[str, str] = {}
+"""Cache populated with a mapping between the name of a file loaded by this module and the SHA-1 hash of that file's content."""
 
 
 def resolve_filename(data_file: FileReference) -> str:
@@ -60,6 +65,11 @@ def _load_content_from_file_name(file_name: str) -> str:
     else:
         with open(file_name, "r") as f:
             file_content = f.read()
+
+    # Compute and remember signature for this file content
+    sig = hashlib.sha1()
+    sig.update(file_content.encode("utf-8"))
+    content_signatures[file_name] = sig.hexdigest()
 
     return file_content
 

--- a/monitoring/uss_qualifier/reports/report.py
+++ b/monitoring/uss_qualifier/reports/report.py
@@ -291,6 +291,19 @@ class TestRunReport(ImplicitDict):
     codebase_version: str
     """Version of codebase used to run uss_qualifier"""
 
+    commit_hash: str
+    """Full commit hash of codebase used to run uss_qualifier"""
+
+    file_signatures: Dict[str, str]
+    """Mapping between the names of files loaded during test run and the SHA-1 hashes of those files' content."""
+
+    baseline_signature: str
+    """Signature of the test run including codebase version and all file signatures except excluded environmental files.
+
+    This field can be used to identify that a particular expected test baseline (codebase, all non-environmental inputs)
+    was run.  The value of this field is computed from codebase_version and all elements of file_signatures that are not
+    explicitly excluded as environmental configuration."""
+
     configuration: TestConfiguration
     """Configuration used to run uss_qualifier"""
 


### PR DESCRIPTION
A common traceability question for uss_qualifier tests will likely be "what test was run?"  This PR attempts to provide a better answer to that question in the form of a "test baseline signature".  A test baseline is all the information about the test including the code running it and all the input files, but excluding information about the test environment or who is participating in the test.  I believe regulators will want to define a test baseline and have a mechanism of easily determining that a particular test run followed that test baseline.

The signature implementation in this PR is simply to take the SHA-1 hash of all components contributing to the test baseline.  The codebase version is included, along with the full commit hash for additional traceability.  Every file loaded as an input to uss_qualifier (according to my search for instances of `open` within monitoring/uss_qualifier) has the SHA-1 hash of that file's content computed, and each file's content hash is included as a component of the test baseline by default.  The configuration file can specify one or more files to omit from the test baseline, allowing environment, participants, and other flexible parameters to be specified without changing the test baseline signature.

The intent of this feature is that if a normal uss_qualifier report indicates a particular test baseline signature that matches a known test baseline signature, then a report reader can be confident that all important aspects (as defined in the baseline) of the test baseline were used in the test run generating that report.

As an example, part of the content of configurations.dev.resources.yaml is split into environment.yaml and environment.yaml is excluded from the development test baseline.