### PR TITLE
[uss_qualifier] Fix requirement sets parser

### DIFF
--- a/monitoring/uss_qualifier/requirements/documentation.py
+++ b/monitoring/uss_qualifier/requirements/documentation.py
@@ -77,9 +77,9 @@ def _length_of_section(values, start_of_section: int) -> int:
     c = start_of_section + 1
     while c < len(values):
         if isinstance(values[c], marko.block.Heading) and values[c].level == level:
-            break
+            return c - start_of_section - 1
         c += 1
-    return c - start_of_section - 1
+    return c - start_of_section # end of file
 
 
 def _find_section(values, section_title: str) -> int:

--- a/monitoring/uss_qualifier/requirements/documentation.py
+++ b/monitoring/uss_qualifier/requirements/documentation.py
@@ -79,7 +79,7 @@ def _length_of_section(values, start_of_section: int) -> int:
         if isinstance(values[c], marko.block.Heading) and values[c].level == level:
             return c - start_of_section - 1
         c += 1
-    return c - start_of_section # end of file
+    return c - start_of_section  # end of file
 
 
 def _find_section(values, section_title: str) -> int:

--- a/monitoring/uss_qualifier/requirements/documentation_test.py
+++ b/monitoring/uss_qualifier/requirements/documentation_test.py
@@ -1,0 +1,22 @@
+from .documentation import resolve_requirements_collection, get_requirement_set
+from .definitions import RequirementCollection, RequirementSetID
+
+
+def test_requirements_extraction():
+    collection = RequirementSetID(
+        "interuss.uss_qualifier.unit_test.set1"
+    )
+    requirement_set = get_requirement_set(collection)
+    assert len(requirement_set.requirement_ids) == 3
+
+    collection = RequirementSetID(
+        "interuss.uss_qualifier.unit_test.set1#Manual Checks"
+    )
+    requirement_set = get_requirement_set(collection)
+    assert len(requirement_set.requirement_ids) == 1
+
+    collection = RequirementSetID(
+        "interuss.uss_qualifier.unit_test.set1#Automated Checks"
+    )
+    requirement_set = get_requirement_set(collection)
+    assert len(requirement_set.requirement_ids) == 2

--- a/monitoring/uss_qualifier/requirements/documentation_test.py
+++ b/monitoring/uss_qualifier/requirements/documentation_test.py
@@ -3,15 +3,11 @@ from .definitions import RequirementCollection, RequirementSetID
 
 
 def test_requirements_extraction():
-    collection = RequirementSetID(
-        "interuss.uss_qualifier.unit_test.set1"
-    )
+    collection = RequirementSetID("interuss.uss_qualifier.unit_test.set1")
     requirement_set = get_requirement_set(collection)
     assert len(requirement_set.requirement_ids) == 3
 
-    collection = RequirementSetID(
-        "interuss.uss_qualifier.unit_test.set1#Manual Checks"
-    )
+    collection = RequirementSetID("interuss.uss_qualifier.unit_test.set1#Manual Checks")
     requirement_set = get_requirement_set(collection)
     assert len(requirement_set.requirement_ids) == 1
 

--- a/monitoring/uss_qualifier/requirements/interuss/uss_qualifier/unit_test.md
+++ b/monitoring/uss_qualifier/requirements/interuss/uss_qualifier/unit_test.md
@@ -1,0 +1,8 @@
+# USS Qualifier unit test requirements
+
+This file is used to defines requirements to support unit testing.
+
+## Dummy requirements
+* <tt>REQ001</tt>
+* <tt>REQ100</tt>
+* <tt>REQ101</tt>

--- a/monitoring/uss_qualifier/requirements/interuss/uss_qualifier/unit_test/set1.md
+++ b/monitoring/uss_qualifier/requirements/interuss/uss_qualifier/unit_test/set1.md
@@ -1,0 +1,13 @@
+# USS Qualifier unit test requirement set
+
+This file is used to validate the correct implementation of the USS Qualifier requirements parser.
+
+## Manual Checks
+
+1. First element
+2. **interuss.uss_qualifier.unit_test.REQ001**
+
+## Automated Checks
+
+1. **interuss.uss_qualifier.unit_test.REQ100**
+2. **interuss.uss_qualifier.unit_test.REQ101**


### PR DESCRIPTION
When using anchored reference for requirement sets, current implementation skip the last markdown block leading to an empty section and ignored requirements. 
This PR fixes this issue.