### PR TITLE
[uss_qualifier] NET0460 evaluate display provider's flight data details endpoint performance

### DIFF
--- a/monitoring/monitorlib/fetch/__init__.py
+++ b/monitoring/monitorlib/fetch/__init__.py
@@ -15,7 +15,7 @@ from yaml.representer import Representer
 
 from implicitdict import ImplicitDict, StringBasedDateTime
 from monitoring.monitorlib import infrastructure
-
+from monitoring.monitorlib.rid import RIDVersion
 
 TIMEOUTS = (5, 5)  # Timeouts of `connect` and `read` in seconds
 ATTEMPTS = (
@@ -211,6 +211,15 @@ class QueryType(str, Enum):
         "astm.f3548.v21.uss.notifyConstraintDetailsChanged"
     )
     F3548v21USSMakeUssReport = "astm.f3548.v21.uss.makeUssReport"
+
+    @staticmethod
+    def flight_details(rid_version: RIDVersion):
+        if rid_version == RIDVersion.f3411_19:
+            return QueryType.F3411v19aFlightDetails
+        elif rid_version == RIDVersion.f3411_22a:
+            return QueryType.F3411v22aFlightDetails
+        else:
+            raise ValueError(f"Unsupported RID version: {rid_version}")
 
 
 class Query(ImplicitDict):

--- a/monitoring/monitorlib/rid.py
+++ b/monitoring/monitorlib/rid.py
@@ -57,15 +57,6 @@ class RIDVersion(str, Enum):
             raise ValueError(f"Unsupported RID version '{self}'")
 
     @property
-    def read_scope(self) -> str:
-        if self == RIDVersion.f3411_19:
-            return v19.constants.Scope.Read
-        elif self == RIDVersion.f3411_22a:
-            return v22a.constants.Scope.DisplayProvider
-        else:
-            raise ValueError("Unsupported RID version '{}'".format(self))
-
-    @property
     def realtime_period(self) -> timedelta:
         if self == RIDVersion.f3411_19:
             return timedelta(seconds=v19.constants.NetMaxNearRealTimeDataPeriodSeconds)
@@ -152,6 +143,24 @@ class RIDVersion(str, Enum):
             return v19.constants.NetDpDataResponse95thPercentileSeconds
         elif self == RIDVersion.f3411_22a:
             return v22a.constants.NetDpDataResponse95thPercentileSeconds
+        else:
+            raise ValueError("Unsupported RID version '{}'".format(self))
+
+    @property
+    def dp_details_resp_percentile95_s(self) -> float:
+        if self == RIDVersion.f3411_19:
+            return v19.constants.NetDpDetailsResponse95thPercentileSeconds
+        elif self == RIDVersion.f3411_22a:
+            return v22a.constants.NetDpDetailsResponse95thPercentileSeconds
+        else:
+            raise ValueError("Unsupported RID version '{}'".format(self))
+
+    @property
+    def dp_details_resp_percentile99_s(self) -> float:
+        if self == RIDVersion.f3411_19:
+            return v19.constants.NetDpDetailsResponse99thPercentileSeconds
+        elif self == RIDVersion.f3411_22a:
+            return v22a.constants.NetDpDetailsResponse99thPercentileSeconds
         else:
             raise ValueError("Unsupported RID version '{}'".format(self))
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/aggregate_checks.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/aggregate_checks.md
@@ -17,6 +17,16 @@ The observers to evaluate in the report.
 
 ## Performance of Display Providers requests test case
 
+### Performance of /display_data/<flight_id> requests test step
+
+For this step, all successful display data queries made during the execution of the previous scenarios are used to compute an aggregate statistic.
+
+#### Performance of /display_data/<flight_id> requests check
+
+**[astm.f3411.v19.NET0460](../../../../requirements/astm/f3411/v19.md) Checks that the DP response times for the
+Display Application's flight details requests have a p95 and p99 that are respectively below
+`NetDpDetailsResponse95thPercentileSeconds` (2 seconds) and `NetDpDetailsResponse99thPercentileSeconds` (6 seconds).
+
 ### Performance of /display_data requests test step
 In this step, all successful display data queries made during the execution of the previous scenarios are aggregated per
 observer and per request (identified by their URLs). For each of those, and using the session length

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/aggregate_checks.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/aggregate_checks.md
@@ -4,7 +4,6 @@
 In this special scenario, the report of previously executed ASTM F3411-22a NetRID scenario(s) are evaluated for the
 performances of the queries made during their execution.
 
-
 ## Resources
 
 ### report_resource
@@ -17,6 +16,16 @@ The service providers to evaluate in the report.
 The observers to evaluate in the report.
 
 ## Performance of Display Providers requests test case
+
+### Performance of /display_data/<flight_id> requests test step
+
+For this step, all successful display data queries made during the execution of the previous scenarios are used to compute an aggregate statistic.
+
+#### Performance of /display_data/<flight_id> requests check
+
+**[astm.f3411.v22a.NET0460](../../../../requirements/astm/f3411/v22a.md) Checks that the DP response times for the
+Display Application's flight details requests have a p95 and p99 that are respectively below
+`NetDpDetailsResponse95thPercentileSeconds` (2 seconds) and `NetDpDetailsResponse99thPercentileSeconds` (6 seconds).
 
 ### Performance of /display_data requests test step
 In this step, all successful display data queries made during the execution of the previous scenarios are aggregated per


### PR DESCRIPTION
Note that validating the performance of the DP for returning details requires us to actually generate some queries for that endpoint.

To this end we query details for each flight that is returned when checking the `display_data` endpoint.