### PR TITLE
[uss_qualifer / flight planner ressource] Add allows_same_priority_intersections configuration

### DIFF
--- a/monitoring/uss_qualifier/configurations/dev/environment.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/environment.yaml
@@ -46,9 +46,11 @@ f3548:
                 # uss1 is the mock_uss directly exposing scdsc functionality
                 -   participant_id: uss1
                     injection_base_url: http://host.docker.internal:8074/scdsc
+                    allows_same_priority_intersections: false
                 # uss2 uses atproxy, with requests being fulfilled by mock_uss with atproxy_client functionality enabled
                 -   participant_id: uss2
                     injection_base_url: http://host.docker.internal:8075/scd
+                    allows_same_priority_intersections: false
     dss:
         resource_type: resources.astm.f3548.v21.DSSInstanceResource
         dependencies:
@@ -66,6 +68,7 @@ f3548_single_scenario:
             flight_planner:
                 participant_id: uss1
                 injection_base_url: http://host.docker.internal:8074/scdsc
+                allows_same_priority_intersections: false
     uss2:
         resource_type: resources.flight_planning.FlightPlannerResource
         dependencies:
@@ -74,3 +77,4 @@ f3548_single_scenario:
             flight_planner:
                 participant_id: uss2
                 injection_base_url: http://host.docker.internal:8074/scdsc
+                allows_same_priority_intersections: false

--- a/monitoring/uss_qualifier/configurations/dev/faa/uft/local_message_signing.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/faa/uft/local_message_signing.yaml
@@ -11,10 +11,13 @@ v1:
             flight_planners:
             - participant_id: uss1
               injection_base_url: http://host.docker.internal:8074/scdsc
+              allows_same_priority_intersections: false
             - participant_id: uss2
               injection_base_url: http://host.docker.internal:8074/scdsc
+              allows_same_priority_intersections: false
             - participant_id: mock_uss
               injection_base_url: http://host.docker.internal:8074/scdsc
+              allows_same_priority_intersections: false
         combination_selector:
           resource_type: resources.flight_planning.FlightPlannerCombinationSelectorResource
           specification:

--- a/monitoring/uss_qualifier/configurations/dev/faa/uft/uft.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/faa/uft/uft.yaml
@@ -18,9 +18,11 @@ v1:
                             # uss1 is the mock_uss directly exposing scdsc functionality
                             - participant_id: uss8074
                               injection_base_url: http://host.docker.internal:8074/scdsc
+                              allows_same_priority_intersections: false
                             # uss2 uses atproxy, with requests being fulfilled by mock_uss with atproxy_client functionality enabled
                             - participant_id: uss8075
                               injection_base_url: http://host.docker.internal:8075/scd
+                              allows_same_priority_intersections: false
                 scd_dss:
                     resource_type: resources.astm.f3548.v21.DSSInstanceResource
                     dependencies:

--- a/monitoring/uss_qualifier/configurations/dev/non_docker/resources.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/non_docker/resources.yaml
@@ -79,8 +79,10 @@ f3548:
       flight_planners:
       - participant_id: uss1
         injection_base_url: http://localhost:8074/scdsc
+        allows_same_priority_intersections: false
       - participant_id: uss2
         injection_base_url: http://localhost:8074/scdsc
+        allows_same_priority_intersections: false
   conflicting_flights:
     resource_type: resources.flight_planning.FlightIntentsResource
     specification:

--- a/monitoring/uss_qualifier/configurations/dev/self_contained_f3548.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/self_contained_f3548.yaml
@@ -39,9 +39,11 @@ v1:
             # uss1 is the mock_uss directly exposing scdsc functionality
             - participant_id: uss1
               injection_base_url: http://host.docker.internal:8074/scdsc
+              allows_same_priority_intersections: false
             # uss2 uses atproxy, with requests being fulfilled by mock_uss with atproxy_client functionality enabled
             - participant_id: uss2
               injection_base_url: http://host.docker.internal:8075/scd
+              allows_same_priority_intersections: false
 
         # Details of conflicting flights (used in nominal planning scenario)
         conflicting_flights:

--- a/monitoring/uss_qualifier/resources/flight_planning/flight_planner.py
+++ b/monitoring/uss_qualifier/resources/flight_planning/flight_planner.py
@@ -34,6 +34,9 @@ class FlightPlannerConfiguration(ImplicitDict):
     timeout_seconds: Optional[float] = None
     """Number of seconds to allow for requests to this flight planner.  If None, use default."""
 
+    allows_same_priority_intersections: bool
+    """True if the regulation under which the flight planner is permits equal priority conflicts."""
+
     def __init__(self, *args, **kwargs):
         super().__init__(**kwargs)
         try:


### PR DESCRIPTION
This resolves the issue described [on this wiki entry](https://github.com/interuss/monitoring/wiki/Enhancements-of-the-automated-testing-interfaces#report-if-regulation-allows-for-equal-priority-conflicts).

This way, it will be possible during the execution of the scenarios to know whether or not the USSs under test allow conflicts of intents with equal priority.

Note that the naming matches the naming of the already-existing field in the mock USS.