### PR TITLE
Allow flight intent injection directly in Activated state

### DIFF
--- a/monitoring/monitorlib/scd.py
+++ b/monitoring/monitorlib/scd.py
@@ -454,7 +454,10 @@ def op_intent_transition_valid(
         )
 
     if transition_from is None:
-        return transition_to == OperationalIntentState.Accepted
+        return transition_to in {
+            OperationalIntentState.Accepted,
+            OperationalIntentState.Activated,
+        }
 
     elif transition_from == OperationalIntentState.Accepted:
         return transition_to in {

--- a/monitoring/uss_qualifier/scenarios/astm/utm/flight_intent_validation/flight_intent_validation.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/flight_intent_validation/flight_intent_validation.py
@@ -262,8 +262,8 @@ class FlightIntentValidation(TestScenario):
             self,
             "Activate valid flight intent",
             self.tested_uss,
-            valid_flight_id,
             self.valid_activated.request,
+            valid_flight_id,
         )
         valid_flight_op_intent_id = resp.operational_intent_id
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.py
@@ -144,7 +144,7 @@ class ConflictHigherPriority(TestScenario):
             assert not scd.vol4s_intersect(
                 self.flight_1_planned_time_range_A.request.operational_intent.volumes,
                 self.flight_1_activated_time_range_B.request.operational_intent.volumes,
-            ), "flight_1_planned_time_range_A and flight_1_planned_time_range_B must not intersect"
+            ), "flight_1_planned_time_range_A and flight_1_activated_time_range_B must not intersect"
 
         except KeyError as e:
             raise ValueError(
@@ -283,8 +283,8 @@ class ConflictHigherPriority(TestScenario):
             self,
             "Attempt to modify planned flight 1 in conflict",
             self.tested_uss,
-            self.flight_1_id,
             self.flight_1_planned_time_range_A_extended.request,
+            self.flight_1_id,
         )
 
         validate_shared_operational_intent(
@@ -311,8 +311,8 @@ class ConflictHigherPriority(TestScenario):
             self,
             "Attempt to activate conflicting flight 1",
             self.tested_uss,
-            self.flight_1_id,
             self.flight_1_activated_time_range_A.request,
+            self.flight_1_id,
         )
 
         validate_shared_operational_intent(
@@ -334,8 +334,8 @@ class ConflictHigherPriority(TestScenario):
             self,
             "Activate flight 1",
             self.tested_uss,
-            self.flight_1_id,
             self.flight_1_activated_time_range_A.request,
+            self.flight_1_id,
         )
 
         _, self.flight_2_id = plan_flight_intent(
@@ -349,16 +349,16 @@ class ConflictHigherPriority(TestScenario):
             self,
             "Activate flight 2",
             self.control_uss,
-            self.flight_2_id,
             self.flight_2_activated_time_range_A.request,
+            self.flight_2_id,
         )
 
         resp_flight_1 = modify_activated_flight_intent(
             self,
             "Modify activated flight 1 in conflict with activated flight 2",
             self.tested_uss,
-            self.flight_1_id,
             self.flight_1_activated_time_range_A_extended.request,
+            self.flight_1_id,
         )
 
         validate_shared_operational_intent(
@@ -385,16 +385,16 @@ class ConflictHigherPriority(TestScenario):
             self,
             "Modify activated flight 2 to not conflict with activated flight 1",
             self.control_uss,
-            self.flight_2_id,
             self.flight_2_activated_time_range_B.request,
+            self.flight_2_id,
         )
 
         _ = modify_activated_priority_conflict_flight_intent(
             self,
             "Attempt to modify activated flight 1 in conflict",
             self.tested_uss,
-            self.flight_1_id,
             self.flight_1_activated_time_range_B.request,
+            self.flight_1_id,
         )
 
         validate_shared_operational_intent(

--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/nominal_planning.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/nominal_planning.py
@@ -179,8 +179,8 @@ class NominalPlanning(TestScenario):
             self,
             "Activate first flight",
             self.uss1,
-            self.first_flight_id,
             self.first_flight_activated.request,
+            self.first_flight_id,
         )
 
         validate_shared_operational_intent(

--- a/monitoring/uss_qualifier/scenarios/flight_planning/prioritization_test_steps.py
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/prioritization_test_steps.py
@@ -49,8 +49,8 @@ def modify_planned_priority_conflict_flight_intent(
     scenario: TestScenarioType,
     test_step: str,
     flight_planner: FlightPlanner,
-    flight_id: str,
     flight_intent: InjectFlightRequest,
+    flight_id: str,
 ) -> InjectFlightResponse:
     """Attempt to modify a planned flight intent that should result in a conflict with a higher priority flight intent.
 
@@ -79,8 +79,8 @@ def activate_priority_conflict_flight_intent(
     scenario: TestScenarioType,
     test_step: str,
     flight_planner: FlightPlanner,
-    flight_id: str,
     flight_intent: InjectFlightRequest,
+    flight_id: Optional[str] = None,
 ) -> InjectFlightResponse:
     """Attempt to activate a flight intent that should result in a conflict with a higher priority flight intent.
 
@@ -109,8 +109,8 @@ def modify_activated_priority_conflict_flight_intent(
     scenario: TestScenarioType,
     test_step: str,
     flight_planner: FlightPlanner,
-    flight_id: str,
     flight_intent: InjectFlightRequest,
+    flight_id: str,
 ) -> InjectFlightResponse:
     """Attempt to modify an activated flight intent that should result in a conflict with a higher priority flight intent.
 
@@ -167,8 +167,8 @@ def modify_planned_conflict_flight_intent(
     scenario: TestScenarioType,
     test_step: str,
     flight_planner: FlightPlanner,
-    flight_id: str,
     flight_intent: InjectFlightRequest,
+    flight_id: str,
 ) -> InjectFlightResponse:
     """Attempt to modify a planned flight intent that should result in a non-permitted conflict with an equal priority flight intent.
 
@@ -197,8 +197,8 @@ def activate_conflict_flight_intent(
     scenario: TestScenarioType,
     test_step: str,
     flight_planner: FlightPlanner,
-    flight_id: str,
     flight_intent: InjectFlightRequest,
+    flight_id: Optional[str] = None,
 ) -> InjectFlightResponse:
     """Attempt to activate a flight intent that should result in a non-permitted conflict with an equal priority flight intent.
 
@@ -227,8 +227,8 @@ def modify_activated_conflict_flight_intent(
     scenario: TestScenarioType,
     test_step: str,
     flight_planner: FlightPlanner,
-    flight_id: str,
     flight_intent: InjectFlightRequest,
+    flight_id: str,
 ) -> InjectFlightResponse:
     """Attempt to modify an activated flight intent that should result in a non-permitted conflict with an equal priority flight intent.
 
@@ -287,8 +287,8 @@ def modify_planned_permitted_conflict_flight_intent(
     scenario: TestScenarioType,
     test_step: str,
     flight_planner: FlightPlanner,
-    flight_id: str,
     flight_intent: InjectFlightRequest,
+    flight_id: str,
 ) -> InjectFlightResponse:
     """Modify a planned flight intent that has a permitted equal priority conflict with another flight intent, that should result in success.
 
@@ -317,8 +317,8 @@ def activate_permitted_conflict_flight_intent(
     scenario: TestScenarioType,
     test_step: str,
     flight_planner: FlightPlanner,
-    flight_id: str,
     flight_intent: InjectFlightRequest,
+    flight_id: Optional[str] = None,
 ) -> InjectFlightResponse:
     """Activate a flight intent that has a permitted equal priority conflict with another flight intent, that should result in success.
 
@@ -347,8 +347,8 @@ def modify_activated_permitted_conflict_flight_intent(
     scenario: TestScenarioType,
     test_step: str,
     flight_planner: FlightPlanner,
-    flight_id: str,
     flight_intent: InjectFlightRequest,
+    flight_id: str,
 ) -> InjectFlightResponse:
     """Modify an activated flight intent that has a permitted equal priority conflict with another flight intent, that should result in success.
 

--- a/monitoring/uss_qualifier/scenarios/flight_planning/test_steps.py
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/test_steps.py
@@ -265,8 +265,8 @@ def activate_flight_intent(
     scenario: TestScenarioType,
     test_step: str,
     flight_planner: FlightPlanner,
-    flight_id: str,
     flight_intent: InjectFlightRequest,
+    flight_id: Optional[str] = None,
 ) -> InjectFlightResponse:
     """Activate a flight intent that should result in success.
 
@@ -295,8 +295,8 @@ def modify_planned_flight_intent(
     scenario: TestScenarioType,
     test_step: str,
     flight_planner: FlightPlanner,
-    flight_id: str,
     flight_intent: InjectFlightRequest,
+    flight_id: str,
 ) -> InjectFlightResponse:
     """Modify a planned flight intent that should result in success.
 
@@ -325,8 +325,8 @@ def modify_activated_flight_intent(
     scenario: TestScenarioType,
     test_step: str,
     flight_planner: FlightPlanner,
-    flight_id: str,
     flight_intent: InjectFlightRequest,
+    flight_id: str,
 ) -> InjectFlightResponse:
     """Modify an activated flight intent that should result in success.
 


### PR DESCRIPTION
Following the discussion for requirement SCD0045.
Order of arguments is changed where not necessarily needed for the purpose of consistency.