### PR TITLE
[uss_qualifier/reports] Link to requirement packages in tested requirements artifact

### DIFF
--- a/monitoring/uss_qualifier/reports/templates/tested_requirements/participant_tested_requirements.html
+++ b/monitoring/uss_qualifier/reports/templates/tested_requirements/participant_tested_requirements.html
@@ -79,7 +79,7 @@
     </tr>
     <tr>
       <td>Test run identifier</td>
-      <td>TR{{ test_run.test_run_id[0:7] }}</td>
+      <td>TR-{{ test_run.test_run_id[0:7] }}</td>
     </tr>
     {% if test_run.start_time %}
       <tr>
@@ -95,11 +95,11 @@
     {% endif %}
     <tr>
       <td>Test baseline identifier</td>
-      <td>TB{{ test_run.baseline[0:7] }}</td>
+      <td>TB-{{ test_run.baseline[0:7] }}</td>
     </tr>
     <tr>
       <td>Environment identifier</td>
-      <td>TE{{ test_run.environment[0:7] }}</td>
+      <td>TE-{{ test_run.environment[0:7] }}</td>
     </tr>
   </table>
 </div>
@@ -131,7 +131,7 @@
                 {% for check in test_step.checks %}
                   <tr>
                     {% if first_row.package %}
-                      <td rowspan="{{ package.rows }}"><span class="sticky_cell_value">{{ package.name }}</span></td>
+                      <td rowspan="{{ package.rows }}"><span class="sticky_cell_value"><a href="{{ package.url }}">{{ package.name }}</a></span></td>
                     {% endif %}
                     {% if first_row.requirement %}
                       <td rowspan="{{ requirement.rows }}" class="{{ requirement.classname }}"><span class="sticky_cell_value">{{ requirement.id }}</span></td>
@@ -188,10 +188,10 @@
         {% else %}
           <tr>
             {% if first_row.package %}
-              <td rowspan="{{ package.rows }}">{{ package.name }}</td>
+              <td rowspan="{{ package.rows }}"><span class="sticky_cell_value"><a href="{{ package.url }}">{{ package.name }}</a></span></td>
             {% endif %}
-            <td class="not_tested">{{ requirement.id }}</td>
-            <td class="not_tested">Not tested</td>
+            <td class="not_tested"><span class="sticky_cell_value">{{ requirement.id }}</span></td>
+            <td class="not_tested"><span class="sticky_cell_value">Not tested</span></td>
             <td colspan="4">Not implemented</td>
           </tr>
 

--- a/monitoring/uss_qualifier/reports/templates/tested_requirements/participant_tested_requirements.html
+++ b/monitoring/uss_qualifier/reports/templates/tested_requirements/participant_tested_requirements.html
@@ -20,6 +20,9 @@
     tr {
       border-top: 1px solid hsla(210,18%,87%,1);
     }
