### PR TITLE
[uss_qualifier] Fix U-space test

### DIFF
--- a/monitoring/uss_qualifier/configurations/dev/f3548.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/f3548.yaml
@@ -12,8 +12,8 @@ v1:
           conflicting_flights: conflicting_flights
           priority_preemption_flights: priority_preemption_flights
           invalid_flight_intents: invalid_flight_intents
-          dss: dss
-          dss_instances: dss_instances
+          dss: scd_dss
+          dss_instances: scd_dss_instances
   artifacts:
     tested_roles:
       report_path: output/tested_roles_f3548

--- a/monitoring/uss_qualifier/configurations/dev/library/environment.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/library/environment.yaml
@@ -138,7 +138,7 @@ f3548:
                 -   participant_id: uss2
                     injection_base_url: http://scdsc.uss2.localutm/scdsc
                     local_debug: true
-    dss:
+    scd_dss:
         $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
         resource_type: resources.astm.f3548.v21.DSSInstanceResource
         dependencies:
@@ -147,7 +147,7 @@ f3548:
             participant_id: uss1
             base_url: http://dss.uss1.localutm
             has_private_address: true
-    dss_instances:
+    scd_dss_instances:
         $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
         resource_type: resources.astm.f3548.v21.DSSInstancesResource
         dependencies:

--- a/monitoring/uss_qualifier/configurations/dev/uspace.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/uspace.yaml
@@ -17,7 +17,8 @@ v1:
           invalid_flight_intents: invalid_flight_intents
           invalid_flight_auth_flights: invalid_flight_auth_flights
           flight_planners: flight_planners
-          dss: dss
+          scd_dss: scd_dss
+          scd_dss_instances: scd_dss_instances
 
           flights_data: adjacent_circular_flights_data
           service_providers: netrid_service_providers_v22a
@@ -26,6 +27,7 @@ v1:
           netrid_dss_instances: netrid_dss_instances_v22a
           id_generator: id_generator
           service_area: service_area
+          problematically_big_area: problematically_big_area
         specification:
           mock_uss_instances_source: mock_uss_instances
           locality_source: locality
@@ -38,7 +40,8 @@ v1:
                 invalid_flight_intents: invalid_flight_intents
                 invalid_flight_auth_flights: invalid_flight_auth_flights
                 flight_planners: flight_planners
-                dss: dss
+                scd_dss: scd_dss
+                scd_dss_instances: scd_dss_instances
 
                 flights_data: flights_data
                 service_providers: service_providers
@@ -47,6 +50,7 @@ v1:
                 netrid_dss_instances: netrid_dss_instances
                 id_generator: id_generator
                 service_area: service_area
+                problematically_big_area: problematically_big_area
             on_failure: Continue
   artifacts:
     tested_roles:

--- a/monitoring/uss_qualifier/reports/report.py
+++ b/monitoring/uss_qualifier/reports/report.py
@@ -609,6 +609,9 @@ class ParticipantCapabilityEvaluationReport(ImplicitDict):
 
 
 class SkippedActionReport(ImplicitDict):
+    timestamp: StringBasedDateTime
+    """The time at which the action was skipped."""
+
     reason: str
     """The reason the action was skipped."""
 

--- a/monitoring/uss_qualifier/reports/templates/sequence_view/overview.html
+++ b/monitoring/uss_qualifier/reports/templates/sequence_view/overview.html
@@ -60,6 +60,9 @@
     .not_tested {
       background-color: rgb(192, 192, 192);
     }
+    .skipped_explanation {
+      font-style: italic;
+    }
   </style>
   {{ explorer_header() }}
 </head>
@@ -167,11 +170,19 @@
             {% endif %}
           {% endif %}
         {% endfor %}
-        <td>
-          <a href="s{{ row.scenario_node.scenario.scenario_index }}.html">{{ row.scenario_node.scenario.name }}</a>
-        </td>
+        {% if row.scenario_node %}
+          <td>
+            <a href="s{{ row.scenario_node.scenario.scenario_index }}.html">{{ row.scenario_node.scenario.name }}</a>
+          </td>
+        {% endif %}
+        {% if row.skipped_action_node %}
+          <td>
+            <p>Skipped: {{ row.skipped_action_node.name }}</p>
+            <p class="skipped_explanation">{{ row.skipped_action_node.skipped_action.reason }}</p>
+          </td>
+        {% endif %}
         {% for participant_id in all_participants %}
-          {% if participant_id in row.scenario_node.scenario.participants %}
+          {% if row.scenario_node and participant_id in row.scenario_node.scenario.participants %}
             {% if row.scenario_node.scenario.participants[participant_id].has_failures %}
               <td class="fail_result">&#x274C;</td>
             {% else %}

