### PR TITLE
Update Shell Scripts to use Docker Compose V2

### DIFF
--- a/build/dev/run_locally.sh
+++ b/build/dev/run_locally.sh
@@ -5,8 +5,8 @@ set -eo pipefail
 # This script will deploy a standalone DSS instance with docker-compose using
 # images from Docker Hub.
 
-if [[ -z $(command -v docker-compose) ]]; then
-  echo "docker-compose is required but not installed.  Visit https://docs.docker.com/compose/install/ to install."
+if [[ -z $(command -v docker compose) ]]; then
+  echo "docker compose is required but not installed.  Visit https://docs.docker.com/compose/install/ to install."
   exit 1
 fi
 
@@ -33,4 +33,4 @@ elif [[ "$DC_COMMAND" == "debug" ]]; then
 fi
 
 # shellcheck disable=SC2086
-docker-compose -f docker-compose_dss.yaml -p dss_sandbox $DC_COMMAND $DC_OPTIONS
+docker compose -f docker-compose_dss.yaml -p dss_sandbox $DC_COMMAND $DC_OPTIONS

--- a/build/dev/run_locally.sh
+++ b/build/dev/run_locally.sh
@@ -2,11 +2,11 @@
 
 set -eo pipefail
 
-# This script will deploy a standalone DSS instance with docker-compose using
+# This script will deploy a standalone DSS instance with docker compose using
 # images from Docker Hub.
 
-if [[ -z $(command -v docker compose) ]]; then
-  echo "docker compose is required but not installed.  Visit https://docs.docker.com/compose/install/ to install."
+if [[ -z $(command -v docker) ]]; then
+  echo "docker is required but not installed.  Visit https://docs.docker.com/install/ to install."
   exit 1
 fi
 

--- a/build/dev/startup/core_service.sh
+++ b/build/dev/startup/core_service.sh
@@ -16,7 +16,7 @@ if [ "$DEBUG_ON" = "1" ]; then
   -log_format console \
   -dump_requests \
   -addr :8082 \
-  -accepted_jwt_audiences localhost,host.docker.internal,local-dss-core-service,dss_sandbox_local-dss-core-service_1,core-service \
+  -accepted_jwt_audiences localhost,host.docker.internal,local-dss-core-service,dss_sandbox-local-dss-core-service-1,core-service \
   -enable_scd \
   -enable_http
 else
@@ -28,7 +28,7 @@ else
   -log_format console \
   -dump_requests \
   -addr :8082 \
-  -accepted_jwt_audiences localhost,host.docker.internal,local-dss-core-service,dss_sandbox_local-dss-core-service_1,core-service \
+  -accepted_jwt_audiences localhost,host.docker.internal,local-dss-core-service,dss_sandbox-local-dss-core-service-1,core-service \
   -enable_scd \
   -enable_http
 fi

--- a/build/dev/wait_for_local_dss.sh
+++ b/build/dev/wait_for_local_dss.sh
@@ -1,7 +1,20 @@
 #!/bin/bash
 
-OAUTH_CONTAINER="dss_sandbox_local-dss-dummy-oauth_1"
-CORE_SERVICE_CONTAINER="dss_sandbox_local-dss-core-service_1"
+compose_version=$(docker compose version --short | awk '{print 2}')
+if [[ $compose_version == 1 ]]; then
+  # Docker Compose V1
+  OAUTH_CONTAINER="dss_sandbox_local-dss-dummy-oauth_1"
+  CORE_SERVICE_CONTAINER="dss_sandbox_local-dss-core-service_1"
+elif [[ $compose_version == 2 ]]; then
+  # Docker Compose V2
+  OAUTH_CONTAINER="dss_sandbox-local-dss-dummy-oauth-1"
+  CORE_SERVICE_CONTAINER="dss_sandbox-local-dss-core-service-1"
+else
+  # Unsupported Docker Version.
+  echo "Unsupported Docker Compose version: $compose_version"
+  exit 1
+fi
+
 declare -a localhost_containers=("$OAUTH_CONTAINER" "$CORE_SERVICE_CONTAINER")
 
 for container_name in "${localhost_containers[@]}"; do

