### PR TITLE
[uss_qualifier/rid/nominal] Add requirement NET0500 to existing check

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/nominal_behavior.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/nominal_behavior.md
@@ -36,6 +36,9 @@ In this step, uss_qualifier injects a single nominal flight into each SP under t
 
 Per **[interuss.automated_testing.rid.injection.UpsertTestSuccess](../../../../requirements/interuss/automated_testing/rid/injection.md)**, the injection attempt of the valid flight should succeed for every NetRID Service Provider under test.
 
+**[astm.f3411.v19.NET0500](../../../../requirements/astm/f3411/v19.md)** requires a Service Provider to provide a persistently supported test instance of their implementation.
+This check will fail if the flight was not successfully injected.
+
 #### Valid flight check
 
 Per **[interuss.automated_testing.rid.injection.UpsertTestResult](../../../../requirements/interuss/automated_testing/rid/injection.md)**, the NetRID Service Provider under test should only make valid modifications to the injected flights.  This includes:

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/nominal_behavior.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/nominal_behavior.md
@@ -36,6 +36,9 @@ In this step, uss_qualifier injects a single nominal flight into each SP under t
 
 Per **[interuss.automated_testing.rid.injection.UpsertTestSuccess](../../../../requirements/interuss/automated_testing/rid/injection.md)**, the injection attempt of the valid flight should succeed for every NetRID Service Provider under test.
 
+**[astm.f3411.v22a.NET0500](../../../../requirements/astm/f3411/v22a.md)** requires a Service Provider to provide a persistently supported test instance of their implementation.
+This check will fail if the flight was not successfully injected.
+
 #### Valid flight check
 
 Per **[interuss.automated_testing.rid.injection.UpsertTestResult](../../../../requirements/interuss/automated_testing/rid/injection.md)**, the NetRID Service Provider under test should only make valid modifications to the injected flights.  This includes:


### PR DESCRIPTION
This assumes that a successful injection means that there is an available SP test instance. I hope it is a valid one.