### PR TITLE
[uss_qualifier] Test DSS Subscription limitations (too many subscriptions)

### DIFF
--- a/monitoring/monitorlib/rid.py
+++ b/monitoring/monitorlib/rid.py
@@ -182,6 +182,15 @@ class RIDVersion(str, Enum):
         else:
             raise ValueError("Unsupported RID version '{}'".format(self))
 
+    @property
+    def dss_max_subscriptions_per_area(self) -> int:
+        if self == RIDVersion.f3411_19:
+            return v19.constants.NetDSSMaxSubscriptionPerArea
+        elif self == RIDVersion.f3411_22a:
+            return v22a.constants.NetDSSMaxSubscriptionPerArea
+        else:
+            raise ValueError("Unsupported RID version '{}'".format(self))
+
     def flights_url_of(self, base_url: str) -> str:
         if self == RIDVersion.f3411_19:
             return base_url

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/subscription_validation.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/subscription_validation.md
@@ -30,17 +30,25 @@ We expect to be allowed to query for existing subscriptions in order to clean th
 
 ## Subscription limitations test case
 
-### Subscription limitations test step
+### Subscription quantity limitations test step
+
+The test will attempt to create 10 identical subscriptions for the same area and expect this to succeed, then create an 11th one and expect it to fail.
+
+#### Create up to the maximum allowed number of subscriptions in an area check
+
+As per **[astm.f3411.v19.DSS0030](../../../../../requirements/astm/f3411/v19.md)**, the DSS API is expected to allow us
+to create multiple subscriptions.
 
 #### Enforce maximum number of subscriptions for an area check
 
-**[astm.f3411.v22a.DSS0050](../../../../../requirements/astm/f3411/v22a.md)** for a given area for which the DSS is responsible, there may be at most NetDSSMaxSubscriptionPerArea (10) subscriptions per USS.
+If the DSS successfully creates an 11th Subscription in the same area instead of rejecting it,
+it will not have performed the Subscription count validation as defined in **[astm.f3411.v19.DSS0050](../../../../../requirements/astm/f3411/v19.md)**
 
-The test will attempt to create 10 subscriptions for the same area and expect this to succeed, then create an 11th one and expect it to fail.
+### Subscription duration limitations test step
 
 #### Enforce maximum duration of subscriptions for an area check
 
-**[astm.f3411.v22a.DSS0060](../../../../../requirements/astm/f3411/v22a.md)** any subscription to the DSS may not exceed NetDSSMaxSubscriptionDuration (24 hours).
+**[astm.f3411.v19.DSS0060](../../../../../requirements/astm/f3411/v19.md)** any subscription to the DSS may not exceed NetDSSMaxSubscriptionDuration (24 hours).
 
 The test will attempt to create a subscription for 24 hours and 10 minutes, and expect this to fail with an HTTP 400 error.
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/subscription_validation.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/subscription_validation.md
@@ -26,17 +26,25 @@ This step ensures that we remove any subscription that may already exist for the
 
 #### Successful subscription query and cleanup check
 
-We expect to be allowed ro query for existing subscriptions in order to clean them up
+We expect to be allowed to query for existing subscriptions in order to clean them up
 
 ## Subscription limitations test case
 
-### Subscription limitations test step
+### Subscription quantity limitations test step
+
+The test will attempt to create 10 identical subscriptions for the same area and expect this to succeed, then create an 11th one and expect it to fail.
+
+#### Create up to the maximum allowed number of subscriptions in an area check
+
+As per **[astm.f3411.v22a.DSS0030](../../../../../requirements/astm/f3411/v22a.md)**, the DSS API is expected to allow us
+to create multiple subscriptions.
 
 #### Enforce maximum number of subscriptions for an area check
 
-**[astm.f3411.v22a.DSS0050](../../../../../requirements/astm/f3411/v22a.md)** for a given area for which the DSS is responsible, there may be at most NetDSSMaxSubscriptionPerArea (10) subscriptions per USS.
+If the DSS successfully creates an 11th Subscription in the same area instead of rejecting it,
+it will not have performed the Subscription count validation as defined in **[astm.f3411.v22a.DSS0050](../../../../../requirements/astm/f3411/v22a.md)**
 
-The test will attempt to create 10 subscriptions for the same area and expect this to succeed, then create an 11th one and expect it to fail.
+### Subscription duration limitations test step
 
 #### Enforce maximum duration of subscriptions for an area check
 


### PR DESCRIPTION
Adds a test to cover DSS0050: for a given area modelled by the DSS, we should only be allowed to create 10 subscriptions, not more.