### PR TITLE
[uss_qualifier] Add ISASimple NetRID DSS scenario

### DIFF
--- a/monitoring/monitorlib/geo.py
+++ b/monitoring/monitorlib/geo.py
@@ -1,7 +1,7 @@
 import math
 from typing import List, Tuple
 import s2sphere
-
+from implicitdict import ImplicitDict
 
 EARTH_CIRCUMFERENCE_KM = 40075
 EARTH_CIRCUMFERENCE_M = EARTH_CIRCUMFERENCE_KM * 1000
@@ -100,3 +100,27 @@ def get_latlngrect_vertices(rect: s2sphere.LatLngRect) -> List[s2sphere.LatLng]:
         s2sphere.LatLng.from_angles(lat=rect.lat_hi(), lng=rect.lng_hi()),
         s2sphere.LatLng.from_angles(lat=rect.lat_hi(), lng=rect.lng_lo()),
     ]
+
+
+class LatLngBoundingBox(ImplicitDict):
+    """Bounding box in latitude and longitude"""
+
+    lat_min: float
+    """Lower latitude bound (degrees)"""
+
+    lng_min: float
+    """Lower longitude bound (degrees)"""
+
+    lat_max: float
+    """Upper latitude bound (degrees)"""
+
+    lng_max: float
+    """Upper longitude bound (degrees)"""
+
+    def to_vertices(self) -> List[s2sphere.LatLng]:
+        return [
+            s2sphere.LatLng.from_degrees(self.lat_min, self.lng_min),
+            s2sphere.LatLng.from_degrees(self.lat_max, self.lng_min),
+            s2sphere.LatLng.from_degrees(self.lat_max, self.lng_max),
+            s2sphere.LatLng.from_degrees(self.lat_min, self.lng_max),
+        ]

--- a/monitoring/monitorlib/mutate/rid.py
+++ b/monitoring/monitorlib/mutate/rid.py
@@ -351,17 +351,26 @@ class ChangedISA(RIDQuery):
             )
 
     @property
-    def subscribers(self) -> List[SubscriberToNotify]:
+    def subscribers(self) -> Optional[List[SubscriberToNotify]]:
         if self.rid_version == RIDVersion.f3411_19:
+            if (
+                "subscribers" not in self._v19_response
+                or self._v19_response.subscribers is None
+            ):
+                return None
             return [
                 SubscriberToNotify(v19_value=sub)
                 for sub in self._v19_response.subscribers
             ]
         elif self.rid_version == RIDVersion.f3411_22a:
