### PR TITLE
[uss_qualifier] Add optional requirements collection specification for tested requirements artifact

### DIFF
--- a/monitoring/uss_qualifier/configurations/configuration.py
+++ b/monitoring/uss_qualifier/configurations/configuration.py
@@ -1,9 +1,10 @@
-from typing import Optional, List
+from typing import Optional, List, Dict
 
 from implicitdict import ImplicitDict
 
 from monitoring.monitorlib.dicts import JSONAddress
 from monitoring.uss_qualifier.fileio import load_dict_with_references
+from monitoring.uss_qualifier.requirements.definitions import RequirementCollection
 from monitoring.uss_qualifier.requirements.documentation import RequirementSetID
 from monitoring.uss_qualifier.resources.definitions import ResourceCollection
 from monitoring.uss_qualifier.suites.definitions import (
@@ -30,9 +31,23 @@ class TestedRolesConfiguration(ImplicitDict):
     """Path of folder to write HTML files containing a fulfilled-requirements-based view of the test report"""
 
 
+TestedRequirementsCollectionIdentifier = str
+"""Identifier for a requirements collection, local to a TestedRequirementsConfiguration artifact configuration."""
+
+
 class TestedRequirementsConfiguration(ImplicitDict):
     output_path: str
     """Path of a folder into which report HTML files should be written"""
+
+    requirement_collections: Optional[
+        Dict[TestedRequirementsCollectionIdentifier, RequirementCollection]
+    ]
+    """Definition of requirement collections specific to production of this artifact."""
+
+    participant_requirements: Optional[
+        Dict[ParticipantID, TestedRequirementsCollectionIdentifier]
+    ]
+    """If a requirement collection is specified for a participant, only the requirements in the specified collection will be listed on that participant's report."""
 
 
 class ReportHTMLConfiguration(ImplicitDict):

--- a/monitoring/uss_qualifier/configurations/dev/f3548.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/f3548.yaml
@@ -20,3 +20,10 @@ v1:
       report_path: output/report_f3548.json
     tested_requirements:
       output_path: output/tested_requirements_f3548
+      requirement_collections:
+        scd:
+          requirement_sets:
+            - astm.f3548.v21.scd#Automated verification
+      participant_requirements:
+        uss1: scd
+        uss2: scd

--- a/monitoring/uss_qualifier/configurations/dev/netrid_v22a.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/netrid_v22a.yaml
@@ -22,3 +22,17 @@ v1:
             report_path: output/tested_roles_netrid_v22a
         tested_requirements:
             output_path: output/tested_requirements_f3411v22a
+            requirement_collections:
+              sp_dp_dss:
+                  requirement_sets:
+                      - astm.f3411.v22a.service_provider#Mandatory requirements
+                      - astm.f3411.v22a.display_provider#Mandatory requirements
+                      - astm.f3411.v22a.dss_provider#Mandatory requirements
+              sp_dss:
+                  requirement_sets:
+                      - astm.f3411.v22a.service_provider#Mandatory requirements
+                      - astm.f3411.v22a.dss_provider#Mandatory requirements
+                      - astm.f3548.v21.scd#Automated verification
+            participant_requirements:
+                uss1: sp_dp_dss
+                uss2: sp_dss

--- a/monitoring/uss_qualifier/configurations/dev/uspace.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/uspace.yaml
@@ -33,3 +33,14 @@ v1:
         output_path: output/capabilities_uspace.html
     tested_requirements:
       output_path: output/tested_requirements_uspace
+      requirement_collections:
+        uspace:
+          requirement_collections:
+            - requirement_sets:
+                - astm.f3411.v22a.service_provider#Mandatory requirements
+                - astm.f3411.v22a.display_provider#Mandatory requirements
+                - astm.f3411.v22a.dss_provider#Mandatory requirements
+                - astm.f3548.v21.scd#Automated verification
+      participant_requirements:
+        uss1: uspace
+        uss2: uspace

--- a/monitoring/uss_qualifier/main.py
+++ b/monitoring/uss_qualifier/main.py
@@ -202,7 +202,7 @@ def main() -> int:
         if config.artifacts.tested_requirements:
             path = config.artifacts.tested_requirements.output_path
             logger.info(f"Writing tested requirements view to {path}")
-            generate_tested_requirements(report, path)
+            generate_tested_requirements(report, config.artifacts.tested_requirements)
 
     return os.EX_OK
 

--- a/monitoring/uss_qualifier/reports/templates/tested_requirements/participant_tested_requirements.html
+++ b/monitoring/uss_qualifier/reports/templates/tested_requirements/participant_tested_requirements.html
@@ -19,6 +19,9 @@ th {
 .not_tested {
   background-color: rgb(192, 192, 192);
 }
+.has_todo {
+  background-color: rgb(255, 255, 192);
+}
   </style>
 </head>
 <body>
@@ -39,70 +42,83 @@ th {
     {% for package in breakdown.packages %}
       {% set first_row.package = True %}
       {% for requirement in package.requirements %}
-        {% set first_row.requirement = True %}
-        {% for test_scenario in requirement.scenarios %}
-          {% set first_row.scenario = True %}
-          {% for test_case in test_scenario.cases %}
-            {% set first_row.case = True %}
-            {% for test_step in test_case.steps %}
-              {% set first_row.step = True %}
-              {% for check in test_step.checks %}
-                <tr>
-                  {% if first_row.package %}
-                    <td rowspan="{{ package.rows }}">{{ package.name }}</td>
-                  {% endif %}
-                  {% if first_row.requirement %}
-                    <td rowspan="{{ requirement.rows }}" class="{{ requirement.classname }}">{{ requirement.id }}</td>
-                  {% endif %}
-                  <td class="{{ check.classname }}">{{ check.result }}</td>
-                  {% if first_row.scenario %}
-                    <td rowspan="{{ test_scenario.rows }}">
-                      {% if test_scenario.url %}
-                        <a href="{{ test_scenario.url }}">{{ test_scenario.name }}</a>
-                      {% else %}
-                        {{ test_scenario.name }}
-                      {% endif %}
-                    </td>
-                  {% endif %}
-                  {% if first_row.case %}
-                    <td rowspan="{{ test_case.rows }}">
-                      {% if test_case.url %}
-                        <a href="{{ test_case.url }}">{{ test_case.name }}</a>
-                      {% else %}
-                        {{ test_case.name }}
-                      {% endif %}
-                    </td>
-                  {% endif %}
-                  {% if first_row.step %}
-                    <td rowspan="{{ test_step.rows }}">
-                      {% if test_step.url %}
-                        <a href="{{ test_step.url }}">{{ test_step.name }}</a>
-                      {% else %}
-                        {{ test_step.name }}
-                      {% endif %}
-                    </td>
-                  {% endif %}
-                  <td class="{{ check.classname }}">
-                    {% if check.url %}
-                      <a href="{{ check.url }}">{{ check.name }}</a>
-                    {% else %}
-                      {{ check.name }}
+        {% if requirement.scenarios %}
+          {% set first_row.requirement = True %}
+          {% for test_scenario in requirement.scenarios %}
+            {% set first_row.scenario = True %}
+            {% for test_case in test_scenario.cases %}
+              {% set first_row.case = True %}
+              {% for test_step in test_case.steps %}
+                {% set first_row.step = True %}
+                {% for check in test_step.checks %}
+                  <tr>
+                    {% if first_row.package %}
+                      <td rowspan="{{ package.rows }}">{{ package.name }}</td>
                     {% endif %}
-                    {% if check.successes + check.failures > 1 %}
-                      ({{ check.successes + check.failures }}x)
+                    {% if first_row.requirement %}
+                      <td rowspan="{{ requirement.rows }}" class="{{ requirement.classname }}">{{ requirement.id }}</td>
                     {% endif %}
-                  </td>
-                </tr>
+                    <td class="{{ check.result_classname }}">{{ check.result }}</td>
+                    {% if first_row.scenario %}
+                      <td rowspan="{{ test_scenario.rows }}">
+                        {% if test_scenario.url %}
+                          <a href="{{ test_scenario.url }}">{{ test_scenario.name }}</a>
+                        {% else %}
+                          {{ test_scenario.name }}
+                        {% endif %}
+                      </td>
+                    {% endif %}
+                    {% if first_row.case %}
+                      <td rowspan="{{ test_case.rows }}">
+                        {% if test_case.url %}
+                          <a href="{{ test_case.url }}">{{ test_case.name }}</a>
+                        {% else %}
+                          {{ test_case.name }}
+                        {% endif %}
+                      </td>
+                    {% endif %}
+                    {% if first_row.step %}
+                      <td rowspan="{{ test_step.rows }}">
+                        {% if test_step.url %}
+                          <a href="{{ test_step.url }}">{{ test_step.name }}</a>
+                        {% else %}
+                          {{ test_step.name }}
+                        {% endif %}
+                      </td>
+                    {% endif %}
+                    <td class="{{ check.check_classname }}">
+                      {% if check.url %}
+                        <a href="{{ check.url }}">{{ check.name }}</a>
+                      {% else %}
+                        {{ check.name }}
+                      {% endif %}
+                      {% if check.successes + check.failures > 1 %}
+                        ({{ check.successes + check.failures }}x)
+                      {% endif %}
+                    </td>
+                  </tr>
 
-                {% set first_row.package = False %}
-                {% set first_row.requirement = False %}
-                {% set first_row.scenario = False %}
-                {% set first_row.case = False %}
-                {% set first_row.step = False %}
+                  {% set first_row.package = False %}
+                  {% set first_row.requirement = False %}
+                  {% set first_row.scenario = False %}
+                  {% set first_row.case = False %}
+                  {% set first_row.step = False %}
+                {% endfor %}
               {% endfor %}
             {% endfor %}
           {% endfor %}
-        {% endfor %}
+        {% else %}
+          <tr>
+            {% if first_row.package %}
+              <td rowspan="{{ package.rows }}">{{ package.name }}</td>
+            {% endif %}
+            <td class="not_tested">{{ requirement.id }}</td>
+            <td class="not_tested">Not tested</td>
+            <td colspan="4">Not implemented</td>
+          </tr>
+
+          {% set first_row.package = False %}
+        {% endif %}
       {% endfor %}
     {% endfor %}
   </table>

--- a/monitoring/uss_qualifier/reports/tested_requirements.py
+++ b/monitoring/uss_qualifier/reports/tested_requirements.py
@@ -1,6 +1,6 @@
 import os
 import shutil
-from typing import List, Union
+from typing import List, Union, Dict, Set, Optional
 
 from implicitdict import ImplicitDict
 from monitoring.monitorlib.inspection import import_submodules
@@ -11,7 +11,11 @@ from monitoring.uss_qualifier.action_generators.documentation.definitions import
 from monitoring.uss_qualifier.action_generators.documentation.documentation import (
     list_potential_actions_for_action_generator_definition,
 )
-from monitoring.uss_qualifier.configurations.configuration import ParticipantID
+from monitoring.uss_qualifier.configurations.configuration import (
+    ParticipantID,
+    TestedRequirementsConfiguration,
+    TestedRequirementsCollectionIdentifier,
+)
 from monitoring.uss_qualifier.fileio import load_dict_with_references
 from monitoring.uss_qualifier.reports import jinja_env
 from monitoring.uss_qualifier.reports.report import (
@@ -20,6 +24,10 @@ from monitoring.uss_qualifier.reports.report import (
     TestScenarioReport,
     PassedCheck,
     FailedCheck,
+)
+from monitoring.uss_qualifier.requirements.definitions import RequirementID
+from monitoring.uss_qualifier.requirements.documentation import (
+    resolve_requirements_collection,
 )
 from monitoring.uss_qualifier.scenarios.definitions import TestScenarioTypeName
 from monitoring.uss_qualifier.scenarios.documentation.parsing import get_documentation
@@ -34,6 +42,7 @@ from monitoring.uss_qualifier.suites.definitions import (
 class TestedCheck(ImplicitDict):
     name: str
     url: str
+    has_todo: bool
     successes: int = 0
     failures: int = 0
 
@@ -47,7 +56,19 @@ class TestedCheck(ImplicitDict):
             return "Pass"
 
     @property
-    def classname(self) -> str:
+    def check_classname(self) -> str:
+        if self.failures > 0:
+            return "fail_result"
+        if self.successes + self.failures == 0:
+            if self.has_todo:
+                return "has_todo"
+            else:
+                return "not_tested"
+        else:
+            return "pass_result"
+
+    @property
+    def result_classname(self) -> str:
         if self.failures > 0:
             return "fail_result"
         if self.successes + self.failures == 0:
@@ -121,7 +142,10 @@ class TestedRequirement(ImplicitDict):
 
     @property
     def rows(self) -> int:
-        return sum(s.rows for s in self.scenarios)
+        n = sum(s.rows for s in self.scenarios)
+        if n == 0:
+            n = 1
+        return n
 
     @property
     def classname(self) -> str:
@@ -147,13 +171,33 @@ class TestedBreakdown(ImplicitDict):
     packages: List[TestedPackage]
 
 
-def generate_tested_requirements(report: TestRunReport, output_path: str) -> None:
+def generate_tested_requirements(
+    report: TestRunReport, config: TestedRequirementsConfiguration
+) -> None:
+    req_collections: Dict[
+        TestedRequirementsCollectionIdentifier, Set[RequirementID]
+    ] = {}
+    if "requirement_collections" in config and config.requirement_collections:
+        req_collections = {
+            k: resolve_requirements_collection(v)
+            for k, v in config.requirement_collections.items()
+        }
+
+    participant_req_collections: Dict[ParticipantID, Set[RequirementID]] = {}
+    if "participant_requirements" in config and config.participant_requirements:
+        for k, v in config.participant_requirements.items():
+            if v not in req_collections:
+                raise ValueError(
+                    f"Participant {k}'s requirement collection {v} is not defined in `requirement_collections` of TestedRequirementsConfiguration"
+                )
+            participant_req_collections[k] = req_collections[v]
+
     import_submodules(scenarios)
     import_submodules(suites)
     import_submodules(action_generators)
 
-    os.makedirs(output_path, exist_ok=True)
-    index_file = os.path.join(output_path, "index.html")
+    os.makedirs(config.output_path, exist_ok=True)
+    index_file = os.path.join(config.output_path, "index.html")
 
     participant_ids = report.report.participant_ids()
     template = jinja_env.get_template("tested_requirements/test_run_report.html")
@@ -164,15 +208,20 @@ def generate_tested_requirements(report: TestRunReport, output_path: str) -> Non
         "tested_requirements/participant_tested_requirements.html"
     )
     for participant_id in participant_ids:
+        req_set = participant_req_collections.get(participant_id, None)
         participant_breakdown = TestedBreakdown(packages=[])
         _populate_breakdown_with_action_report(
-            participant_breakdown, report.report, participant_id
+            participant_breakdown, report.report, participant_id, req_set
         )
         _populate_breakdown_with_action_declaration(
-            participant_breakdown, report.configuration.action
+            participant_breakdown, report.configuration.action, req_set
         )
+        if participant_id in participant_req_collections:
+            _populate_breakdown_with_req_set(
+                participant_breakdown, participant_req_collections[participant_id]
+            )
         _sort_breakdown(participant_breakdown)
-        participant_file = os.path.join(output_path, f"{participant_id}.html")
+        participant_file = os.path.join(config.output_path, f"{participant_id}.html")
         with open(participant_file, "w") as f:
             f.write(
                 template.render(
@@ -189,22 +238,50 @@ def _sort_breakdown(breakdown: TestedBreakdown) -> None:
             requirement.scenarios.sort(key=lambda s: s.name)
 
 
+def _populate_breakdown_with_req_set(
+    breakdown: TestedBreakdown, req_set: Set[RequirementID]
+) -> None:
+    for req_id in req_set:
+        package_id = req_id.package()
+        matches = [p for p in breakdown.packages if p.id == package_id]
+        if matches:
+            tested_package = matches[0]
+        else:
+            tested_package = TestedPackage(
+                id=package_id, name=package_id, requirements=[]
+            )
+            breakdown.packages.append(tested_package)
+
+        short_req_id = req_id.split(".")[-1]
+        matches = [r for r in tested_package.requirements if r.id == short_req_id]
+        if matches:
+            tested_requirement = matches[0]
+        else:
+            tested_requirement = TestedRequirement(id=short_req_id, scenarios=[])
+            tested_package.requirements.append(tested_requirement)
+
+
 def _populate_breakdown_with_action_report(
     breakdown: TestedBreakdown,
     action: TestSuiteActionReport,
     participant_id: ParticipantID,
+    req_set: Optional[Set[RequirementID]],
 ) -> None:
     test_suite, test_scenario, action_generator = action.get_applicable_report()
     if test_scenario:
         return _populate_breakdown_with_scenario_report(
-            breakdown, action.test_scenario, participant_id
+            breakdown, action.test_scenario, participant_id, req_set
         )
     elif test_suite:
         for subaction in action.test_suite.actions:
-            _populate_breakdown_with_action_report(breakdown, subaction, participant_id)
+            _populate_breakdown_with_action_report(
+                breakdown, subaction, participant_id, req_set
+            )
     elif action_generator:
         for subaction in action.action_generator.actions:
-            _populate_breakdown_with_action_report(breakdown, subaction, participant_id)
+            _populate_breakdown_with_action_report(
+                breakdown, subaction, participant_id, req_set
+            )
     else:
         raise ValueError(f"Unsupported test suite report type")
 
@@ -213,6 +290,7 @@ def _populate_breakdown_with_scenario_report(
     breakdown: TestedBreakdown,
     scenario_report: TestScenarioReport,
     participant_id: ParticipantID,
+    req_set: Optional[Set[RequirementID]],
 ) -> None:
     scenario_type_name = scenario_report.scenario_type
     for case in scenario_report.cases:
@@ -221,7 +299,9 @@ def _populate_breakdown_with_scenario_report(
                 if participant_id not in check.participants:
                     continue
                 for req_id in check.requirements:
-                    package_id = ".".join(req_id.split(".")[0:-1])
+                    if req_set is not None and req_id not in req_set:
+                        continue
+                    package_id = req_id.package()
                     package_name = "<br>.".join(package_id.split("."))
                     matches = [p for p in breakdown.packages if p.id == package_id]
                     if matches:
@@ -283,7 +363,9 @@ def _populate_breakdown_with_scenario_report(
                     if matches:
                         tested_check = matches[0]
                     else:
-                        tested_check = TestedCheck(name=check.name, url="")
+                        tested_check = TestedCheck(
+                            name=check.name, url="", has_todo=False
+                        )  # TODO: Consider populating has_todo with documentation instead
                         if isinstance(check, FailedCheck):
                             tested_check.url = check.documentation_url
                         tested_step.checks.append(tested_check)
@@ -298,10 +380,13 @@ def _populate_breakdown_with_scenario_report(
 def _populate_breakdown_with_action_declaration(
     breakdown: TestedBreakdown,
     action: Union[TestSuiteActionDeclaration, PotentialGeneratedAction],
+    req_set: Optional[Set[RequirementID]],
 ) -> None:
     action_type = action.get_action_type()
     if action_type == ActionType.TestScenario:
-        _populate_breakdown_with_scenario(breakdown, action.test_scenario.scenario_type)
+        _populate_breakdown_with_scenario(
+            breakdown, action.test_scenario.scenario_type, req_set
+        )
     elif action_type == ActionType.TestSuite:
         if "suite_type" in action.test_suite and action.test_suite.suite_type:
             suite_def: TestSuiteDefinition = ImplicitDict.parse(
@@ -309,13 +394,13 @@ def _populate_breakdown_with_action_declaration(
                 TestSuiteDefinition,
             )
             for action in suite_def.actions:
-                _populate_breakdown_with_action_declaration(breakdown, action)
+                _populate_breakdown_with_action_declaration(breakdown, action, req_set)
         elif (
             "suite_definition" in action.test_suite
             and action.test_suite.suite_definition
         ):
             for action in action.test_suite.suite_definition:
-                _populate_breakdown_with_action_declaration(breakdown, action)
+                _populate_breakdown_with_action_declaration(breakdown, action, req_set)
         else:
             raise ValueError(f"Test suite action missing suite type or definition")
     elif action_type == ActionType.ActionGenerator:
@@ -323,13 +408,15 @@ def _populate_breakdown_with_action_declaration(
             action.action_generator
         )
         for action in potential_actions:
-            _populate_breakdown_with_action_declaration(breakdown, action)
+            _populate_breakdown_with_action_declaration(breakdown, action, req_set)
     else:
         raise NotImplementedError(f"Unsupported test suite action type: {action_type}")
 
 
 def _populate_breakdown_with_scenario(
-    breakdown: TestedBreakdown, scenario_type_name: TestScenarioTypeName
+    breakdown: TestedBreakdown,
+    scenario_type_name: TestScenarioTypeName,
+    req_set: Optional[Set[RequirementID]],
 ) -> None:
     scenario_type = get_scenario_type_by_name(scenario_type_name)
     scenario_doc = get_documentation(scenario_type)
@@ -337,7 +424,9 @@ def _populate_breakdown_with_scenario(
         for step in case.steps:
             for check in step.checks:
                 for req_id in check.applicable_requirements:
-                    package_id = ".".join(req_id.split(".")[0:-1])
+                    if req_set is not None and req_id not in req_set:
+                        continue
+                    package_id = req_id.package()
                     package_name = "<br>.".join(package_id.split("."))
                     matches = [p for p in breakdown.packages if p.id == package_id]
                     if matches:
@@ -397,8 +486,9 @@ def _populate_breakdown_with_scenario(
                     if matches:
                         tested_check = matches[0]
                     else:
-                        tested_check = TestedCheck(name=check.name, url=check.url)
-                        if not check.has_todo:
-                            tested_step.checks.append(tested_check)
+                        tested_check = TestedCheck(
+                            name=check.name, url=check.url, has_todo=check.has_todo
+                        )
+                        tested_step.checks.append(tested_check)
                     if not tested_check.url:
                         tested_check.url = check.url

--- a/schemas/monitoring/uss_qualifier/configurations/configuration/TestedRequirementsConfiguration.json
+++ b/schemas/monitoring/uss_qualifier/configurations/configuration/TestedRequirementsConfiguration.json
@@ -10,6 +10,38 @@
     "output_path": {
       "description": "Path of a folder into which report HTML files should be written",
       "type": "string"
+    },
+    "participant_requirements": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "If a requirement collection is specified for a participant, only the requirements in the specified collection will be listed on that participant's report.",
+      "properties": {
+        "$ref": {
+          "description": "Path to content that replaces the $ref",
+          "type": "string"
+        }
+      },
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "requirement_collections": {
+      "additionalProperties": {
+        "$ref": "../../requirements/definitions/RequirementCollection.json"
+      },
+      "description": "Definition of requirement collections specific to production of this artifact.",
+      "properties": {
+        "$ref": {
+          "description": "Path to content that replaces the $ref",
+          "type": "string"
+        }
+      },
+      "type": [
+        "object",
+        "null"
+      ]
     }
   },
   "required": [


### PR DESCRIPTION
This PR introduces the capability to define a set of requirements that each participant wants to demonstrate compliance with via the tested requirements artifact.  If omitted, the set of requirements is assumed to be all the currently-documented requirements potentially testable by the test run configuration (same as before this PR).