### PR TITLE
[uss_qualifier/scenarios/utm/ValidateNotSharedOperationalIntent] catch exceptions in __exit__

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/utm/test_steps.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/test_steps.py
@@ -64,6 +64,13 @@ class ValidateNotSharedOperationalIntent(object):
         )
 
     def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_type is not None:
+            self._scenario.record_note(
+                self._flight_planner.participant_id,
+                f"Skipped ValidateNotSharedOperationalIntent due to raised exception ({exc_type}: {exc_val}).",
+            )
+            return
+
         self._scenario.begin_test_step(self._test_step)
         self._scenario.record_query(self._initial_query)
 


### PR DESCRIPTION
Noticed the issue on some failing tests: if there is an expection interrupting the test exception while in the middle of `ValidateNotSharedOperationalIntent`, the `__exit__` function will be called anyway, but the test framework will error out at `begin_test_step`. This catches the exception (passed as a param), record a note and return if there is an exception. 