### PR TITLE
[uss-qualifier] add NET0270 b and c

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common_dictionary_evaluator.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common_dictionary_evaluator.py
@@ -1,8 +1,7 @@
 import datetime
+import s2sphere
 from typing import List, Optional
 from monitoring.monitorlib.fetch.rid import (
-    FetchedUSSFlightDetails,
-    FetchedUSSFlights,
     FetchedFlights,
     FlightDetails,
 )
@@ -35,16 +34,23 @@ class RIDCommonDictionaryEvaluator(object):
         self._rid_version = rid_version
 
     def evaluate_sp_flights(
-        self, observed_flights: FetchedFlights, participants: List[str]
+        self,
+        requested_area: s2sphere.LatLngRect,
+        observed_flights: FetchedFlights,
+        participants: List[str],
     ):
-        for _, uss_flights in observed_flights.uss_flight_queries.items():
+        for url, uss_flights in observed_flights.uss_flight_queries.items():
             # For the timing checks, we want to look at the flights relative to the query
             # they came from, as they may be provided from different SP's.
             for f in uss_flights.flights:
-                self.evaluate_sp_flight_recent_positions(
+                self.evaluate_sp_flight_recent_positions_times(
                     f,
                     uss_flights.query.response.reported.datetime,
                     participants,
+                )
+
+                self.evaluate_sp_flight_recent_positions_crossing_area_boundary(
+                    requested_area, f, participants
                 )
 
         if self._rid_version == RIDVersion.f3411_22a:
@@ -55,7 +61,7 @@ class RIDCommonDictionaryEvaluator(object):
                     participants,
                 )
 
-    def _evaluate_recent_position(
+    def _evaluate_recent_position_time(
         self, p: Position, query_time: datetime.datetime, check: PendingCheck
     ):
         """Check that the position's timestamp is at most 60 seconds before the request time."""
@@ -66,14 +72,83 @@ class RIDCommonDictionaryEvaluator(object):
                 severity=Severity.Medium,
             )
 
