### PR TITLE
[monitorlib] Refactor functions in fetch.rid + mutate.rid

### DIFF
--- a/monitoring/mock_uss/riddp/routes_observation.py
+++ b/monitoring/mock_uss/riddp/routes_observation.py
@@ -94,7 +94,7 @@ def riddp_display_data() -> Tuple[str, int]:
     t = arrow.utcnow().datetime
     isa_list: FetchedISAs = fetch.isas(view, t, t, rid_version, utm_client)
     if not isa_list.success:
-        msg = f"Error fetching ISAs from DSS: {isa_list.error}"
+        msg = f"Error fetching ISAs from DSS: {isa_list.errors}"
         logger.error(msg)
         response = ErrorResponse(message=msg)
         response["fetched_isas"] = isa_list

--- a/monitoring/mock_uss/ridsp/routes_injection.py
+++ b/monitoring/mock_uss/ridsp/routes_injection.py
@@ -17,7 +17,7 @@ from monitoring.mock_uss.riddp.config import KEY_RID_VERSION
 from monitoring.mock_uss.ridsp import utm_client
 from . import database
 from .database import db
-
+from monitoring.monitorlib import geo
 
 require_config_value(KEY_BASE_URL)
 require_config_value(KEY_RID_VERSION)
@@ -64,7 +64,9 @@ def ridsp_create_test(test_id: str) -> Tuple[str, int]:
             f"Unable to determine base URL for RID version {rid_version}"
         )
     mutated_isa = mutate.put_isa(
-        area=rect,
+        area_vertices=geo.get_latlngrect_vertices(rect),
+        alt_lo=0,
+        alt_hi=3048,
         start_time=t0,
         end_time=t1,
         uss_base_url=uss_base_url,

--- a/monitoring/mock_uss/tracer/context.py
+++ b/monitoring/mock_uss/tracer/context.py
@@ -13,7 +13,7 @@ from monitoring.mock_uss.tracer.tracer_poll import (
     TASK_POLL_OPS,
     TASK_POLL_CONSTRAINTS,
 )
-from monitoring.monitorlib import ids, versioning
+from monitoring.monitorlib import ids, versioning, geo
 from monitoring.monitorlib import fetch
 import monitoring.monitorlib.fetch.rid
 import monitoring.monitorlib.fetch.scd
@@ -130,7 +130,9 @@ def _subscribe_rid(resources: ResourceSet, uss_base_url: str) -> None:
     _clear_existing_rid_subscription(resources, "old")
 
     create_result = mutate.rid.upsert_subscription(
-        area=resources.area,
+        area_vertices=geo.get_latlngrect_vertices(resources.area),
+        alt_lo=0,
+        alt_hi=3048,
         start_time=resources.start_time,
         end_time=resources.end_time,
         uss_base_url=uss_base_url,

--- a/monitoring/monitorlib/fetch/summarize.py
+++ b/monitoring/monitorlib/fetch/summarize.py
@@ -35,7 +35,7 @@ def isas(fetched: rid.FetchedISAs) -> Dict:
             isa_key = "{} ({})".format(isa.id, isa.owner)
             summary[isa.flights_url][isa_key] = isa_summary
     else:
-        summary["error"] = fetched.error
+        summary["error"] = fetched.errors
     return summary
 
 

--- a/monitoring/monitorlib/geo.py
+++ b/monitoring/monitorlib/geo.py
@@ -90,3 +90,13 @@ def bounding_rect(latlngs: List[Tuple[float, float]]) -> s2sphere.LatLngRect:
 def get_latlngrect_diagonal_km(rect: s2sphere.LatLngRect) -> float:
     """Compute the distance in km between two opposite corners of the rect"""
     return rect.lo().get_distance(rect.hi()).degrees * EARTH_CIRCUMFERENCE_KM / 360
+
+
+def get_latlngrect_vertices(rect: s2sphere.LatLngRect) -> List[s2sphere.LatLng]:
+    """Returns the rect as a list of vertices"""
+    return [
+        s2sphere.LatLng.from_angles(lat=rect.lat_lo(), lng=rect.lng_lo()),
+        s2sphere.LatLng.from_angles(lat=rect.lat_lo(), lng=rect.lng_hi()),
+        s2sphere.LatLng.from_angles(lat=rect.lat_hi(), lng=rect.lng_hi()),
+        s2sphere.LatLng.from_angles(lat=rect.lat_hi(), lng=rect.lng_lo()),
+    ]

--- a/monitoring/monitorlib/rid_v2.py
+++ b/monitoring/monitorlib/rid_v2.py
@@ -1,29 +1,60 @@
 import datetime
+from typing import List
 
 import s2sphere
-from uas_standards.astm.f3411.v22a.api import Time, Altitude, Polygon, LatLngPoint
+from implicitdict import ImplicitDict, StringBasedDateTime
+from uas_standards.astm.f3411.v22a.api import (
+    Time,
+    Altitude,
+    LatLngPoint,
+    Volume4D,
+)
 
 from . import rid_v1 as rid_v1
 
 
 def make_time(t: datetime.datetime) -> Time:
-    return Time(format="RFC3339", value=t.strftime(DATE_FORMAT))
+    return Time(format="RFC3339", value=StringBasedDateTime(t))
 
 
 def make_altitude(altitude_meters: float) -> Altitude:
     return Altitude(reference="W84", units="M", value=altitude_meters)
 
 
-def make_polygon_outline(area: s2sphere.LatLngRect) -> Polygon:
-    return Polygon(
-        vertices=[
-            LatLngPoint(lat=area.lat_lo().degrees, lng=area.lng_lo().degrees),
-            LatLngPoint(lat=area.lat_lo().degrees, lng=area.lng_hi().degrees),
-            LatLngPoint(lat=area.lat_hi().degrees, lng=area.lng_hi().degrees),
-            LatLngPoint(lat=area.lat_hi().degrees, lng=area.lng_lo().degrees),
-        ]
+def make_lat_lng_point(lat: float, lng: float) -> LatLngPoint:
+    return LatLngPoint(lat=lat, lng=lng)
+
+
+def make_lat_lng_point_from_s2(point: s2sphere.LatLng) -> LatLngPoint:
+    return make_lat_lng_point(point.lat().degrees, point.lng().degrees)
+
+
+def make_volume_4d(
+    vertices: List[s2sphere.LatLng],
+    alt_lo: float,
+    alt_hi: float,
+    start_time: datetime.datetime,
+    end_time: datetime.datetime,
+) -> Volume4D:
+    return ImplicitDict.parse(
+        {
+            "volume": {
+                "outline_polygon": {
+                    "vertices": [
+                        {"lat": vertex.lat().degrees, "lng": vertex.lng().degrees}
+                        for vertex in vertices
+                    ],
+                },
+                "altitude_lower": make_altitude(alt_lo),
+                "altitude_upper": make_altitude(alt_hi),
+            },
+            "time_start": make_time(start_time),
+            "time_end": make_time(end_time),
+        },
+        Volume4D,
     )
 
 
 DATE_FORMAT = rid_v1.DATE_FORMAT
 geo_polygon_string = rid_v1.geo_polygon_string
+geo_polygon_string_from_s2 = rid_v1.geo_polygon_string_from_s2


### PR DESCRIPTION
Refactors needed for DSS interoperability tests:
- `RIDQuery`:
  - single inherited implementation of `success`
  - define `errors` to be overridden by children classes
- `put_isa` + `upsert_subscription`: ability to fully specify parameters