### PR TITLE
[uss_qualifier] Migrate test_isa_validation prober to the new qualifier

### DIFF
--- a/monitoring/prober/infrastructure.py
+++ b/monitoring/prober/infrastructure.py
@@ -100,7 +100,7 @@ ResourceType = int
 resource_type_code_descriptions: Dict[ResourceType, str] = {}
 
 
-# Next code: 368
+# Next code: 369
 def register_resource_type(code: int, description: str) -> ResourceType:
     """Register that the specified code refers to the described resource.
 

--- a/monitoring/uss_qualifier/configurations/dev/library/resources.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/library/resources.yaml
@@ -46,6 +46,21 @@ net_rid:
             reference_time: '2023-01-10T00:00:00.123456+00:00'
             time_start: '2023-01-10T00:00:01.123456+00:00'
             time_end: '2023-01-10T01:00:01.123456+00:00'
+    problematically_big_area: # A huge (as in "too big") area for checks around area sizes
+        $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
+        resource_type: resources.VerticesResource
+        specification:
+            vertices:
+              - lat: -23
+                lng: 130
+              - lat: -24
+                lng: 130
+              - lat: -24
+                lng: 132
+              - lat: -23
+                lng: 132
+
+
 
 net_rid_sims:
     adjacent_circular_flights_data:

--- a/monitoring/uss_qualifier/configurations/dev/netrid_v19.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/netrid_v19.yaml
@@ -15,6 +15,7 @@ v1:
                     dss_instances: netrid_dss_instances_v19
                     id_generator: id_generator
                     service_area: service_area
+                    problematically_big_area: problematically_big_area
     artifacts:
         report:
             report_path: output/report_netrid_v19.json

--- a/monitoring/uss_qualifier/configurations/dev/netrid_v22a.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/netrid_v22a.yaml
@@ -15,6 +15,7 @@ v1:
                     dss_instances: netrid_dss_instances_v22a
                     id_generator: id_generator
                     service_area: service_area
+                    problematically_big_area: problematically_big_area
     artifacts:
         report:
             report_path: output/report_netrid_v22a.json

--- a/monitoring/uss_qualifier/resources/__init__.py
+++ b/monitoring/uss_qualifier/resources/__init__.py
@@ -1,0 +1,1 @@
+from .vertices import VerticesResource

--- a/monitoring/uss_qualifier/resources/vertices.py
+++ b/monitoring/uss_qualifier/resources/vertices.py
@@ -1,0 +1,21 @@
+from typing import List
+
+from implicitdict import ImplicitDict
+
+from monitoring.monitorlib.geo import LatLngPoint
+from monitoring.uss_qualifier.resources.resource import Resource
+
+
+class VerticesSpecification(ImplicitDict):
+    """Specifies a list of vertices representing a 2D area.
+    Useful for passing arbitrary areas to test scenarios."""
+
+    vertices: List[LatLngPoint]
+    """Represents a 2D area"""
+
+
+class VerticesResource(Resource[VerticesSpecification]):
+    specification: VerticesSpecification
+
+    def __init__(self, specification: VerticesSpecification):
+        self.specification = specification

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/isa_simple.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/isa_simple.py
@@ -11,15 +11,9 @@ from monitoring.uss_qualifier.common_data_definitions import Severity
 from monitoring.uss_qualifier.resources.astm.f3411.dss import DSSInstanceResource
 from monitoring.uss_qualifier.resources.interuss.id_generator import IDGeneratorResource
 from monitoring.uss_qualifier.resources.netrid.service_area import ServiceAreaResource
+from monitoring.uss_qualifier.resources import VerticesResource
 from monitoring.uss_qualifier.scenarios.astm.netrid.dss_wrapper import DSSWrapper
 from monitoring.uss_qualifier.scenarios.scenario import GenericTestScenario
-
-HUGE_VERTICES: List[s2sphere.LatLng] = [
-    s2sphere.LatLng.from_degrees(lng=130, lat=-23),
-    s2sphere.LatLng.from_degrees(lng=130, lat=-24),
-    s2sphere.LatLng.from_degrees(lng=132, lat=-24),
-    s2sphere.LatLng.from_degrees(lng=132, lat=-23),
-]
 
 
 class ISASimple(GenericTestScenario):
@@ -27,11 +21,14 @@ class ISASimple(GenericTestScenario):
 
     ISA_TYPE = register_resource_type(348, "ISA")
 
+    _huge_are: List[s2sphere.LatLng]
+
     def __init__(
         self,
         dss: DSSInstanceResource,
         id_generator: IDGeneratorResource,
         isa: ServiceAreaResource,
+        problematically_big_area: VerticesResource,
     ):
         super().__init__()
         self._dss = (
@@ -46,6 +43,9 @@ class ISASimple(GenericTestScenario):
         self._isa_start_time = self._isa.shifted_time_start(now)
         self._isa_end_time = self._isa.shifted_time_end(now)
         self._isa_area = [vertex.as_s2sphere() for vertex in self._isa.footprint]
+        self._huge_area = [
+            v.as_s2sphere() for v in problematically_big_area.specification.vertices
+        ]
 
     def run(self):
         self.begin_test_scenario()
@@ -362,7 +362,7 @@ class ISASimple(GenericTestScenario):
                 _ = self._dss_wrapper.search_isas_expect_response_code(
                     check,
                     expected_error_codes={413},
-                    area=HUGE_VERTICES,
+                    area=self._huge_area,
                 )
 
             self.end_test_step()

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/isa_validation.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/isa_validation.py
@@ -1,0 +1,329 @@
+import copy
+import datetime
+from typing import Optional, List, Dict, Any
+
+import arrow
+import s2sphere
+from uas_standards.astm.f3411 import v19, v22a
+
+from monitoring.monitorlib.fetch import query_and_describe
+from monitoring.monitorlib.mutate.rid import ChangedISA
+from monitoring.monitorlib.rid import RIDVersion
+from monitoring.prober.infrastructure import register_resource_type
+from monitoring.uss_qualifier.common_data_definitions import Severity
+from monitoring.uss_qualifier.resources import VerticesResource
+from monitoring.uss_qualifier.resources.astm.f3411.dss import DSSInstanceResource
+from monitoring.uss_qualifier.resources.interuss.id_generator import IDGeneratorResource
+from monitoring.uss_qualifier.resources.netrid.service_area import ServiceAreaResource
+from monitoring.uss_qualifier.scenarios.astm.netrid.common.dss import utils
+from monitoring.uss_qualifier.scenarios.astm.netrid.dss_wrapper import DSSWrapper
+from monitoring.uss_qualifier.scenarios.scenario import GenericTestScenario
+
+
+class ISAValidation(GenericTestScenario):
+    """Based on prober/rid/v2/test_isa_validation.py from the legacy prober tool."""
+
+    ISA_TYPE = register_resource_type(368, "ISA")
+
+    _huge_are: List[s2sphere.LatLng]
+
+    create_isa_path: str
+
+    write_scope: str
+
+    def __init__(
+        self,
+        dss: DSSInstanceResource,
+        id_generator: IDGeneratorResource,
+        isa: ServiceAreaResource,
+        problematically_big_area: VerticesResource,
+    ):
+        super().__init__()
+        self._dss = (
+            dss.dss_instance
+        )  # TODO: delete once _delete_isa_if_exists updated to use dss_wrapper
+        self._dss_wrapper = DSSWrapper(self, dss.dss_instance)
+        self._isa_id = id_generator.id_factory.make_id(ISAValidation.ISA_TYPE)
+        self._isa_version: Optional[str] = None
+        self._isa = isa.specification
+
+        now = arrow.utcnow().datetime
+        self._isa_start_time = self._isa.shifted_time_start(now)
+        self._isa_end_time = self._isa.shifted_time_end(now)
+        self._isa_area = [vertex.as_s2sphere() for vertex in self._isa.footprint]
+
+        self._huge_area = [
+            v.as_s2sphere() for v in problematically_big_area.specification.vertices
+        ]
+
+        if self._dss.rid_version == RIDVersion.f3411_19:
+            self.create_isa_path = v19.api.OPERATIONS[
+                v19.api.OperationID.CreateSubscription
+            ].path
+            self.write_scope = v19.constants.Scope.Write
+        elif self._dss.rid_version == RIDVersion.f3411_22a:
+            self.create_isa_path = v22a.api.OPERATIONS[
+                v22a.api.OperationID.CreateSubscription
+            ].path
+            self.write_scope = v22a.constants.Scope.ServiceProvider
+        else:
+            ValueError(f"Unsupported RID version '{self._dss.rid_version}'")
+
+    def run(self):
+        self.begin_test_scenario()
+
+        self._setup_case()
+
+        self.begin_test_case("ISA Validation")
+        self.begin_test_step("ISA Validation")
+
+        (create_isa_url, json_body) = self._isa_huge_area_check()
+
+        self._isa_empty_vertices_check()
+        self._isa_start_time_in_past()
+        self._isa_start_time_after_time_end()
+        self._isa_vertices_are_valid()
+
+        self._isa_missing_outline(create_isa_url, json_body)
+        self._isa_missing_volume(create_isa_url, json_body)
+
+        self.end_test_step()
+        self.end_test_case()
+        self.end_test_scenario()
+
+    def _setup_case(self):
+        self.begin_test_case("Setup")
+
+        def _ensure_clean_workspace_step():
+            self.begin_test_step("Ensure clean workspace")
+
+            self._delete_isa_if_exists()
+
+            self.end_test_step()
+
+        _ensure_clean_workspace_step()
+
+        self.end_test_case()
+
+    def _delete_isa_if_exists(self):
+        utils.delete_isa_if_exists(
+            self,
+            isa_id=self._isa_id,
+            rid_version=self._dss.rid_version,
+            session=self._dss.client,
+            server_id=self._dss_wrapper.participant_id,
+        )
+
+    def _isa_huge_area_check(self) -> (str, Dict[str, Any]):
+        """Returns the request's URL and json payload for subsequently re-using it.
+
+        It is of the following form (note that v19 and v22a have slight differences):
+
+        "extents": {
+            "volume": {
+                "outline_polygon": {
+                        "vertices": [],
+                },
+                "altitude_lower": 20.0,
+                "altitude_upper": 400.0,
+            },
+            "time_start": <timestamp>,
+            "time_end": <timestamp>,
+        },
+        "uss_base_url": <base_url>,
+        """
+
+        with self.check("ISA huge area", [self._dss_wrapper.participant_id]) as check:
+            q = self._dss_wrapper.put_isa_expect_response_code(
+                check=check,
+                expected_error_codes={400},
+                area_vertices=self._huge_area,
+                alt_lo=self._isa.altitude_min,
+                alt_hi=self._isa.altitude_max,
+                start_time=self._isa_start_time,
+                end_time=self._isa_end_time,
+                uss_base_url=self._isa.base_url,
+                isa_id=self._isa_id,
+                isa_version=self._isa_version,
+            )
+
+        return q.dss_query.query.request.url, q.dss_query.query.request.json
+
+    def _isa_empty_vertices_check(self):
+
+        with self.check(
+            "ISA empty vertices", [self._dss_wrapper.participant_id]
+        ) as check:
+            self._dss_wrapper.put_isa_expect_response_code(
+                check=check,
+                expected_error_codes={400},
+                area_vertices=[],
+                alt_lo=self._isa.altitude_min,
+                alt_hi=self._isa.altitude_max,
+                start_time=self._isa_start_time,
+                end_time=self._isa_end_time,
+                uss_base_url=self._isa.base_url,
+                isa_id=self._isa_id,
+                isa_version=self._isa_version,
+            )
+
+    def _isa_start_time_in_past(self):
+        time_start = datetime.datetime.utcnow() - datetime.timedelta(minutes=10)
+        time_end = time_start + datetime.timedelta(minutes=60)
+
+        with self.check(
+            "ISA start time in the past", [self._dss_wrapper.participant_id]
+        ) as check:
+            self._dss_wrapper.put_isa_expect_response_code(
+                check=check,
+                expected_error_codes={400},
+                area_vertices=self._isa_area,
+                alt_lo=self._isa.altitude_min,
+                alt_hi=self._isa.altitude_max,
+                start_time=time_start,
+                end_time=time_end,
+                uss_base_url=self._isa.base_url,
+                isa_id=self._isa_id,
+                isa_version=self._isa_version,
+            )
+
+    def _isa_start_time_after_time_end(self):
+        with self.check(
+            "ISA start time after end time", [self._dss_wrapper.participant_id]
+        ) as check:
+            self._dss_wrapper.put_isa_expect_response_code(
+                check=check,
+                expected_error_codes={400},
+                area_vertices=self._isa_area,
+                alt_lo=self._isa.altitude_min,
+                alt_hi=self._isa.altitude_max,
+                start_time=self._isa.time_end.datetime,
+                end_time=self._isa.time_start.datetime,
+                uss_base_url=self._isa.base_url,
+                isa_id=self._isa_id,
+                isa_version=self._isa_version,
+            )
+
+    def _isa_vertices_are_valid(self):
+        INVALID_VERTICES: List[s2sphere.LatLng] = [
+            s2sphere.LatLng.from_degrees(lat=130, lng=-23),
+            s2sphere.LatLng.from_degrees(lat=130, lng=-24),
+            s2sphere.LatLng.from_degrees(lat=132, lng=-24),
+            s2sphere.LatLng.from_degrees(lat=132, lng=-23),
+        ]
+
+        with self.check(
+            "ISA vertices are valid", [self._dss_wrapper.participant_id]
+        ) as check:
+            self._dss_wrapper.put_isa_expect_response_code(
+                check=check,
+                expected_error_codes={400},
+                area_vertices=INVALID_VERTICES,
+                alt_lo=self._isa.altitude_min,
+                alt_hi=self._isa.altitude_max,
+                start_time=self._isa.time_start.datetime,
+                end_time=self._isa.time_end.datetime,
+                uss_base_url=self._isa.base_url,
+                isa_id=self._isa_id,
+                isa_version=self._isa_version,
+            )
+
+    def _isa_missing_outline(self, create_isa_url: str, json_body: Dict[str, Any]):
+        payload = copy.deepcopy(json_body)
+        if self._dss.rid_version == RIDVersion.f3411_19:
+            del payload["extents"]["spatial_volume"]["footprint"]
+        elif self._dss.rid_version == RIDVersion.f3411_22a:
+            del payload["extents"]["volume"]["outline_polygon"]
+
+        with self.check(
+            "ISA missing outline", [self._dss_wrapper.participant_id]
+        ) as check:
+            q = query_and_describe(
+                client=self._dss.client,
+                verb="PUT",
+                url=create_isa_url,
+                scope=self.write_scope,
+                json=payload,
+            )
+            if self._dss.rid_version == RIDVersion.f3411_19:
+                rid_query = ChangedISA(v19_query=q)
+            elif self._dss.rid_version == RIDVersion.f3411_22a:
+                rid_query = ChangedISA(v22a_query=q)
+            else:
+                raise ValueError(f"Unknown RID version: {self._dss.rid_version}")
+
+            self._dss_wrapper._handle_query_result(
+                check=check,
+                q=rid_query,
+                fail_msg="ISA Creation with missing outline has unexpected result code",
+                required_status_code={400},
+                severity=Severity.High,
+            )
+
+    def _isa_missing_volume(self, create_isa_url: str, json_body: Dict[str, Any]):
+        payload = copy.deepcopy(json_body)
+        if self._dss.rid_version == RIDVersion.f3411_19:
+            del payload["extents"]["spatial_volume"]
+        elif self._dss.rid_version == RIDVersion.f3411_22a:
+            del payload["extents"]["volume"]
+
+        with self.check(
+            "ISA missing volume", [self._dss_wrapper.participant_id]
+        ) as check:
+            q = query_and_describe(
+                client=self._dss.client,
+                verb="PUT",
+                url=create_isa_url,
+                scope=self.write_scope,
+                json=payload,
+            )
+            if self._dss.rid_version == RIDVersion.f3411_19:
+                rid_query = ChangedISA(v19_query=q)
+            elif self._dss.rid_version == RIDVersion.f3411_22a:
+                rid_query = ChangedISA(v22a_query=q)
+            else:
+                raise ValueError(f"Unknown RID version: {self._dss.rid_version}")
+
+            self._dss_wrapper._handle_query_result(
+                check=check,
+                q=rid_query,
+                fail_msg="ISA Creation with missing outline has unexpected result code",
+                required_status_code={400},
+                severity=Severity.High,
+            )
+
+    def _isa_missing_extents(self, create_isa_url: str, json_body: Dict[str, Any]):
+        payload = copy.deepcopy(json_body)
+        del payload["extents"]
+
+        with self.check(
+            "ISA missing extents", [self._dss_wrapper.participant_id]
+        ) as check:
+            q = query_and_describe(
+                client=self._dss.client,
+                verb="PUT",
+                url=create_isa_url,
+                scope=self.write_scope,
+                json=payload,
+            )
+            if self._dss.rid_version == RIDVersion.f3411_19:
+                rid_query = ChangedISA(v19_query=q)
+            elif self._dss.rid_version == RIDVersion.f3411_22a:
+                rid_query = ChangedISA(v22a_query=q)
+            else:
+                raise ValueError(f"Unknown RID version: {self._dss.rid_version}")
+
+            self._dss_wrapper._handle_query_result(
+                check=check,
+                q=rid_query,
+                fail_msg="ISA Creation with missing outline has unexpected result code",
+                required_status_code={400},
+                severity=Severity.High,
+            )
+
+    def cleanup(self):
+        self.begin_cleanup()
+
+        self._delete_isa_if_exists()
+
+        self.end_cleanup()

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/utils.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/utils.py
@@ -1,0 +1,62 @@
+from typing import Optional
+
+from monitoring.monitorlib.fetch import rid as fetch
+from monitoring.monitorlib.mutate import rid as mutate
+from monitoring.monitorlib.infrastructure import UTMClientSession
+from monitoring.monitorlib.rid import RIDVersion
+from monitoring.uss_qualifier.common_data_definitions import Severity
+from monitoring.uss_qualifier.scenarios.scenario import GenericTestScenario
+
+
+def delete_isa_if_exists(
+    scenario: GenericTestScenario,
+    isa_id: str,
+    rid_version: RIDVersion,
+    session: UTMClientSession,
+    server_id: Optional[str] = None,
+):
+    fetched = fetch.isa(
+        isa_id,
+        rid_version=rid_version,
+        session=session,
+        server_id=server_id,
+    )
+    scenario.record_query(fetched.query)
+    with scenario.check("Successful ISA query", [server_id]) as check:
+        if not fetched.success and fetched.status_code != 404:
+            check.record_failed(
+                "ISA information could not be retrieved",
+                Severity.High,
+                f"{server_id} DSS instance returned {fetched.status_code} when queried for ISA {isa_id}",
+                query_timestamps=[fetched.query.request.timestamp],
+            )
+
+    if fetched.success:
+        deleted = mutate.delete_isa(
+            isa_id,
+            fetched.isa.version,
+            rid_version,
+            session,
+            server_id=server_id,
+        )
+        scenario.record_query(deleted.dss_query.query)
+        for subscriber_id, notification in deleted.notifications.items():
+            scenario.record_query(notification.query)
+        with scenario.check("Removed pre-existing ISA", [server_id]) as check:
+            if not deleted.dss_query.success:
+                check.record_failed(
+                    "Could not delete pre-existing ISA",
+                    Severity.High,
+                    f"Attempting to delete ISA {isa_id} from the {server_id} DSS returned error {deleted.dss_query.status_code}",
+                    query_timestamps=[deleted.dss_query.query.request.timestamp],
+                )
+        for subscriber_url, notification in deleted.notifications.items():
+            with scenario.check("Notified subscriber", [subscriber_url]) as check:
+                # TODO: Find a better way to identify a subscriber who couldn't be notified
+                if not notification.success:
+                    check.record_failed(
+                        "Could not notify ISA subscriber",
+                        Severity.Medium,
+                        f"Attempting to notify subscriber for ISA {isa_id} at {subscriber_url} resulted in {notification.status_code}",
+                        query_timestamps=[notification.query.request.timestamp],
+                    )

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/__init__.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/__init__.py
@@ -1,3 +1,4 @@
 from .isa_simple import ISASimple
+from .isa_validation import ISAValidation
 from .subscription_validation import SubscriptionValidation
 from .crdb_access import CRDBAccess

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/isa_simple.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/isa_simple.md
@@ -19,6 +19,10 @@ after its time of applicability.
 
 [`ServiceAreaResource`](../../../../../resources/netrid/service_area.py) describing an ISA to be created.
 
+### problematically_big_area
+
+[`VerticesResource`](../../../../../resources/vertices.py) describing an area designed to be too big to be accepted by the DSS.
+
 ## Setup test case
 
 ### Ensure clean workspace test step

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/isa_validation.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/isa_validation.md
@@ -1,0 +1,99 @@
+# ASTM NetRID DSS: Submitted ISA Validations test scenario
+
+## Overview
+
+Perform basic operations on a single DSS instance to create an ISA and query it during its time of applicability and
+after its time of applicability.
+
+## Resources
+
+### dss
+
+[`DSSInstanceResource`](../../../../../resources/astm/f3411/dss.py) to be tested in this scenario.
+
+### id_generator
+
+[`IDGeneratorResource`](../../../../../resources/interuss/id_generator.py) providing the ISA ID for this scenario.
+
+### isa
+
+[`ServiceAreaResource`](../../../../../resources/netrid/service_area.py) describing an ISA to be created.
+
+### problematically_big_area
+
+[`VerticesResource`](../../../../../resources/vertices.py) describing an area designed to be too big to be accepted by the DSS.
+
+## Setup test case
+
+### Ensure clean workspace test step
+
+This scenario creates an ISA with a known ID.  This step ensures that ISA does not exist before the start of the main
+part of the test.
+
+#### Successful ISA query check
+
+**[astm.f3411.v19.DSS0030](../../../../../requirements/astm/f3411/v19.md)** requires the implementation of the DSS endpoint enabling retrieval of information about a specific ISA; if the individual ISA cannot be retrieved and the error isn't a 404, then this requirement isn't met.
+
+#### Removed pre-existing ISA check
+
+If an ISA with the intended ID is already present in the DSS, it needs to be removed before proceeding with the test.  If that ISA cannot be deleted, then the **[astm.f3411.v19.DSS0030](../../../../../requirements/astm/f3411/v19.md)** requirement to implement the ISA deletion endpoint might not be met.
+
+#### Notified subscriber check
+
+When a pre-existing ISA needs to be deleted to ensure a clean workspace, any subscribers to ISAs in that area must be notified (as specified by the DSS).  If a notification cannot be delivered, then the **[astm.f3411.v19.NET0710](../../../../../requirements/astm/f3411/v19.md)** requirement to implement the POST ISAs endpoint isn't met.
+
+
+## ISA Validation test case
+
+### ISA Validation test step
+
+#### ISA huge area check
+
+Attempting to put a too large ISA should result in a 400.
+
+#### ISA empty vertices check
+
+An ISA with a empty `vertices` array in the `extents.spatial_volume.footprint` field of the ISA creation payload should not result in a successful submission.
+
+#### ISA start time in the past check
+
+The DSS must reject ISAs with start times in the past.
+
+#### ISA start time after end time check
+
+The DSS must reject ISAs for which the start time is after the end time.
+
+#### ISA vertices are valid check
+
+The DSS must reject ISAs with invalid vertices, such as vertices that have latitude or longitude outside meaningful ranges.
+
+#### ISA missing outline check
+
+If the outline polygon is missing from the `extents.spatial_volume.footprint` field in the payload of the ISA creation request,
+the DSS is expected to reject the request.
+
+#### ISA missing volume check
+
+If the outline polygon is missing from the `extents.spatial_volume` field in the payload of the ISA creation request,
+the DSS is expected to reject the request.
+
+#### ISA missing extents check
+
+If the `extents` field is missing from the payload of the ISA creation request,
+the DSS is expected to reject the request.
+
+## Cleanup
+
+The cleanup phase of this test scenario attempts to remove the ISA if the test ended prematurely.
+
+### Successful ISA query check
+
+**[astm.f3411.v19.DSS0030](../../../../../requirements/astm/f3411/v19.md)** requires the implementation of the DSS endpoint enabling retrieval of information about a specific ISA; if the individual ISA cannot be retrieved and the error isn't a 404, then this requirement isn't met.
+
+### Removed pre-existing ISA check
+
+If an ISA with the intended ID is still present in the DSS, it needs to be removed before exiting the test. If that ISA cannot be deleted, then the **[astm.f3411.v19.DSS0030](../../../../../requirements/astm/f3411/v19.md)** requirement to implement the ISA deletion endpoint might not be met.
+
+### Notified subscriber check
+
+When an ISA is deleted, subscribers must be notified. If a subscriber cannot be notified, that subscriber USS did not correctly implement "POST Identification Service Area" in **[astm.f3411.v19.NET0730](../../../../../requirements/astm/f3411/v19.md)**.

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/isa_validation.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/isa_validation.py
@@ -1,0 +1,8 @@
+from monitoring.uss_qualifier.scenarios.astm.netrid.common.dss.isa_validation import (
+    ISAValidation as CommonISAValidation,
+)
+from monitoring.uss_qualifier.scenarios.scenario import TestScenario
+
+
+class ISAValidation(TestScenario, CommonISAValidation):
+    pass

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/__init__.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/__init__.py
@@ -1,3 +1,4 @@
 from .isa_simple import ISASimple
+from .isa_validation import ISAValidation
 from .subscription_validation import SubscriptionValidation
 from .crdb_access import CRDBAccess

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/isa_simple.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/isa_simple.md
@@ -19,6 +19,10 @@ after its time of applicability.
 
 [`ServiceAreaResource`](../../../../../resources/netrid/service_area.py) describing an ISA to be created.
 
+### problematically_big_area
+
+[`VerticesResource`](../../../../../resources/vertices.py) describing an area designed to be too big to be accepted by the DSS.
+
 ## Setup test case
 
 ### Ensure clean workspace test step

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/isa_validation.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/isa_validation.md
@@ -1,0 +1,99 @@
+# ASTM NetRID DSS: Submitted ISA Validations test scenario
+
+## Overview
+
+Perform basic operations on a single DSS instance to create an ISA and query it during its time of applicability and
+after its time of applicability.
+
+## Resources
+
+### dss
+
+[`DSSInstanceResource`](../../../../../resources/astm/f3411/dss.py) to be tested in this scenario.
+
+### id_generator
+
+[`IDGeneratorResource`](../../../../../resources/interuss/id_generator.py) providing the ISA ID for this scenario.
+
+### isa
+
+[`ServiceAreaResource`](../../../../../resources/netrid/service_area.py) describing an ISA to be created.
+
+### problematically_big_area
+
+[`VerticesResource`](../../../../../resources/vertices.py) describing an area designed to be too big to be accepted by the DSS.
+
+## Setup test case
+
+### Ensure clean workspace test step
+
+This scenario creates an ISA with a known ID.  This step ensures that ISA does not exist before the start of the main
+part of the test.
+
+#### Successful ISA query check
+
+**[astm.f3411.v22a.DSS0030](../../../../../requirements/astm/f3411/v22a.md)** requires the implementation of the DSS endpoint enabling retrieval of information about a specific ISA; if the individual ISA cannot be retrieved and the error isn't a 404, then this requirement isn't met.
+
+#### Removed pre-existing ISA check
+
+If an ISA with the intended ID is already present in the DSS, it needs to be removed before proceeding with the test.  If that ISA cannot be deleted, then the **[astm.f3411.v22a.DSS0030](../../../../../requirements/astm/f3411/v22a.md)** requirement to implement the ISA deletion endpoint might not be met.
+
+#### Notified subscriber check
+
+When a pre-existing ISA needs to be deleted to ensure a clean workspace, any subscribers to ISAs in that area must be notified (as specified by the DSS).  If a notification cannot be delivered, then the **[astm.f3411.v22a.NET0710](../../../../../requirements/astm/f3411/v22a.md)** requirement to implement the POST ISAs endpoint isn't met.
+
+
+## ISA Validation test case
+
+### ISA Validation test step
+
+#### ISA huge area check
+
+Attempting to put a too large ISA should result in a 400.
+
+#### ISA empty vertices check
+
+An ISA with a empty `vertices` array in the `extents.volume.outline_polygon` field of the ISA creation payload should not result in a successful submission.
+
+#### ISA start time in the past check
+
+The DSS must reject ISAs with start times in the past.
+
+#### ISA start time after end time check
+
+The DSS must reject ISAs for which the start time is after the end time.
+
+#### ISA vertices are valid check
+
+The DSS must reject ISAs with invalid vertices, such as vertices that have latitude or longitude outside meaningful ranges.
+
+#### ISA missing outline check
+
+If the outline polygon is missing from the `extents.volume.outline_polygon` field in the payload of the ISA creation request,
+the DSS is expected to reject the request.
+
+#### ISA missing volume check
+
+If the outline polygon is missing from the `extents.volume` field in the payload of the ISA creation request,
+the DSS is expected to reject the request.
+
+#### ISA missing extents check
+
+If the `extents` field is missing from the payload of the ISA creation request,
+the DSS is expected to reject the request.
+
+## Cleanup
+
+The cleanup phase of this test scenario attempts to remove the ISA if the test ended prematurely.
+
+### Successful ISA query check
+
+**[astm.f3411.v22a.DSS0030](../../../../../requirements/astm/f3411/v22a.md)** requires the implementation of the DSS endpoint enabling retrieval of information about a specific ISA; if the individual ISA cannot be retrieved and the error isn't a 404, then this requirement isn't met.
+
+### Removed pre-existing ISA check
+
+If an ISA with the intended ID is still present in the DSS, it needs to be removed before exiting the test. If that ISA cannot be deleted, then the **[astm.f3411.v22a.DSS0030](../../../../../requirements/astm/f3411/v22a.md)** requirement to implement the ISA deletion endpoint might not be met.
+
+### Notified subscriber check
+
+When an ISA is deleted, subscribers must be notified. If a subscriber cannot be notified, that subscriber USS did not correctly implement "POST Identification Service Area" in **[astm.f3411.v22a.NET0730](../../../../../requirements/astm/f3411/v22a.md)**.

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/isa_validation.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/isa_validation.py
@@ -1,0 +1,8 @@
+from monitoring.uss_qualifier.scenarios.astm.netrid.common.dss.isa_validation import (
+    ISAValidation as CommonISAValidation,
+)
+from monitoring.uss_qualifier.scenarios.scenario import TestScenario
+
+
+class ISAValidation(TestScenario, CommonISAValidation):
+    pass

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_19.md
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_19.md
@@ -94,7 +94,7 @@
   <tr>
     <td><a href="../../../requirements/astm/f3411/v19.md">DSS0030</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/netrid/v19/dss_interoperability.md">ASTM F3411-19 NetRID DSS interoperability</a><br><a href="../../../scenarios/astm/netrid/v19/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../../scenarios/astm/netrid/v19/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/netrid/v19/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
+    <td><a href="../../../scenarios/astm/netrid/v19/dss_interoperability.md">ASTM F3411-19 NetRID DSS interoperability</a><br><a href="../../../scenarios/astm/netrid/v19/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../../scenarios/astm/netrid/v19/dss/isa_validation.md">ASTM NetRID DSS: Submitted ISA Validations</a><br><a href="../../../scenarios/astm/netrid/v19/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/netrid/v19/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3411/v19.md">DSS0050</a></td>
@@ -274,12 +274,12 @@
   <tr>
     <td><a href="../../../requirements/astm/f3411/v19.md">NET0710</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/netrid/v19/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../../scenarios/astm/netrid/v19/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
+    <td><a href="../../../scenarios/astm/netrid/v19/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../../scenarios/astm/netrid/v19/dss/isa_validation.md">ASTM NetRID DSS: Submitted ISA Validations</a><br><a href="../../../scenarios/astm/netrid/v19/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3411/v19.md">NET0730</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/netrid/v19/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a></td>
+    <td><a href="../../../scenarios/astm/netrid/v19/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../../scenarios/astm/netrid/v19/dss/isa_validation.md">ASTM NetRID DSS: Submitted ISA Validations</a></td>
   </tr>
   <tr>
     <td rowspan="4" style="vertical-align:top;"><a href="../../../requirements/interuss/automated_testing/rid/injection.md">interuss<br>.automated_testing<br>.rid<br>.injection</a></td>

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_19.yaml
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_19.yaml
@@ -7,6 +7,7 @@ resources:
   dss_instances: resources.astm.f3411.DSSInstancesResource
   id_generator: resources.interuss.IDGeneratorResource
   service_area: resources.netrid.ServiceAreaResource
+  problematically_big_area: resources.VerticesResource
 actions:
   - action_generator:
       generator_type: action_generators.astm.f3411.ForEachDSS
@@ -14,6 +15,7 @@ actions:
         dss_instances: dss_instances
         id_generator: id_generator
         service_area: service_area
+        problematically_big_area: problematically_big_area
       specification:
         action_to_repeat:
           test_suite:
@@ -23,6 +25,7 @@ actions:
               all_dss_instances: dss_instances
               id_generator: id_generator
               isa: service_area
+              problematically_big_area: problematically_big_area
           on_failure: Continue
         dss_instances_source: dss_instances
         dss_instance_id: dss

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_19/dss_probing.md
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_19/dss_probing.md
@@ -5,9 +5,10 @@
 ## [Actions](../../../README.md#actions)
 
 1. Scenario: [ASTM NetRID DSS: Simple ISA](../../../../scenarios/astm/netrid/v19/dss/isa_simple.md) ([`scenarios.astm.netrid.v19.dss.ISASimple`](../../../../scenarios/astm/netrid/v19/dss/isa_simple.py))
-2. Scenario: [ASTM NetRID DSS: Subscription Validation](../../../../scenarios/astm/netrid/v19/dss/subscription_validation.md) ([`scenarios.astm.netrid.v19.dss.SubscriptionValidation`](../../../../scenarios/astm/netrid/v19/dss/subscription_validation.py))
-3. Scenario: [ASTM F3411-19 NetRID DSS interoperability](../../../../scenarios/astm/netrid/v19/dss_interoperability.md) ([`scenarios.astm.netrid.v19.DSSInteroperability`](../../../../scenarios/astm/netrid/v19/dss_interoperability.py))
-4. Scenario: [ASTM NetRID DSS: Direct CRDB access](../../../../scenarios/astm/netrid/v19/dss/crdb_access.md) ([`scenarios.astm.netrid.v19.dss.CRDBAccess`](../../../../scenarios/astm/netrid/v19/dss/crdb_access.py))
+2. Scenario: [ASTM NetRID DSS: Submitted ISA Validations](../../../../scenarios/astm/netrid/v19/dss/isa_validation.md) ([`scenarios.astm.netrid.v19.dss.ISAValidation`](../../../../scenarios/astm/netrid/v19/dss/isa_validation.py))
+3. Scenario: [ASTM NetRID DSS: Subscription Validation](../../../../scenarios/astm/netrid/v19/dss/subscription_validation.md) ([`scenarios.astm.netrid.v19.dss.SubscriptionValidation`](../../../../scenarios/astm/netrid/v19/dss/subscription_validation.py))
+4. Scenario: [ASTM F3411-19 NetRID DSS interoperability](../../../../scenarios/astm/netrid/v19/dss_interoperability.md) ([`scenarios.astm.netrid.v19.DSSInteroperability`](../../../../scenarios/astm/netrid/v19/dss_interoperability.py))
+5. Scenario: [ASTM NetRID DSS: Direct CRDB access](../../../../scenarios/astm/netrid/v19/dss/crdb_access.md) ([`scenarios.astm.netrid.v19.dss.CRDBAccess`](../../../../scenarios/astm/netrid/v19/dss/crdb_access.py))
 
 ## [Checked requirements](../../../README.md#checked-requirements)
 
@@ -92,7 +93,7 @@
   <tr>
     <td><a href="../../../../requirements/astm/f3411/v19.md">DSS0030</a></td>
     <td>Implemented</td>
-    <td><a href="../../../../scenarios/astm/netrid/v19/dss_interoperability.md">ASTM F3411-19 NetRID DSS interoperability</a><br><a href="../../../../scenarios/astm/netrid/v19/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../../../scenarios/astm/netrid/v19/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a></td>
+    <td><a href="../../../../scenarios/astm/netrid/v19/dss_interoperability.md">ASTM F3411-19 NetRID DSS interoperability</a><br><a href="../../../../scenarios/astm/netrid/v19/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../../../scenarios/astm/netrid/v19/dss/isa_validation.md">ASTM NetRID DSS: Submitted ISA Validations</a><br><a href="../../../../scenarios/astm/netrid/v19/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a></td>
   </tr>
   <tr>
     <td><a href="../../../../requirements/astm/f3411/v19.md">DSS0050</a></td>
@@ -177,11 +178,11 @@
   <tr>
     <td><a href="../../../../requirements/astm/f3411/v19.md">NET0710</a></td>
     <td>Implemented</td>
-    <td><a href="../../../../scenarios/astm/netrid/v19/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a></td>
+    <td><a href="../../../../scenarios/astm/netrid/v19/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../../../scenarios/astm/netrid/v19/dss/isa_validation.md">ASTM NetRID DSS: Submitted ISA Validations</a></td>
   </tr>
   <tr>
     <td><a href="../../../../requirements/astm/f3411/v19.md">NET0730</a></td>
     <td>Implemented</td>
-    <td><a href="../../../../scenarios/astm/netrid/v19/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a></td>
+    <td><a href="../../../../scenarios/astm/netrid/v19/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../../../scenarios/astm/netrid/v19/dss/isa_validation.md">ASTM NetRID DSS: Submitted ISA Validations</a></td>
   </tr>
 </table>

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_19/dss_probing.yaml
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_19/dss_probing.yaml
@@ -4,6 +4,7 @@ resources:
   all_dss_instances: resources.astm.f3411.DSSInstancesResource?
   id_generator: resources.interuss.IDGeneratorResource
   isa: resources.netrid.ServiceAreaResource
+  problematically_big_area: resources.VerticesResource
 actions:
   - test_scenario:
       scenario_type: scenarios.astm.netrid.v19.dss.ISASimple
@@ -11,6 +12,14 @@ actions:
         dss: dss
         id_generator: id_generator
         isa: isa
+        problematically_big_area: problematically_big_area
+  - test_scenario:
+      scenario_type: scenarios.astm.netrid.v19.dss.ISAValidation
+      resources:
+        dss: dss
+        id_generator: id_generator
+        isa: isa
+        problematically_big_area: problematically_big_area
   - test_scenario:
       scenario_type: scenarios.astm.netrid.v19.dss.SubscriptionValidation
       resources:

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a.md
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a.md
@@ -94,7 +94,7 @@
   <tr>
     <td><a href="../../../requirements/astm/f3411/v22a.md">DSS0030</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/netrid/v22a/dss_interoperability.md">ASTM F3411-22a NetRID DSS interoperability</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/netrid/v22a/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
+    <td><a href="../../../scenarios/astm/netrid/v22a/dss_interoperability.md">ASTM F3411-22a NetRID DSS interoperability</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/isa_validation.md">ASTM NetRID DSS: Submitted ISA Validations</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/netrid/v22a/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3411/v22a.md">DSS0050</a></td>
@@ -384,12 +384,12 @@
   <tr>
     <td><a href="../../../requirements/astm/f3411/v22a.md">NET0710</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../../scenarios/astm/netrid/v22a/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
+    <td><a href="../../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/isa_validation.md">ASTM NetRID DSS: Submitted ISA Validations</a><br><a href="../../../scenarios/astm/netrid/v22a/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3411/v22a.md">NET0730</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a></td>
+    <td><a href="../../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/isa_validation.md">ASTM NetRID DSS: Submitted ISA Validations</a></td>
   </tr>
   <tr>
     <td rowspan="4" style="vertical-align:top;"><a href="../../../requirements/interuss/automated_testing/rid/injection.md">interuss<br>.automated_testing<br>.rid<br>.injection</a></td>

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a.yaml
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a.yaml
@@ -7,6 +7,7 @@ resources:
   dss_instances: resources.astm.f3411.DSSInstancesResource
   id_generator: resources.interuss.IDGeneratorResource
   service_area: resources.netrid.ServiceAreaResource
+  problematically_big_area: resources.VerticesResource
 actions:
   - action_generator:
       generator_type: action_generators.astm.f3411.ForEachDSS
@@ -14,6 +15,7 @@ actions:
         dss_instances: dss_instances
         id_generator: id_generator
         service_area: service_area
+        problematically_big_area: problematically_big_area
       specification:
         action_to_repeat:
           test_suite:
@@ -23,6 +25,7 @@ actions:
               all_dss_instances: dss_instances
               id_generator: id_generator
               isa: service_area
+              problematically_big_area: problematically_big_area
           on_failure: Continue
         dss_instances_source: dss_instances
         dss_instance_id: dss

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a/dss_probing.md
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a/dss_probing.md
@@ -5,9 +5,10 @@
 ## [Actions](../../../README.md#actions)
 
 1. Scenario: [ASTM NetRID DSS: Simple ISA](../../../../scenarios/astm/netrid/v22a/dss/isa_simple.md) ([`scenarios.astm.netrid.v22a.dss.ISASimple`](../../../../scenarios/astm/netrid/v22a/dss/isa_simple.py))
-2. Scenario: [ASTM NetRID DSS: Subscription Validation](../../../../scenarios/astm/netrid/v22a/dss/subscription_validation.md) ([`scenarios.astm.netrid.v22a.dss.SubscriptionValidation`](../../../../scenarios/astm/netrid/v22a/dss/subscription_validation.py))
-3. Scenario: [ASTM F3411-22a NetRID DSS interoperability](../../../../scenarios/astm/netrid/v22a/dss_interoperability.md) ([`scenarios.astm.netrid.v22a.DSSInteroperability`](../../../../scenarios/astm/netrid/v22a/dss_interoperability.py))
-4. Scenario: [ASTM NetRID DSS: Direct CRDB access](../../../../scenarios/astm/netrid/v22a/dss/crdb_access.md) ([`scenarios.astm.netrid.v22a.dss.CRDBAccess`](../../../../scenarios/astm/netrid/v22a/dss/crdb_access.py))
+2. Scenario: [ASTM NetRID DSS: Submitted ISA Validations](../../../../scenarios/astm/netrid/v22a/dss/isa_validation.md) ([`scenarios.astm.netrid.v22a.dss.ISAValidation`](../../../../scenarios/astm/netrid/v22a/dss/isa_validation.py))
+3. Scenario: [ASTM NetRID DSS: Subscription Validation](../../../../scenarios/astm/netrid/v22a/dss/subscription_validation.md) ([`scenarios.astm.netrid.v22a.dss.SubscriptionValidation`](../../../../scenarios/astm/netrid/v22a/dss/subscription_validation.py))
+4. Scenario: [ASTM F3411-22a NetRID DSS interoperability](../../../../scenarios/astm/netrid/v22a/dss_interoperability.md) ([`scenarios.astm.netrid.v22a.DSSInteroperability`](../../../../scenarios/astm/netrid/v22a/dss_interoperability.py))
+5. Scenario: [ASTM NetRID DSS: Direct CRDB access](../../../../scenarios/astm/netrid/v22a/dss/crdb_access.md) ([`scenarios.astm.netrid.v22a.dss.CRDBAccess`](../../../../scenarios/astm/netrid/v22a/dss/crdb_access.py))
 
 ## [Checked requirements](../../../README.md#checked-requirements)
 
@@ -92,7 +93,7 @@
   <tr>
     <td><a href="../../../../requirements/astm/f3411/v22a.md">DSS0030</a></td>
     <td>Implemented</td>
-    <td><a href="../../../../scenarios/astm/netrid/v22a/dss_interoperability.md">ASTM F3411-22a NetRID DSS interoperability</a><br><a href="../../../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../../../scenarios/astm/netrid/v22a/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a></td>
+    <td><a href="../../../../scenarios/astm/netrid/v22a/dss_interoperability.md">ASTM F3411-22a NetRID DSS interoperability</a><br><a href="../../../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../../../scenarios/astm/netrid/v22a/dss/isa_validation.md">ASTM NetRID DSS: Submitted ISA Validations</a><br><a href="../../../../scenarios/astm/netrid/v22a/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a></td>
   </tr>
   <tr>
     <td><a href="../../../../requirements/astm/f3411/v22a.md">DSS0050</a></td>
@@ -182,11 +183,11 @@
   <tr>
     <td><a href="../../../../requirements/astm/f3411/v22a.md">NET0710</a></td>
     <td>Implemented</td>
-    <td><a href="../../../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a></td>
+    <td><a href="../../../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../../../scenarios/astm/netrid/v22a/dss/isa_validation.md">ASTM NetRID DSS: Submitted ISA Validations</a></td>
   </tr>
   <tr>
     <td><a href="../../../../requirements/astm/f3411/v22a.md">NET0730</a></td>
     <td>Implemented</td>
-    <td><a href="../../../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a></td>
+    <td><a href="../../../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../../../scenarios/astm/netrid/v22a/dss/isa_validation.md">ASTM NetRID DSS: Submitted ISA Validations</a></td>
   </tr>
 </table>

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a/dss_probing.yaml
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a/dss_probing.yaml
@@ -4,6 +4,7 @@ resources:
   all_dss_instances: resources.astm.f3411.DSSInstancesResource?
   id_generator: resources.interuss.IDGeneratorResource
   isa: resources.netrid.ServiceAreaResource
+  problematically_big_area: resources.VerticesResource
 actions:
   - test_scenario:
       scenario_type: scenarios.astm.netrid.v22a.dss.ISASimple
@@ -11,6 +12,14 @@ actions:
         dss: dss
         id_generator: id_generator
         isa: isa
+        problematically_big_area: problematically_big_area
+  - test_scenario:
+      scenario_type: scenarios.astm.netrid.v22a.dss.ISAValidation
+      resources:
+        dss: dss
+        id_generator: id_generator
+        isa: isa
+        problematically_big_area: problematically_big_area
   - test_scenario:
       scenario_type: scenarios.astm.netrid.v22a.dss.SubscriptionValidation
       resources:

--- a/monitoring/uss_qualifier/suites/interuss/dss/all_tests.md
+++ b/monitoring/uss_qualifier/suites/interuss/dss/all_tests.md
@@ -92,7 +92,7 @@
   <tr>
     <td><a href="../../../requirements/astm/f3411/v19.md">DSS0030</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/netrid/v19/dss_interoperability.md">ASTM F3411-19 NetRID DSS interoperability</a><br><a href="../../../scenarios/astm/netrid/v19/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../../scenarios/astm/netrid/v19/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a></td>
+    <td><a href="../../../scenarios/astm/netrid/v19/dss_interoperability.md">ASTM F3411-19 NetRID DSS interoperability</a><br><a href="../../../scenarios/astm/netrid/v19/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../../scenarios/astm/netrid/v19/dss/isa_validation.md">ASTM NetRID DSS: Submitted ISA Validations</a><br><a href="../../../scenarios/astm/netrid/v19/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3411/v19.md">DSS0050</a></td>
@@ -177,12 +177,12 @@
   <tr>
     <td><a href="../../../requirements/astm/f3411/v19.md">NET0710</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/netrid/v19/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a></td>
+    <td><a href="../../../scenarios/astm/netrid/v19/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../../scenarios/astm/netrid/v19/dss/isa_validation.md">ASTM NetRID DSS: Submitted ISA Validations</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3411/v19.md">NET0730</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/netrid/v19/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a></td>
+    <td><a href="../../../scenarios/astm/netrid/v19/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../../scenarios/astm/netrid/v19/dss/isa_validation.md">ASTM NetRID DSS: Submitted ISA Validations</a></td>
   </tr>
   <tr>
     <td rowspan="34" style="vertical-align:top;"><a href="../../../requirements/astm/f3411/v22a.md">astm<br>.f3411<br>.v22a</a></td>
@@ -258,7 +258,7 @@
   <tr>
     <td><a href="../../../requirements/astm/f3411/v22a.md">DSS0030</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/netrid/v22a/dss_interoperability.md">ASTM F3411-22a NetRID DSS interoperability</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a></td>
+    <td><a href="../../../scenarios/astm/netrid/v22a/dss_interoperability.md">ASTM F3411-22a NetRID DSS interoperability</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/isa_validation.md">ASTM NetRID DSS: Submitted ISA Validations</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3411/v22a.md">DSS0050</a></td>
@@ -348,11 +348,11 @@
   <tr>
     <td><a href="../../../requirements/astm/f3411/v22a.md">NET0710</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a></td>
+    <td><a href="../../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/isa_validation.md">ASTM NetRID DSS: Submitted ISA Validations</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3411/v22a.md">NET0730</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a></td>
+    <td><a href="../../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/isa_validation.md">ASTM NetRID DSS: Submitted ISA Validations</a></td>
   </tr>
 </table>

--- a/monitoring/uss_qualifier/suites/uspace/network_identification.md
+++ b/monitoring/uss_qualifier/suites/uspace/network_identification.md
@@ -89,7 +89,7 @@
   <tr>
     <td><a href="../../requirements/astm/f3411/v22a.md">DSS0030</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/netrid/v22a/dss_interoperability.md">ASTM F3411-22a NetRID DSS interoperability</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../scenarios/astm/netrid/v22a/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a><br><a href="../../scenarios/astm/netrid/v22a/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
+    <td><a href="../../scenarios/astm/netrid/v22a/dss_interoperability.md">ASTM F3411-22a NetRID DSS interoperability</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_validation.md">ASTM NetRID DSS: Submitted ISA Validations</a><br><a href="../../scenarios/astm/netrid/v22a/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a><br><a href="../../scenarios/astm/netrid/v22a/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3411/v22a.md">DSS0050</a></td>
@@ -379,12 +379,12 @@
   <tr>
     <td><a href="../../requirements/astm/f3411/v22a.md">NET0710</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../scenarios/astm/netrid/v22a/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
+    <td><a href="../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_validation.md">ASTM NetRID DSS: Submitted ISA Validations</a><br><a href="../../scenarios/astm/netrid/v22a/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3411/v22a.md">NET0730</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a></td>
+    <td><a href="../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_validation.md">ASTM NetRID DSS: Submitted ISA Validations</a></td>
   </tr>
   <tr>
     <td rowspan="4" style="vertical-align:top;"><a href="../../requirements/interuss/automated_testing/rid/injection.md">interuss<br>.automated_testing<br>.rid<br>.injection</a></td>

--- a/monitoring/uss_qualifier/suites/uspace/required_services.md
+++ b/monitoring/uss_qualifier/suites/uspace/required_services.md
@@ -90,7 +90,7 @@
   <tr>
     <td><a href="../../requirements/astm/f3411/v22a.md">DSS0030</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/netrid/v22a/dss_interoperability.md">ASTM F3411-22a NetRID DSS interoperability</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../scenarios/astm/netrid/v22a/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a><br><a href="../../scenarios/astm/netrid/v22a/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
+    <td><a href="../../scenarios/astm/netrid/v22a/dss_interoperability.md">ASTM F3411-22a NetRID DSS interoperability</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_validation.md">ASTM NetRID DSS: Submitted ISA Validations</a><br><a href="../../scenarios/astm/netrid/v22a/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a><br><a href="../../scenarios/astm/netrid/v22a/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3411/v22a.md">DSS0050</a></td>
@@ -380,12 +380,12 @@
   <tr>
     <td><a href="../../requirements/astm/f3411/v22a.md">NET0710</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../scenarios/astm/netrid/v22a/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
+    <td><a href="../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_validation.md">ASTM NetRID DSS: Submitted ISA Validations</a><br><a href="../../scenarios/astm/netrid/v22a/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3411/v22a.md">NET0730</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a></td>
+    <td><a href="../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_validation.md">ASTM NetRID DSS: Submitted ISA Validations</a></td>
   </tr>
   <tr>
     <td rowspan="19" style="vertical-align:top;"><a href="../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>

--- a/schemas/monitoring/monitorlib/geo/Altitude.json
+++ b/schemas/monitoring/monitorlib/geo/Altitude.json
@@ -1,0 +1,34 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/monitorlib/geo/Altitude.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "monitoring.monitorlib.geo.Altitude, as defined in monitoring/monitorlib/geo.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "reference": {
+      "enum": [
+        "W84",
+        "SFC"
+      ],
+      "type": "string"
+    },
+    "units": {
+      "enum": [
+        "M",
+        "FT"
+      ],
+      "type": "string"
+    },
+    "value": {
+      "type": "number"
+    }
+  },
+  "required": [
+    "reference",
+    "units",
+    "value"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/monitorlib/geo/Circle.json
+++ b/schemas/monitoring/monitorlib/geo/Circle.json
@@ -1,0 +1,22 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/monitorlib/geo/Circle.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "monitoring.monitorlib.geo.Circle, as defined in monitoring/monitorlib/geo.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "center": {
+      "$ref": "LatLngPoint.json"
+    },
+    "radius": {
+      "$ref": "Radius.json"
+    }
+  },
+  "required": [
+    "center",
+    "radius"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/monitorlib/geo/LatLngBoundingBox.json
+++ b/schemas/monitoring/monitorlib/geo/LatLngBoundingBox.json
@@ -1,0 +1,34 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/monitorlib/geo/LatLngBoundingBox.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Bounding box in latitude and longitude\n\nmonitoring.monitorlib.geo.LatLngBoundingBox, as defined in monitoring/monitorlib/geo.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "lat_max": {
+      "description": "Upper latitude bound (degrees)",
+      "type": "number"
+    },
+    "lat_min": {
+      "description": "Lower latitude bound (degrees)",
+      "type": "number"
+    },
+    "lng_max": {
+      "description": "Upper longitude bound (degrees)",
+      "type": "number"
+    },
+    "lng_min": {
+      "description": "Lower longitude bound (degrees)",
+      "type": "number"
+    }
+  },
+  "required": [
+    "lat_max",
+    "lat_min",
+    "lng_max",
+    "lng_min"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/monitorlib/geo/LatLngPoint.json
+++ b/schemas/monitoring/monitorlib/geo/LatLngPoint.json
@@ -1,0 +1,24 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/monitorlib/geo/LatLngPoint.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Vertex in latitude and longitude\n\nmonitoring.monitorlib.geo.LatLngPoint, as defined in monitoring/monitorlib/geo.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "lat": {
+      "description": "Latitude (degrees)",
+      "type": "number"
+    },
+    "lng": {
+      "description": "Longitude (degrees)",
+      "type": "number"
+    }
+  },
+  "required": [
+    "lat",
+    "lng"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/monitorlib/geo/Polygon.json
+++ b/schemas/monitoring/monitorlib/geo/Polygon.json
@@ -1,0 +1,21 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/monitorlib/geo/Polygon.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "monitoring.monitorlib.geo.Polygon, as defined in monitoring/monitorlib/geo.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "vertices": {
+      "items": {
+        "$ref": "LatLngPoint.json"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "vertices"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/monitorlib/geo/Radius.json
+++ b/schemas/monitoring/monitorlib/geo/Radius.json
@@ -1,0 +1,26 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/monitorlib/geo/Radius.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "monitoring.monitorlib.geo.Radius, as defined in monitoring/monitorlib/geo.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "units": {
+      "enum": [
+        "M",
+        "FT"
+      ],
+      "type": "string"
+    },
+    "value": {
+      "type": "number"
+    }
+  },
+  "required": [
+    "units",
+    "value"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/monitorlib/geo/Volume3D.json
+++ b/schemas/monitoring/monitorlib/geo/Volume3D.json
@@ -1,0 +1,52 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/monitorlib/geo/Volume3D.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "monitoring.monitorlib.geo.Volume3D, as defined in monitoring/monitorlib/geo.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "altitude_lower": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "Altitude.json"
+        }
+      ]
+    },
+    "altitude_upper": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "Altitude.json"
+        }
+      ]
+    },
+    "outline_circle": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "Circle.json"
+        }
+      ]
+    },
+    "outline_polygon": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "Polygon.json"
+        }
+      ]
+    }
+  },
+  "type": "object"
+}

--- a/schemas/monitoring/uss_qualifier/resources/vertices/VerticesSpecification.json
+++ b/schemas/monitoring/uss_qualifier/resources/vertices/VerticesSpecification.json
@@ -1,0 +1,22 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/uss_qualifier/resources/vertices/VerticesSpecification.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Specifies a list of vertices representing a 2D area.\nUseful for passing arbitrary areas to test scenarios.\n\nmonitoring.uss_qualifier.resources.vertices.VerticesSpecification, as defined in monitoring/uss_qualifier/resources/vertices.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "vertices": {
+      "description": "Represents a 2D area",
+      "items": {
+        "$ref": "../../../monitorlib/geo/LatLngPoint.json"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "vertices"
+  ],
+  "type": "object"
+}


### PR DESCRIPTION
Migrates the previous `test_isa_validation` prober test to the new qualifier.

This attempts to support both v19 and v22a.