--- a/build/dev/wait_for_local_dss.sh
+++ b/build/dev/wait_for_local_dss.sh
@@ -1,22 +1,28 @@
 #!/bin/bash
 
-compose_version=$(docker compose version --short | awk '{print 2}')
-if [[ $compose_version == 1 ]]; then
-  # Docker Compose V1
-  OAUTH_CONTAINER="dss_sandbox_local-dss-dummy-oauth_1"
-  CORE_SERVICE_CONTAINER="dss_sandbox_local-dss-core-service_1"
-elif [[ $compose_version == 2 ]]; then
-  # Docker Compose V2
-  OAUTH_CONTAINER="dss_sandbox-local-dss-dummy-oauth-1"
-  CORE_SERVICE_CONTAINER="dss_sandbox-local-dss-core-service-1"
-else
-  # Unsupported Docker Version.
-  echo "Unsupported Docker Compose version: $compose_version"
-  exit 1
-fi
+# Docker Compose V2
+OAUTH_CONTAINER="dss_sandbox-local-dss-dummy-oauth-1"
+CORE_SERVICE_CONTAINER="dss_sandbox-local-dss-core-service-1"
 
 declare -a localhost_containers=("$OAUTH_CONTAINER" "$CORE_SERVICE_CONTAINER")
 
+# 2 minute timer to prevent infinite looping if a docker issue is present.
+timeout_duration=120
+
+# check to see if 2 minutes has elapsed which indicates a problem with the container(s)
+check_timeout() {
+   local start_time="$1"
+   local error_message="$2"
+   current_time=$(date +%s)
+   elapsed_time=$((current_time-start_time))
+   if ((elapsed_time >= timeout_duration)); then
+     echo "$error_message" 
+     exit 1
+   fi
+}
+
+# start the timer
+start_time=$(date +%s)
 for container_name in "${localhost_containers[@]}"; do
   last_message=""
   while true; do
@@ -30,6 +36,7 @@ for container_name in "${localhost_containers[@]}"; do
       printf '%s' "${new_message}"
       last_message="${new_message}"
     fi
+    check_timeout "$start_time" "Timeout reached. Container failed to start. Exiting."
     sleep 3
   done
   if [ -n "${last_message}" ]; then
@@ -37,6 +44,8 @@ for container_name in "${localhost_containers[@]}"; do
   fi
 done
 
+# reset the timer
+start_time=$(date +%s)
 last_message=""
 while true; do
   health_status="$( docker container inspect -f '{{.State.Health.Status}}' "${CORE_SERVICE_CONTAINER}" )"
@@ -50,6 +59,7 @@ while true; do
         printf '%s' "${new_message}"
         last_message="${new_message}"
       fi
+      check_timeout "$start_time" "Timeout reached. Container failed to become available. Exiting."
       sleep 3
     fi
 done

--- a/monitoring/prober/run_locally.sh
+++ b/monitoring/prober/run_locally.sh
@@ -13,8 +13,8 @@ else
 fi
 cd "${BASEDIR}/../.." || exit 1
 
-CORE_SERVICE_CONTAINER="dss_sandbox_local-dss-core-service_1"
-OAUTH_CONTAINER="dss_sandbox_local-dss-dummy-oauth_1"
+CORE_SERVICE_CONTAINER="dss_sandbox-local-dss-core-service-1"
+OAUTH_CONTAINER="dss_sandbox-local-dss-dummy-oauth-1"
 declare -a localhost_containers=("$CORE_SERVICE_CONTAINER" "$OAUTH_CONTAINER")
 
 for container_name in "${localhost_containers[@]}"; do


### PR DESCRIPTION
Due to the difference in naming conventions employed by Docker Compose V1 and V2 the script needed to be updated to handle both possibilities. 