### PR TITLE
fix Docker container build on ARM hardware

### DIFF
--- a/monitoring/Dockerfile
+++ b/monitoring/Dockerfile
@@ -13,6 +13,10 @@ FROM python:3.8-slim
 # Not -alpine because: https://stackoverflow.com/a/58028091/651139
 
 RUN apt-get update && apt-get install -y openssl curl libgeos-dev gcc && apt-get install ca-certificates
+
+# required for gevent to build without error in an ARM environment
+RUN apt-get update && apt-get install -y libffi-dev libssl-dev python3-dev build-essential
+
 RUN mkdir -p /app/monitoring
 COPY ./requirements.txt /app/monitoring/requirements.txt
 RUN pip install -r /app/monitoring/requirements.txt


### PR DESCRIPTION
I can't confirm that the issue fixed by this PR only happens to me or applies to anyone trying to run the mocks and qualifier on an ARM environment (e.g. apple macbook m1).

The problem: running scripts such as `./monitoring/mock_uss/start_all_local_mocks.sh` ends with an error message: 

```bash
× Building wheel for gevent (pyproject.toml) did not run successfully.
exit code: 1
```

Installing those extra dependencies fixes the issue.