### PR TITLE
[uss_qualifier] Validate configuration and add configuration-based execution options

### DIFF
--- a/monitoring/uss_qualifier/README.md
+++ b/monitoring/uss_qualifier/README.md
@@ -20,11 +20,13 @@ This section provides a specific set of commands to execute uss_qualifier for de
 2. Go to repository root: `cd monitoring`
 3. Bring up a local UTM ecosystem (DSS + dummy auth): `make start-locally`
 4. Bring up mock USSs: `make start-uss-mocks`
-5. Run uss_qualifier explicitly specifying a configuration to use: `monitoring/uss_qualifier/run_locally.sh configurations.dev.local_test`
+5. Run uss_qualifier explicitly specifying a configuration to use: `monitoring/uss_qualifier/run_locally.sh configurations.dev.noop`
 
-After building, uss_qualifier should take a few minutes to run and then `report.json` should appear in [monitoring/uss_qualifier](.)
+After building, uss_qualifier should take a few minutes to run and then `report_*.json` should appear in [monitoring/uss_qualifier](.)
 
-At this point, uss_qualifier can be run again with a different configuration targeted at the development resources brought up in steps 3-6; for instance: `monitoring/uss_qualifier/run_locally.sh configurations.dev.self_contained_f3548`
+At this point, uss_qualifier can be run again with a different configuration targeted at the development resources brought up in steps 3-4; for instance: `monitoring/uss_qualifier/run_locally.sh configurations.dev.self_contained_f3548`
+
+Note that all baseline test configurations using local mocks can be run with `monitoring/uss_qualifier/run_locally.sh`.
 
 ### Local testing
 

--- a/monitoring/uss_qualifier/configurations/configuration.py
+++ b/monitoring/uss_qualifier/configurations/configuration.py
@@ -73,9 +73,3 @@ class USSQualifierConfigurationV1(ImplicitDict):
 class USSQualifierConfiguration(ImplicitDict):
     v1: Optional[USSQualifierConfigurationV1]
     """Configuration in version 1 format"""
-
-    @staticmethod
-    def from_string(config_string: str) -> "USSQualifierConfiguration":
-        return ImplicitDict.parse(
-            load_dict_with_references(config_string), USSQualifierConfiguration
-        )

--- a/monitoring/uss_qualifier/run_locally.sh
+++ b/monitoring/uss_qualifier/run_locally.sh
@@ -18,7 +18,10 @@ if [ -z "$DO_NOT_BUILD_MONITORING" ]; then
 fi
 
 CONFIG_NAME="${1:-ALL}"
-OTHER_ARGS="${@:2}"
+
+# https://stackoverflow.com/a/9057392
+# shellcheck disable=SC2124
+OTHER_ARGS=${@:2}
 
 if [ "$CONFIG_NAME" == "ALL" ]; then
   declare -a all_configurations=( \

--- a/monitoring/uss_qualifier/run_locally.sh
+++ b/monitoring/uss_qualifier/run_locally.sh
@@ -18,6 +18,7 @@ if [ -z "$DO_NOT_BUILD_MONITORING" ]; then
 fi
 
 CONFIG_NAME="${1:-ALL}"
+OTHER_ARGS="${@:2}"
 
 if [ "$CONFIG_NAME" == "ALL" ]; then
   declare -a all_configurations=( \
@@ -41,7 +42,7 @@ else
 
   AUTH_SPEC='DummyOAuth(http://oauth.authority.localutm:8085/token,uss_qualifier)'
 
-  QUALIFIER_OPTIONS="$CONFIG_FLAG"
+  QUALIFIER_OPTIONS="$CONFIG_FLAG $OTHER_ARGS"
 
   OUTPUT_DIR="monitoring/uss_qualifier/output"
   mkdir -p "$OUTPUT_DIR"

--- a/monitoring/uss_qualifier/validation.py
+++ b/monitoring/uss_qualifier/validation.py
@@ -1,0 +1,51 @@
+from typing import List
+
+from implicitdict import ImplicitDict
+from monitoring.monitorlib.schema_validation import (
+    ValidationError,
+    validate_implicitdict_object,
+)
+from monitoring.uss_qualifier.configurations.configuration import (
+    USSQualifierConfiguration,
+)
+from monitoring.uss_qualifier.resources.definitions import ResourceDeclaration
+from monitoring.uss_qualifier.resources.resource import get_resource_types
+
+
+def validate_config(config: dict) -> List[ValidationError]:
+    """Validate raw data intended to be used to create a USSQualifierConfiguration.
+
+    Args:
+        config: Raw nested dict object intended to be parsed into a USSQualifierConfiguration.
+
+    Returns: List of validation errors discovered.
+    """
+    result = validate_implicitdict_object(config, USSQualifierConfiguration)
+
+    if not result:
+        base_path = "$.v1.test_run.resources.resource_declarations"
+        resource_declarations = config
+        for child in base_path.split(".")[1:]:
+            resource_declarations = resource_declarations.get(child, {})
+        for resource_id, declaration in resource_declarations.items():
+            declaration = ImplicitDict.parse(declaration, ResourceDeclaration)
+            path = base_path + "." + resource_id
+            try:
+                _, specification_type = get_resource_types(declaration)
+            except ValueError as e:
+                result.append(ValidationError(message=str(e), json_path=path))
+                continue
+            for e in validate_implicitdict_object(
+                declaration.specification, specification_type
+            ):
+                subpath = e.json_path
+                if subpath.startswith("$."):
+                    subpath = subpath[2:]
+                result.append(
+                    ValidationError(
+                        message=e.message,
+                        json_path=path + ".specification." + subpath,
+                    )
+                )
+
+    return result


### PR DESCRIPTION
Constructing a valid configuration can be difficult given the fairly huge data structure being defined, potentially over many different files.  To help users create, edit, and manage these configurations, this PR first robustly validates an input configuration using ImplicitDict-generated JSON Schema before proceeding.  It also adds some execution options to only validate the configuration, and to write the flattened configuration for review or archival.

Separately, it fixes some uss_qualifier documentation in README.md.