-    def evaluate_sp_flight_recent_positions(
+    def evaluate_sp_flight_recent_positions_times(
         self, f: Flight, query_time: datetime.datetime, participants: List[str]
     ):
         with self._test_scenario.check(
             "Recent positions timestamps", participants
         ) as check:
             for p in f.recent_positions:
-                self._evaluate_recent_position(p, query_time, check)
+                self._evaluate_recent_position_time(p, query_time, check)
+
+    def _chronological_positions(self, f: Flight) -> List[s2sphere.LatLng]:
+        """
+        Returns the recent positions of the flight, ordered by time with the oldest first, and the most recent last.
+        """
+        return [
+            s2sphere.LatLng.from_degrees(p.lat, p.lng)
+            for p in sorted(f.recent_positions, key=lambda p: p.time)
+        ]
+
+    def _sliding_triples(
+        self, points: List[s2sphere.LatLng]
+    ) -> List[List[s2sphere.LatLng]]:
+        """
+        Returns a list of triples of consecutive positions in passed the list.
+        """
+        return [
+            (points[i], points[i + 1], points[i + 2]) for i in range(len(points) - 2)
+        ]
+
+    def evaluate_sp_flight_recent_positions_crossing_area_boundary(
+        self, requested_area: s2sphere.LatLngRect, f: Flight, participants: List[str]
+    ):
+        with self._test_scenario.check(
+            "Recent positions for aircraft crossing the requested area boundary show only one position before or after crossing",
+            participants,
+        ) as check:
+
+            def fail_check():
+                check.record_failed(
+                    "A position outside the area was neither preceded nor followed by a position inside the area.",
+                    details=f"Positions: {f.recent_positions}, requested_area: {requested_area}",
+                    severity=Severity.Medium,
+                )
+
+            positions = self._chronological_positions(f)
+            if len(positions) < 2:
+                # Check does not apply in this case
+                return
+
+            if len(positions) == 2:
+                # Only one of the positions can be outside the area. If both are, we fail.
+                if not requested_area.contains(
+                    positions[0]
+                ) and not requested_area.contains(positions[1]):
+                    fail_check()
+                return
+
+            # For each sliding triple we check that if the middle position is outside the area, then either
+            # the first or the last position is inside the area. This means checking for any point that is inside the
+            # area in the triple and failing otherwise
+            for triple in self._sliding_triples(self._chronological_positions(f)):
+                if not (
+                    requested_area.contains(triple[0])
+                    or requested_area.contains(triple[1])
+                    or requested_area.contains(triple[2])
+                ):
+                    fail_check()
+
+            # Finally we need to check for the forbidden corner cases of having the two first or two last positions being outside.
+            # (These won't be caught by the iteration on the triples above)
+            if (
+                not requested_area.contains(positions[0])
+                and not requested_area.contains(positions[1])
+            ) or (
+                not requested_area.contains(positions[-1])
+                and not requested_area.contains(positions[-2])
+            ):
+                fail_check()
 
     def evaluate_sp_details(self, details: FlightDetails, participants: List[str]):
         if self._rid_version == RIDVersion.f3411_22a:

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common_dictionary_evaluator_test.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common_dictionary_evaluator_test.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta, timezone
+import s2sphere
 from typing import List, Tuple
 from monitoring.monitorlib.rid import RIDVersion
 from monitoring.monitorlib.fetch.rid import Flight
@@ -197,7 +198,7 @@ def _assert_evaluate_sp_flight_recent_positions(
             test_scenario=self,
             rid_version=RIDVersion.f3411_22a,
         )
-        evaluator.evaluate_sp_flight_recent_positions(
+        evaluator.evaluate_sp_flight_recent_positions_times(
             f, query_time, RIDVersion.f3411_22a
         )
 
@@ -222,8 +223,206 @@ def test_evaluate_sp_flight_recent_positions():
     )
 
 
+def _assert_evaluate_sp_flight_recent_positions_crossing_area_boundary(
+    requested_area: s2sphere.LatLngRect, f: Flight, outcome: bool
+):
+    def step_under_test(self: UnitTestScenario):
+        evaluator = RIDCommonDictionaryEvaluator(
+            config=EvaluationConfiguration(),
+            test_scenario=self,
+            rid_version=RIDVersion.f3411_22a,
+        )
+        evaluator.evaluate_sp_flight_recent_positions_crossing_area_boundary(
+            requested_area, f, RIDVersion.f3411_22a
+        )
+
+    unit_test_scenario = UnitTestScenario(step_under_test).execute_unit_test()
+    assert unit_test_scenario.get_report().successful == outcome
+
+
+def test_evaluate_sp_flight_recent_positions_crossing_area_boundary():
+    # Mock flight with no recent position: should pass
+    _assert_evaluate_sp_flight_recent_positions_crossing_area_boundary(
+        s2sphere.LatLngRect(
+            s2sphere.LatLng.from_degrees(0.0, 0.0),
+            s2sphere.LatLng.from_degrees(0.5, 0.5),
+        ),
+        mock_flight(datetime.now(timezone.utc), 0, 10),
+        True,
+    )
+    # Mock flight with one recent position: should pass event if outside of area
+    _assert_evaluate_sp_flight_recent_positions_crossing_area_boundary(
+        s2sphere.LatLngRect(
+            s2sphere.LatLng.from_degrees(0.0, 0.0),
+            s2sphere.LatLng.from_degrees(0.5, 0.5),
+        ),
+        mock_flight(datetime.now(timezone.utc), 1, 10),
+        True,
+    )
+
+    # Mock flight with two recent positions within area: should pass
+    _assert_evaluate_sp_flight_recent_positions_crossing_area_boundary(
+        s2sphere.LatLngRect(
+            s2sphere.LatLng.from_degrees(0.0, 0.0),
+            s2sphere.LatLng.from_degrees(2, 2),
+        ),
+        mock_flight(datetime.now(timezone.utc), 2, 10),
+        True,
+    )
+
+    # Mock flight with two recent positions outside area: should fail
+    _assert_evaluate_sp_flight_recent_positions_crossing_area_boundary(
+        s2sphere.LatLngRect(
+            s2sphere.LatLng.from_degrees(0.0, 0.0),
+            s2sphere.LatLng.from_degrees(0.5, 0.5),
+        ),
+        mock_flight(datetime.now(timezone.utc), 2, 10),
+        False,
+    )
+
+    # Mock flight with two recent positions, one of which is outside area: should pass
+    f2_1 = mock_flight(datetime.now(timezone.utc), 0, 0)
+    f2_1.v22a_value.recent_positions = to_positions(
+        [(1.0, 1.0), (-1.0, -1.0)], datetime.now(timezone.utc)
+    )
+    _assert_evaluate_sp_flight_recent_positions_crossing_area_boundary(
+        s2sphere.LatLngRect(
+            s2sphere.LatLng.from_degrees(0.0, 0.0),
+            s2sphere.LatLng.from_degrees(2.0, 2.0),
+        ),
+        f2_1,
+        True,
+    )
+
+    f2_2 = mock_flight(datetime.now(timezone.utc), 0, 0)
+    f2_2.v22a_value.recent_positions = to_positions(
+        [(-1.0, -1.0), (1.0, 1.0)], datetime.now(timezone.utc)
+    )
+    _assert_evaluate_sp_flight_recent_positions_crossing_area_boundary(
+        s2sphere.LatLngRect(
+            s2sphere.LatLng.from_degrees(0.0, 0.0),
+            s2sphere.LatLng.from_degrees(2.0, 2.0),
+        ),
+        f2_2,
+        True,
+    )
+
+    # Mock flight with 3 recent positions completely outside requested area: should fail
+    _assert_evaluate_sp_flight_recent_positions_crossing_area_boundary(
+        s2sphere.LatLngRect(
+            s2sphere.LatLng.from_degrees(0.0, 0.0),
+            s2sphere.LatLng.from_degrees(0.5, 0.5),
+        ),
+        mock_flight(datetime.now(timezone.utc), 3, 10),
+        False,
+    )
+
+    # Mock flight with 3 recent positions, the second of which is in the area: should pass
+    f3_1 = mock_flight(datetime.now(timezone.utc), 0, 0)
+    f3_1.v22a_value.recent_positions = to_positions(
+        [(-1.0, -1.0), (1.0, 1.0), (3.0, 3.0)], datetime.now(timezone.utc)
+    )
+    _assert_evaluate_sp_flight_recent_positions_crossing_area_boundary(
+        s2sphere.LatLngRect(
+            s2sphere.LatLng.from_degrees(0.0, 0.0),
+            s2sphere.LatLng.from_degrees(2.0, 2.0),
+        ),
+        f3_1,
+        True,
+    )
+
+    # Mock flight with 3 recent positions, only the last of which is in the area: should fail
+    f3_2 = mock_flight(datetime.now(timezone.utc), 0, 0)
+    f3_2.v22a_value.recent_positions = to_positions(
+        [(-1.0, -1.0), (3.0, 3.0), (1.0, 1.0)], datetime.now(timezone.utc)
+    )
+    _assert_evaluate_sp_flight_recent_positions_crossing_area_boundary(
+        s2sphere.LatLngRect(
+            s2sphere.LatLng.from_degrees(0.0, 0.0),
+            s2sphere.LatLng.from_degrees(2.0, 2.0),
+        ),
+        f3_2,
+        False,
+    )
+
+    # Mock flight with 3 recent positions, only the first of which is in the area: should fail
+    f3_3 = mock_flight(datetime.now(timezone.utc), 0, 0)
+    f3_3.v22a_value.recent_positions = to_positions(
+        [(1.0, 1.0), (3.0, 3.0), (-1.0, -1.0)], datetime.now(timezone.utc)
+    )
+    _assert_evaluate_sp_flight_recent_positions_crossing_area_boundary(
+        s2sphere.LatLngRect(
+            s2sphere.LatLng.from_degrees(0.0, 0.0),
+            s2sphere.LatLng.from_degrees(2.0, 2.0),
+        ),
+        f3_3,
+        False,
+    )
+
+    # Mock flight with 3 recent positions within requested area: should pass
+    _assert_evaluate_sp_flight_recent_positions_crossing_area_boundary(
+        s2sphere.LatLngRect(
+            s2sphere.LatLng.from_degrees(0.0, 0.0),
+            s2sphere.LatLng.from_degrees(2, 2),
+        ),
+        mock_flight(datetime.now(timezone.utc), 3, 10),
+        True,
+    )
+
+    # Mock flight with 4 recent positions, last position outside requested area: should pass
+    f4_1 = mock_flight(datetime.now(timezone.utc), 0, 0)
+    f4_1.v22a_value.recent_positions = to_positions(
+        [(1.0, 1.0), (1.0, 1.0), (1.0, 1.0), (3.0, 3.0)], datetime.now(timezone.utc)
+    )
+    _assert_evaluate_sp_flight_recent_positions_crossing_area_boundary(
+        s2sphere.LatLngRect(
+            s2sphere.LatLng.from_degrees(0.0, 0.0),
+            s2sphere.LatLng.from_degrees(2.0, 2.0),
+        ),
+        f4_1,
+        True,
+    )
+
+    # Mock flight with 4 recent positions, first position outside requested area: should pass
+    f4_2 = mock_flight(datetime.now(timezone.utc), 0, 0)
+    f4_2.v22a_value.recent_positions = to_positions(
+        [(3.0, 3.0), (1.0, 1.0), (1.0, 1.0), (1.0, 1.0)], datetime.now(timezone.utc)
+    )
+    _assert_evaluate_sp_flight_recent_positions_crossing_area_boundary(
+        s2sphere.LatLngRect(
+            s2sphere.LatLng.from_degrees(0.0, 0.0),
+            s2sphere.LatLng.from_degrees(2.0, 2.0),
+        ),
+        f4_2,
+        True,
+    )
+
+    # Mock flight completely within requested area: should pass
+    _assert_evaluate_sp_flight_recent_positions_crossing_area_boundary(
+        s2sphere.LatLngRect(
+            s2sphere.LatLng.from_degrees(0.0, 0.0),
+            s2sphere.LatLng.from_degrees(2, 2),
+        ),
+        mock_flight(datetime.now(timezone.utc), 7, 10),
+        True,
+    )
+
+    # Mock flight completely outside requested area: should fail
+    _assert_evaluate_sp_flight_recent_positions_crossing_area_boundary(
+        s2sphere.LatLngRect(
+            s2sphere.LatLng.from_degrees(0.0, 0.0),
+            s2sphere.LatLng.from_degrees(0.5, 0.5),
+        ),
+        mock_flight(datetime.now(timezone.utc), 7, 10),
+        False,
+    )
+
+
 def mock_flight(
-    last_position_time: datetime, positions_count: int, positions_time_delta_s: int
+    last_position_time: datetime,
+    positions_count: int,
+    positions_time_delta_s: int,
+    position: Tuple[int, int] = (1.0, 1.0),
 ) -> Flight:
     v22a_flight = v22a.api.RIDFlight(
         id="flightId",
@@ -232,14 +431,17 @@ def mock_flight(
         operating_area=None,  # Not required for tests at the moment
         simulated=True,
         recent_positions=mock_positions(
-            last_position_time, positions_count, positions_time_delta_s
+            last_position_time, positions_count, positions_time_delta_s, position
         ),
     )
     return Flight(v22a_value=v22a_flight)
 
 
 def mock_positions(
-    last_time: datetime, amount: int, positions_time_delta_s: int
+    last_time: datetime,
+    amount: int,
+    positions_time_delta_s: int,
+    position: Tuple[int, int] = (1.0, 1.0),
 ) -> List[v22a.api.RIDRecentAircraftPosition]:
     """generate a list of positions with the last one at last_time and the next ones going back in time by 10 seconds"""
     return [
@@ -249,7 +451,26 @@ def mock_positions(
                     last_time - timedelta(seconds=positions_time_delta_s * i)
                 )
             ),
-            position=v22a.api.RIDAircraftPosition(lat=1.0, lng=1.0),
+            position=v22a.api.RIDAircraftPosition(lat=position[0], lng=position[1]),
         )
         for i in range(amount)
+    ]
+
+
+def to_positions(
+    coords: List[Tuple[float, float]],
+    first_time: datetime,
+    positions_time_delta_s: int = 1,
+) -> v22a.api.RIDRecentAircraftPosition:
+    """transform the collection of coordinates"""
+    return [
+        v22a.api.RIDRecentAircraftPosition(
+            time=v22a.api.Time(
+                value=v22a.api.StringBasedDateTime(
+                    first_time - timedelta(seconds=positions_time_delta_s * i)
+                )
+            ),
+            position=v22a.api.RIDAircraftPosition(lat=coords[i][0], lng=coords[i][1]),
+        )
+        for i in range(len(coords))
     ]

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/display_data_evaluator.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/display_data_evaluator.py
@@ -749,11 +749,12 @@ class RIDObservationEvaluator(object):
             )
         else:
             self._evaluate_normal_sp_observation(
-                sp_observation, mapping_by_injection_id
+                rect, sp_observation, mapping_by_injection_id
             )
 
     def _evaluate_normal_sp_observation(
         self,
+        requested_area: s2sphere.LatLngRect,
         sp_observation: FetchedFlights,
         mappings: Dict[str, TelemetryMapping],
     ) -> None:
