### PR TITLE
[uss_qualifier/scenarios/aggregate_checks] Convert unattributed queries check to a note

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/aggregate_checks.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/aggregate_checks.py
@@ -154,17 +154,10 @@ class AggregateChecks(ReportEvaluationScenario):
             if query.get("server_id") is None
         ]
         if len(unattr_queries) > 0:
-            # TODO clean this up: this is an internal requirement and not a check,
-            #  leaving as-is during development to make sure the test-suite runs but we know about unattributed queries
-            #  ultimately this check could go into the constructor and blow things up early
-
-            with self.check(
-                "No unattributed queries",
-                [],
-            ) as check:
-                check.record_failed(
-                    f"found unattributed queries: {unattr_queries}", Severity.Medium
-                )
+            self.record_note(
+                "unattributed-queries",
+                f"found unattributed queries: {unattr_queries}",
+            )
 
     def _inspect_participant_queries(
         self, participant_id: str, participant_queries: List[fetch.Query]

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/aggregate_checks.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/aggregate_checks.md
@@ -67,13 +67,6 @@ as being in "local debug" mode, they may serve requests over http without produc
 
 If non-encrypted interactions such as plaintext queries over http are allowed, **[astm.f3411.v19.NET0220](../../../../requirements/astm/f3411/v19.md)** is not satisfied.
 
-#### No unattributed queries check
-
-All queries must have been attributed to a participant: an unattributed query means that one of the test cases has not
-properly recorded to which participant it was made.
-
-This is an internal requirement and does not necessarily imply that there is a problem with the participants under test.
-
 ## Mock USS interactions evaluation test case
 
 In this test case, the interactions with a mock_uss instance (if provided) are obtained and then examined to verify

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/aggregate_checks.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/aggregate_checks.md
@@ -63,13 +63,6 @@ of the durations for the replies to requested flights in an area do not exceed t
 Inspects all record queries for their usage of https. If services such as a service provider, observer or DSS are marked
 as being in "local debug" mode, they may serve requests over http without producing failed checks despite their lack of encryption.
 
-#### No unattributed queries check
-
-All queries must have been attributed to a participant: an unattributed query means that one of the test cases has not
-properly recorded to which participant it was made.
-
-This is an internal requirement and does not necessarily imply that there is a problem with the participants under test.
-
 #### All interactions happen over https check
 
 If non-encrypted interactions such as plaintext queries over http are allowed, **[astm.f3411.v22a.NET0220](../../../../requirements/astm/f3411/v22a.md)** is not satisfied.


### PR DESCRIPTION
This check was problematic for #204 where there is a query that is not attributed but that's OK (a notification to a non-existent USS during the DSS interoperability scenario). Having a trace of the information is useful though, so this PR transforms it into a recorded note.