-            return [
-                SubscriberToNotify(v22a_value=sub)
-                for sub in self._v22a_response.subscribers
-            ]
+            return (
+                [
+                    SubscriberToNotify(v22a_value=sub)
+                    for sub in self._v22a_response.subscribers
+                ]
+                if "subscribers" in self._v22a_response
+                else []
+            )
         else:
             raise NotImplementedError(
                 f"Cannot retrieve subscribers to notify using RID version {self.rid_version}"

--- a/monitoring/monitorlib/rid.py
+++ b/monitoring/monitorlib/rid.py
@@ -6,6 +6,7 @@ import arrow
 from monitoring.monitorlib import schema_validation
 from uas_standards.astm.f3411 import v19, v22a
 import uas_standards.astm.f3411.v19.constants
+import uas_standards.astm.f3411.v22a.api
 import uas_standards.astm.f3411.v22a.constants
 
 
@@ -43,6 +44,15 @@ class RIDVersion(str, Enum):
             return schema_validation.F3411_19.GetFlightDetailsResponse
         elif self == RIDVersion.f3411_22a:
             return schema_validation.F3411_22a.GetFlightDetailsResponse
+        else:
+            raise ValueError(f"Unsupported RID version '{self}'")
+
+    @property
+    def openapi_put_isa_response_path(self) -> str:
+        if self == RIDVersion.f3411_19:
+            return schema_validation.F3411_19.PutIdentificationServiceAreaResponse
+        elif self == RIDVersion.f3411_22a:
+            return schema_validation.F3411_22a.PutIdentificationServiceAreaResponse
         else:
             raise ValueError(f"Unsupported RID version '{self}'")
 
@@ -108,3 +118,12 @@ class RIDVersion(str, Enum):
             return "v22a"
         else:
             return "unknown"
+
+    def flights_url_of(self, base_url: str) -> str:
+        if self == RIDVersion.f3411_19:
+            return base_url
+        elif self == RIDVersion.f3411_22a:
+            flights_path = v22a.api.OPERATIONS[v22a.api.OperationID.SearchFlights].path
+            return base_url + flights_path
+        else:
+            raise ValueError("Unsupported RID version '{}'".format(self))

--- a/monitoring/monitorlib/schema_validation.py
+++ b/monitoring/monitorlib/schema_validation.py
@@ -13,12 +13,18 @@ class F3411_19(str, Enum):
     OpenAPIPath = "interfaces/rid/v1/remoteid/augmented.yaml"
     GetFlightsResponse = "components.schemas.GetFlightsResponse"
     GetFlightDetailsResponse = "components.schemas.GetFlightDetailsResponse"
+    PutIdentificationServiceAreaResponse = (
+        "components.schemas.PutIdentificationServiceAreaResponse"
+    )
 
 
 class F3411_22a(str, Enum):
     OpenAPIPath = "interfaces/rid/v2/remoteid/updated.yaml"
     GetFlightsResponse = "components.schemas.GetFlightsResponse"
     GetFlightDetailsResponse = "components.schemas.GetFlightDetailsResponse"
+    PutIdentificationServiceAreaResponse = (
+        "components.schemas.PutIdentificationServiceAreaResponse"
+    )
 
 
 class F3548_21(str, Enum):

--- a/monitoring/uss_qualifier/action_generators/astm/f3411/__init__.py
+++ b/monitoring/uss_qualifier/action_generators/astm/f3411/__init__.py
@@ -1,0 +1,1 @@
+from .for_each_dss import ForEachDSS

--- a/monitoring/uss_qualifier/action_generators/astm/f3411/for_each_dss.py
+++ b/monitoring/uss_qualifier/action_generators/astm/f3411/for_each_dss.py
@@ -1,0 +1,78 @@
+from typing import Dict, List, Optional
+
+from implicitdict import ImplicitDict
+
+from monitoring.monitorlib.inspection import fullname
+from monitoring.uss_qualifier.reports.report import TestSuiteActionReport
+from monitoring.uss_qualifier.resources.astm.f3411 import (
+    DSSInstanceResource,
+    DSSInstancesResource,
+)
+from monitoring.uss_qualifier.resources.definitions import ResourceID
+from monitoring.uss_qualifier.resources.resource import ResourceType
+from monitoring.uss_qualifier.suites.definitions import TestSuiteActionDeclaration
+from monitoring.uss_qualifier.suites.suite import (
+    ActionGenerator,
+    TestSuiteAction,
+    ReactionToFailure,
+)
+
+
+class ForEachDSSSpecification(ImplicitDict):
+    action_to_repeat: TestSuiteActionDeclaration
+    """Test suite action to run for each DSS instance"""
+
+    dss_instances_source: ResourceID
+    """ID of the resource providing the single DSS instance"""
+
+    dss_instance_id: ResourceID
+    """Resource IDs of DSS input to the action_to_repeat"""
+
+
+class ForEachDSS(ActionGenerator[ForEachDSSSpecification]):
+    _actions: List[TestSuiteAction]
+    _current_action: int
+    _failure_reaction: ReactionToFailure
+
+    def __init__(
+        self,
+        specification: ForEachDSSSpecification,
+        resources: Dict[ResourceID, ResourceType],
+    ):
+        if specification.dss_instances_source not in resources:
+            raise ValueError(
+                f"Resource ID {specification.dss_instances_source} specified as `dss_instances` was not present in the available resource pool"
+            )
+        dss_instances_resource: DSSInstancesResource = resources[
+            specification.dss_instances_source
+        ]
+        if not isinstance(dss_instances_resource, DSSInstancesResource):
+            raise ValueError(
+                f"Expected resource ID {specification.dss_instances_source} to be a {fullname(DSSInstancesResource)} but it was a {fullname(dss_instances_resource.__class__)} instead"
+            )
+        dss_instances = dss_instances_resource.dss_instances
+
+        self._actions = []
+        for dss_instance in dss_instances:
+            modified_resources = {k: v for k, v in resources.items()}
+            modified_resources[
+                specification.dss_instance_id
+            ] = DSSInstanceResource.from_dss_instance(dss_instance)
+
+            self._actions.append(
+                TestSuiteAction(specification.action_to_repeat, modified_resources)
+            )
+
+        self._current_action = 0
+        self._failure_reaction = specification.action_to_repeat.on_failure
+
+    def run_next_action(self) -> Optional[TestSuiteActionReport]:
+        if self._current_action < len(self._actions):
+            report = self._actions[self._current_action].run()
+            self._current_action += 1
+            if not report.successful():
+                if self._failure_reaction == ReactionToFailure.Abort:
+                    self._current_action = len(self._actions)
+            return report
+        else:
+            return None

--- a/monitoring/uss_qualifier/configurations/dev/local_test.json
+++ b/monitoring/uss_qualifier/configurations/dev/local_test.json
@@ -24,7 +24,9 @@
             "invalid_flight_intents": "invalid_flight_intents",
             "invalid_flight_auth_flights": "invalid_flight_auth_flights",
             "dss": "dss",
-            "netrid_dss_instances_v22a": "netrid_dss_instances_v22a"
+            "netrid_dss_instances_v22a": "netrid_dss_instances_v22a",
+            "id_generator": "id_generator",
+            "service_area": "service_area"
           }
         }
       }

--- a/monitoring/uss_qualifier/configurations/dev/netrid_v22a.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/netrid_v22a.yaml
@@ -12,6 +12,8 @@ v1:
                     observers: netrid_observers_v22a
                     evaluation_configuration: netrid_observation_evaluation_configuration
                     dss_instances: netrid_dss_instances_v22a
+                    id_generator: id_generator
+                    service_area: service_area
     artifacts:
         "$ref": artifacts.yaml#/relative
         tested_roles:

--- a/monitoring/uss_qualifier/configurations/dev/resources.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/resources.yaml
@@ -20,8 +20,8 @@ net_rid:
         dependencies:
             auth_adapter: utm_auth
         specification:
-            example_audience: localhost
-            example_scope: rid.display_provider
+            whoami_audience: localhost
+            whoami_scope: rid.display_provider
     service_area:
         resource_type: resources.netrid.ServiceAreaResource
         specification:

