### PR TITLE
[uss_qualifier] Add report evaluation scenario feature

### DIFF
--- a/monitoring/uss_qualifier/resources/interuss/report.py
+++ b/monitoring/uss_qualifier/resources/interuss/report.py
@@ -1,0 +1,19 @@
+import json
+
+from implicitdict import ImplicitDict
+
+from monitoring.uss_qualifier.reports.report import TestSuiteReport
+from monitoring.uss_qualifier.resources.resource import Resource
+
+
+class TestSuiteReportResource(Resource[TestSuiteReport]):
+    report: TestSuiteReport
+
+    def __init__(
+        self,
+        specification: TestSuiteReport,
+    ):
+        self.report = ImplicitDict.parse(
+            json.loads(json.dumps(specification)),
+            TestSuiteReport,
+        )

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/aggregate_checks.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/aggregate_checks.py
@@ -1,7 +1,7 @@
 from typing import List
 
 from monitoring.uss_qualifier.scenarios.interuss.evaluation_scenario import (
-    GenericReportEvaluationScenario,
+    ReportEvaluationScenario,
 )
 
 from monitoring.uss_qualifier.resources.interuss.report import TestSuiteReportResource
@@ -17,7 +17,7 @@ from monitoring.uss_qualifier.resources.netrid.service_providers import (
 # TODO: implement me
 
 
-class AggregateChecks(GenericReportEvaluationScenario):
+class AggregateChecks(ReportEvaluationScenario):
     _service_providers: List[NetRIDServiceProvider]
     _observers: List[RIDSystemObserver]
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/aggregate_checks.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/aggregate_checks.py
@@ -1,0 +1,50 @@
+from typing import List
+
+from monitoring.uss_qualifier.scenarios.interuss.evaluation_scenario import (
+    GenericReportEvaluationScenario,
+)
+
+from monitoring.uss_qualifier.resources.interuss.report import TestSuiteReportResource
+from monitoring.uss_qualifier.resources.netrid import (
+    NetRIDServiceProviders,
+    NetRIDObserversResource,
+)
+from monitoring.uss_qualifier.resources.netrid.observers import RIDSystemObserver
+from monitoring.uss_qualifier.resources.netrid.service_providers import (
+    NetRIDServiceProvider,
+)
+
+# TODO: implement me
+
+
+class AggregateChecks(GenericReportEvaluationScenario):
+    _service_providers: List[NetRIDServiceProvider]
+    _observers: List[RIDSystemObserver]
+
+    def __init__(
+        self,
+        report_resource: TestSuiteReportResource,
+        service_providers: NetRIDServiceProviders,
+        observers: NetRIDObserversResource,
+    ):
+        super().__init__(report_resource)
+        self._service_providers = service_providers.service_providers
+        self._observers = observers.observers
+
+    def run(self):
+        self.begin_test_scenario()
+        self.record_note("dummy", "TODO: this is a dummy implementation")
+
+        self.begin_test_case("Dummy")
+        self.begin_test_step("Dummy")
+
+        with self.check("Dummy", []) as check:
+            self.record_note("nb_sps", f"{len(self._service_providers)}")
+            self.record_note("nb_obs", f"{len(self._observers)}")
+
+        self.end_test_step()
+        self.end_test_case()
+        self.end_test_scenario()
+
+    def cleanup(self):
+        self.skip_cleanup()

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/__init__.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/__init__.py
@@ -1,2 +1,3 @@
 from .dss_interoperability import DSSInteroperability
 from .nominal_behavior import NominalBehavior
+from .aggregate_checks import AggregateChecks

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/aggregate_checks.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/aggregate_checks.md
@@ -1,0 +1,25 @@
+# ASTM F3411-19 NetRID aggregate checks test scenario
+
+## Overview
+TODO
+
+## Resources
+
+### report_resource
+TODO: automatically injected resource
+
+### service_providers
+TODO
+
+### observers
+TODO
+
+## Dummy test case
+TODO
+
+### Dummy test step
+TODO
+
+#### Dummy check
+TODO
+

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/aggregate_checks.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/aggregate_checks.py
@@ -1,0 +1,10 @@
+from monitoring.uss_qualifier.scenarios.interuss.evaluation_scenario import (
+    ReportEvaluationScenario,
+)
+from monitoring.uss_qualifier.scenarios.astm.netrid.common.aggregate_checks import (
+    AggregateChecks as CommonAggregateChecks,
+)
+
+
+class AggregateChecks(ReportEvaluationScenario, CommonAggregateChecks):
+    pass

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/aggregate_checks.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/aggregate_checks.py
@@ -1,10 +1,8 @@
-from monitoring.uss_qualifier.scenarios.interuss.evaluation_scenario import (
-    ReportEvaluationScenario,
-)
 from monitoring.uss_qualifier.scenarios.astm.netrid.common.aggregate_checks import (
     AggregateChecks as CommonAggregateChecks,
 )
+from monitoring.uss_qualifier.scenarios.scenario import TestScenario
 
 
-class AggregateChecks(ReportEvaluationScenario, CommonAggregateChecks):
+class AggregateChecks(TestScenario, CommonAggregateChecks):
     pass

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/__init__.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/__init__.py
@@ -1,2 +1,3 @@
 from .dss_interoperability import DSSInteroperability
 from .nominal_behavior import NominalBehavior
+from .aggregate_checks import AggregateChecks

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/aggregate_checks.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/aggregate_checks.md
@@ -1,0 +1,25 @@
+# ASTM F3411-22a NetRID aggregate checks test scenario
+
+## Overview
+TODO
+
+## Resources
+
+### report_resource
+TODO: automatically injected resource
+
+### service_providers
+TODO
+
+### observers
+TODO
+
+## Dummy test case
+TODO
+
+### Dummy test step
+TODO
+
+#### Dummy check
+TODO
+

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/aggregate_checks.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/aggregate_checks.py
@@ -1,0 +1,10 @@
+from monitoring.uss_qualifier.scenarios.interuss.evaluation_scenario import (
+    ReportEvaluationScenario,
+)
+from monitoring.uss_qualifier.scenarios.astm.netrid.common.aggregate_checks import (
+    AggregateChecks as CommonAggregateChecks,
+)
+
+
+class AggregateChecks(ReportEvaluationScenario, CommonAggregateChecks):
+    pass

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/aggregate_checks.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/aggregate_checks.py
@@ -1,10 +1,8 @@
-from monitoring.uss_qualifier.scenarios.interuss.evaluation_scenario import (
-    ReportEvaluationScenario,
-)
 from monitoring.uss_qualifier.scenarios.astm.netrid.common.aggregate_checks import (
     AggregateChecks as CommonAggregateChecks,
 )
+from monitoring.uss_qualifier.scenarios.scenario import TestScenario
 
 
-class AggregateChecks(ReportEvaluationScenario, CommonAggregateChecks):
+class AggregateChecks(TestScenario, CommonAggregateChecks):
     pass

--- a/monitoring/uss_qualifier/scenarios/interuss/evaluation_scenario.py
+++ b/monitoring/uss_qualifier/scenarios/interuss/evaluation_scenario.py
@@ -10,8 +10,6 @@ from monitoring.uss_qualifier.scenarios.scenario import (
 )
 
 
-# TODO: move to scenarios/interuss ???
-
 REPORT_RESOURCE_ID: ResourceID = "report_resource"
 
 
@@ -25,7 +23,6 @@ class GenericReportEvaluationScenario(GenericTestScenario):
     ):
         super().__init__()
         self.report = report_resource.report
