### PR TITLE
[.editorconfig] Set default indent size to 2 except for .py files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,10 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
-indent_size = 4
+indent_size = 2
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.py]
+indent_size = 4


### PR DESCRIPTION
In the repo, all the `*.json`, `*.yml`  and others files have an indent of size 2. It seems that only `*.py` files actually have an indent of size 4. So this change should normally reflect the actual practices of the repo.