--- a/monitoring/uss_qualifier/configurations/dev/resources.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/resources.yaml
@@ -15,6 +15,24 @@ net_rid:
     netrid_observation_evaluation_configuration:
         resource_type: resources.netrid.EvaluationConfigurationResource
         specification: { }
+    id_generator:
+        resource_type: resources.interuss.IDGeneratorResource
+        dependencies:
+            auth_adapter: utm_auth
+        specification:
+            example_audience: localhost
+            example_scope: rid.display_provider
+    service_area:
+        resource_type: resources.netrid.ServiceAreaResource
+        specification:
+            base_url: https://uss.example.com/dummy_base_url
+            footprint:
+                lat_min: 37.1853
+                lng_min: -80.6140
+                lat_max: 37.2148
+                lng_max: -80.5440
+            altitude_min: 0
+            altitude_max: 3048
 
 net_rid_sims:
     adjacent_circular_flights_data:

--- a/monitoring/uss_qualifier/reports/graphs.py
+++ b/monitoring/uss_qualifier/reports/graphs.py
@@ -1,6 +1,7 @@
 from typing import Optional, List, Set, Tuple, Dict
 
 import graphviz
+from loguru import logger
 
 from implicitdict import ImplicitDict
 
@@ -186,7 +187,11 @@ def _make_action_generator_nodes(
     children: List[NodeName] = []
     for action in report.actions:
         if "test_suite" in action:
-            raise NotImplementedError()
+            # TODO: Support visualization of test suite actions with an action generator
+            logger.warning(
+                "test_suite action is being omitted from the action generator because graph representation of a test suite from an action generator is not yet supported"
+            )
+            new_nodes = []
         elif "test_scenario" in action:
             new_nodes = _make_test_scenario_nodes(
                 None, action.test_scenario, nodes_by_id, namer, True

--- a/monitoring/uss_qualifier/reports/report.py
+++ b/monitoring/uss_qualifier/reports/report.py
@@ -178,7 +178,7 @@ class ErrorReport(ImplicitDict):
             message=str(e),
             timestamp=StringBasedDateTime(datetime.utcnow()),
             stacktrace="".join(
-                traceback.format_exception(etype=type(e), value=e, tb=e.__traceback__)
+                traceback.format_exception(type(e), value=e, tb=e.__traceback__)
             ),
         )
 

--- a/monitoring/uss_qualifier/resources/astm/f3411/__init__.py
+++ b/monitoring/uss_qualifier/resources/astm/f3411/__init__.py
@@ -1,1 +1,1 @@
-from .dss import DSSInstancesResource
+from .dss import DSSInstanceResource, DSSInstancesResource

--- a/monitoring/uss_qualifier/resources/astm/f3411/dss.py
+++ b/monitoring/uss_qualifier/resources/astm/f3411/dss.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import List
 from urllib.parse import urlparse
 
@@ -43,6 +44,26 @@ class DSSInstance(object):
         self.participant_id = participant_id
         self.rid_version = rid_version
         self.client = infrastructure.UTMClientSession(base_url, auth_adapter)
+
+
+class DSSInstanceResource(Resource[DSSInstanceSpecification]):
+    dss_instance: DSSInstance
+
+    def __init__(
+        self, specification: DSSInstanceSpecification, auth_adapter: AuthAdapterResource
+    ):
+        self.dss_instance = DSSInstance(
+            specification.participant_id,
+            specification.base_url,
+            specification.rid_version,
+            auth_adapter.adapter,
+        )
+
+    @classmethod
+    def from_dss_instance(cls, dss_instance: DSSInstance) -> DSSInstanceResource:
+        self = cls.__new__(cls)
+        self.dss_instance = dss_instance
+        return self
 
 
 class DSSInstancesSpecification(ImplicitDict):

--- a/monitoring/uss_qualifier/resources/interuss/__init__.py
+++ b/monitoring/uss_qualifier/resources/interuss/__init__.py
@@ -1,1 +1,2 @@
+from .id_generator import IDGeneratorResource
 from .mock_uss import MockUSSResource

--- a/monitoring/uss_qualifier/resources/interuss/id_generator.py
+++ b/monitoring/uss_qualifier/resources/interuss/id_generator.py
@@ -8,14 +8,17 @@ from monitoring.uss_qualifier.resources.resource import Resource
 
 class IDGeneratorSpecification(ImplicitDict):
     """Generated IDs contain the client's identity so the appropriate client can clean up any dangling resources.
+
+    Note that this may not be necessary/important with the resolution of https://github.com/interuss/dss/issues/939
+
     To determine the client's identity, an access token is retrieved and the subscriber is read from the obtained token.
     Therefore, the client running uss_qualifier must have the ability to obtain an access token via an auth adapter.
     """
 
-    example_audience: str
+    whoami_audience: str
     """Audience to request for the access token used to determine subscriber identity."""
 
-    example_scope: str
+    whoami_scope: str
     """Scope to request for the access token used to determine subscribe identity.  Must be a scope that the client is
     authorized to obtain."""
 
@@ -29,12 +32,12 @@ class IDGeneratorResource(Resource[IDGeneratorSpecification]):
         auth_adapter: AuthAdapterResource,
     ):
         token = auth_adapter.adapter.issue_token(
-            specification.example_audience, [specification.example_scope]
+            specification.whoami_audience, [specification.whoami_scope]
         )
         payload = jwt.decode(token, options={"verify_signature": False})
         if "sub" not in payload:
             raise ValueError(
-                f"`sub` claim not found in payload of token using {type(auth_adapter).__name__} requesting {specification.example_scope} scope for {specification.example_audience} audience: {token}"
+                f"`sub` claim not found in payload of token using {type(auth_adapter).__name__} requesting {specification.whoami_scope} scope for {specification.whoami_audience} audience: {token}"
             )
         subscriber = payload["sub"]
         self.id_factory = IDFactory(subscriber)

