### PR TITLE
[CI] Update GitHub checkout action version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         echo "Branch: ${{ github.ref }}"
         docker images
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: true
     - name: Python lint
@@ -92,7 +92,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: true
           path: monitoring

--- a/.github/workflows/dev-checks.yml
+++ b/.github/workflows/dev-checks.yml
@@ -9,20 +9,20 @@ jobs:
     name: Clone on Windows
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Checkout on Windows
         run: echo "Project successfully cloned on ${{ runner.os }}. See `Set up Job` stage for more details about the Runner."
   macos:
     name: Clone on Mac
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Checkout on Mac
         run: echo "Project successfully cloned on ${{ runner.os }}. See `Set up Job` stage for more details about the Runner."
   ubuntu:
     name: Clone on Ubuntu
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Checkout on Ubuntu
         run: echo "Project successfully cloned on ${{ runner.os }}. See `Set up Job` stage for more details about the Runner."

--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -31,7 +31,7 @@ jobs:
           docker images
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/monitoring-test.yml
+++ b/.github/workflows/monitoring-test.yml
@@ -26,7 +26,7 @@ jobs:
         echo "Branch: ${{ github.ref }}"
         docker images
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: true
     - name: Run ${{ inputs.name }} test


### PR DESCRIPTION
Currently, our Actions summaries have warnings that our [checkout@v2 action](https://github.com/actions/checkout) "uses node12 which is deprecated and will be forced to run on node16".  This PR upgrades to checkout@v4 to resolve those warnings.  No functional changes are intended or anticipated.