### PR TITLE
Update custom network definition for local DSS

### DIFF
--- a/build/dev/docker-compose_dss.yaml
+++ b/build/dev/docker-compose_dss.yaml
@@ -15,6 +15,8 @@ services:
     ports:
       - "8080:8080"
     restart: always
+    networks:
+      - dss_sandbox_default_network
 
   local-dss-rid-bootstrapper:
     image: interuss/dss:v0.8.0-rc2
@@ -24,6 +26,8 @@ services:
     entrypoint: /startup/rid_bootstrapper.sh
     depends_on:
       - local-dss-crdb
+    networks:
+      - dss_sandbox_default_network
 
   local-dss-scd-bootstrapper:
     image: interuss/dss:v0.8.0-rc2
@@ -33,6 +37,8 @@ services:
     entrypoint: /startup/scd_bootstrapper.sh
     depends_on:
       - local-dss-crdb
+    networks:
+      - dss_sandbox_default_network
 
   local-dss-core-service:
     image: interuss/dss:v0.8.0-rc2
@@ -47,12 +53,21 @@ services:
     depends_on:
       - local-dss-rid-bootstrapper
       - local-dss-scd-bootstrapper
+    networks:
+      - dss_sandbox_default_network
 
   local-dss-dummy-oauth:
     image: interuss/dummy-oauth
     command: -private_key_file /var/test-certs/auth2.key
     ports:
       - "8085:8085"
+    networks:
+      - dss_sandbox_default_network
+
+
+networks:
+  dss_sandbox_default_network:
+    name: dss_sandbox-default
 
 volumes:
   local-dss-data:

--- a/monitoring/loadtest/README.md
+++ b/monitoring/loadtest/README.md
@@ -31,11 +31,11 @@ Simply build the Docker container with the Dockerfile from the root directory. A
 
 1. If testing local DSS instance, be sure that the loadtest (monitoring) container has access to the DSS container
 
-    a. For ISA run: `docker run -e AUTH_SPEC="DummyOAuth(http://host.docker.internal:8085/token,uss1)" --network="dss_sandbox_default" -p 8089:8089 interuss/monitoring locust -f loadtest/locust_files/ISA.py`
+    a. For ISA run: `docker run -e AUTH_SPEC="DummyOAuth(http://host.docker.internal:8085/token,uss1)" --network="dss_sandbox-default" -p 8089:8089 interuss/monitoring locust -f loadtest/locust_files/ISA.py`
 
-    b. For ISA run: `docker run -e AUTH_SPEC="DummyOAuth(http://host.docker.internal:8085/token,uss1)" --network="dss_sandbox_default" -p 8089:8089 interuss/monitoring locust -f loadtest/locust_files/Sub.py`
+    b. For ISA run: `docker run -e AUTH_SPEC="DummyOAuth(http://host.docker.internal:8085/token,uss1)" --network="dss_sandbox-default" -p 8089:8089 interuss/monitoring locust -f loadtest/locust_files/Sub.py`
 
 ## Use
 1. Navigate to http://localhost:8089
 1. Start new test with number of Users to spawn and the rate to spawn them.
-1. For the Host, provide the DSS Core Service endpoint used for testing. An example of such url is: http://dss_sandbox_local-dss-core-service_1:8082/v1/dss/ in case local environment is setup by [run_locally.sh](../../build/dev/run_locally.sh)
+1. For the Host, provide the DSS Core Service endpoint used for testing. An example of such url is: http://dss_sandbox-local-dss-core-service-1:8082/v1/dss/ in case local environment is setup by [run_locally.sh](../../build/dev/run_locally.sh)

--- a/monitoring/prober/run_locally.sh
+++ b/monitoring/prober/run_locally.sh
@@ -37,7 +37,7 @@ mkdir -p "$OUTPUT_DIR"
 if ! docker run --link "$OAUTH_CONTAINER":oauth \
 	--link "$CORE_SERVICE_CONTAINER":core-service \
 	-u "$(id -u):$(id -g)" \
-	--network dss_sandbox_default \
+	--network dss_sandbox-default \
 	-v "$(pwd)/$OUTPUT_DIR:/app/$OUTPUT_DIR" \
 	-w /app/monitoring/prober \
 	interuss/monitoring \


### PR DESCRIPTION
Updated dss_sandbox network definition to use a custom naming convention there-in making it independent of V1/V2 naming convention issues.