### PR TITLE
[uss_qualifier] Add F3411 check for NET0290

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/netrid/display_data_evaluator.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/display_data_evaluator.py
@@ -387,7 +387,8 @@ class RIDObservationEvaluator(object):
                     or injected_telemetry.position["extrapolated"] is False
                 ) and (
                     "extrapolated" in mapping.observed_flight.most_recent_position
-                    and mapping.observed_flight.most_recent_position["extrapolated"] is True
+                    and mapping.observed_flight.most_recent_position["extrapolated"]
+                    is True
                 ):
                     check.record_failed(
                         "Position Data is using extrapolation when Telemetry is available.",

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/display_data_evaluator.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/display_data_evaluator.py
@@ -378,22 +378,33 @@ class RIDObservationEvaluator(object):
             with self._test_scenario.check(
                 "Telemetry being used when present",
                 [
-                    observer.participant_id,
                     mapping.injected_flight.uss_participant_id,
                 ],
             ) as check:
-                if (
-                    "extrapolated" not in injected_telemetry.position
-                    or injected_telemetry.position["extrapolated"] is False
-                ) and (
+                injected_telemetry_extrapolated = (
+                    "extrapolated" in injected_telemetry.position
+                    and injected_telemetry.position.extrapolated
+                )
+
+                observed_telemetry_extrapolated = (
                     "extrapolated" in mapping.observed_flight.most_recent_position
                     and mapping.observed_flight.most_recent_position["extrapolated"]
-                    is True
+                )
+
+                # if telemetry is present then extrapolated position data should not be used.
+                if (
+                    not injected_telemetry_extrapolated
+                    and observed_telemetry_extrapolated
                 ):
                     check.record_failed(
                         "Position Data is using extrapolation when Telemetry is available.",
                         Severity.Medium,
-                        details=f"{mapping.injected_flight.uss_participant_id}'s flight with injection ID {mapping.injected_flight.flight.injection_id} in test {mapping.injected_flight.test_id} had telemetry index {mapping.telemetry_index} at {injected_telemetry.timestamp} with lat={injected_telemetry.position.lat}, lng={injected_telemetry.position.lng}, alt={injected_telemetry.position.alt}, but Service Provider reported lat={observed_position.lat}, lng={observed_position.lng}, alt={observed_position.alt} at {mapping.observed_flight.query.query.request.initiated_at}",
+                        details=(
+                            f"{mapping.injected_flight.uss_participant_id}'s flight with injection ID "
+                            f"{mapping.injected_flight.flight.injection_id} in test {mapping.injected_flight.test_id} had telemetry index {mapping.telemetry_index} at {injected_telemetry.timestamp} "
+                            f"with extrapolated position state, but Service Provider reported non-extrapolated telemetry at {mapping.observed_flight.query.query.request.initiated_at}. "
+                            f"Extrapolation State: Injected={injected_telemetry_extrapolated}, Observed={observed_telemetry_extrapolated}"
+                        ),
                     )
 
     def _evaluate_flight_presence(

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/nominal_behavior.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/nominal_behavior.md
@@ -116,6 +116,10 @@ The timestamps of the injected telemetry usually start in the future.  If a flig
 
 **[astm.f3411.v19.NET0260](../../../../requirements/astm/f3411/v19.md)** requires a SP to provide flights up to *NetMaxNearRealTimeDataPeriod* in the past, but an SP should preserve privacy and ensure relevancy by not sharing flights that are further in the past than this window.
 
+#### Telemetry being used when present check
+
+**[astm.f3411.v19.NET0290](../../../../requirements/astm/f3411/v19.md)** requires a SP uses Telemetry vs extrapolation when telemetry is present.
+
 #### Observed altitude check
 
 **[astm.f3411.v19.NET0470](../../../../requirements/astm/f3411/v19.md)** requires that a Display Provider provides any specified data fields in accordance with the common data dictionary when responding to a Display Application.  If the observed altitude of a flight does not match the altitude of the injected telemetry, this check will fail.

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/nominal_behavior.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/nominal_behavior.md
@@ -144,6 +144,10 @@ The timestamps of the injected telemetry usually start in the future.  If a flig
 
 **[astm.f3411.v22a.NET0260](../../../../requirements/astm/f3411/v22a.md)** requires a SP to provide flights up to *NetMaxNearRealTimeDataPeriod* in the past, but an SP should preserve privacy and ensure relevancy by not sharing flights that are further in the past than this window.
 
+#### Telemetry being used when present check
+
+**[astm.f3411.v22a.NET0290](../../../../requirements/astm/f3411/v22a.md)** requires a SP uses Telemetry vs extrapolation when telemetry is present.
+
 #### Observed altitude check
 
 **[astm.f3411.v22a.NET0470](../../../../requirements/astm/f3411/v22a.md)** requires that a Display Provider provides any specified data fields in accordance with the common data dictionary when responding to a Display Application.  If the observed altitude of a flight does not match the altitude of the injected telemetry, this check will fail.


### PR DESCRIPTION
These changes are to ensure that Telemetry is being used when available and not extrapolation.