-        # TODO: use the kwargs to fetch with RESOURCE_ID ???
 
     @staticmethod
     def inject_report_resource(
@@ -35,31 +32,6 @@ class GenericReportEvaluationScenario(GenericTestScenario):
     ):
         resources_mapping[REPORT_RESOURCE_ID] = REPORT_RESOURCE_ID
         resources[REPORT_RESOURCE_ID] = TestSuiteReportResource(report)
-
-    # @staticmethod
-    # def make_test_suite_action(
-    #     scenario_declaration: TestScenarioDeclaration,
-    #     resources: Dict[ResourceID, ResourceType],
-    #     report: TestSuiteReport,
-    # ) -> TestSuiteAction:
-    #     scenario_declaration = ImplicitDict.parse(
-    #         json.loads(json.dumps(scenario_declaration)),
-    #         TestScenarioDeclaration,
-    #     )
-    #     scenario_declaration.resources = dict(scenario_declaration.resources, **{REPORT_RESOURCE_ID: REPORT_RESOURCE_ID}) # todo inject from resource
-    #     action_declaration = ImplicitDict.parse(
-    #         dict(
-    #             test_scenario=scenario_declaration,
-    #         ),
-    #         TestSuiteActionDeclaration,
-    #     )
-    #     action_resources = dict(
-    #         resources,
-    #         **{REPORT_RESOURCE_ID: TestSuiteReportResource(report)},
-    #     )
-    #     return TestSuiteAction(
-    #         action=action_declaration, resources=action_resources
-    #     )
 
 
 class ReportEvaluationScenario(GenericReportEvaluationScenario, TestScenario):

--- a/monitoring/uss_qualifier/scenarios/interuss/evaluation_scenario.py
+++ b/monitoring/uss_qualifier/scenarios/interuss/evaluation_scenario.py
@@ -6,14 +6,13 @@ from monitoring.uss_qualifier.resources.interuss.report import TestSuiteReportRe
 from monitoring.uss_qualifier.resources.resource import ResourceType
 from monitoring.uss_qualifier.scenarios.scenario import (
     GenericTestScenario,
-    TestScenario,
 )
 
 
 REPORT_RESOURCE_ID: ResourceID = "report_resource"
 
 
-class GenericReportEvaluationScenario(GenericTestScenario):
+class ReportEvaluationScenario(GenericTestScenario):
 
     report: TestSuiteReport
 
