### PR TITLE
[hygiene] Apply shell lint entire repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ format: json-schema
 	cd monitoring && make format
 
 .PHONY: lint
-lint:
+lint: shell-lint
 	cd monitoring && make lint
 	cd schemas && make lint
 
@@ -35,8 +35,7 @@ validate-uss-qualifier-docs:
 
 .PHONY: shell-lint
 shell-lint:
-	echo "===== Checking DSS shell lint except monitoring =====" && find . -name '*.sh' | grep -v '^./interfaces/astm-utm' | grep -v '^./monitoring' | xargs docker run --rm -v "$(CURDIR):/monitoring" -w /monitoring koalaman/shellcheck
-	cd monitoring && make shell-lint
+	find . -name '*.sh' | grep -v '^./interfaces' | xargs docker run --rm -v "$(CURDIR):/monitoring" -w /monitoring koalaman/shellcheck
 
 .PHONY: json-schema
 json-schema:

--- a/monitoring/Makefile
+++ b/monitoring/Makefile
@@ -12,12 +12,6 @@ python-lint:
 	cd monitorlib && make python-lint
 	cd prober && make python-lint
 
-.PHONY: shell-lint
-shell-lint:
-	cd uss_qualifier && make shell-lint
-	cd mock_uss && make shell-lint
-	cd prober && make shell-lint
-
 .PHONY: format
 format:
 	cd uss_qualifier && make format

--- a/monitoring/atproxy/start.sh
+++ b/monitoring/atproxy/start.sh
@@ -24,7 +24,7 @@ gunicorn \
     --workers=4 \
     --threads=2 \
     --timeout 60 \
-    --bind=0.0.0.0:${port} \
+    "--bind=0.0.0.0:${port}" \
     --log-level debug \
     --config ./gunicorn.conf.py \
     monitoring.atproxy.app:webapp

--- a/monitoring/mock_uss/Makefile
+++ b/monitoring/mock_uss/Makefile
@@ -1,14 +1,10 @@
 .PHONY: lint
-lint: python-lint shell-lint
+lint: python-lint
 	echo "mock_uss lint complete"
 
 .PHONY: python-lint
 python-lint:
 	docker run --rm -v "$(CURDIR):/code" -w /code pyfound/black:22.10.0 black --check . || (echo "Linter didn't succeed. You can use the following command to fix python linter issues: make format" && exit 1)
-
-.PHONY: shell-lint
-shell-lint:
-	find . -name '*.sh' | xargs docker run --rm -v "$(CURDIR):/code" -w /code koalaman/shellcheck
 
 .PHONY: format
 format:

--- a/monitoring/prober/Makefile
+++ b/monitoring/prober/Makefile
@@ -1,13 +1,9 @@
 .PHONY: lint
-lint: python-lint shell-lint
+lint: python-lint
 
 .PHONY: python-lint
 python-lint:
 	docker run --rm -v "$(CURDIR):/code" -w /code pyfound/black:22.10.0 black --check . || (echo "Linter didn't succeed. You can use the following command to fix python linter issues: make format" && exit 1)
-
-.PHONY: shell-lint
-shell-lint:
-	find . -name '*.sh' | xargs docker run --rm -v "$(CURDIR):/code" -w /code koalaman/shellcheck
 
 .PHONY: format
 format:

--- a/monitoring/uss_qualifier/Makefile
+++ b/monitoring/uss_qualifier/Makefile
@@ -1,5 +1,5 @@
 .PHONY: lint
-lint: validate-docs python-lint shell-lint
+lint: validate-docs python-lint
 
 .PHONY: validate-docs
 validate-docs:
@@ -9,10 +9,6 @@ validate-docs:
 .PHONY: python-lint
 python-lint:
 	docker run --rm -v "$(CURDIR):/code" -w /code pyfound/black:22.10.0 black --check . || (echo "Linter didn't succeed. You can use the following command to fix python linter issues: make format" && exit 1)
-
-.PHONY: shell-lint
-shell-lint:
-	find . -name '*.sh' | xargs docker run --rm -v "$(CURDIR):/code" -w /code koalaman/shellcheck
 
 .PHONY: format
 format: format-documentation


### PR DESCRIPTION
Previously, we applied shell lint to specific subfolders and had a nested Makefile structure to do so.  This PR removes all that nesting and applies shell lint to the entire repo, minus `interfaces`, at the repository root.  Only one change is needed to accommodate this broader approach.