### PR TITLE
[CI] Rename CI steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,13 +48,12 @@ jobs:
         cd monitoring/mock_uss
         make test
 
-  uss_qualifier_F3411-22a-test:
-    name: uss_qualifier tests (F3411-22a configuration)
+  uss_qualifier-test:
+    name: uss_qualifier tests
     uses: ./.github/workflows/monitoring-test.yml
     with:
-      name: uss_qualifier_F3411-22a
+      name: uss_qualifier
       script: |
-        export RID_VERSION=F3411-22a \
           CONFIG_NAME="" \
           USS_QUALIFIER_STOP_FAST=true
 
@@ -62,12 +61,11 @@ jobs:
         make test
 
   uss_qualifier_F3411-19-test:
-    name: uss_qualifier tests (F3411-19 configuration)
+    name: uss_qualifier F3411-19 tests
     uses: ./.github/workflows/monitoring-test.yml
     with:
       name: uss_qualifier_F3411-19
       script: |
-        export RID_VERSION=F3411-19 \
           CONFIG_NAME=configurations.dev.netrid_v19 \
           USS_QUALIFIER_STOP_FAST=true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
     with:
       name: uss_qualifier
       script: |
-          CONFIG_NAME="" \
+        export CONFIG_NAME="" \
           USS_QUALIFIER_STOP_FAST=true
 
         cd monitoring/uss_qualifier
@@ -66,7 +66,7 @@ jobs:
     with:
       name: uss_qualifier_F3411-19
       script: |
-          CONFIG_NAME=configurations.dev.netrid_v19 \
+        export CONFIG_NAME=configurations.dev.netrid_v19 \
           USS_QUALIFIER_STOP_FAST=true
 
         cd monitoring/uss_qualifier

--- a/monitoring/uss_qualifier/scripts/test_docker_fully_mocked.sh
+++ b/monitoring/uss_qualifier/scripts/test_docker_fully_mocked.sh
@@ -50,11 +50,9 @@ echo "============="
 make start-locally
 make start-uss-mocks
 
-RID_VERSION=${RID_VERSION:-"F3411-22a"}
 CONFIG_NAME=${CONFIG_NAME:-""}
 echo "Selecting configuration"
 echo "============="
-echo "RID_VERSION: $RID_VERSION"
 echo "CONFIG_NAME: $CONFIG_NAME"
 
 


### PR DESCRIPTION
Currently, the most important CI step is labeled with "F3411-22a" because, previously, we had to deploy the local USS mocks differently to test F3411-19 versus F3411-22a.  This PR first removes the "F3411-22a" label to make it clear that this step is the main uss_qualifier test set, then it also removes the last RID_VERSION environment variable switch as it is no longer needed.