### PR TITLE
[uss_qualifier] NET0450 check that observed details (from a display provider) correspond to injected ones

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/netrid/display_data_evaluator.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/display_data_evaluator.py
@@ -433,6 +433,7 @@ class RIDObservationEvaluator(object):
 
         # Check details of flights (once per flight)
         for mapping in mapping_by_injection_id.values():
+
             with self._test_scenario.check(
                 "Successful details observation",
                 [mapping.injected_flight.uss_participant_id],
@@ -441,9 +442,10 @@ class RIDObservationEvaluator(object):
                 if mapping.observed_flight.id in self._retrieved_flight_details:
                     continue
 
-                details, query = observer.observe_flight_details(
+                details_obs, query = observer.observe_flight_details(
                     mapping.observed_flight.id, self._rid_version
                 )
+
                 self._test_scenario.record_query(query)
 
                 if query.status_code != 200:
@@ -454,9 +456,17 @@ class RIDObservationEvaluator(object):
                         query_timestamps=[query.request.timestamp],
                     )
                 else:
+                    telemetry_inj = mapping.injected_flight.flight.telemetry[
+                        mapping.telemetry_index
+                    ]
+                    # Get details that are expected to be valid for the present telemetry:
+                    details_inj = mapping.injected_flight.flight.get_details(
+                        telemetry_inj.timestamp.datetime
+                    )
                     self._retrieved_flight_details.add(mapping.observed_flight.id)
                     self._common_dictionary_evaluator.evaluate_dp_details(
-                        details,
+                        details_inj,
+                        details_obs,
                         participants=[
                             observer.participant_id,
                         ],

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/nominal_behavior.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/nominal_behavior.md
@@ -216,6 +216,10 @@ Per **[interuss.automated_testing.rid.observation.ObservationSuccess](../../../.
 
 **[astm.f3411.v22a.NET0470](../../../../requirements/astm/f3411/v22a.md)** requires that Net-RID Display Provider shall provide access to required and optional fields to Remote ID Display Applications according to the Common Dictionary. This check validates that if the UAS ID is in serial number format, its format is valid. (**[astm.f3411.v22a.NET0470,Table1,1a](../../../../requirements/astm/f3411/v22a.md)**)
 
+#### UAS ID is consistent with injected one check
+
+If the UAS ID contained in flight details returned by a display provider does not correspond to the injected one, the DP is not providing accurate data and is thus in breach of **[astm.f3411.v22a.NET0450](../../../../requirements/astm/f3411/v22a.md)**
+
 #### Timestamp consistency with Common Dictionary check
 
 **[astm.f3411.v22a.NET0470](../../../../requirements/astm/f3411/v22a.md)** requires that Net-RID Display Provider shall provide access to required and optional fields to Remote ID Display Applications according to the Common Dictionary. This check validates that timestamps are relative to UTC. (**[astm.f3411.v22a.NET0470,Table1,5](../../../../requirements/astm/f3411/v22a.md)**)
@@ -231,6 +235,10 @@ If the timestamp reported for an observation does not correspond to the injected
 #### Operator ID consistency with Common Dictionary check
 
 **[astm.f3411.v22a.NET0470](../../../../requirements/astm/f3411/v22a.md)** requires that Net-RID Display Provider shall (NET0470) provide access to required and optional fields to Remote ID Display Applications according to the Common Dictionary. This check validates that the Operator ID, if present, is valid. (**[astm.f3411.v22a.NET0470,Table1,9](../../../../requirements/astm/f3411/v22a.md)**)
+
+#### Operator ID is consistent with injected one check
+
+If the Operator ID contained in flight details returned by a display provider does not correspond to the injected one, the DP is not providing accurate data and is thus in breach of **[astm.f3411.v22a.NET0450](../../../../requirements/astm/f3411/v22a.md)**
 
 #### Current Position consistency with Common Dictionary check
 
@@ -269,13 +277,26 @@ If the speed reported for an observation does not correspond to the injected one
 
 **[astm.f3411.v22a.NET0470](../../../../requirements/astm/f3411/v22a.md)** requires that Net-RID Display Provider shall provide access to required and optional fields to Remote ID Display Applications according to the Common Dictionary. This check validates that the Operator Latitude (**[astm.f3411.v22a.NET0470,Table1,23](../../../../requirements/astm/f3411/v22a.md)**) and Longitude (**[astm.f3411.v22a.NET0470,Table1,24](../../../../requirements/astm/f3411/v22a.md)**), if present, are valid.
 
+#### Operator Location is consistent with injected one check
+
+If the Operator Location contained in flight details returned by a display provider does not correspond to the injected one, the DP is not providing accurate data and is thus in breach of **[astm.f3411.v22a.NET0450](../../../../requirements/astm/f3411/v22a.md)**
+
 #### Operator Altitude consistency with Common Dictionary check
 
 **[astm.f3411.v22a.NET0470](../../../../requirements/astm/f3411/v22a.md)** requires that Net-RID Display Provider shall provide access to required and optional fields to Remote ID Display Applications according to the Common Dictionary. This check validates that, if present, the Operator Altitude is based on WGS-84 height above ellipsoid (HAE) and is provided in meters. (**[astm.f3411.v22a.NET0470,Table1,25](../../../../requirements/astm/f3411/v22a.md)**)
 
+#### Operator Altitude is consistent with injected one check
+
+If the Operator Altitude contained in flight details returned by a display provider does not correspond to the injected one, the DP is not providing accurate data and is thus in breach of **[astm.f3411.v22a.NET0450](../../../../requirements/astm/f3411/v22a.md)**
+
 #### Operator Altitude Type consistency with Common Dictionary check
 
 **[astm.f3411.v22a.NET0470](../../../../requirements/astm/f3411/v22a.md)** requires that Net-RID Display Provider shall provide access to required and optional fields to Remote ID Display Applications according to the Common Dictionary. This check validates that the Operator Altitude Type is valid, if present. (**[astm.f3411.v22a.NET0470,Table1,26](../../../../requirements/astm/f3411/v22a.md)**)
+
+#### Operator Altitude Type is consistent with injected one check
+
+If the Operator Altitude Type contained in flight details returned by a display provider does not correspond to the injected one, the DP is not providing accurate data and is thus in breach of **[astm.f3411.v22a.NET0450](../../../../requirements/astm/f3411/v22a.md)**
+
 
 ## Cleanup
 


### PR DESCRIPTION
Also validate details that are observed through the DP.

Note that this PR also replaces a few dashes (from – to -) 