### PR TITLE
[uss_qualifier] Clean up ISA in ISASimple scenario

### DIFF
--- a/monitoring/uss_qualifier/run_locally.sh
+++ b/monitoring/uss_qualifier/run_locally.sh
@@ -32,10 +32,10 @@ if [ "$CONFIG_NAME" == "ALL" ]; then
     "configurations.dev.general_flight_auth" \
     "configurations.dev.f3548" \
     "configurations.dev.f3548_self_contained" \
+    "configurations.dev.netrid_v22a" \
     "configurations.dev.uspace" \
   )
   # TODO: Add configurations.dev.netrid_v19
-  # TODO: Add configurations.dev.netrid_v22a
   echo "Running configurations: ${all_configurations[*]}"
   for configuration_name in "${all_configurations[@]}"; do
     monitoring/uss_qualifier/run_locally.sh "$configuration_name"

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/isa_simple.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/isa_simple.py
@@ -49,9 +49,7 @@ class ISASimple(GenericTestScenario):
 
         self.end_test_case()
 
-    def _ensure_clean_workspace_step(self):
-        self.begin_test_step("Ensure clean workspace")
-
+    def _delete_isa_if_exists(self):
         fetched = fetch.isa(
             self._isa_id, rid_version=self._dss.rid_version, session=self._dss.client
         )
@@ -95,6 +93,11 @@ class ISASimple(GenericTestScenario):
                             f"Attempting to notify subscriber for ISA {self._isa_id} at {subscriber_url} resulted in {notification.status_code}",
                             query_timestamps=[notification.query.request.timestamp],
                         )
+
+    def _ensure_clean_workspace_step(self):
+        self.begin_test_step("Ensure clean workspace")
+
+        self._delete_isa_if_exists()
 
         self.end_test_step()
 
@@ -251,6 +254,6 @@ class ISASimple(GenericTestScenario):
     def cleanup(self):
         self.begin_cleanup()
 
-        # TODO: Remove ISA if still present
+        self._delete_isa_if_exists()
 
         self.end_cleanup()

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/isa_simple.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/isa_simple.md
@@ -79,3 +79,11 @@ The API for **[astm.f3411.v22a.DSS0030](../../../../../requirements/astm/f3411/v
 ## Cleanup
 
 The cleanup phase of this test scenario attempts to remove the ISA if the test ended prematurely.
+
+#### Successful ISA query check
+
+**[astm.f3411.v22a.DSS0030](../../../../../requirements/astm/f3411/v22a.md)** requires the implementation of the DSS endpoint enabling retrieval of information about a specific ISA; if the individual ISA cannot be retrieved and the error isn't a 404, then this requirement isn't met.
+
+#### Removed pre-existing ISA check
+
+If an ISA with the intended ID is still present in the DSS, it needs to be removed before exiting the test.  If that ISA cannot be deleted, then the **[astm.f3411.v22a.DSS0030](../../../../../requirements/astm/f3411/v22a.md)** requirement to implement the ISA deletion endpoint might not be met.

--- a/schemas/monitoring/uss_qualifier/configurations/configuration/ArtifactsConfiguration.json
+++ b/schemas/monitoring/uss_qualifier/configurations/configuration/ArtifactsConfiguration.json
@@ -1,45 +1,14 @@
 {
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/uss_qualifier/configurations/configuration/ArtifactsConfiguration.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "type": "object",
+  "description": "monitoring.uss_qualifier.configurations.configuration.ArtifactsConfiguration, as defined in monitoring/uss_qualifier/configurations/configuration.py",
   "properties": {
     "$ref": {
-      "type": "string",
-      "description": "Path to content that replaces the $ref"
-    },
-    "report_html": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "$ref": "ReportHTMLConfiguration.json"
-        }
-      ],
-      "description": "If specified, configuration describing how an HTML version of the report should be generated"
-    },
-    "report": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "$ref": "ReportConfiguration.json"
-        }
-      ],
-      "description": "Configuration for report generation"
-    },
-    "tested_roles": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "$ref": "TestedRolesConfiguration.json"
-        }
-      ],
-      "description": "If specified, configuration describing a desired report summarizing tested requirements for each specified participant and role"
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
     },
     "graph": {
+      "description": "If specified, configuration describing a desired graph visualization summarizing the test run",
       "oneOf": [
         {
           "type": "null"
@@ -47,10 +16,52 @@
         {
           "$ref": "GraphConfiguration.json"
         }
-      ],
-      "description": "If specified, configuration describing a desired graph visualization summarizing the test run"
+      ]
+    },
+    "redact_access_tokens": {
+      "description": "When True, look for instances of \"Authorization\" keys in the report with values starting \"Bearer \" and redact the signature from those access tokens",
+      "type": "boolean"
+    },
+    "report": {
+      "description": "Configuration for report generation",
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "ReportConfiguration.json"
+        }
+      ]
+    },
+    "report_html": {
+      "description": "If specified, configuration describing how an HTML version of the report should be generated",
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "ReportHTMLConfiguration.json"
+        }
+      ]
+    },
+    "templated_reports": {
+      "description": "List of report templates to be rendered",
+      "items": {
+        "$ref": "TemplatedReportConfiguration.json"
+      },
+      "type": "array"
+    },
+    "tested_roles": {
+      "description": "If specified, configuration describing a desired report summarizing tested requirements for each specified participant and role",
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "TestedRolesConfiguration.json"
+        }
+      ]
     }
   },