@@ -32,7 +31,3 @@ class GenericReportEvaluationScenario(GenericTestScenario):
     ):
         resources_mapping[REPORT_RESOURCE_ID] = REPORT_RESOURCE_ID
         resources[REPORT_RESOURCE_ID] = TestSuiteReportResource(report)
-
-
-class ReportEvaluationScenario(GenericReportEvaluationScenario, TestScenario):
-    pass

--- a/monitoring/uss_qualifier/scenarios/interuss/evaluation_scenario.py
+++ b/monitoring/uss_qualifier/scenarios/interuss/evaluation_scenario.py
@@ -1,0 +1,66 @@
+from typing import Dict
+
+from monitoring.uss_qualifier.reports.report import TestSuiteReport
+from monitoring.uss_qualifier.resources.definitions import ResourceID
+from monitoring.uss_qualifier.resources.interuss.report import TestSuiteReportResource
+from monitoring.uss_qualifier.resources.resource import ResourceType
+from monitoring.uss_qualifier.scenarios.scenario import (
+    GenericTestScenario,
+    TestScenario,
+)
+
+
+# TODO: move to scenarios/interuss ???
+
+REPORT_RESOURCE_ID: ResourceID = "report_resource"
+
+
+class GenericReportEvaluationScenario(GenericTestScenario):
+
+    report: TestSuiteReport
+
+    def __init__(
+        self,
+        report_resource: TestSuiteReportResource,
+    ):
+        super().__init__()
+        self.report = report_resource.report
+        # TODO: use the kwargs to fetch with RESOURCE_ID ???
+
+    @staticmethod
+    def inject_report_resource(
+        resources_mapping: Dict[ResourceID, ResourceID],
+        resources: Dict[ResourceID, ResourceType],
+        report: TestSuiteReport,
+    ):
+        resources_mapping[REPORT_RESOURCE_ID] = REPORT_RESOURCE_ID
+        resources[REPORT_RESOURCE_ID] = TestSuiteReportResource(report)
+
+    # @staticmethod
+    # def make_test_suite_action(
+    #     scenario_declaration: TestScenarioDeclaration,
+    #     resources: Dict[ResourceID, ResourceType],
+    #     report: TestSuiteReport,
+    # ) -> TestSuiteAction:
+    #     scenario_declaration = ImplicitDict.parse(
+    #         json.loads(json.dumps(scenario_declaration)),
+    #         TestScenarioDeclaration,
+    #     )
+    #     scenario_declaration.resources = dict(scenario_declaration.resources, **{REPORT_RESOURCE_ID: REPORT_RESOURCE_ID}) # todo inject from resource
+    #     action_declaration = ImplicitDict.parse(
+    #         dict(
+    #             test_scenario=scenario_declaration,
+    #         ),
+    #         TestSuiteActionDeclaration,
+    #     )
+    #     action_resources = dict(
+    #         resources,
+    #         **{REPORT_RESOURCE_ID: TestSuiteReportResource(report)},
+    #     )
+    #     return TestSuiteAction(
+    #         action=action_declaration, resources=action_resources
+    #     )
+
+
+class ReportEvaluationScenario(GenericReportEvaluationScenario, TestScenario):
+    pass

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_19.yaml
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_19.yaml
@@ -20,6 +20,11 @@ actions:
         evaluation_configuration: evaluation_configuration
         dss_pool: dss_instances
     on_failure: Continue
+report_evaluation_scenario:
+  scenario_type: scenarios.astm.netrid.v19.AggregateChecks
+  resources:
+    service_providers: service_providers
+    observers: observers
 participant_verifiable_capabilities:
     - id: service_provider
       name: NetRID Service Provider

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a.yaml
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a.yaml
@@ -20,6 +20,11 @@ actions:
         evaluation_configuration: evaluation_configuration
         dss_pool: dss_instances
     on_failure: Continue
+report_evaluation_scenario:
+  scenario_type: scenarios.astm.netrid.v22a.AggregateChecks
+  resources:
+    service_providers: service_providers
+    observers: observers
 participant_verifiable_capabilities:
   - id: service_provider
     name: NetRID Service Provider

--- a/monitoring/uss_qualifier/suites/definitions.py
+++ b/monitoring/uss_qualifier/suites/definitions.py
@@ -159,6 +159,9 @@ class TestSuiteDefinition(ImplicitDict):
     actions: List[TestSuiteActionDeclaration]
     """The actions to take when running the test suite.  Components will be executed in order."""
 
+    report_evaluation_scenario: Optional[TestScenarioDeclaration]
+    """The scenario executed after all the actions that evaluates the test suite report. Must be a ReportEvaluationScenario."""
+
     participant_verifiable_capabilities: Optional[List[ParticipantCapabilityDefinition]]
     """Definitions of capabilities verified by this test suite for individual participants."""
 


### PR DESCRIPTION
This adds in the test framework the ability to define in test suites a report evaluation scenario, which if defined will be executed after all the actions were executed.
Such a scenario needs to inherit from `ReportEvaluationScenario`.
The framework will inject the report as a resource.
This also bootstraps the RID aggregate check scenarios v19+v22a with a dummy implementation.