### PR TITLE
[uss_qualifier] Fix behavior for failed check during cleanup

### DIFF
--- a/monitoring/uss_qualifier/suites/suite.py
+++ b/monitoring/uss_qualifier/suites/suite.py
@@ -112,7 +112,7 @@ class TestSuiteAction(object):
             try:
                 scenario.cleanup()
             except (ScenarioCannotContinueError, TestRunCannotContinueError):
-                pass
+                scenario.ensure_cleanup_ended()
         except KeyboardInterrupt:
             raise
         except Exception as e:


### PR DESCRIPTION
Logs for one CI run are included below.  In that run, a failed check occurred during cleanup and this failed check was promoted to critical severity which raised an exception.  The exception stopped end_cleanup from being called which caused the scenario to raise another exception when trying to retrieve the report since the scenario was still CleaningUp at that point rather than Complete.  This PR attempts to ensure that a scenario will be transitioned to Complete even if an exception occurs during cleanup.  It also stops upgrading failed checks during cleanup to Critical so that cleanup is more likely to happen successfully.