### PR TITLE
[uss_qualifier] validate_shared_operational_intent: mark some checks as validating requirement OPIN0025

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/utm/test_steps.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/test_steps.py
@@ -94,14 +94,11 @@ def validate_shared_operational_intent(
     test_step: str,
     flight_intent: InjectFlightRequest,
     op_intent_id: str,
-) -> bool:
+):
     """Validate that operational intent information was correctly shared for a flight intent.
 
     This function implements the test step described in
     validate_shared_operational_intent.md.
-
-    Returns:
-      False if the scenario should stop, True otherwise.
     """
     scenario.begin_test_step(test_step)
     extent = bounding_vol4(
@@ -118,7 +115,6 @@ def validate_shared_operational_intent(
                 details=f"Received status code {query.status_code} from the DSS",
                 query_timestamps=[query.request.timestamp],
             )
-            return False
 
     matching_op_intent_refs = [
         op_intent_ref
@@ -135,7 +131,6 @@ def validate_shared_operational_intent(
                 details=f"USS {flight_planner.participant_id} indicated that it created an operational intent with ID {op_intent_id}, but no operational intent references with that ID were found in the DSS in the area of the flight intent",
                 query_timestamps=[query.request.timestamp],
             )
-            return False
     op_intent_ref = matching_op_intent_refs[0]
 
     op_intent, query = dss.get_full_op_intent(op_intent_ref)
@@ -150,7 +145,6 @@ def validate_shared_operational_intent(
                 details=f"Received status code {query.status_code} from {flight_planner.participant_id} when querying for details of operational intent {op_intent_id}",
                 query_timestamps=[query.request.timestamp],
             )
-            return False
 
     with scenario.check(
         "Operational intent details data format", [flight_planner.participant_id]
@@ -184,7 +178,6 @@ def validate_shared_operational_intent(
                 details=error_text,
                 query_timestamps=[query.request.timestamp],
             )
-            return False
 
     with scenario.check(
         "Off-nominal volumes", [flight_planner.participant_id]

--- a/monitoring/uss_qualifier/scenarios/astm/utm/validate_shared_operational_intent.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/validate_shared_operational_intent.md
@@ -8,11 +8,11 @@ This step verifies that a created flight is shared properly per ASTM F3548-21 by
 
 ## Operational intent shared correctly check
 
-If a reference to the operational intent for the flight is not found in the DSS, this check will fail per **astm.f3548.v21.USS0005**.
+If a reference to the operational intent for the flight is not found in the DSS, this check will fail per **astm.f3548.v21.USS0005** and **astm.f3548.v21.OPIN0025**.
 
 ## Operational intent details retrievable check
 
-If the operational intent details for the flight cannot be retrieved from the USS, this check will fail per **astm.f3548.v21.USS0105**.
+If the operational intent details for the flight cannot be retrieved from the USS, this check will fail per **astm.f3548.v21.USS0105** and **astm.f3548.v21.OPIN0025**.
 
 ## Operational intent details data format check
 
@@ -20,7 +20,7 @@ If the operational intent details response does not validate against [the GetOpe
 
 ## Correct operational intent details check
 
-If the operational intent details reported by the USS do not match the user's flight intent, this check will fail per **astm.f3548.v21.OPIN0025**.
+If the operational intent details reported by the USS do not match the user's flight intent, this check will fail per **interuss.automated_testing.flight_planning.ExpectedBehavior** and **astm.f3548.v21.OPIN0025**.
 
 ## Off-nominal volumes check
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/validate_shared_operational_intent.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/validate_shared_operational_intent.md
@@ -20,7 +20,7 @@ If the operational intent details response does not validate against [the GetOpe
 
 ## Correct operational intent details check
 
-If the operational intent details reported by the USS do not match the user's flight intent, this check will fail per **interuss.automated_testing.flight_planning.ExpectedBehavior**.
+If the operational intent details reported by the USS do not match the user's flight intent, this check will fail per **astm.f3548.v21.OPIN0025**.
 
 ## Off-nominal volumes check
 


### PR DESCRIPTION
Update after feedback: add validation of the OPIN0025 requirement on some checks (if "1) the operational intent reference isn't found in the DSS or 2) the operational intent details aren't obtainable or accurate").

The additional part (i.e. "the intent of the original check [...] is to make sure the operational intent actually shared is compatible with the user's flight intent") is left for another PR.

Additionally here I removed the return value of the function `validate_shared_operational_intent`.