-  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/uss_qualifier/configurations/configuration/ArtifactsConfiguration.json",
-  "description": "monitoring.uss_qualifier.configurations.configuration.ArtifactsConfiguration, as defined in monitoring/uss_qualifier/configurations/configuration.py"
+  "type": "object"
 }

--- a/schemas/monitoring/uss_qualifier/configurations/configuration/ReportConfiguration.json
+++ b/schemas/monitoring/uss_qualifier/configurations/configuration/ReportConfiguration.json
@@ -1,23 +1,19 @@
 {
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/uss_qualifier/configurations/configuration/ReportConfiguration.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "type": "object",
+  "description": "monitoring.uss_qualifier.configurations.configuration.ReportConfiguration, as defined in monitoring/uss_qualifier/configurations/configuration.py",
   "properties": {
     "$ref": {
-      "type": "string",
-      "description": "Path to content that replaces the $ref"
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
     },
     "report_path": {
-      "type": "string",
-      "description": "File name of the report to write (if test_config provided) or read (if test_config not provided)"
-    },
-    "redact_access_tokens": {
-      "type": "boolean",
-      "description": "When True, look for instances of \"Authorization\" keys in the report with values starting \"Bearer \" and redact the signature from those access tokens"
+      "description": "File name of the report to write (if test_config provided) or read (if test_config not provided)",
+      "type": "string"
     }
   },
-  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/uss_qualifier/configurations/configuration/ReportConfiguration.json",
-  "description": "monitoring.uss_qualifier.configurations.configuration.ReportConfiguration, as defined in monitoring/uss_qualifier/configurations/configuration.py",
   "required": [
     "report_path"
-  ]
+  ],
+  "type": "object"
 }

--- a/schemas/monitoring/uss_qualifier/configurations/configuration/TemplatedReportConfiguration.json
+++ b/schemas/monitoring/uss_qualifier/configurations/configuration/TemplatedReportConfiguration.json
@@ -1,0 +1,35 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/uss_qualifier/configurations/configuration/TemplatedReportConfiguration.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "monitoring.uss_qualifier.configurations.configuration.TemplatedReportConfiguration, as defined in monitoring/uss_qualifier/configurations/configuration.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "configuration": {
+      "description": "Configuration to be injected in the templated report",
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "TemplatedReportInjectedConfiguration.json"
+        }
+      ]
+    },
+    "output_path": {
+      "description": "Path of HTML file to contain the rendered templated report",
+      "type": "string"
+    },
+    "template_url": {
+      "description": "Url of the template to download from",
+      "type": "string"
+    }
+  },
+  "required": [
+    "output_path",
+    "template_url"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/uss_qualifier/configurations/configuration/TemplatedReportInjectedConfiguration.json
+++ b/schemas/monitoring/uss_qualifier/configurations/configuration/TemplatedReportInjectedConfiguration.json
@@ -1,0 +1,12 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/uss_qualifier/configurations/configuration/TemplatedReportInjectedConfiguration.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "monitoring.uss_qualifier.configurations.configuration.TemplatedReportInjectedConfiguration, as defined in monitoring/uss_qualifier/configurations/configuration.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    }
+  },
+  "type": "object"
+}

--- a/schemas/monitoring/uss_qualifier/reports/templates/InjectedConfiguration.json
+++ b/schemas/monitoring/uss_qualifier/reports/templates/InjectedConfiguration.json
@@ -1,0 +1,19 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/uss_qualifier/reports/templates/InjectedConfiguration.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "monitoring.uss_qualifier.reports.templates.InjectedConfiguration, as defined in monitoring/uss_qualifier/reports/templates.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "report": {
+      "$ref": "../report/TestRunReport.json",
+      "description": "Report instance to inject in the templated report"
+    }
+  },
+  "required": [
+    "report"
+  ],
+  "type": "object"
+}


### PR DESCRIPTION
Previously, the ISASimple scenario would not clean up the ISA which would cause problems in the rest of the NetRID suite.  This PR fixes that bug and also enables netrid_v22a as a configuration in the CI.  netrid_v19 is still excluded from CI to avoid lengthening CI execution time even more.

This PR also includes some schema file changes as a result of `make format` that apparently weren't detected as not regenerated in `make lint` for a previous PR.