--- a/monitoring/uss_qualifier/suites/suite.py
+++ b/monitoring/uss_qualifier/suites/suite.py
@@ -220,6 +220,7 @@ class TestSuite(object):
             except MissingResourceError as e:
                 skipped_actions.append(
                     SkippedActionReport(
+                        timestamp=StringBasedDateTime(arrow.utcnow().datetime),
                         reason=str(e),
                         action_declaration_index=a,
                         declaration=action_dec,

--- a/monitoring/uss_qualifier/suites/uspace/flight_auth.yaml
+++ b/monitoring/uss_qualifier/suites/uspace/flight_auth.yaml
@@ -6,6 +6,7 @@ resources:
   invalid_flight_intents: resources.flight_planning.FlightIntentsResource
   flight_planners: resources.flight_planning.FlightPlannersResource
   dss: resources.astm.f3548.v21.DSSInstanceResource
+  dss_instances: resources.astm.f3548.v21.DSSInstancesResource?
 
 actions:
 - test_suite:
@@ -16,6 +17,7 @@ actions:
       invalid_flight_intents: invalid_flight_intents
       flight_planners: flight_planners
       dss: dss
+      dss_instances: dss_instances
   on_failure: Continue
 - action_generator:
     generator_type: action_generators.flight_planning.FlightPlannerCombinations

--- a/monitoring/uss_qualifier/suites/uspace/network_identification.yaml
+++ b/monitoring/uss_qualifier/suites/uspace/network_identification.yaml
@@ -7,6 +7,7 @@ resources:
   dss_instances: resources.astm.f3411.DSSInstancesResource
   id_generator: resources.interuss.IDGeneratorResource
   service_area: resources.netrid.ServiceAreaResource
+  problematically_big_area: resources.VerticesResource
 actions:
 - test_suite:
     suite_type: suites.astm.netrid.f3411_22a
@@ -18,6 +19,7 @@ actions:
       dss_instances: dss_instances
       id_generator: id_generator
       service_area: service_area
+      problematically_big_area: problematically_big_area
   on_failure: Continue
 participant_verifiable_capabilities:
 - id: uspace_netrid_service_provider

--- a/monitoring/uss_qualifier/suites/uspace/required_services.yaml
+++ b/monitoring/uss_qualifier/suites/uspace/required_services.yaml
@@ -5,7 +5,8 @@ resources:
   invalid_flight_intents: resources.flight_planning.FlightIntentsResource
   invalid_flight_auth_flights: resources.flight_planning.FlightIntentsResource
   flight_planners: resources.flight_planning.FlightPlannersResource
-  dss: resources.astm.f3548.v21.DSSInstanceResource
+  scd_dss: resources.astm.f3548.v21.DSSInstanceResource
+  scd_dss_instances: resources.astm.f3548.v21.DSSInstancesResource?
 
   flights_data: resources.netrid.FlightDataResource
   service_providers: resources.netrid.NetRIDServiceProviders
@@ -14,6 +15,7 @@ resources:
   netrid_dss_instances: resources.astm.f3411.DSSInstancesResource
   id_generator: resources.interuss.IDGeneratorResource
   service_area: resources.netrid.ServiceAreaResource
+  problematically_big_area: resources.VerticesResource
 actions:
 - test_suite:
     suite_type: suites.uspace.flight_auth
@@ -23,7 +25,8 @@ actions:
       invalid_flight_intents: invalid_flight_intents
       invalid_flight_auth_flights: invalid_flight_auth_flights
       flight_planners: flight_planners
-      dss: dss
+      dss: scd_dss
+      dss_instances: scd_dss_instances
   on_failure: Continue
 - test_suite:
     suite_type: suites.uspace.network_identification
@@ -35,6 +38,7 @@ actions:
       dss_instances: netrid_dss_instances
       id_generator: id_generator
       service_area: service_area
+      problematically_big_area: problematically_big_area
   on_failure: Continue
 participant_verifiable_capabilities:
     - id: required_services

--- a/schemas/monitoring/uss_qualifier/reports/report/SkippedActionReport.json
+++ b/schemas/monitoring/uss_qualifier/reports/report/SkippedActionReport.json
@@ -18,12 +18,18 @@
     "reason": {
       "description": "The reason the action was skipped.",
       "type": "string"
+    },
+    "timestamp": {
+      "description": "The time at which the action was skipped.",
+      "format": "date-time",
+      "type": "string"
     }
   },
   "required": [
     "action_declaration_index",
     "declaration",
-    "reason"
+    "reason",
+    "timestamp"
   ],
   "type": "object"
 }


### PR DESCRIPTION
Currently, the U-space development test is skipping two test suites because recently-created resources are not being provided to the lower-level test suites by the high-level test suites.  This is causing a few different artifacts to render in confusing ways.  This PR first fixes the sequence view artifact to show skipped actions in a reasonable way, and then fixes the skipped actions by providing the new resources from the higher-level test suites.