### PR TITLE
[uss_qualifier] Do not grant capability if no requirement has been checked.

### DIFF
--- a/monitoring/uss_qualifier/reports/capabilities.py
+++ b/monitoring/uss_qualifier/reports/capabilities.py
@@ -121,7 +121,8 @@ def evaluate_requirements_checked_conditions(
         for req_id in passed_check.requirements:
             if req_id in req_checked:
                 req_checked[req_id] = True
-    return all(req_checked.values())
+    outcomes = req_checked.values()
+    return outcomes and all(outcomes)
 
 
 @capability_condition_evaluator(CapabilityVerifiedCondition)

--- a/monitoring/uss_qualifier/reports/capability_definitions.py
+++ b/monitoring/uss_qualifier/reports/capability_definitions.py
@@ -17,19 +17,25 @@ class SpecificCondition(ImplicitDict):
 
 
 class AllConditions(SpecificCondition):
-    """Condition will only be satisfied when all specified conditions are satisfied."""
+    """Condition will only be satisfied when all specified conditions are satisfied.
+
+    Note that an empty list of conditions will result in a successful evaluation."""
 
     conditions: List[CapabilityVerificationCondition]
 
 
 class AnyCondition(SpecificCondition):
-    """Condition will be satisfied when any of the specified conditions are satisfied."""
+    """Condition will be satisfied when any of the specified conditions are satisfied.
+
+    Note that an empty list of conditions will result in an unsuccessful evaluation."""
 
     conditions: List[CapabilityVerificationCondition]
 
 
 class RequirementsCheckedCondition(SpecificCondition):
-    """Condition will only be satisfied if at least one successful check exists for all specified requirements."""
+    """Condition will only be satisfied if at least one successful check exists for all specified requirements.
+
+    Note that an empty collection of requirements will result in an unsuccessful evaluation."""
 
     checked: RequirementCollection
     """Each requirement contained within this collection must be covered by at least one successful check."""
@@ -44,8 +50,9 @@ class NoFailedChecksCondition(SpecificCondition):
 
 
 class CapabilityVerifiedCondition(SpecificCondition):
-    """Condition will be satisfied when the specified capability is verified. Note that a capability
-    verified by an empty list of requirements will evaluate to false."""
+    """Condition will be satisfied when the specified capability is verified.
+
+    Note that a capability which do not declare any requirement will result in an unsuccessful evaluation."""
 
     capability_id: CapabilityID
     """Identifier of capability that must be verified for this condition to be satisfied."""

--- a/monitoring/uss_qualifier/reports/capability_definitions.py
+++ b/monitoring/uss_qualifier/reports/capability_definitions.py
@@ -45,7 +45,7 @@ class NoFailedChecksCondition(SpecificCondition):
 
 class CapabilityVerifiedCondition(SpecificCondition):
     """Condition will be satisfied when the specified capability is verified. Note that a capability
-    without requirement will evaluate to false."""
+    verified by an empty list of requirements will evaluate to false."""
 
     capability_id: CapabilityID
     """Identifier of capability that must be verified for this condition to be satisfied."""

--- a/monitoring/uss_qualifier/reports/capability_definitions.py
+++ b/monitoring/uss_qualifier/reports/capability_definitions.py
@@ -44,7 +44,8 @@ class NoFailedChecksCondition(SpecificCondition):
 
 
 class CapabilityVerifiedCondition(SpecificCondition):
-    """Condition will be satisfied when the specified capability is verified."""
+    """Condition will be satisfied when the specified capability is verified. Note that a capability
+    without requirement will evaluate to false."""
 
     capability_id: CapabilityID
     """Identifier of capability that must be verified for this condition to be satisfied."""


### PR DESCRIPTION
This PR changes the capability granting condition to consider an empty capability requirement set as not successful.