### PR TITLE
[mock_uss] Improve logging and use request_ids

### DIFF
--- a/monitoring/mock_uss/database.py
+++ b/monitoring/mock_uss/database.py
@@ -54,3 +54,7 @@ db = SynchronizedValue(
     Database(one_time_tasks=[], task_errors=[], periodic_tasks={}),
     decoder=lambda b: ImplicitDict.parse(json.loads(b.decode("utf-8")), Database),
 )
+
+fulfilled_request_ids = SynchronizedValue(
+    [], decoder=lambda b: json.loads(b.decode("utf-8"))
+)

--- a/monitoring/monitorlib/fetch/__init__.py
+++ b/monitoring/monitorlib/fetch/__init__.py
@@ -2,6 +2,7 @@ import datetime
 import json
 import os
 import traceback
+import uuid
 from typing import Dict, Optional, List
 
 from enum import Enum
@@ -312,6 +313,12 @@ def query_and_describe(
     req_kwargs = kwargs.copy()
     if "timeout" not in req_kwargs:
         req_kwargs["timeout"] = TIMEOUTS
+
+    # Attach a request_id field to the JSON body of any outgoing request with a JSON body that doesn't already have one
+    if "json" in req_kwargs and "request_id" not in req_kwargs["json"]:
+        json_body = json.loads(json.dumps(req_kwargs["json"]))
+        json_body["request_id"] = str(uuid.uuid4())
+        req_kwargs["json"] = json_body
 
     failures = []
     # Note: retry logic could be attached to the `client` Session by `mount`ing an HTTPAdapter with custom

--- a/monitoring/monitorlib/fetch/__init__.py
+++ b/monitoring/monitorlib/fetch/__init__.py
@@ -315,7 +315,11 @@ def query_and_describe(
         req_kwargs["timeout"] = TIMEOUTS
 
     # Attach a request_id field to the JSON body of any outgoing request with a JSON body that doesn't already have one
-    if "json" in req_kwargs and isinstance(req_kwargs["json"], dict) and "request_id" not in req_kwargs["json"]:
+    if (
+        "json" in req_kwargs
+        and isinstance(req_kwargs["json"], dict)
+        and "request_id" not in req_kwargs["json"]
+    ):
         json_body = json.loads(json.dumps(req_kwargs["json"]))
         json_body["request_id"] = str(uuid.uuid4())
         req_kwargs["json"] = json_body

--- a/monitoring/monitorlib/fetch/__init__.py
+++ b/monitoring/monitorlib/fetch/__init__.py
@@ -315,7 +315,7 @@ def query_and_describe(
         req_kwargs["timeout"] = TIMEOUTS
 
     # Attach a request_id field to the JSON body of any outgoing request with a JSON body that doesn't already have one
-    if "json" in req_kwargs and "request_id" not in req_kwargs["json"]:
+    if "json" in req_kwargs and isinstance(req_kwargs["json"], dict) and "request_id" not in req_kwargs["json"]:
         json_body = json.loads(json.dumps(req_kwargs["json"]))
         json_body["request_id"] = str(uuid.uuid4())
         req_kwargs["json"] = json_body


### PR DESCRIPTION
In an effort to address #230, this PR adds some additional logging in mock_uss and also attempts to make sure mutating requests are not accidentally repeated.  The latter is accomplished by always appending a `request_id` field to any outgoing requests which contain a JSON body and don't already have this field, then checking for that field in handlers for mutating operations.