### PR TITLE
[mock_uss/scdsc] fix extents published at DSS and fix conflict in Activated state

### DIFF
--- a/monitoring/monitorlib/scd.py
+++ b/monitoring/monitorlib/scd.py
@@ -152,7 +152,7 @@ class ImplicitSubscriptionParameters(ImplicitDict):
 
 
 class PutOperationalIntentReferenceParameters(ImplicitDict):
-    extents: Volume4D
+    extents: List[Volume4D]
     key: List[str]
     state: str
     uss_base_url: str


### PR DESCRIPTION
- fixes the operational intent reference published at the DSS: it is supposed to contain the off-nominal volumes
- fixes exception for conflicts: according to standard, only the operational intent being modified is supposed to be Activated, not necessarily both
- also fixes the type of `extents` in the model used for the REST API 
- also add some debug logging that was useful when debugging the issues fixed here