### PR TITLE
[uss_qualifier] Split flight intents processing in two steps

### DIFF
--- a/monitoring/uss_qualifier/resources/flight_planning/flight_intents_resource.py
+++ b/monitoring/uss_qualifier/resources/flight_planning/flight_intents_resource.py
@@ -3,7 +3,6 @@ import json
 from typing import Dict
 
 import arrow
-import bc_jsonpath_ng.ext
 from implicitdict import ImplicitDict, StringBasedDateTime
 
 from monitoring.uss_qualifier.fileio import load_dict_with_references
@@ -15,9 +14,6 @@ from monitoring.uss_qualifier.resources.flight_planning.flight_intent import (
     FlightIntent,
     FlightIntentID,
 )
-
-
-_time_finder = bc_jsonpath_ng.ext.parse("$..[time_start,time_end].value.`parent`")
 
 
 class FlightIntentsResource(Resource[FlightIntentsSpecification]):
@@ -33,9 +29,7 @@ class FlightIntentsResource(Resource[FlightIntentsSpecification]):
     def get_flight_intents(self) -> Dict[FlightIntentID, FlightIntent]:
         """Resolve the underlying delta flight intents and shift appropriately times."""
 
-        t0 = arrow.utcnow() + self._planning_time
-
-        # process intents in order of dependency
+        # process intents in order of dependency to resolve deltas
         processed_intents: Dict[FlightIntentID, FlightIntent] = {}
         unprocessed_intent_ids = list(self._intent_collection.intents.keys())
 
@@ -50,10 +44,6 @@ class FlightIntentsResource(Resource[FlightIntentsSpecification]):
                     processed_intent = ImplicitDict.parse(
                         json.loads(json.dumps(unprocessed_intent.full)), FlightIntent
                     )
-                    times_to_shift = [
-                        m.value for m in _time_finder.find(processed_intent)
-                    ]
-
                 elif unprocessed_intent.has_field_with_value("delta"):
                     if unprocessed_intent.delta.source not in processed_intents:
                         # delta source has not been processed yet
@@ -66,23 +56,8 @@ class FlightIntentsResource(Resource[FlightIntentsSpecification]):
                         ),
                         FlightIntent,
                     )
-                    times_to_shift = []
-                    for unprocessed_match in _time_finder.find(
-                        unprocessed_intent.delta.mutation
-                    ):
-                        processed_matches = unprocessed_match.full_path.find(
-                            processed_intent
-                        )
-                        if processed_matches:
-                            times_to_shift.append(processed_matches[0].value)
-
                 else:
                     raise ValueError(f"{intent_id} is invalid")
-
-                # shift times
-                dt = t0 - processed_intent.reference_time.datetime
-                for t in times_to_shift:
-                    t.value = StringBasedDateTime(t.value.datetime + dt)
 
                 nb_processed += 1
                 processed_intents[intent_id] = processed_intent
@@ -92,6 +67,22 @@ class FlightIntentsResource(Resource[FlightIntentsSpecification]):
                 raise ValueError(
                     "Unresolvable dependency detected between intents: "
                     + ", ".join(i_id for i_id in unprocessed_intent_ids)
+                )
+
+        # shift times
+        t0 = arrow.utcnow() + self._planning_time
+
+        for intent_id, intent in processed_intents.items():
+            dt = t0 - intent.reference_time.datetime
+            for volume in (
+                intent.request.operational_intent.volumes
+                + intent.request.operational_intent.off_nominal_volumes
+            ):
+                volume.time_start.value = StringBasedDateTime(
+                    volume.time_start.value.datetime + dt
+                )
+                volume.time_end.value = StringBasedDateTime(
+                    volume.time_end.value.datetime + dt
                 )
 
         return processed_intents


### PR DESCRIPTION
This reverts the fix implemented in #79 and fixes the issue differently. The issue was that a mutation of the `reference_time` would not be taken into account, as in, with a mutated `reference_time` the times would not be shifted.
This PR fixes this by iterating an additional time on the processed flight intents to shift properly all the times after all the deltas are resolved.