--- a/monitoring/uss_qualifier/resources/interuss/id_generator.py
+++ b/monitoring/uss_qualifier/resources/interuss/id_generator.py
@@ -1,0 +1,40 @@
+from implicitdict import ImplicitDict
+import jwt
+
+from monitoring.prober.infrastructure import IDFactory
+from monitoring.uss_qualifier.resources.communications import AuthAdapterResource
+from monitoring.uss_qualifier.resources.resource import Resource
+
+
+class IDGeneratorSpecification(ImplicitDict):
+    """Generated IDs contain the client's identity so the appropriate client can clean up any dangling resources.
+    To determine the client's identity, an access token is retrieved and the subscriber is read from the obtained token.
+    Therefore, the client running uss_qualifier must have the ability to obtain an access token via an auth adapter.
+    """
+
+    example_audience: str
+    """Audience to request for the access token used to determine subscriber identity."""
+
+    example_scope: str
+    """Scope to request for the access token used to determine subscribe identity.  Must be a scope that the client is
+    authorized to obtain."""
+
+
+class IDGeneratorResource(Resource[IDGeneratorSpecification]):
+    id_factory: IDFactory
+
+    def __init__(
+        self,
+        specification: IDGeneratorSpecification,
+        auth_adapter: AuthAdapterResource,
+    ):
+        token = auth_adapter.adapter.issue_token(
+            specification.example_audience, [specification.example_scope]
+        )
+        payload = jwt.decode(token, options={"verify_signature": False})
+        if "sub" not in payload:
+            raise ValueError(
+                f"`sub` claim not found in payload of token using {type(auth_adapter).__name__} requesting {specification.example_scope} scope for {specification.example_audience} audience: {token}"
+            )
+        subscriber = payload["sub"]
+        self.id_factory = IDFactory(subscriber)

--- a/monitoring/uss_qualifier/resources/netrid/__init__.py
+++ b/monitoring/uss_qualifier/resources/netrid/__init__.py
@@ -2,3 +2,4 @@ from .service_providers import NetRIDServiceProviders
 from .observers import NetRIDObserversResource
 from .evaluation import EvaluationConfigurationResource
 from .flight_data_resources import FlightDataResource, FlightDataStorageResource
+from .service_area import ServiceAreaResource

--- a/monitoring/uss_qualifier/resources/netrid/service_area.py
+++ b/monitoring/uss_qualifier/resources/netrid/service_area.py
@@ -1,0 +1,29 @@
+from implicitdict import ImplicitDict
+from monitoring.monitorlib.geo import LatLngBoundingBox
+
+from monitoring.uss_qualifier.resources.resource import Resource
+
+
+class ServiceAreaSpecification(ImplicitDict):
+    base_url: str
+    """Base URL to use for the Identification Service Area.
+
+    Note that this is the API base URL, not the flights URL (as specified in F3411-19).
+
+    This URL will probably not identify a real resource in tests."""
+
+    footprint: LatLngBoundingBox
+    """2D outline of service area"""
+
+    altitude_min: float = 0
+    """Lower altitude bound of service area, meters above WGS84 ellipsoid"""
+
+    altitude_max: float = 3048
+    """Upper altitude bound of service area, meters above WGS84 ellipsoid"""
+
+
+class ServiceAreaResource(Resource[ServiceAreaSpecification]):
+    specification: ServiceAreaSpecification
+
+    def __init__(self, specification: ServiceAreaSpecification):
+        self.specification = specification

--- a/monitoring/uss_qualifier/resources/resource.py
+++ b/monitoring/uss_qualifier/resources/resource.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
-import inspect
-from typing import Dict, Generic, TypeVar
+import json
+from typing import get_type_hints, Dict, Generic, TypeVar
 
 from implicitdict import ImplicitDict
 
@@ -89,19 +89,21 @@ def _make_resource(
             )
         )
 
-    constructor_signature = inspect.signature(resource_type.__init__)
+    constructor_signature = get_type_hints(resource_type.__init__)
     specification_type = None
     constructor_args = {}
-    for arg_name, arg in constructor_signature.parameters.items():
+    for arg_name, arg_type in constructor_signature.items():
+        if arg_name == "return":
+            continue
         if arg_name == "self":
             continue
         if arg_name == "specification":
