### PR TITLE
[uss_qualifier] Add option to stop uss_qualifier fast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
       env:
         RID_VERSION: F3411-22a
         CONFIG_NAME: configurations.dev.local_test
+        USS_QUALIFIER_STOP_FAST: true
     - name: uss_qualifier tests - ASTM NetRID F3411-19 Test Suite
       run: |
         cd monitoring/uss_qualifier
@@ -68,6 +69,7 @@ jobs:
       env:
         RID_VERSION: F3411-19
         CONFIG_NAME: configurations.dev.netrid_v19
+        USS_QUALIFIER_STOP_FAST: true
     - name: prober tests
       run: |
         cd monitoring/prober

--- a/monitoring/uss_qualifier/run_locally.sh
+++ b/monitoring/uss_qualifier/run_locally.sh
@@ -44,6 +44,7 @@ docker run ${docker_args} --name uss_qualifier \
   -u "$(id -u):$(id -g)" \
   -e PYTHONBUFFERED=1 \
   -e AUTH_SPEC=${AUTH_SPEC} \
+  -e USS_QUALIFIER_STOP_FAST=${USS_QUALIFIER_STOP_FAST:-} \
   -v "$(pwd)/$OUTPUT_DIR:/app/$OUTPUT_DIR" \
   -w /app/monitoring/uss_qualifier \
   interuss/monitoring \

--- a/monitoring/uss_qualifier/scenarios/astm/utm/test_steps.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/test_steps.py
@@ -67,9 +67,9 @@ class ValidateNotSharedOperationalIntent(object):
         if exc_type is not None:
             self._scenario.record_note(
                 self._flight_planner.participant_id,
-                f"Skipped ValidateNotSharedOperationalIntent due to raised exception ({exc_type}: {exc_val}).",
+                f"Exception occurred during ValidateNotSharedOperationalIntent ({exc_type}: {exc_val}).",
             )
-            return
+            raise exc_val
 
         self._scenario.begin_test_step(self._test_step)
         self._scenario.record_query(self._initial_query)

--- a/monitoring/uss_qualifier/suites/suite.py
+++ b/monitoring/uss_qualifier/suites/suite.py
@@ -108,7 +108,10 @@ class TestSuiteAction(object):
             except (ScenarioCannotContinueError, TestRunCannotContinueError):
                 pass
             scenario.go_to_cleanup()
-            scenario.cleanup()
+            try:
+                scenario.cleanup()
+            except (ScenarioCannotContinueError, TestRunCannotContinueError):
+                pass
         except KeyboardInterrupt:
             raise
         except Exception as e:


### PR DESCRIPTION
Currently, we not-infrequently experience problems communicating between containers during CI checks.  Since CI requires fully-successful tests, as soon as one of these errors occurs, we know the CI cannot succeed.  But, test execution continues because we do not fail fast.  This PR adds an option (specified via USS_QUALIFIER_STOP_FAST environment variable, marked true in CI) to upgrade any failed test check to critical severity, thus causing the test run to end early.

This PR also fixes a bug where some test steps would swallow any exception (including TestRunCannotContinueError raised by critical-severity failed checks) and continue execution with only a note that an exception had occurred.

Finally, this PR also tidies the cleanup action of a TestScenario so that if a critical-severity failed check is encountered during cleanup, this is not reported as a generic execution error, but rather normal flow control relating to the failed check's severity.