### PR TITLE
[uss_qualifier] Add a no-op test scenario

### DIFF
--- a/monitoring/uss_qualifier/configurations/dev/noop.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/noop.yaml
@@ -1,0 +1,29 @@
+v1:
+  test_run:
+    resources:
+      resource_declarations:
+        noop_config:
+          resource_type: resources.dev.NoOpResource
+          specification:
+            sleep_secs: 5
+
+    action:
+      test_suite:
+        suite_definition:
+          name: No-op
+          resources: 
+            noop_config: resources.dev.NoOpResource
+          actions:
+          - test_scenario:
+              scenario_type: scenarios.dev.NoOp
+              resources:
+                noop_config: noop_config
+            on_failure: Continue
+        resources:
+          noop_config: noop_config
+
+  artifacts:
+    report:
+      # Path to main report output
+      report_path: output/report.json
+      redact_access_tokens: true

--- a/monitoring/uss_qualifier/resources/dev/__init__.py
+++ b/monitoring/uss_qualifier/resources/dev/__init__.py
@@ -1,0 +1,1 @@
+from .noop import NoOpResource

--- a/monitoring/uss_qualifier/resources/dev/noop.py
+++ b/monitoring/uss_qualifier/resources/dev/noop.py
@@ -1,0 +1,15 @@
+from implicitdict import ImplicitDict
+
+from monitoring.uss_qualifier.resources.resource import Resource
+
+
+class NoOpSpecification(ImplicitDict):
+    sleep_secs: int
+    """Duration for which to sleep, expressed in seconds."""
+
+
+class NoOpResource(Resource[NoOpSpecification]):
+    sleep_secs: int
+
+    def __init__(self, specification: NoOpSpecification):
+        self.sleep_secs = specification.sleep_secs

--- a/monitoring/uss_qualifier/scenarios/dev/__init__.py
+++ b/monitoring/uss_qualifier/scenarios/dev/__init__.py
@@ -1,0 +1,1 @@
+from .noop import NoOp

--- a/monitoring/uss_qualifier/scenarios/dev/noop.md
+++ b/monitoring/uss_qualifier/scenarios/dev/noop.md
@@ -1,0 +1,15 @@
+# NoOp test scenario
+
+This test scenario is intended for basic diagnostic testing. It sleeps for a specified amount of time and takes no further action.
+
+## Resources
+
+### noop_config
+
+A [`NoOpResource`](../../resources/dev/noop.py) containing the sleep configuration.
+
+## Sleep test case
+
+### Sleep test step
+
+This test step simply sleeps for the specified number of seconds.

--- a/monitoring/uss_qualifier/scenarios/dev/noop.py
+++ b/monitoring/uss_qualifier/scenarios/dev/noop.py
@@ -1,0 +1,29 @@
+import time
+from datetime import datetime
+
+from monitoring.uss_qualifier.resources.dev import NoOpResource
+from monitoring.uss_qualifier.scenarios.scenario import TestScenario
+
+
+class NoOp(TestScenario):
+    def __init__(self, noop_config: NoOpResource):
+        super().__init__()
+        self.sleep_secs = noop_config.sleep_secs
+
+    def run(self):
+        self.begin_test_scenario()
+        self.begin_test_case("Sleep")
+        self.begin_test_step("Sleep")
+
+        self.record_note(
+            "Start time",
+            f"Starting at {datetime.utcnow().isoformat()}Z, sleeping for {self.sleep_secs}s...",
+        )
+
+        time.sleep(self.sleep_secs)
+
+        self.record_note("End time", f"Ending at {datetime.utcnow().isoformat()}Z.")
+
+        self.end_test_step()
+        self.end_test_case()
+        self.end_test_scenario()


### PR DESCRIPTION
Add a "no-op" `TestScenario` with the accompanying `Resource` and an example configuration.

This is useful for basic end-to-end tests when integrating the `uss_qualifier` into other systems, without any dependencies on external services.