@@ -798,6 +799,7 @@ class RIDObservationEvaluator(object):
                         query_timestamps=[flights_query.query.request.timestamp],
                     )
             self._common_dictionary_evaluator.evaluate_sp_flights(
+                requested_area,
                 sp_observation,
                 participants=[mapping.injected_flight.uss_participant_id],
             )

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/nominal_behavior.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/nominal_behavior.md
@@ -50,9 +50,14 @@ This particular test requires each flight to be uniquely identifiable by its 2D 
 If a DSS was provided to this test scenario, uss_qualifier acts as a Display Provider to query Service Providers under test in this step.
 
 #### Recent positions timestamps check
-**[astm.f3411.v22a.NET0270](../../../../requirements/astm/f3411/v22a.md)** requires all recent positions to be within the NetMaxNearRealTimeDataPeriod. This check will fail if any of the reported positions are older than the maximally allowed period plus NetSpDataResponseTime99thPercentile.
+**[astm.f3411.v19.NET0270](../../../../requirements/astm/f3411/v19.md)** requires all recent positions to be within the NetMaxNearRealTimeDataPeriod. This check will fail if any of the reported positions are older than the maximally allowed period plus NetSpDataResponseTime99thPercentile.
 
-TODO Julien add required checks here for NET0270 b) and c)
+#### Recent positions for aircraft crossing the requested area boundary show only one position before or after crossing check
+**[astm.f3411.v19.NET0270](../../../../requirements/astm/f3411/v19.md)** requires that when an aircraft enters or leaves the queried area, the last or first reported position outside the area is provided in the recent positions, as long as it is not older than NetMaxNearRealTimeDataPeriod.
+
+This implies that any recent position outside the area must be either preceded or followed by a position inside the area.
+
+(This check validates NET0270 b and c).
 
 #### Flights data format check
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/nominal_behavior.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/nominal_behavior.md
@@ -52,7 +52,12 @@ If a DSS was provided to this test scenario, uss_qualifier acts as a Display Pro
 #### Recent positions timestamps check
 **[astm.f3411.v22a.NET0270](../../../../requirements/astm/f3411/v22a.md)** requires all recent positions to be within the NetMaxNearRealTimeDataPeriod. This check will fail if any of the reported positions are older than the maximally allowed period plus NetSpDataResponseTime99thPercentile.
 
-TODO Julien add required checks here for NET0270 b) and c)
+#### Recent positions for aircraft crossing the requested area boundary show only one position before or after crossing check
+**[astm.f3411.v22a.NET0270](../../../../requirements/astm/f3411/v22a.md)** requires that when an aircraft enters or leaves the queried area, the last or first reported position outside the area is provided in the recent positions, as long as it is not older than NetMaxNearRealTimeDataPeriod.
+
+This implies that any recent position outside the area must be either preceded or followed by a position inside the area.
+
+(This check validates NET0270 b and c).
 
 #### Flights data format check
 


### PR DESCRIPTION
Note that both conditions (b and c) are controlled for together for simplifying the implementation. 

For reference, net-0270 b and c respectively state that upon entering or leaving the requested area, the requester is only provided with the last/first data point outside of the area.

Most of the logic is there to handle the case where an aircraft would cross the boundary multiple times within the minute for which recent data can be displayed.