### PR TITLE
[mock_uss/riddp + uss_qualifier/netrid/observers] Update observation endpoints to use scopes of correct version

### DIFF
--- a/monitoring/mock_uss/riddp/routes_observation.py
+++ b/monitoring/mock_uss/riddp/routes_observation.py
@@ -5,7 +5,6 @@ import flask
 from loguru import logger
 import s2sphere
 from uas_standards.astm.f3411.v19.api import ErrorResponse
-from uas_standards.astm.f3411.v19.constants import Scope
 
 from monitoring.monitorlib import geo
 from monitoring.monitorlib.fetch import rid as fetch
@@ -63,7 +62,7 @@ def _make_flight_observation(
 
 
 @webapp.route("/riddp/observation/display_data", methods=["GET"])
-@requires_scope([Scope.Read])
+@requires_scope([webapp.config[KEY_RID_VERSION].read_scope])
 def riddp_display_data() -> Tuple[str, int]:
     """Implements retrieval of current display data per automated testing API."""
 
@@ -156,7 +155,7 @@ def riddp_display_data() -> Tuple[str, int]:
 
 
 @webapp.route("/riddp/observation/display_data/<flight_id>", methods=["GET"])
-@requires_scope([Scope.Read])
+@requires_scope([webapp.config[KEY_RID_VERSION].read_scope])
 def riddp_flight_details(flight_id: str) -> Tuple[str, int]:
     """Implements get flight details endpoint per automated testing API."""
 

--- a/monitoring/uss_qualifier/configurations/dev/environment.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/environment.yaml
@@ -30,6 +30,7 @@ net_rid:
         specification:
             observers:
                 - participant_id: uss2
+                  rid_version: F3411-19
                   observation_base_url: http://host.docker.internal:8073/riddp/observation
     netrid_observers_v22a:
         resource_type: resources.netrid.NetRIDObserversResource
@@ -38,6 +39,7 @@ net_rid:
         specification:
             observers:
                 - participant_id: uss2
+                  rid_version: F3411-22a
                   observation_base_url: http://host.docker.internal:8083/riddp/observation
     netrid_dss_instances_v19:
         resource_type: resources.astm.f3411.DSSInstancesResource

--- a/monitoring/uss_qualifier/configurations/dev/faa/uft/uft.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/faa/uft/uft.yaml
@@ -60,6 +60,7 @@ v1:
                     specification:
                         observers:
                             -   participant_id: uss8073
+                                rid_version: F3411-19
                                 observation_base_url: http://host.docker.internal:8073/riddp/observation
                 evaluation_configuration:
                     resource_type: resources.netrid.EvaluationConfigurationResource

--- a/monitoring/uss_qualifier/configurations/dev/non_docker/resources.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/non_docker/resources.yaml
@@ -33,6 +33,7 @@ net_rid:
     specification:
       observers:
       - participant_id: uss2
+        rid_version: F3411-19
         observation_base_url: http://localhost:8073/riddp/observation
   netrid_observers_v22a:
     resource_type: resources.netrid.NetRIDObserversResource
@@ -41,6 +42,7 @@ net_rid:
     specification:
       observers:
       - participant_id: uss2
+        rid_version: F3411-22a
         observation_base_url: http://localhost:8083/riddp/observation
   netrid_observation_evaluation_configuration:
     resource_type: resources.netrid.EvaluationConfigurationResource

--- a/monitoring/uss_qualifier/resources/netrid/observers.py
+++ b/monitoring/uss_qualifier/resources/netrid/observers.py
@@ -18,12 +18,13 @@ class RIDSystemObserver(object):
         participant_id: str,
         base_url: str,
         auth_adapter: infrastructure.AuthAdapter,
+        rid_version: RIDVersion,
     ):
         self.session = UTMClientSession(base_url, auth_adapter)
         self.participant_id = participant_id
 
         # TODO: Change observation API to use an InterUSS scope rather than re-using an ASTM scope
-        self.rid_version = RIDVersion.f3411_19
+        self.rid_version = rid_version
 
     def observe_system(
         self, rect: s2sphere.LatLngRect
@@ -73,6 +74,9 @@ class ObserverConfiguration(ImplicitDict):
     participant_id: str
     """Participant ID of the observer providing a view of RID data in the system"""
 
+    rid_version: RIDVersion
+    """Version of ASTM F3411 implemented by this observer"""
+
     observation_base_url: str
     """Base URL for the observer's implementation of the interfaces/automated-testing/rid/observation.yaml API"""
 
@@ -91,7 +95,10 @@ class NetRIDObserversResource(Resource[NetRIDObserversSpecification]):
     ):
         self.observers = [
             RIDSystemObserver(
-                o.participant_id, o.observation_base_url, auth_adapter.adapter
+                o.participant_id,
+                o.observation_base_url,
+                auth_adapter.adapter,
+                o.rid_version,
             )
             for o in specification.observers
         ]


### PR DESCRIPTION
~~Note: this PR depends on #128. While it can already be reviewed, I am leaving it as draft until it is merged.~~