-            specification_type = arg.annotation
+            specification_type = arg_type
             continue
         if arg_name not in declaration.dependencies:
             raise ValueError(
                 'Resource declaration for {} is missing a source for dependency "{}"'.format(
-                    declaration.resource_type, arg
+                    declaration.resource_type, arg_type
                 )
             )
         if declaration.dependencies[arg_name] not in resource_pool:

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/isa_simple.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/isa_simple.py
@@ -1,0 +1,256 @@
+from datetime import timedelta
+
+import arrow
+
+from monitoring.monitorlib import schema_validation
+from monitoring.monitorlib.fetch import rid as fetch
+from monitoring.monitorlib.mutate import rid as mutate
+from monitoring.prober.infrastructure import register_resource_type
+from monitoring.uss_qualifier.common_data_definitions import Severity
+from monitoring.uss_qualifier.resources.astm.f3411.dss import DSSInstanceResource
+from monitoring.uss_qualifier.resources.interuss.id_generator import IDGeneratorResource
+from monitoring.uss_qualifier.resources.netrid.service_area import ServiceAreaResource
+from monitoring.uss_qualifier.scenarios.scenario import GenericTestScenario
+
+
+MAX_SKEW = 1e-6  # seconds maximum difference between expected and actual timestamps
+
+
+class ISASimple(GenericTestScenario):
+    """Based on prober/rid/v2/test_isa_simple.py from the legacy prober tool."""
+
+    ISA_TYPE = register_resource_type(348, "ISA")
+
+    def __init__(
+        self,
+        dss: DSSInstanceResource,
+        id_generator: IDGeneratorResource,
+        isa: ServiceAreaResource,
+    ):
+        super().__init__()
+        self._dss = dss.dss_instance
+        self._isa_id = id_generator.id_factory.make_id(ISASimple.ISA_TYPE)
+        self._isa = isa.specification
+
+    def run(self):
+        self.begin_test_scenario()
+
+        self._setup_case()
+        self._create_and_check_isa_case()
+        self._update_and_search_isa_case()
+        self._delete_isa_case()
+
+        self.end_test_scenario()
+
+    def _setup_case(self):
+        self.begin_test_case("Setup")
+
+        self._ensure_clean_workspace_step()
+
+        self.end_test_case()
+
+    def _ensure_clean_workspace_step(self):
+        self.begin_test_step("Ensure clean workspace")
+
+        fetched = fetch.isa(
+            self._isa_id, rid_version=self._dss.rid_version, session=self._dss.client
+        )
+        self.record_query(fetched.query)
+        with self.check("Successful ISA query", [self._dss.participant_id]) as check:
+            if not fetched.success and fetched.status_code != 404:
+                check.record_failed(
+                    "ISA information could not be retrieved",
+                    Severity.High,
+                    f"{self._dss.participant_id} DSS instance returned {fetched.status_code} when queried for ISA {self._isa_id}",
+                    query_timestamps=[fetched.query.request.timestamp],
+                )
+
+        if fetched.success:
+            deleted = mutate.delete_isa(
+                self._isa_id,
+                fetched.isa.version,
+                self._dss.rid_version,
+                self._dss.client,
+            )
+            self.record_query(deleted.dss_query.query)
+            for subscriber_id, notification in deleted.notifications.items():
+                self.record_query(notification.query)
+            with self.check(
+                "Removed pre-existing ISA", [self._dss.participant_id]
+            ) as check:
+                if not deleted.dss_query.success:
+                    check.record_failed(
+                        "Could not delete pre-existing ISA",
+                        Severity.High,
+                        f"Attempting to delete ISA {self._isa_id} from the {self._dss.participant_id} DSS returned error {deleted.dss_query.status_code}",
+                        query_timestamps=[deleted.dss_query.query.request.timestamp],
+                    )
+            for subscriber_url, notification in deleted.notifications.items():
+                with self.check("Notified subscriber", [subscriber_url]) as check:
+                    # TODO: Find a better way to identify a subscriber who couldn't be notified
+                    if not notification.success:
+                        check.record_failed(
+                            "Could not notify ISA subscriber",
+                            Severity.Medium,
+                            f"Attempting to notify subscriber for ISA {self._isa_id} at {subscriber_url} resulted in {notification.status_code}",
+                            query_timestamps=[notification.query.request.timestamp],
+                        )
+
+        self.end_test_step()
+
+    def _create_and_check_isa_case(self):
+        self.begin_test_case("Create and check ISA")
+
+        self._create_isa_step()
+
+        # TODO: Get ISA by ID
+
+        self.end_test_case()
+
+    def _create_isa_step(self):
+        self.begin_test_step("Create ISA")
+
+        start_time = arrow.utcnow().datetime + timedelta(seconds=1)
+        end_time = start_time + timedelta(minutes=60)
+        area = self._isa.footprint.to_vertices()
+        isa_change = mutate.put_isa(
+            area_vertices=area,
+            start_time=start_time,
+            end_time=end_time,
+            uss_base_url=self._isa.base_url,
+            isa_id=self._isa_id,
+            rid_version=self._dss.rid_version,
+            utm_client=self._dss.client,
+            isa_version=None,
+            alt_lo=self._isa.altitude_min,
+            alt_hi=self._isa.altitude_max,
+        )
+        self.record_query(isa_change.dss_query.query)
+        for notification_query in isa_change.notifications.values():
+            self.record_query(notification_query.query)
+        t_dss = isa_change.dss_query.query.request.timestamp
+
+        with self.check("ISA created", [self._dss.participant_id]) as check:
+            if isa_change.dss_query.status_code == 200:
+                check.record_passed()
+            elif isa_change.dss_query.status_code == 201:
+                check.record_failed(
+                    f"PUT ISA returned technically-incorrect 201",
+                    Severity.Low,
+                    "DSS should return 200 from PUT ISA, but instead returned the reasonable-but-technically-incorrect code 201",
+                    query_timestamps=[t_dss],
+                )
+            else:
+                check.record_failed(
+                    f"PUT ISA returned {isa_change.dss_query.status_code}",
+                    Severity.High,
+                    f"DSS should return 200 from PUT ISA, but instead returned {isa_change.dss_query.status_code}",
+                    query_timestamps=[t_dss],
+                )
+
+        with self.check("ISA ID matches", [self._dss.participant_id]) as check:
+            if isa_change.dss_query.isa.id != self._isa_id:
+                check.record_failed(
+                    f"PUT ISA returned ISA with incorrect ID",
+                    Severity.High,
+                    f"DSS should have recorded and returned the ISA ID {self._isa_id} as requested in the path, but response body instead specified {isa_change.dss_query.isa.id}",
+                    query_timestamps=[t_dss],
+                )
+        with self.check("ISA URL matches", [self._dss.participant_id]) as check:
+            expected_flights_url = self._dss.rid_version.flights_url_of(
+                self._isa.base_url
+            )
+            actual_flights_url = isa_change.dss_query.isa.flights_url
+            if actual_flights_url != expected_flights_url:
+                check.record_failed(
+                    f"PUT ISA returned ISA with incorrect URL",
+                    Severity.High,
+                    f"DSS should have returned an ISA with a flights URL of {expected_flights_url}, but instead the ISA returned had a flights URL of {actual_flights_url}",
+                    query_timestamps=[t_dss],
+                )
+        with self.check("ISA start time matches", [self._dss.participant_id]) as check:
+            if (
+                abs((isa_change.dss_query.isa.time_start - start_time).total_seconds())
+                > MAX_SKEW
+            ):
+                check.record_failed(
+                    "PUT ISA returned ISA with incorrect start time",
+                    Severity.High,
+                    f"DSS should have returned an ISA with a start time of {start_time}, but instead the ISA returned had a start time of {isa_change.dss_query.isa.time_start}",
+                    query_timestamps=[t_dss],
+                )
+        with self.check("ISA end time matches", [self._dss.participant_id]) as check:
+            if (
+                abs((isa_change.dss_query.isa.time_end - end_time).total_seconds())
+                > MAX_SKEW
+            ):
+                check.record_failed(
+                    "PUT ISA returned ISA with incorrect end time",
+                    Severity.High,
+                    f"DSS should have returned an ISA with an end time of {end_time}, but instead the ISA returned had an end time of {isa_change.dss_query.isa.time_end}",
+                    query_timestamps=[t_dss],
+                )
+        with self.check("ISA version format", [self._dss.participant_id]) as check:
+            if not all(
+                c not in "\0\t\r\n#%/:?@[\]" for c in isa_change.dss_query.isa.version
+            ):
+                check.record_failed(
+                    "PUT ISA returned ISA with invalid version format",
+                    Severity.High,
+                    f"DSS returned an ISA with a version that is not URL-safe: {isa_change.dss_query.isa.version}",
+                    query_timestamps=[t_dss],
+                )
+
+        with self.check("ISA response format", [self._dss.participant_id]) as check:
+            errors = schema_validation.validate(
+                self._dss.rid_version.openapi_path,
+                self._dss.rid_version.openapi_put_isa_response_path,
+                isa_change.dss_query.query.response.json,
+            )
+            if errors:
+                details = "\n".join(f"[{e.json_path}] {e.message}" for e in errors)
+                check.record_failed(
+                    "PUT ISA response format was invalid",
+                    Severity.Medium,
+                    "Found the following schema validation errors in the DSS response:\n"
+                    + details,
+                    query_timestamps=[t_dss],
+                )
+
+        # TODO: Validate subscriber notifications
+
+        self.end_test_step()
+
+    def _update_and_search_isa_case(self):
+        self.begin_test_case("Update and search ISA")
+
+        # TODO: Update ISA
+        # TODO: Get ISA by ID
+        # TODO: Search with invalid params
+        # TODO: Search by earliest time (included)
+        # TODO: Search by earliest time (excluded)
+        # TODO: Search by latest time (included)
+        # TODO: Search by latest time (excluded)
+        # TODO: Search by area only
+        # TODO: Search by huge area
+
+        self.end_test_case()
+
+    def _delete_isa_case(self):
+        self.begin_test_case("Delete ISA")
+
+        # TODO: Delete with wrong version
+        # TODO: Delete with empty version
+        # TODO: Delete ISA
+        # TODO: Get ISA by ID
+        # TODO: Search ISA
+        # TODO: Search ISA with loop
+
+        self.end_test_case()
+
+    def cleanup(self):
+        self.begin_cleanup()
+
+        # TODO: Remove ISA if still present
+
+        self.end_cleanup()

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/nominal_behavior.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/nominal_behavior.py
@@ -103,9 +103,7 @@ class NominalBehavior(GenericTestScenario):
                 query = target.submit_test(p, test_id)
             except RequestException as e:
                 stacktrace = "".join(
-                    traceback.format_exception(
-                        etype=type(e), value=e, tb=e.__traceback__
-                    )
+                    traceback.format_exception(type(e), value=e, tb=e.__traceback__)
                 )
                 check.record_failed(
                     summary="Error while trying to inject test flight",
@@ -257,9 +255,7 @@ class NominalBehavior(GenericTestScenario):
                 check.record_passed()
             except (RequestException, ValueError) as e:
                 stacktrace = "".join(
-                    traceback.format_exception(
-                        etype=type(e), value=e, tb=e.__traceback__
-                    )
+                    traceback.format_exception(type(e), value=e, tb=e.__traceback__)
                 )
                 check.record_failed(
                     summary="Error while trying to delete test flight",

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/__init__.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/__init__.py
@@ -1,0 +1,1 @@
+from .isa_simple import ISASimple

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/isa_simple.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/isa_simple.md
@@ -1,0 +1,81 @@
+# ASTM NetRID DSS: Simple ISA test scenario
+
+## Overview
+
+Perform basic operations on a single DSS instance to create an ISA and query it during its time of applicability and
+after its time of applicability.
+
+## Resources
+
+### dss
+
+[`DSSInstanceResource`](../../../../resources/astm/f3411/dss.py) to be tested in this scenario.
+
+### id_generator
+
+[`IDGeneratorResource`](../../../../resources/interuss/id_generator.py) providing the ISA ID for this scenario.
+
+### isa
+
+[`ServiceAreaResource`](../../../../resources/netrid/service_area.py) describing an ISA to be created.
+
+## Setup test case
+
+### Ensure clean workspace test step
+
+This scenario creates an ISA with a known ID.  This step ensures that ISA does not exist before the start of the main
+part of the test.
+
+#### Successful ISA query check
+
+**[astm.f3411.v22a.DSS0030](../../../../../requirements/astm/f3411/v22a.md)** requires the implementation of the DSS endpoint enabling retrieval of information about a specific ISA; if the individual ISA cannot be retrieved and the error isn't a 404, then this requirement isn't met.
+
+#### Removed pre-existing ISA check
+
+If an ISA with the intended ID is already present in the DSS, it needs to be removed before proceeding with the test.  If that ISA cannot be deleted, then the **[astm.f3411.v22a.DSS0030](../../../../../requirements/astm/f3411/v22a.md)** requirement to implement the ISA deletion endpoint might not be met.
+
+#### Notified subscriber check
+
+When a pre-existing ISA needs to be deleted to ensure a clean workspace, any subscribers to ISAs in that area must be notified (as specified by the DSS).  If a notification cannot be delivered, then the **[astm.f3411.v22a.NET0710](../../../../../requirements/astm/f3411/v22a.md)** requirement to implement the POST ISAs endpoint isn't met.
+
+## Create and check ISA test case
+
+### Create ISA test step
+
+This step attempts to create an ISA with a 60-minute expiration.
+
+#### ISA created check
+
+If the ISA cannot be created, the PUT DSS endpoint in **[astm.f3411.v22a.DSS0030](../../../../../requirements/astm/f3411/v22a.md)** is likely not implemented correctly.
+
+#### ISA ID matches check
+
+When the ISA is created, the DSS returns the ID of the ISA in the response body.  If this ID does not match the ID in the resource path, **[astm.f3411.v22a.DSS0030](../../../../../requirements/astm/f3411/v22a.md)** was not implemented correctly and this check will fail.
+
+#### ISA URL matches check
+
+When the ISA is created, the DSS returns the URL of the ISA in the response body.  If this URL does not match the URL requested, **[astm.f3411.v22a.DSS0030](../../../../../requirements/astm/f3411/v22a.md)** is not implemented correctly and this check will fail.
+
+#### ISA start time matches check
+
+The ISA creation request specified an exact start time slightly past now, so the DSS should have created an ISA starting at exactly that time.  If the DSS response indicates the ISA start time is not this value, **[astm.f3411.v22a.DSS0030](../../../../../requirements/astm/f3411/v22a.md)** is not implemented correctly and this check will fail.
+
+#### ISA end time matches check
+
+The ISA creation request specified an exact end time, so the DSS should have created an ISA ending at exactly that time.  If the DSS response indicates the ISA end time is not this value, **[astm.f3411.v22a.DSS0030](../../../../../requirements/astm/f3411/v22a.md)** is not implemented correctly and this check will fail.
+
+#### ISA version format check
+
+Because the ISA version must be used in URLs, it must be URL-safe even though the ASTM standards do not explicitly require this.  If the indicated ISA version is not URL-safe, this check will fail.
+
+#### ISA response format check
+
+The API for **[astm.f3411.v22a.DSS0030](../../../../../requirements/astm/f3411/v22a.md)** specifies an explicit format that the DSS responses must follow.  If the DSS response does not validate against this format, this check will fail.
+
+## Update and search ISA test case
+
+## Delete ISA test case
+
+## Cleanup
+
+The cleanup phase of this test scenario attempts to remove the ISA if the test ended prematurely.

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/isa_simple.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/isa_simple.md
@@ -9,15 +9,15 @@ after its time of applicability.
 
 ### dss
 
-[`DSSInstanceResource`](../../../../resources/astm/f3411/dss.py) to be tested in this scenario.
+[`DSSInstanceResource`](../../../../../resources/astm/f3411/dss.py) to be tested in this scenario.
 
 ### id_generator
 
-[`IDGeneratorResource`](../../../../resources/interuss/id_generator.py) providing the ISA ID for this scenario.
+[`IDGeneratorResource`](../../../../../resources/interuss/id_generator.py) providing the ISA ID for this scenario.
 
 ### isa
 
-[`ServiceAreaResource`](../../../../resources/netrid/service_area.py) describing an ISA to be created.
+[`ServiceAreaResource`](../../../../../resources/netrid/service_area.py) describing an ISA to be created.
 
 ## Setup test case
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/isa_simple.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/isa_simple.py
@@ -1,0 +1,8 @@
+from monitoring.uss_qualifier.scenarios.astm.netrid.common.dss.isa_simple import (
+    ISASimple as CommonISASimple,
+)
+from monitoring.uss_qualifier.scenarios.scenario import TestScenario
+
+
+class ISASimple(TestScenario, CommonISASimple):
+    pass

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a.yaml
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a.yaml
@@ -5,7 +5,39 @@ resources:
   observers: resources.netrid.NetRIDObserversResource
   evaluation_configuration: resources.netrid.EvaluationConfigurationResource
   dss_instances: resources.astm.f3411.DSSInstancesResource
+  id_generator: resources.interuss.IDGeneratorResource
+  service_area: resources.netrid.ServiceAreaResource
 actions:
+  - action_generator:
+      generator_type: action_generators.astm.f3411.ForEachDSS
+      resources:
+        dss_instances: dss_instances
+        id_generator: id_generator
+        service_area: service_area
+      specification:
+        action_to_repeat:
+          test_suite:
+            suite_definition:
+              name: DSS instance validator
+              resources:
+                dss: resources.astm.f3411.DSSInstanceResource
+                id_generator: resources.interuss.IDGeneratorResource
+                isa: resources.netrid.ServiceAreaResource
+              actions:
+                - test_scenario:
+                    scenario_type: scenarios.astm.netrid.v22a.dss.ISASimple
+                    resources:
+                      dss: dss
+                      id_generator: id_generator
+                      isa: isa
+            resources:
+              dss: dss
+              id_generator: id_generator
+              isa: service_area
+          on_failure: Continue
+        dss_instances_source: dss_instances
+        dss_instance_id: dss
+      on_failure: Continue
   - test_scenario:
       scenario_type: scenarios.astm.netrid.v22a.DSSInteroperability
       resources:

--- a/monitoring/uss_qualifier/suites/dev/local_test.yaml
+++ b/monitoring/uss_qualifier/suites/dev/local_test.yaml
@@ -15,6 +15,8 @@ resources:
   invalid_flight_auth_flights: resources.flight_planning.FlightIntentsResource
   dss: resources.astm.f3548.v21.DSSInstanceResource
   netrid_dss_instances_v22a: resources.astm.f3411.DSSInstancesResource
+  id_generator: resources.interuss.IDGeneratorResource
+  service_area: resources.netrid.ServiceAreaResource
 actions:
 - test_suite:
     suite_type: suites.interuss.generate_test_data
@@ -39,4 +41,6 @@ actions:
       observers: observers
       evaluation_configuration: evaluation_configuration
       netrid_dss_instances: netrid_dss_instances_v22a
+      id_generator: id_generator
+      service_area: service_area
   on_failure: Continue

--- a/monitoring/uss_qualifier/suites/uspace/network_identification.yaml
+++ b/monitoring/uss_qualifier/suites/uspace/network_identification.yaml
@@ -5,7 +5,8 @@ resources:
   observers: resources.netrid.NetRIDObserversResource
   evaluation_configuration: resources.netrid.EvaluationConfigurationResource
   dss_instances: resources.astm.f3411.DSSInstancesResource
-
+  id_generator: resources.interuss.IDGeneratorResource
+  service_area: resources.netrid.ServiceAreaResource
 actions:
 - test_suite:
     suite_type: suites.astm.netrid.f3411_22a
@@ -15,6 +16,8 @@ actions:
       observers: observers
       evaluation_configuration: evaluation_configuration
       dss_instances: dss_instances
+      id_generator: id_generator
+      service_area: service_area
   on_failure: Continue
 participant_verifiable_capabilities:
 - id: uspace_netrid_service_provider

--- a/monitoring/uss_qualifier/suites/uspace/required_services.yaml
+++ b/monitoring/uss_qualifier/suites/uspace/required_services.yaml
@@ -12,6 +12,8 @@ resources:
   observers: resources.netrid.NetRIDObserversResource
   evaluation_configuration: resources.netrid.EvaluationConfigurationResource
   netrid_dss_instances: resources.astm.f3411.DSSInstancesResource
+  id_generator: resources.interuss.IDGeneratorResource
+  service_area: resources.netrid.ServiceAreaResource
 actions:
 - test_suite:
     suite_type: suites.uspace.flight_auth
@@ -31,6 +33,8 @@ actions:
       observers: observers
       evaluation_configuration: evaluation_configuration
       dss_instances: netrid_dss_instances
+      id_generator: id_generator
+      service_area: service_area
   on_failure: Continue
 participant_verifiable_capabilities:
     - id: required_services


### PR DESCRIPTION
This PR begins the migration of the tests performed in the legacy `prober` tool to uss_qualifier.  It starts by implementing the first portion of test_isa_simple.py from prober, with TODOs for the unimplemented portions.

Two brand new resources are added: an ID generator, to make ISA IDs that can be easily inspected as test IDs by a human, and a service area definition, to describe how test ISAs should look (where they are, etc).  Also, a single DSS instance resource is added (as a companion to the existing resource representing a pool of DSS instances).  These resources are defined in the dev configuration resources.yaml and added to the F3411-22a suite and all suites that end up using that suite.

Since prober acts on a single DSS instance, a ForEachDSS action generator is added to step through each instance in a provided pool and run the migrated prober tests on it.

The `etype=` parameter specification is removed from 3 statements to support running with Python 3.11 as there was a breaking change in the parameter name in Python 3.10.

resource.py reflection is updated slightly to support resource definitions using string-based annotations (like when using `from __future__ import annotations`).