### PR TITLE
[uss_qualifier] Add NET0450 to existing checks

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/netrid/display_data_evaluator.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/display_data_evaluator.py
@@ -366,9 +366,18 @@ class RIDObservationEvaluator(object):
             ]
             observed_position = mapping.observed_flight.most_recent_position
             injected_position = injected_telemetry.position
+
+            with self._test_scenario.check("Altitude is present") as check:
+                if "alt" not in injected_position:
+                    check.record_failed(
+                        summary="Displayed flight is missing altitude",
+                        severity=Severity.Medium,
+                        details=f"Displayed data for injected flight {mapping.injected_flight.flight.injection_id} in test {mapping.injected_flight.test_id} at {injected_telemetry.timestamp} does not have altitude",
+                    )
+
             if "alt" in observed_position:
                 with self._test_scenario.check(
-                    "Observed altitude",
+                    "Correct up-to-date altitude",
                     [
                         observer.participant_id,
                         mapping.injected_flight.uss_participant_id,

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/nominal_behavior.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/nominal_behavior.md
@@ -130,9 +130,13 @@ The timestamps of the injected telemetry usually start in the future.  If a flig
 
 **[astm.f3411.v19.NET0290](../../../../requirements/astm/f3411/v19.md)** requires a SP uses Telemetry vs extrapolation when telemetry is present.
 
-#### Observed altitude check
+#### Altitude is present check
 
-**[astm.f3411.v19.NET0470](../../../../requirements/astm/f3411/v19.md)** requires that a Display Provider provides any specified data fields in accordance with the common data dictionary when responding to a Display Application.  If the observed altitude of a flight does not match the altitude of the injected telemetry, this check will fail.
+Failure to report the altitude of a flight is a violation of **[astm.f3411.v19.NET0470](../../../../requirements/astm/f3411/v19.md)**.
+
+#### Correct up-to-date altitude check
+
+If the observed altitude of a flight does not match the altitude of the injected telemetry, the display provider is not providing precise and up-to-date information, and thus does not respect **[astm.f3411.v19.NET0450](../../../../requirements/astm/f3411/v19.md)**.
 
 #### Area too large check
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/nominal_behavior.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/nominal_behavior.md
@@ -158,9 +158,13 @@ The timestamps of the injected telemetry usually start in the future.  If a flig
 
 **[astm.f3411.v22a.NET0290](../../../../requirements/astm/f3411/v22a.md)** requires a SP uses Telemetry vs extrapolation when telemetry is present.
 
-#### Observed altitude check
+#### Altitude is present check
 
-**[astm.f3411.v22a.NET0470](../../../../requirements/astm/f3411/v22a.md)** requires that a Display Provider provides any specified data fields in accordance with the common data dictionary when responding to a Display Application.  If the observed altitude of a flight does not match the altitude of the injected telemetry, this check will fail.
+Failure to report the altitude of a flight is a violation of **[astm.f3411.v22a.NET0470](../../../../requirements/astm/f3411/v22a.md)**.
+
+#### Correct up-to-date altitude check
+
+If the observed altitude of a flight does not match the altitude of the injected telemetry, the display provider is not providing precise and up-to-date information, and thus does not respect **[astm.f3411.v22a.NET0450](../../../../requirements/astm/f3411/v22a.md)**.
 
 #### Area too large check
 

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_19.md
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_19.md
@@ -21,7 +21,7 @@
     <th>Checked in</th>
   </tr>
   <tr>
-    <td rowspan="44" style="vertical-align:top;"><a href="../../../requirements/astm/f3411/v19.md">astm<br>.f3411<br>.v19</a></td>
+    <td rowspan="45" style="vertical-align:top;"><a href="../../../requirements/astm/f3411/v19.md">astm<br>.f3411<br>.v19</a></td>
     <td><a href="../../../requirements/astm/f3411/v19.md">A2-6-1,1a</a></td>
     <td>Implemented</td>
     <td><a href="../../../scenarios/astm/netrid/v19/dss_interoperability.md">ASTM F3411-19 NetRID DSS interoperability</a></td>
@@ -210,6 +210,11 @@
     <td><a href="../../../requirements/astm/f3411/v19.md">NET0440</a></td>
     <td>Implemented</td>
     <td><a href="../../../scenarios/astm/netrid/v19/aggregate_checks.md">ASTM F3411-19 NetRID aggregate checks</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3411/v19.md">NET0450</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/netrid/v19/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3411/v19.md">NET0470</a></td>

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a.md
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a.md
@@ -27,7 +27,7 @@
     <td><a href="../../../scenarios/astm/netrid/v22a/aggregate_checks.md">ASTM F3411-22a NetRID aggregate checks</a></td>
   </tr>
   <tr>
-    <td rowspan="52" style="vertical-align:top;"><a href="../../../requirements/astm/f3411/v22a.md">astm<br>.f3411<br>.v22a</a></td>
+    <td rowspan="53" style="vertical-align:top;"><a href="../../../requirements/astm/f3411/v22a.md">astm<br>.f3411<br>.v22a</a></td>
     <td><a href="../../../requirements/astm/f3411/v22a.md">A2-6-1,1a</a></td>
     <td>Implemented</td>
     <td><a href="../../../scenarios/astm/netrid/v22a/dss_interoperability.md">ASTM F3411-22a NetRID DSS interoperability</a></td>
@@ -251,6 +251,11 @@
     <td><a href="../../../requirements/astm/f3411/v22a.md">NET0440</a></td>
     <td>Implemented</td>
     <td><a href="../../../scenarios/astm/netrid/v22a/aggregate_checks.md">ASTM F3411-22a NetRID aggregate checks</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3411/v22a.md">NET0450</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/netrid/v22a/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3411/v22a.md">NET0470</a></td>

--- a/monitoring/uss_qualifier/suites/uspace/network_identification.md
+++ b/monitoring/uss_qualifier/suites/uspace/network_identification.md
@@ -22,7 +22,7 @@
     <td><a href="../../scenarios/astm/netrid/v22a/aggregate_checks.md">ASTM F3411-22a NetRID aggregate checks</a></td>
   </tr>
   <tr>
-    <td rowspan="52" style="vertical-align:top;"><a href="../../requirements/astm/f3411/v22a.md">astm<br>.f3411<br>.v22a</a></td>
+    <td rowspan="53" style="vertical-align:top;"><a href="../../requirements/astm/f3411/v22a.md">astm<br>.f3411<br>.v22a</a></td>
     <td><a href="../../requirements/astm/f3411/v22a.md">A2-6-1,1a</a></td>
     <td>Implemented</td>
     <td><a href="../../scenarios/astm/netrid/v22a/dss_interoperability.md">ASTM F3411-22a NetRID DSS interoperability</a></td>
@@ -246,6 +246,11 @@
     <td><a href="../../requirements/astm/f3411/v22a.md">NET0440</a></td>
     <td>Implemented</td>
     <td><a href="../../scenarios/astm/netrid/v22a/aggregate_checks.md">ASTM F3411-22a NetRID aggregate checks</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3411/v22a.md">NET0450</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/netrid/v22a/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3411/v22a.md">NET0470</a></td>

--- a/monitoring/uss_qualifier/suites/uspace/required_services.md
+++ b/monitoring/uss_qualifier/suites/uspace/required_services.md
@@ -23,7 +23,7 @@
     <td><a href="../../scenarios/astm/netrid/v22a/aggregate_checks.md">ASTM F3411-22a NetRID aggregate checks</a></td>
   </tr>
   <tr>
-    <td rowspan="52" style="vertical-align:top;"><a href="../../requirements/astm/f3411/v22a.md">astm<br>.f3411<br>.v22a</a></td>
+    <td rowspan="53" style="vertical-align:top;"><a href="../../requirements/astm/f3411/v22a.md">astm<br>.f3411<br>.v22a</a></td>
     <td><a href="../../requirements/astm/f3411/v22a.md">A2-6-1,1a</a></td>
     <td>Implemented</td>
     <td><a href="../../scenarios/astm/netrid/v22a/dss_interoperability.md">ASTM F3411-22a NetRID DSS interoperability</a></td>
@@ -247,6 +247,11 @@
     <td><a href="../../requirements/astm/f3411/v22a.md">NET0440</a></td>
     <td>Implemented</td>
     <td><a href="../../scenarios/astm/netrid/v22a/aggregate_checks.md">ASTM F3411-22a NetRID aggregate checks</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3411/v22a.md">NET0450</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/netrid/v22a/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3411/v22a.md">NET0470</a></td>


### PR DESCRIPTION
As discussed with @barroco NET0450 is probably already checked for implicitly, and we need to properly mention that.