### PR TITLE
[uss_qualifier] Require config flag at the parser level

### DIFF
--- a/monitoring/uss_qualifier/main.py
+++ b/monitoring/uss_qualifier/main.py
@@ -34,7 +34,7 @@ def parseArgs() -> argparse.Namespace:
     parser.add_argument(
         "--config",
         help="Configuration string according to monitoring/uss_qualifier/configurations/README.md",
-        required=True
+        required=True,
     )
 
     parser.add_argument(

--- a/monitoring/uss_qualifier/main.py
+++ b/monitoring/uss_qualifier/main.py
@@ -34,6 +34,7 @@ def parseArgs() -> argparse.Namespace:
     parser.add_argument(
         "--config",
         help="Configuration string according to monitoring/uss_qualifier/configurations/README.md",
+        required=True
     )
 
     parser.add_argument(


### PR DESCRIPTION
Small improvement to catch the missing config flag when parsing the command line arguments and gracefully exit.