+    table tr:nth-child(2n) {
+      background-color: #f6f8fa;
+    }
     td {
       padding: 6px 6px;
       vertical-align: top;

--- a/monitoring/uss_qualifier/reports/tested_requirements.py
+++ b/monitoring/uss_qualifier/reports/tested_requirements.py
@@ -5,6 +5,7 @@ from typing import List, Union, Dict, Set, Optional
 from implicitdict import ImplicitDict, StringBasedDateTime
 
 from monitoring.monitorlib.inspection import import_submodules
+from monitoring.monitorlib.versioning import repo_url_of
 from monitoring.uss_qualifier import scenarios, suites, action_generators
 from monitoring.uss_qualifier.action_generators.documentation.definitions import (
     PotentialGeneratedAction,
@@ -26,7 +27,7 @@ from monitoring.uss_qualifier.reports.report import (
     PassedCheck,
     FailedCheck,
 )
-from monitoring.uss_qualifier.requirements.definitions import RequirementID
+from monitoring.uss_qualifier.requirements.definitions import RequirementID, PackageID
 from monitoring.uss_qualifier.requirements.documentation import (
     resolve_requirements_collection,
 )
@@ -160,7 +161,8 @@ class TestedRequirement(ImplicitDict):
 
 
 class TestedPackage(ImplicitDict):
-    id: str
+    id: PackageID
+    url: str
     name: str
     requirements: List[TestedRequirement]
 
@@ -275,8 +277,9 @@ def _populate_breakdown_with_req_set(
         if matches:
             tested_package = matches[0]
         else:
+            url = repo_url_of(package_id.md_file_path())
             tested_package = TestedPackage(
-                id=package_id, name=package_id, requirements=[]
+                id=package_id, url=url, name=package_id, requirements=[]
             )
             breakdown.packages.append(tested_package)
 
@@ -336,8 +339,9 @@ def _populate_breakdown_with_scenario_report(
                         tested_package = matches[0]
                     else:
                         # TODO: Improve name of package by using title of page
+                        url = repo_url_of(package_id.md_file_path())
                         tested_package = TestedPackage(
-                            id=package_id, name=package_name, requirements=[]
+                            id=package_id, url=url, name=package_name, requirements=[]
                         )
                         breakdown.packages.append(tested_package)
 
@@ -461,8 +465,9 @@ def _populate_breakdown_with_scenario(
                         tested_package = matches[0]
                     else:
                         # TODO: Improve name of package by using title of page
+                        url = repo_url_of(package_id.md_file_path())
                         tested_package = TestedPackage(
-                            id=package_id, name=package_name, requirements=[]
+                            id=package_id, url=url, name=package_name, requirements=[]
                         )
                         breakdown.packages.append(tested_package)
 

--- a/monitoring/uss_qualifier/requirements/definitions.py
+++ b/monitoring/uss_qualifier/requirements/definitions.py
@@ -35,13 +35,41 @@ class RequirementID(str):
         )
         return md_filename
 
-    def requirement_name(self) -> str:
+    def short_requirement_name(self) -> str:
         parts = self.split(".")
         return parts[-1]
 
-    def package(self) -> str:
+    def package(self) -> PackageID:
         parts = self.split(".")
-        return ".".join(parts[:-1])
+        return PackageID(".".join(parts[:-1]))
+
+
+class PackageID(str):
+    """Identifier for a package containing requirements.
+
+    Form: <FOLDERS>.md_file_name_without_extension
+
+    PackageID is a Python-style package reference to a .md file (without extension)
+    relative to uss_qualifier/requirements.  For instance, the PackageID for the file
+    located at uss_qualifier/requirements/astm/f3548/v21.md would be
+    `astm.f3548.v21`.
+    """
+
+    def __new__(cls, value):
+        illegal_characters = "#%&{}\\<>*?/ $!'\":@+`|="
+        if any(c in value for c in illegal_characters):
+            raise ValueError(
+                f'PackageID "{value}" may not contain any of these characters: {illegal_characters}'
+            )
+        str_value = str.__new__(cls, value)
+        return str_value
+
+    def md_file_path(self) -> str:
+        parts = self.split(".")
+        md_filename = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), os.path.join(*parts) + ".md")
+        )
+        return md_filename
 
 
 class RequirementSetID(str):

--- a/monitoring/uss_qualifier/requirements/documentation.py
+++ b/monitoring/uss_qualifier/requirements/documentation.py
@@ -11,6 +11,7 @@ from monitoring.uss_qualifier.requirements.definitions import (
     RequirementCollection,
     RequirementID,
     RequirementSetID,
+    PackageID,
 )
 
 
@@ -22,7 +23,7 @@ class Requirement(object):
 _verified_requirements: Set[RequirementID] = set()
 
 
-def _verify_requirements(parent: marko.element.Element, package: str) -> None:
+def _verify_requirements(parent: marko.element.Element, package: PackageID) -> None:
     if hasattr(parent, "children") and not isinstance(parent.children, str):
         for i, child in enumerate(parent.children):
             if isinstance(child, str):
@@ -51,7 +52,7 @@ def _load_requirement(requirement_id: RequirementID) -> None:
     _verify_requirements(doc, requirement_id.package())
     if requirement_id not in _verified_requirements:
         raise ValueError(
-            f'Requirement "{requirement_id.requirement_name()}" could not be found in "{md_filename}", so the requirement {requirement_id} could not be loaded (the file must contain `<tt>{requirement_id.requirement_name()}</tt>` somewhere in it, but does not)'
+            f'Requirement "{requirement_id.short_requirement_name()}" could not be found in "{md_filename}", so the requirement {requirement_id} could not be loaded (the file must contain `<tt>{requirement_id.short_requirement_name()}</tt>` somewhere in it, but does not)'
         )
 
 

--- a/monitoring/uss_qualifier/suites/documentation/documentation.py
+++ b/monitoring/uss_qualifier/suites/documentation/documentation.py
@@ -170,7 +170,9 @@ def make_test_suite_documentation(
             package_caption = "<br>.".join(package.split("."))
             package_line = f'    <td rowspan="{len(req_ids_by_package[package])}" style="vertical-align:top;"><a href="{req_md_path}">{package_caption}</a></td>'
             for req_id in sorted(req_ids_by_package[package]):
-                req_text = f'<a href="{req_md_path}">{req_id.requirement_name()}</a>'
+                req_text = (
+                    f'<a href="{req_md_path}">{req_id.short_requirement_name()}</a>'
+                )
 
                 has_todo = False
                 has_complete = False


### PR DESCRIPTION
This PR primarily adds links to requirement packages in the tested_requirements artifact optionally produced by uss_qualifier.  To accomplish this, it establishes a new explicit PackageID type and propagates that new type to appropriate places.

This PR also addresses a few minor issues with the tested_requirements artifact: it adds a dash to some identifiers, some missing span tags, and alternating-rows background formatting.

Finally, this PR improves the name of a RequirementID method to be more specific.