### PR TITLE
[uss_qualifier] Inspect all collected queries for the usage of https (NET0220)

### DIFF
--- a/monitoring/monitorlib/fetch/__init__.py
+++ b/monitoring/monitorlib/fetch/__init__.py
@@ -269,12 +269,15 @@ def describe_query(
     query_type: Optional[QueryType] = None,
     server_id: Optional[str] = None,
 ) -> Query:
-    return Query(
+    query = Query(
         request=describe_request(resp.request, initiated_at),
         response=describe_response(resp),
-        server_id=server_id,
-        query_type=query_type,
     )
+    if query_type is not None:
+        query.query_type = query_type
+    if server_id is not None:
+        query.server_id = server_id
+    return query
 
 
 def query_and_describe(
@@ -282,6 +285,7 @@ def query_and_describe(
     verb: str,
     url: str,
     query_type: Optional[QueryType] = None,
+    server_id: Optional[str] = None,
     **kwargs,
 ) -> Query:
     """Attempt to perform a query, and then describe the results of that attempt.
@@ -294,6 +298,7 @@ def query_and_describe(
         verb: HTTP verb to perform at the specified URL.
         url: URL to query.
         query_type: If specified, the known type of query that this is.
+        server_id: If specified, the participant identifier of the server being queried.
         **kwargs: Any keyword arguments that should be applied to the <session>.request method when invoking it.
 
     Returns:
@@ -305,7 +310,6 @@ def query_and_describe(
     else:
         utm_session = True
     req_kwargs = kwargs.copy()
-    req_kwargs.pop("server_id", None)
     if "timeout" not in req_kwargs:
         req_kwargs["timeout"] = TIMEOUTS
 
@@ -320,7 +324,7 @@ def query_and_describe(
                 client.request(verb, url, **req_kwargs),
                 t0,
                 query_type=query_type,
-                server_id=kwargs.get("server_id", None),
+                server_id=server_id,
             )
         except (requests.Timeout, urllib3.exceptions.ReadTimeoutError) as e:
             failure_message = f"query_and_describe attempt {attempt + 1} from PID {os.getpid()} to {verb} {url} failed with timeout {type(e).__name__}: {str(e)}"
@@ -350,7 +354,7 @@ def query_and_describe(
             elapsed_s=(t1 - t0).total_seconds(),
             reported=StringBasedDateTime(t1),
         ),
-        server_id=kwargs.get("server_id", None),
+        server_id=server_id,
     )
     if query_type is not None:
         result.query_type = query_type

--- a/monitoring/monitorlib/mutate/rid.py
+++ b/monitoring/monitorlib/mutate/rid.py
@@ -99,6 +99,7 @@ def upsert_subscription(
     rid_version: RIDVersion,
     utm_client: infrastructure.UTMClientSession,
     subscription_version: Optional[str] = None,
+    server_id: Optional[str] = None,
 ) -> ChangedSubscription:
     mutation = "create" if subscription_version is None else "update"
     if rid_version == RIDVersion.f3411_19:
@@ -126,7 +127,12 @@ def upsert_subscription(
         return ChangedSubscription(
             mutation=mutation,
             v19_query=fetch.query_and_describe(
-                utm_client, op.verb, url, json=body, scope=v19.constants.Scope.Read
+                utm_client,
+                op.verb,
+                url,
+                json=body,
+                scope=v19.constants.Scope.Read,
+                server_id=server_id,
             ),
         )
     elif rid_version == RIDVersion.f3411_22a:
@@ -154,6 +160,7 @@ def upsert_subscription(
                 url,
                 json=body,
                 scope=v22a.constants.Scope.DisplayProvider,
+                server_id=server_id,
             ),
         )
     else:
@@ -167,6 +174,7 @@ def delete_subscription(
     subscription_version: str,
     rid_version: RIDVersion,
     utm_client: infrastructure.UTMClientSession,
+    server_id: Optional[str] = None,
 ) -> ChangedSubscription:
     if rid_version == RIDVersion.f3411_19:
         op = v19.api.OPERATIONS[v19.api.OperationID.DeleteSubscription]
@@ -174,7 +182,11 @@ def delete_subscription(
         return ChangedSubscription(
             mutation="delete",
             v19_query=fetch.query_and_describe(
-                utm_client, op.verb, url, scope=v19.constants.Scope.Read
+                utm_client,
+                op.verb,
+                url,
+                scope=v19.constants.Scope.Read,
+                server_id=server_id,
             ),
         )
     elif rid_version == RIDVersion.f3411_22a:
@@ -183,7 +195,11 @@ def delete_subscription(
         return ChangedSubscription(
             mutation="delete",
             v22a_query=fetch.query_and_describe(
-                utm_client, op.verb, url, scope=v22a.constants.Scope.DisplayProvider
+                utm_client,
+                op.verb,
+                url,
+                scope=v22a.constants.Scope.DisplayProvider,
+                server_id=server_id,
             ),
         )
     else:
@@ -238,6 +254,7 @@ class SubscriberToNotify(ImplicitDict):
         isa_id: str,
         utm_session: infrastructure.UTMClientSession,
         isa: Optional[ISA] = None,
+        server_id: Optional[str] = None,
     ) -> ISAChangeNotification:
         # Note that optional `extents` are not specified
         if self.rid_version == RIDVersion.f3411_19:
@@ -254,6 +271,7 @@ class SubscriberToNotify(ImplicitDict):
                     url,
                     json=body,
                     scope=v19.constants.Scope.Write,
+                    server_id=server_id,
                 )
             )
         elif self.rid_version == RIDVersion.f3411_22a:
@@ -271,6 +289,7 @@ class SubscriberToNotify(ImplicitDict):
                     url,
                     json=body,
                     scope=v22a.constants.Scope.ServiceProvider,
+                    server_id=server_id,
                 )
             )
         else:
@@ -422,6 +441,7 @@ def put_isa(
     rid_version: RIDVersion,
     utm_client: infrastructure.UTMClientSession,
     isa_version: Optional[str] = None,
+    server_id: Optional[str] = None,
 ) -> ISAChange:
     mutation = "create" if isa_version is None else "update"
     if rid_version == RIDVersion.f3411_19:
@@ -445,7 +465,12 @@ def put_isa(
         dss_response = ChangedISA(
             mutation=mutation,
             v19_query=fetch.query_and_describe(
-                utm_client, op.verb, url, json=body, scope=v19.constants.Scope.Write
+                utm_client,
+                op.verb,
+                url,
+                json=body,
+                scope=v19.constants.Scope.Write,
+                server_id=server_id,
             ),
         )
     elif rid_version == RIDVersion.f3411_22a:
@@ -477,6 +502,7 @@ def put_isa(
                 url,
                 json=body,
                 scope=v22a.constants.Scope.ServiceProvider,
+                server_id=server_id,
             ),
         )
     else:
@@ -499,6 +525,7 @@ def delete_isa(
     isa_version: str,
     rid_version: RIDVersion,
     utm_client: infrastructure.UTMClientSession,
+    server_id: Optional[str] = None,
 ) -> ISAChange:
     if rid_version == RIDVersion.f3411_19:
         op = v19.api.OPERATIONS[v19.api.OperationID.DeleteIdentificationServiceArea]
@@ -506,7 +533,11 @@ def delete_isa(
         dss_response = ChangedISA(
             mutation="delete",
             v19_query=fetch.query_and_describe(
-                utm_client, op.verb, url, scope=v19.constants.Scope.Write
+                utm_client,
+                op.verb,
+                url,
+                scope=v19.constants.Scope.Write,
+                server_id=server_id,
             ),
         )
     elif rid_version == RIDVersion.f3411_22a:
@@ -515,7 +546,11 @@ def delete_isa(
         dss_response = ChangedISA(
             mutation="delete",
             v22a_query=fetch.query_and_describe(
-                utm_client, op.verb, url, scope=v22a.constants.Scope.ServiceProvider
+                utm_client,
+                op.verb,
+                url,
+                scope=v22a.constants.Scope.ServiceProvider,
+                server_id=server_id,
             ),
         )
     else:

--- a/monitoring/monitorlib/mutate/scd.py
+++ b/monitoring/monitorlib/mutate/scd.py
@@ -55,6 +55,7 @@ def put_subscription(
     min_alt_m: float = 0,
     max_alt_m: float = 3048,
     version: Optional[str] = None,
+    server_id: Optional[str] = None,
 ) -> MutatedSubscription:
     body = {
         "extents": scd.make_vol4(
@@ -72,18 +73,25 @@ def put_subscription(
     if version:
         url += f"/{version}"
     result = MutatedSubscription(
-        fetch.query_and_describe(utm_client, "PUT", url, json=body, scope=scd.SCOPE_SC)
+        fetch.query_and_describe(
+            utm_client, "PUT", url, json=body, scope=scd.SCOPE_SC, server_id=server_id
+        )
     )
     result.mutation = "update" if version else "create"
     return result
 
 
 def delete_subscription(
-    utm_client: infrastructure.UTMClientSession, subscription_id: str, version: str
+    utm_client: infrastructure.UTMClientSession,
+    subscription_id: str,
+    version: str,
+    server_id: Optional[str] = None,
 ) -> MutatedSubscription:
     url = f"/dss/v1/subscriptions/{subscription_id}/{version}"
     result = MutatedSubscription(
-        fetch.query_and_describe(utm_client, "DELETE", url, scope=scd.SCOPE_SC)
+        fetch.query_and_describe(
+            utm_client, "DELETE", url, scope=scd.SCOPE_SC, server_id=server_id
+        )
     )
     result.mutation = "delete"
     return result

--- a/monitoring/uss_qualifier/configurations/dev/library/environment.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/library/environment.yaml
@@ -34,6 +34,7 @@ net_rid:
             service_providers:
                 - participant_id: uss2
                   injection_base_url: http://v19.ridsp.uss2.localutm/ridsp/injection
+                  local_debug: true
     netrid_service_providers_v22a:
         $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
         resource_type: resources.netrid.NetRIDServiceProviders
@@ -43,6 +44,7 @@ net_rid:
             service_providers:
                 - participant_id: uss1
                   injection_base_url: http://v22a.ridsp.uss1.localutm/ridsp/injection
+                  local_debug: true
     netrid_observers_v19:
         $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
         resource_type: resources.netrid.NetRIDObserversResource
@@ -52,6 +54,7 @@ net_rid:
             observers:
                 - participant_id: uss3
                   observation_base_url: http://v19.riddp.uss3.localutm/riddp/observation
+                  local_debug: true
     netrid_observers_v22a:
         $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
         resource_type: resources.netrid.NetRIDObserversResource
@@ -61,6 +64,7 @@ net_rid:
             observers:
                 - participant_id: uss1
                   observation_base_url: http://v22a.riddp.uss1.localutm/riddp/observation
+                  local_debug: true
     netrid_dss_instances_v19:
         $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
         resource_type: resources.astm.f3411.DSSInstancesResource
@@ -123,6 +127,7 @@ f3548:
                 # uss1 is the mock_uss directly exposing scdsc functionality
                 -   participant_id: uss1
                     injection_base_url: http://scdsc.uss1.localutm/scdsc
+                    local_debug: true
 
                 # The atproxy has been disabled since it is suspected to be responsible of issue #28. Replaced by another simple mock_uss
                 # # uss2 uses atproxy, with requests being fulfilled by mock_uss with atproxy_client functionality enabled
@@ -132,6 +137,7 @@ f3548:
                 # uss2 is the mock_uss directly exposing scdsc functionality
                 -   participant_id: uss2
                     injection_base_url: http://scdsc.uss2.localutm/scdsc
+                    local_debug: true
     dss:
         $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
         resource_type: resources.astm.f3548.v21.DSSInstanceResource
@@ -152,6 +158,7 @@ f3548_single_scenario:
             flight_planner:
                 participant_id: uss1
                 injection_base_url: http://scdsc.uss1.localutm/scdsc
+                local_debug: true
     uss2:
         $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
         resource_type: resources.flight_planning.FlightPlannerResource
@@ -161,3 +168,4 @@ f3548_single_scenario:
             flight_planner:
                 participant_id: uss2
                 injection_base_url: http://scdsc.uss2.localutm/scdsc
+                local_debug: true

--- a/monitoring/uss_qualifier/resources/astm/f3411/dss.py
+++ b/monitoring/uss_qualifier/resources/astm/f3411/dss.py
@@ -69,6 +69,7 @@ class DSSInstance(object):
 
         if has_private_address is not None:
             self.has_private_address = has_private_address
+            self.local_debug = True
         if local_debug is not None:
             self.local_debug = local_debug
 

--- a/monitoring/uss_qualifier/resources/astm/f3548/v21/dss.py
+++ b/monitoring/uss_qualifier/resources/astm/f3548/v21/dss.py
@@ -53,7 +53,12 @@ class DSSInstance(object):
         url = "/dss/v1/operational_intent_references/query"
         req = QueryOperationalIntentReferenceParameters(area_of_interest=extent)
         query = fetch.query_and_describe(
-            self.client, "POST", url, scope=SCOPE_SC, json=req
+            self.client,
+            "POST",
+            url,
+            scope=SCOPE_SC,
+            json=req,
+            server_id=self.participant_id,
         )
         if query.status_code != 200:
             result = None
@@ -67,7 +72,9 @@ class DSSInstance(object):
         self, op_intent_ref: OperationalIntentReference
     ) -> Tuple[OperationalIntent, fetch.Query]:
         url = f"{op_intent_ref.uss_base_url}/uss/v1/operational_intents/{op_intent_ref.id}"
-        query = fetch.query_and_describe(self.client, "GET", url, scope=SCOPE_SC)
+        query = fetch.query_and_describe(
+            self.client, "GET", url, scope=SCOPE_SC, server_id=self.participant_id
+        )
         if query.status_code != 200:
             result = None
         else:

--- a/monitoring/uss_qualifier/resources/flight_planning/flight_planner.py
+++ b/monitoring/uss_qualifier/resources/flight_planning/flight_planner.py
@@ -90,7 +90,12 @@ class FlightPlanner:
         url = "{}/v1/flights/{}".format(self.config.injection_base_url, flight_id)
 
         query = fetch.query_and_describe(
-            self.client, "PUT", url, json=request, scope=SCOPE_SCD_QUALIFIER_INJECT
+            self.client,
+            "PUT",
+            url,
+            json=request,
+            scope=SCOPE_SCD_QUALIFIER_INJECT,
+            server_id=self.config.participant_id,
         )
         if query.status_code != 200:
             raise QueryError(
@@ -116,7 +121,11 @@ class FlightPlanner:
     ) -> Tuple[DeleteFlightResponse, fetch.Query]:
         url = "{}/v1/flights/{}".format(self.config.injection_base_url, flight_id)
         query = fetch.query_and_describe(
-            self.client, "DELETE", url, scope=SCOPE_SCD_QUALIFIER_INJECT
+            self.client,
+            "DELETE",
+            url,
+            scope=SCOPE_SCD_QUALIFIER_INJECT,
+            server_id=self.config.participant_id,
         )
         if query.status_code != 200:
             raise QueryError(
@@ -139,7 +148,11 @@ class FlightPlanner:
     def get_target_information(self) -> FlightPlannerInformation:
         url_status = "{}/v1/status".format(self.config.injection_base_url)
         version_query = fetch.query_and_describe(
-            self.client, "GET", url_status, scope=SCOPE_SCD_QUALIFIER_INJECT
+            self.client,
+            "GET",
+            url_status,
+            scope=SCOPE_SCD_QUALIFIER_INJECT,
+            server_id=self.config.participant_id,
         )
         if version_query.status_code != 200:
             raise QueryError(
@@ -159,7 +172,11 @@ class FlightPlanner:
 
         url_capabilities = "{}/v1/capabilities".format(self.config.injection_base_url)
         capabilities_query = fetch.query_and_describe(
-            self.client, "GET", url_capabilities, scope=SCOPE_SCD_QUALIFIER_INJECT
+            self.client,
+            "GET",
+            url_capabilities,
+            scope=SCOPE_SCD_QUALIFIER_INJECT,
+            server_id=self.config.participant_id,
         )
         if capabilities_query.status_code != 200:
             raise QueryError(
@@ -187,7 +204,12 @@ class FlightPlanner:
         req = ClearAreaRequest(request_id=str(uuid.uuid4()), extent=extent)
         url = f"{self.config.injection_base_url}/v1/clear_area_requests"
         query = fetch.query_and_describe(
-            self.client, "POST", url, scope=SCOPE_SCD_QUALIFIER_INJECT, json=req
+            self.client,
+            "POST",
+            url,
+            scope=SCOPE_SCD_QUALIFIER_INJECT,
+            json=req,
+            server_id=self.config.participant_id,
         )
         if query.status_code != 200:
             raise QueryError(

--- a/monitoring/uss_qualifier/resources/interuss/mock_uss.py
+++ b/monitoring/uss_qualifier/resources/interuss/mock_uss.py
@@ -25,7 +25,11 @@ class MockUSSClient(object):
 
     def get_status(self) -> fetch.Query:
         return fetch.query_and_describe(
-            self.session, "GET", "/scdsc/v1/status", scope=SCOPE_SCD_QUALIFIER_INJECT
+            self.session,
+            "GET",
+            "/scdsc/v1/status",
+            scope=SCOPE_SCD_QUALIFIER_INJECT,
+            server_id=self.participant_id,
         )
 
     # TODO: Add other methods to interact with the mock USS in other ways (like starting/stopping message signing data collection)

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/isa_simple.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/isa_simple.py
@@ -51,7 +51,10 @@ class ISASimple(GenericTestScenario):
 
     def _delete_isa_if_exists(self):
         fetched = fetch.isa(
-            self._isa_id, rid_version=self._dss.rid_version, session=self._dss.client
+            self._isa_id,
+            rid_version=self._dss.rid_version,
+            session=self._dss.client,
+            server_id=self._dss.participant_id,
         )
         self.record_query(fetched.query)
         with self.check("Successful ISA query", [self._dss.participant_id]) as check:
@@ -69,6 +72,7 @@ class ISASimple(GenericTestScenario):
                 fetched.isa.version,
                 self._dss.rid_version,
                 self._dss.client,
+                server_id=self._dss.participant_id,
             )
             self.record_query(deleted.dss_query.query)
             for subscriber_id, notification in deleted.notifications.items():
@@ -127,6 +131,7 @@ class ISASimple(GenericTestScenario):
             isa_version=None,
             alt_lo=self._isa.altitude_min,
             alt_hi=self._isa.altitude_max,
+            server_id=self._dss.participant_id,
         )
         self.record_query(isa_change.dss_query.query)
         for notification_query in isa_change.notifications.values():

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/misbehavior.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/misbehavior.py
@@ -176,6 +176,7 @@ class Misbehavior(GenericTestScenario):
                 get_details=True,
                 rid_version=self._rid_version,
                 session=self._dss.client,
+                server_id=self._dss.participant_id,
             )
             # We fish out the queries that were used to grab the flights from the SP,
             # and attempt to re-query without credentials. This should fail.
@@ -206,6 +207,7 @@ class Misbehavior(GenericTestScenario):
                     url=fq.query.request.url,
                     json=fq.query.request.json,
                     data=fq.query.request.body,
+                    server_id=self._dss.participant_id,
                 )
                 logger.info(
                     f"Repeating query to {fq.query.request.url} without credentials"

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/display_data_evaluator.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/display_data_evaluator.py
@@ -235,6 +235,7 @@ class RIDObservationEvaluator(object):
                 get_details=True,
                 rid_version=self._rid_version,
                 session=self._dss.client,
+                server_id=self._dss.participant_id,
             )
             for q in sp_observation.queries:
                 self._test_scenario.record_query(q)

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/dss_wrapper.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/dss_wrapper.py
@@ -107,6 +107,7 @@ class DSSWrapper(object):
                 isa_id=isa_id,
                 rid_version=self._dss.rid_version,
                 session=self._dss.client,
+                server_id=self._dss.participant_id,
             )
 
             self._handle_query_result(check, isa, f"Failed to get ISA {isa_id}")
@@ -160,6 +161,7 @@ class DSSWrapper(object):
                 isa_version=isa_version,
                 rid_version=self._dss.rid_version,
                 utm_client=self._dss.client,
+                server_id=self._dss.participant_id,
             )
 
             self._handle_query_result(
@@ -223,6 +225,7 @@ class DSSWrapper(object):
                 isa_version=isa_version,
                 rid_version=self._dss.rid_version,
                 utm_client=self._dss.client,
+                server_id=self._dss.participant_id,
             )
 
             self._handle_query_result(
@@ -261,6 +264,7 @@ class DSSWrapper(object):
                 isa_id=isa_id,
                 rid_version=self._dss.rid_version,
                 session=self._dss.client,
+                server_id=self._dss.participant_id,
             )
 
             self._handle_query_result(
@@ -275,6 +279,7 @@ class DSSWrapper(object):
                 isa_version=isa.isa.version,
                 rid_version=self._dss.rid_version,
                 utm_client=self._dss.client,
+                server_id=self._dss.participant_id,
             )
 
             self._handle_query_result(
@@ -309,6 +314,7 @@ class DSSWrapper(object):
                 area=area,
                 rid_version=self._dss.rid_version,
                 session=self._dss.client,
+                server_id=self._dss.participant_id,
             )
 
             self._handle_query_result(
@@ -339,6 +345,7 @@ class DSSWrapper(object):
                 subscription_id=sub_id,
                 rid_version=self._dss.rid_version,
                 session=self._dss.client,
+                server_id=self._dss.participant_id,
             )
 
             self._handle_query_result(
@@ -378,6 +385,7 @@ class DSSWrapper(object):
                 subscription_id=sub_id,
                 rid_version=self._dss.rid_version,
                 session=self._dss.client,
+                server_id=self._dss.participant_id,
             )
 
             self._handle_query_result(
@@ -420,6 +428,7 @@ class DSSWrapper(object):
                 subscription_version=sub_version,
                 rid_version=self._dss.rid_version,
                 utm_client=self._dss.client,
+                server_id=self._dss.participant_id,
             )
 
             self._handle_query_result(
@@ -468,6 +477,7 @@ class DSSWrapper(object):
                 subscription_version=sub_version,
                 rid_version=self._dss.rid_version,
                 utm_client=self._dss.client,
+                server_id=self._dss.participant_id,
             )
 
             self._handle_query_result(
@@ -499,6 +509,7 @@ class DSSWrapper(object):
                 subscription_version=sub_version,
                 rid_version=self._dss.rid_version,
                 utm_client=self._dss.client,
+                server_id=self._dss.participant_id,
             )
 
             self._handle_query_result(
@@ -537,6 +548,7 @@ class DSSWrapper(object):
                 subscription_id=sub_id,
                 rid_version=self._dss.rid_version,
                 session=self._dss.client,
+                server_id=self._dss.participant_id,
             )
 
             self._handle_query_result(
@@ -555,6 +567,7 @@ class DSSWrapper(object):
                 subscription_version=sub.subscription.version,
                 rid_version=self._dss.rid_version,
                 utm_client=self._dss.client,
+                server_id=self._dss.participant_id,
             )
 
             self._handle_query_result(

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/aggregate_checks.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/aggregate_checks.md
@@ -56,6 +56,24 @@ of the durations for the subsequent display data queries do not exceed the respe
 of the durations for the replies to requested flights in an area do not exceed the respective thresholds
 `NetSpDataResponseTime95thPercentile` (1 second) and `NetSpDataResponseTime99thPercentile` (3 seconds).
 
+## Verify https is in use test case
+
+### Verify https is in use test step
+
+Inspects all record queries for their usage of https. If services such as a service provider, observer or DSS are marked
+as being in "local debug" mode, they may serve requests over http without producing failed checks despite their lack of encryption.
+
+#### All interactions happen over https check
+
+If non-encrypted interactions such as plaintext queries over http are allowed, **[astm.f3411.v19.NET0220](../../../../requirements/astm/f3411/v19.md)** is not satisfied.
+
+#### No unattributed queries check
+
+All queries must have been attributed to a participant: an unattributed query means that one of the test cases has not
+properly recorded to which participant it was made.
+
+This is an internal requirement and does not necessarily imply that there is a problem with the participants under test.
+
 ## Mock USS interactions evaluation test case
 
 In this test case, the interactions with a mock_uss instance (if provided) are obtained and then examined to verify
@@ -71,14 +89,3 @@ If one of the Display Provider test participants was found to have sent a query 
 area requested, then that participant will have violated **[astm.f3411.v19.NET0240](../../../../requirements/astm/f3411/v19.md)**.
 
 TODO: Implement this check
-
-## Verify https is in use test case
-
-### Verify https is in use test step
-
-Inspects all record queries for their usage of https. If resources such as a service provide, observer or DSS are marked
-as being in "local debug" mode, they may serve requests over https without breaking the test suite.
-
-#### All interactions happen over https check
-
-If non-encrypted interactions such as plaintext queries over http are allowed, **[astm.f3411.v19.NET0220](../../../../requirements/astm/f3411/v19.md)** is not satisfied.

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/aggregate_checks.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/aggregate_checks.md
@@ -15,6 +15,9 @@ The service providers to evaluate in the report.
 ### observers
 The observers to evaluate in the report.
 
+### dss_instances
+The DSS instances that have been relied upon or tested by the framework.
+
 ## Performance of Display Providers requests test case
 
 ### Performance of /display_data/<flight_id> requests test step
@@ -68,3 +71,14 @@ If one of the Display Provider test participants was found to have sent a query 
 area requested, then that participant will have violated **[astm.f3411.v19.NET0240](../../../../requirements/astm/f3411/v19.md)**.
 
 TODO: Implement this check
+
+## Verify https is in use test case
+
+### Verify https is in use test step
+
+Inspects all record queries for their usage of https. If resources such as a service provide, observer or DSS are marked
+as being in "local debug" mode, they may serve requests over https without breaking the test suite.
+
+#### All interactions happen over https check
+
+If non-encrypted interactions such as plaintext queries over http are allowed, **[astm.f3411.v19.NET0220](../../../../requirements/astm/f3411/v19.md)** is not satisfied.

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/aggregate_checks.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/aggregate_checks.py
@@ -1,4 +1,5 @@
 from monitoring.monitorlib.rid import RIDVersion
+from monitoring.uss_qualifier.resources.astm.f3411 import DSSInstancesResource
 from monitoring.uss_qualifier.resources.interuss.report import TestSuiteReportResource
 from monitoring.uss_qualifier.resources.netrid import (
     NetRIDServiceProviders,
@@ -16,6 +17,7 @@ class AggregateChecks(TestScenario, CommonAggregateChecks):
         report_resource: TestSuiteReportResource,
         service_providers: NetRIDServiceProviders,
         observers: NetRIDObserversResource,
+        dss_instances: DSSInstancesResource,
     ):
-        super().__init__(report_resource, service_providers, observers)
+        super().__init__(report_resource, service_providers, observers, dss_instances)
         self._rid_version = RIDVersion.f3411_19

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/aggregate_checks.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/aggregate_checks.md
@@ -15,6 +15,9 @@ The service providers to evaluate in the report.
 ### observers
 The observers to evaluate in the report.
 
+### dss_instances
+The DSS instances that have been relied upon or tested by the framework.
+
 ## Performance of Display Providers requests test case
 
 ### Performance of /display_data/<flight_id> requests test step
@@ -68,3 +71,14 @@ If one of the Display Provider test participants was found to have sent a query 
 area requested, then that participant will have violated **[astm.f3411.v22a.NET0240](../../../../requirements/astm/f3411/v22a.md)**.
 
 TODO: Implement this check
+
+## Verify https is in use test case
+
+### Verify https is in use test step
+
+Inspects all record queries for their usage of https. If resources such as a service provide, observer or DSS are marked
+as being in "local debug" mode, they may serve requests over https without breaking the test suite.
+
+#### All interactions happen over https check
+
+If non-encrypted interactions such as plaintext queries over http are allowed, **[astm.f3411.v19.NET0220](../../../../requirements/astm/f3411/v19.md)** is not satisfied.

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/aggregate_checks.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/aggregate_checks.md
@@ -56,6 +56,24 @@ of the durations for the subsequent display data queries do not exceed the respe
 of the durations for the replies to requested flights in an area do not exceed the respective thresholds
 `NetSpDataResponseTime95thPercentile` (1 second) and `NetSpDataResponseTime99thPercentile` (3 seconds).
 
+## Verify https is in use test case
+
+### Verify https is in use test step
+
+Inspects all record queries for their usage of https. If services such as a service provider, observer or DSS are marked
+as being in "local debug" mode, they may serve requests over http without producing failed checks despite their lack of encryption.
+
+#### No unattributed queries check
+
+All queries must have been attributed to a participant: an unattributed query means that one of the test cases has not
+properly recorded to which participant it was made.
+
+This is an internal requirement and does not necessarily imply that there is a problem with the participants under test.
+
+#### All interactions happen over https check
+
+If non-encrypted interactions such as plaintext queries over http are allowed, **[astm.f3411.v19.NET0220](../../../../requirements/astm/f3411/v19.md)** is not satisfied.
+
 ## Mock USS interactions evaluation test case
 
 In this test case, the interactions with a mock_uss instance (if provided) are obtained and then examined to verify
@@ -71,14 +89,3 @@ If one of the Display Provider test participants was found to have sent a query 
 area requested, then that participant will have violated **[astm.f3411.v22a.NET0240](../../../../requirements/astm/f3411/v22a.md)**.
 
 TODO: Implement this check
-
-## Verify https is in use test case
-
-### Verify https is in use test step
-
-Inspects all record queries for their usage of https. If resources such as a service provide, observer or DSS are marked
-as being in "local debug" mode, they may serve requests over https without breaking the test suite.
-
-#### All interactions happen over https check
-
-If non-encrypted interactions such as plaintext queries over http are allowed, **[astm.f3411.v19.NET0220](../../../../requirements/astm/f3411/v19.md)** is not satisfied.

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/aggregate_checks.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/aggregate_checks.py
@@ -1,4 +1,5 @@
 from monitoring.monitorlib.rid import RIDVersion
+from monitoring.uss_qualifier.resources.astm.f3411 import DSSInstancesResource
 from monitoring.uss_qualifier.resources.interuss.report import TestSuiteReportResource
 from monitoring.uss_qualifier.resources.netrid import (
     NetRIDServiceProviders,
@@ -16,6 +17,7 @@ class AggregateChecks(TestScenario, CommonAggregateChecks):
         report_resource: TestSuiteReportResource,
         service_providers: NetRIDServiceProviders,
         observers: NetRIDObserversResource,
+        dss_instances: DSSInstancesResource,
     ):
-        super().__init__(report_resource, service_providers, observers)
+        super().__init__(report_resource, service_providers, observers, dss_instances)
         self._rid_version = RIDVersion.f3411_22a

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_19.md
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_19.md
@@ -21,7 +21,7 @@
     <th>Checked in</th>
   </tr>
   <tr>
-    <td rowspan="43" style="vertical-align:top;"><a href="../../../requirements/astm/f3411/v19.md">astm<br>.f3411<br>.v19</a></td>
+    <td rowspan="44" style="vertical-align:top;"><a href="../../../requirements/astm/f3411/v19.md">astm<br>.f3411<br>.v19</a></td>
     <td><a href="../../../requirements/astm/f3411/v19.md">A2-6-1,1a</a></td>
     <td>Implemented</td>
     <td><a href="../../../scenarios/astm/netrid/v19/dss_interoperability.md">ASTM F3411-19 NetRID DSS interoperability</a></td>
@@ -165,6 +165,11 @@
     <td><a href="../../../requirements/astm/f3411/v19.md">DSS0210</a></td>
     <td>Implemented</td>
     <td><a href="../../../scenarios/astm/netrid/v19/dss_interoperability.md">ASTM F3411-19 NetRID DSS interoperability</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3411/v19.md">NET0220</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/netrid/v19/aggregate_checks.md">ASTM F3411-19 NetRID aggregate checks</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3411/v19.md">NET0240</a></td>

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_19.yaml
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_19.yaml
@@ -52,6 +52,7 @@ report_evaluation_scenario:
   resources:
     service_providers: service_providers
     observers: observers
+    dss_instances: dss_instances
 participant_verifiable_capabilities:
     - id: service_provider
       name: NetRID Service Provider

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a.md
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a.md
@@ -21,6 +21,12 @@
     <th>Checked in</th>
   </tr>
   <tr>
+    <td rowspan="1" style="vertical-align:top;"><a href="../../../requirements/astm/f3411/v19.md">astm<br>.f3411<br>.v19</a></td>
+    <td><a href="../../../requirements/astm/f3411/v19.md">NET0220</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/netrid/v22a/aggregate_checks.md">ASTM F3411-22a NetRID aggregate checks</a></td>
+  </tr>
+  <tr>
     <td rowspan="52" style="vertical-align:top;"><a href="../../../requirements/astm/f3411/v22a.md">astm<br>.f3411<br>.v22a</a></td>
     <td><a href="../../../requirements/astm/f3411/v22a.md">A2-6-1,1a</a></td>
     <td>Implemented</td>

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a.yaml
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a.yaml
@@ -54,6 +54,7 @@ report_evaluation_scenario:
   resources:
     service_providers: service_providers
     observers: observers
+    dss_instances: dss_instances
 participant_verifiable_capabilities:
   - id: service_provider
     name: NetRID Service Provider

--- a/monitoring/uss_qualifier/suites/uspace/network_identification.md
+++ b/monitoring/uss_qualifier/suites/uspace/network_identification.md
@@ -16,6 +16,12 @@
     <th>Checked in</th>
   </tr>
   <tr>
+    <td rowspan="1" style="vertical-align:top;"><a href="../../requirements/astm/f3411/v19.md">astm<br>.f3411<br>.v19</a></td>
+    <td><a href="../../requirements/astm/f3411/v19.md">NET0220</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/netrid/v22a/aggregate_checks.md">ASTM F3411-22a NetRID aggregate checks</a></td>
+  </tr>
+  <tr>
     <td rowspan="52" style="vertical-align:top;"><a href="../../requirements/astm/f3411/v22a.md">astm<br>.f3411<br>.v22a</a></td>
     <td><a href="../../requirements/astm/f3411/v22a.md">A2-6-1,1a</a></td>
     <td>Implemented</td>

--- a/monitoring/uss_qualifier/suites/uspace/required_services.md
+++ b/monitoring/uss_qualifier/suites/uspace/required_services.md
@@ -17,6 +17,12 @@
     <th>Checked in</th>
   </tr>
   <tr>
+    <td rowspan="1" style="vertical-align:top;"><a href="../../requirements/astm/f3411/v19.md">astm<br>.f3411<br>.v19</a></td>
+    <td><a href="../../requirements/astm/f3411/v19.md">NET0220</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/netrid/v22a/aggregate_checks.md">ASTM F3411-22a NetRID aggregate checks</a></td>
+  </tr>
+  <tr>
     <td rowspan="52" style="vertical-align:top;"><a href="../../requirements/astm/f3411/v22a.md">astm<br>.f3411<br>.v22a</a></td>
     <td><a href="../../requirements/astm/f3411/v22a.md">A2-6-1,1a</a></td>
     <td>Implemented</td>


### PR DESCRIPTION
Checking for NET0220 by ensuring all queries to USSes are relying on https.

In order to validate that queries are not sent in cleartext while not breaking local non-https setups, this:

* tags all/most queries with the server_id it is intended to
* adds a `local_debug` flag to service providers, observers and dss'es 
* adds a check to the aggregate checks that validates all recorded queries are using https when they target an USS that isn't in `local_debug` mode.

Open questions/notes:
* We may want to add the participant_id/server_id to the UTM session object? That might make this PR a bit simple.