### PR TITLE
[uss_qualifier] Test NET0260 UAS ID Serial Number

### DIFF
--- a/monitoring/uss_qualifier/requirements/astm/f3411/v22a.md
+++ b/monitoring/uss_qualifier/requirements/astm/f3411/v22a.md
@@ -28,10 +28,10 @@ For information on these requirements, refer to [the ASTM standard F3411-22a](ht
 * <tt>NET0250</tt>
 * <tt>NET0260</tt>
   * <tt>NET0260,Table1,1</tt>: UAS ID, any option
-    * <tt>NET0260,Table1,1.1</tt>: UAS ID, option 1 - serial number
-    * <tt>NET0260,Table1,1.2</tt>: UAS ID, option 2 - registration id
-    * <tt>NET0260,Table1,1.3</tt>: UAS ID, option 3 - utm (uuid)
-    * <tt>NET0260,Table1,1.4</tt>: UAS ID, option 4 - specific session id
+    * <tt>NET0260,Table1,1a</tt>: UAS ID, option 1 - serial number
+    * <tt>NET0260,Table1,1b</tt>: UAS ID, option 2 - registration id
+    * <tt>NET0260,Table1,1c</tt>: UAS ID, option 3 - utm (uuid)
+    * <tt>NET0260,Table1,1d</tt>: UAS ID, option 4 - specific session id
   * <tt>NET0260,Table1,2</tt>: UA Type
   * <tt>NET0260,Table1,3</tt>: UA Classification
   * <tt>NET0260,Table1,4</tt>: UA Classification Type
@@ -84,10 +84,10 @@ For information on these requirements, refer to [the ASTM standard F3411-22a](ht
 * <tt>NET0460</tt>
 * <tt>NET0470</tt>
   * <tt>NET0470,Table1,1</tt>: UAS ID, any option
-    * <tt>NET0470,Table1,1.1</tt>: UAS ID, option 1 - Serial Number
-    * <tt>NET0470,Table1,1.2</tt>: UAS ID, option 2 - Registration ID
-    * <tt>NET0470,Table1,1.3</tt>: UAS ID, option 3 - UTM (UUID)
-    * <tt>NET0470,Table1,1.4</tt>: UAS ID, option 4 - Specific Session ID
+    * <tt>NET0470,Table1,1a</tt>: UAS ID, option 1 - Serial Number
+    * <tt>NET0470,Table1,1b</tt>: UAS ID, option 2 - Registration ID
+    * <tt>NET0470,Table1,1c</tt>: UAS ID, option 3 - UTM (UUID)
+    * <tt>NET0470,Table1,1d</tt>: UAS ID, option 4 - Specific Session ID
   * <tt>NET0470,Table1,2</tt>: UA Type
   * <tt>NET0470,Table1,3</tt>: UA Classification
   * <tt>NET0470,Table1,4</tt>: UA Classification Type

--- a/monitoring/uss_qualifier/requirements/astm/f3411/v22a/display_provider.md
+++ b/monitoring/uss_qualifier/requirements/astm/f3411/v22a/display_provider.md
@@ -53,19 +53,19 @@ This file describes the set of ASTM F3411-22a requirements with which a USS fulf
 
 #### UAS ID Serial Number transmitter
 
-  * **astm.f3411.v22a.NET0470,Table1,1.1**
+  * **astm.f3411.v22a.NET0470,Table1,1a**
 
 #### UAS ID Registration ID transmitter
 
-  * **astm.f3411.v22a.NET0470,Table1,1.2**
+  * **astm.f3411.v22a.NET0470,Table1,1b**
 
 #### UAS ID UTM (UUID) transmitter
 
-  * **astm.f3411.v22a.NET0470,Table1,1.3**
+  * **astm.f3411.v22a.NET0470,Table1,1c**
 
 #### UAS ID Specific Session ID transmitter
 
-  * **astm.f3411.v22a.NET0470,Table1,1.4**
+  * **astm.f3411.v22a.NET0470,Table1,1d**
 
 #### UA Type transmitter
 

--- a/monitoring/uss_qualifier/requirements/astm/f3411/v22a/service_provider.md
+++ b/monitoring/uss_qualifier/requirements/astm/f3411/v22a/service_provider.md
@@ -82,7 +82,7 @@ All Service Provider Role requirements can be verified by automation.
 
 #### UAS ID Serial Number provider
 
-  * **astm.f3411.v22a.NET0260,Table1,1.1**
+  * **astm.f3411.v22a.NET0260,Table1,1a**
 
 #### Height provider
 

--- a/monitoring/uss_qualifier/resources/netrid/simulation/operator_flight_details.py
+++ b/monitoring/uss_qualifier/resources/netrid/simulation/operator_flight_details.py
@@ -2,6 +2,7 @@ from faker import Faker
 import string
 import random
 import uuid
+from uas_standards.ansi_cta_2063_a import SerialNumber
 
 from uas_standards.astm.f3411.v19.api import LatLngPoint
 
@@ -14,8 +15,7 @@ class OperatorFlightDataGenerator:
         self.random = random
 
     def generate_serial_number(self):
-        value = bytes(self.random.randint(0, 255) for _ in range(16))
-        return str(uuid.UUID(bytes=value, version=4))
+        return str(SerialNumber.generate_valid())
 
     def generate_registration_number(self, prefix="CHE"):
         registration_number = prefix + "".join(

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/nominal_behavior.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/nominal_behavior.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 import traceback
 import uuid
 import time

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common_dictionary_evaluator.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common_dictionary_evaluator.py
@@ -1,0 +1,72 @@
+from typing import List, Optional
+from monitoring.monitorlib.fetch.rid import FetchedUSSFlightDetails
+from monitoring.uss_qualifier.common_data_definitions import Severity
+from monitoring.uss_qualifier.resources.netrid.evaluation import EvaluationConfiguration
+from monitoring.uss_qualifier.scenarios.scenario import TestScenarioType
+from monitoring.monitorlib.rid import RIDVersion
+from uas_standards.ansi_cta_2063_a import SerialNumber
+from uas_standards.astm.f3411.v22a.api import UASID
+from loguru import logger
+
+
+class RIDCommonDictionaryEvaluator(object):
+    def __init__(
+        self,
+        config: EvaluationConfiguration,
+        test_scenario: TestScenarioType,
+        rid_version: RIDVersion,
+    ) -> None:
+        self._config = config
+        self._test_scenario = test_scenario
+        self._rid_version = rid_version
+
+    def evaluate_sp_details_response(
+        self, sp_response: FetchedUSSFlightDetails, participants: List[str]
+    ):
+        if self._rid_version == RIDVersion.f3411_22a:
+            self.evaluate_uas_id(sp_response.details.v22a_value.uas_id, participants)
+
+    def evaluate_uas_id(self, value: Optional[UASID], participants: List[str]):
+        if self._rid_version == RIDVersion.f3411_22a:
+            formats_keys = [
+                "serial_number",
+                "registration_id",
+                "utm_id",
+                "specific_session_id",
+            ]
+            formats_count = (
+                0
+                if value is None
+                else sum([0 if value.get(v, None) is None else 1 for v in formats_keys])
+            )
+            with self._test_scenario.check(
+                "UAS ID presence in flight details", participants
+            ) as check:
+                if formats_count == 0:
+                    check.record_failed(
+                        "UAS ID not present as required by the Common Dictionary definition",
+                        severity=Severity.Medium,
+                    )
+                    return
+
+            serial_number = value.get("serial_number", None)
+            if serial_number:
+                with self._test_scenario.check(
+                    "UAS ID (Serial Number format) consistency with Common Dictionary",
+                    participants,
+                ) as check:
+                    if not SerialNumber(serial_number).valid:
+                        check.record_failed(
+                            f"Invalid uas_id serial number: {serial_number}",
+                            participants,
+                        )
+                    else:
+                        check.record_passed()
+
+            # TODO: Add registration id format check
+            # TODO: Add utm id format check
+            # TODO: Add specific session id format check
+        else:
+            logger.debug(
+                f"Unsupported version {self._rid_version}: skipping uas_id evaluation"
+            )

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/display_data_evaluator.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/display_data_evaluator.py
@@ -6,6 +6,9 @@ from loguru import logger
 import math
 import s2sphere
 from s2sphere import LatLng, LatLngRect
+from monitoring.uss_qualifier.scenarios.astm.netrid.common_dictionary_evaluator import (
+    RIDCommonDictionaryEvaluator,
+)
 
 from monitoring.monitorlib.fetch import Query
 from monitoring.monitorlib.fetch.rid import (
@@ -194,6 +197,9 @@ class RIDObservationEvaluator(object):
         dss: Optional[DSSInstance] = None,
     ):
         self._test_scenario = test_scenario
+        self._common_dictionary_evaluator = RIDCommonDictionaryEvaluator(
+            config, self._test_scenario, rid_version
+        )
         self._injected_flights = injected_flights
         self._virtual_observer = VirtualObserver(
             injected_flights=InjectedFlightCollection(injected_flights),
@@ -792,6 +798,10 @@ class RIDObservationEvaluator(object):
                         ),
                         query_timestamps=[details_query.query.request.timestamp],
                     )
+
+            self._common_dictionary_evaluator.evaluate_sp_details_response(
+                details_query, [mapping.injected_flight.uss_participant_id]
+            )
 
     def _evaluate_area_too_large_sp_observation(
         self,

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/nominal_behavior.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/nominal_behavior.md
@@ -79,6 +79,14 @@ The timestamps of the injected telemetry usually start in the future.  If a flig
 
 **[astm.f3411.v22a.NET0710](../../../../requirements/astm/f3411/v22a.md)** requires a Service Provider to implement the P2P portion of the OpenAPI specification.  This check will fail if the response to the flight details endpoint does not validate against the OpenAPI-specified schema.
 
+#### UAS ID presence in flight details check
+
+**[astm.f3411.v22a.NET0260](../../../../requirements/astm/f3411/v22a.md)** requires that relevant Remote ID data, consistent with the common data dictionary, be reported by the Service Provider. This check validates that the UAS ID is present in the information sent by the Service Provider. (**[astm.f3411.v22a.NET0260,Table1,1](../../../../requirements/astm/f3411/v22a.md)**)
+
+#### UAS ID (Serial Number format) consistency with Common Dictionary check
+
+**[astm.f3411.v22a.NET0260](../../../../requirements/astm/f3411/v22a.md)** requires that relevant Remote ID data, consistent with the common data dictionary, be reported by the Service Provider. This check validates that the UAS ID is in serial number format. (**[astm.f3411.v22a.NET0260,Table1,1a](../../../../requirements/astm/f3411/v22a.md)**)
+
 #### Lingering flight check
 
 **[astm.f3411.v22a.NET0260](../../../../requirements/astm/f3411/v22a.md)** requires a SP to provide flights up to *NetMaxNearRealTimeDataPeriod* in the past, but an SP should preserve privacy and ensure relevancy by not sharing flights that are further in the past than this window.

--- a/monitoring/uss_qualifier/suites/uspace/network_identification.yaml
+++ b/monitoring/uss_qualifier/suites/uspace/network_identification.yaml
@@ -42,4 +42,4 @@ participant_verifiable_capabilities:
               - display_provider_speed_transmitter # Speed
               - display_provider_operator_position_transmitter # Operator Location
               - display_provider_operational_status_transmitter # Operational Status
-            capability_location: '$.actions[?(@.test_suite)].test_suite[?(@.suite_type=="suites.astm.utm.f3411_v22a")]'
+            capability_location: '$..*[?(@.suite_type=="suites.astm.netrid.f3411_22a")]'


### PR DESCRIPTION
This PR is the first of a serie to test Common Dictionary consistency. It checks NET0260 UAS ID is present in at least one format and if a serial number is provided, its value is valid.

Note that NET0260,Table1,1 sub requirements have been renamed to not include a "." which broke the format validation of requirement IDs.