### PR TITLE
[hygiene] Apply black to entire repo

### DIFF
--- a/build/dev/extract_json_field.py
+++ b/build/dev/extract_json_field.py
@@ -18,5 +18,7 @@ for field in fields:
         try:
             obj = obj[field]
         except KeyError:
-            raise ValueError(f"Could not find field '{field}' in '{sys.argv[1]}' for {sys.argv[2]}; available keys: {list(obj.keys())}")
+            raise ValueError(
+                f"Could not find field '{field}' in '{sys.argv[1]}' for {sys.argv[2]}; available keys: {list(obj.keys())}"
+            )
 print(obj)

--- a/monitoring/atproxy/config.py
+++ b/monitoring/atproxy/config.py
@@ -5,34 +5,35 @@ from werkzeug.security import generate_password_hash
 
 from monitoring.monitorlib import auth_validation
 
-ENV_KEY_PREFIX = 'ATPROXY'
-ENV_KEY_PUBLIC_KEY = '{}_PUBLIC_KEY'.format(ENV_KEY_PREFIX)
-ENV_KEY_TOKEN_AUDIENCE = '{}_TOKEN_AUDIENCE'.format(ENV_KEY_PREFIX)
-ENV_KEY_CLIENT_BASIC_AUTH = '{}_CLIENT_BASIC_AUTH'.format(ENV_KEY_PREFIX)
-ENV_KEY_QUERY_TIMEOUT = '{}_QUERY_TIMEOUT'.format(ENV_KEY_PREFIX)
+ENV_KEY_PREFIX = "ATPROXY"
+ENV_KEY_PUBLIC_KEY = "{}_PUBLIC_KEY".format(ENV_KEY_PREFIX)
+ENV_KEY_TOKEN_AUDIENCE = "{}_TOKEN_AUDIENCE".format(ENV_KEY_PREFIX)
+ENV_KEY_CLIENT_BASIC_AUTH = "{}_CLIENT_BASIC_AUTH".format(ENV_KEY_PREFIX)
+ENV_KEY_QUERY_TIMEOUT = "{}_QUERY_TIMEOUT".format(ENV_KEY_PREFIX)
 
 # These keys map to entries in the Config class
-KEY_TOKEN_PUBLIC_KEY = 'TOKEN_PUBLIC_KEY'
-KEY_TOKEN_AUDIENCE = 'TOKEN_AUDIENCE'
-KEY_CLIENT_BASIC_AUTH = 'CLIENT_BASIC_AUTH'
-KEY_QUERY_TIMEOUT = 'QUERY_TIMEOUT'
+KEY_TOKEN_PUBLIC_KEY = "TOKEN_PUBLIC_KEY"
+KEY_TOKEN_AUDIENCE = "TOKEN_AUDIENCE"
+KEY_CLIENT_BASIC_AUTH = "CLIENT_BASIC_AUTH"
+KEY_QUERY_TIMEOUT = "QUERY_TIMEOUT"
 
-KEY_CODE_VERSION = 'MONITORING_VERSION'
+KEY_CODE_VERSION = "MONITORING_VERSION"
 
-workspace_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'workspace')
+workspace_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "workspace")
 
 
 class Config(object):
     TOKEN_PUBLIC_KEY = auth_validation.fix_key(
-        os.environ.get(ENV_KEY_PUBLIC_KEY, '')).encode('utf-8')
-    TOKEN_AUDIENCE = os.environ.get(ENV_KEY_TOKEN_AUDIENCE, '')
+        os.environ.get(ENV_KEY_PUBLIC_KEY, "")
+    ).encode("utf-8")
+    TOKEN_AUDIENCE = os.environ.get(ENV_KEY_TOKEN_AUDIENCE, "")
     CLIENT_BASIC_AUTH = os.environ[ENV_KEY_CLIENT_BASIC_AUTH]
     QUERY_TIMEOUT = float(os.environ.get(ENV_KEY_QUERY_TIMEOUT, "59"))
-    CODE_VERSION = os.environ.get(KEY_CODE_VERSION, 'Unknown')
+    CODE_VERSION = os.environ.get(KEY_CODE_VERSION, "Unknown")
 
 
 def get_users(basic_auth: str) -> Dict[str, str]:
-    user_pass = [v.strip() for v in basic_auth.split(':')]
+    user_pass = [v.strip() for v in basic_auth.split(":")]
     if len(user_pass) != 2:
         raise ValueError('Expected "username:password", got "{}"'.format(basic_auth))
     return {user_pass[0]: generate_password_hash(user_pass[1])}

--- a/monitoring/atproxy/database.py
+++ b/monitoring/atproxy/database.py
@@ -10,9 +10,10 @@ from implicitdict import ImplicitDict
 # --- All queries ---
 class QueryState(str, enum.Enum):
     """Whether a query is being handled, or has already been handled."""
-    Queued = 'Queued'
-    BeingHandled = 'BeingHandled'
-    Complete = 'Complete'
+
+    Queued = "Queued"
+    BeingHandled = "BeingHandled"
+    Complete = "Complete"
 
 
 class Query(ImplicitDict):
@@ -51,4 +52,5 @@ class Database(ImplicitDict):
 
 db = SynchronizedValue(
     Database(),
-    decoder=lambda b: ImplicitDict.parse(json.loads(b.decode('utf-8')), Database))
+    decoder=lambda b: ImplicitDict.parse(json.loads(b.decode("utf-8")), Database),
+)

--- a/monitoring/atproxy/gunicorn.conf.py
+++ b/monitoring/atproxy/gunicorn.conf.py
@@ -8,14 +8,29 @@ from loguru import logger
 
 def pre_request(worker: Worker, req: Request):
     """gunicorn server hook called just before a worker processes the request."""
-    logger.debug("gunicorn pre_request from worker {} (OS PID {}): {} {}", worker.pid, os.getpid(), req.method, req.path)
+    logger.debug(
+        "gunicorn pre_request from worker {} (OS PID {}): {} {}",
+        worker.pid,
+        os.getpid(),
+        req.method,
+        req.path,
+    )
 
 
 def post_request(worker: Worker, req: Request, environ: dict, resp: Response):
     """gunicorn server hook called after a worker processes the request."""
-    logger.debug("gunicorn post_request from worker {} (OS PID {}): {} {} -> {}", worker.pid, os.getpid(), req.method, req.path, resp.status_code)
+    logger.debug(
+        "gunicorn post_request from worker {} (OS PID {}): {} {} -> {}",
+        worker.pid,
+        os.getpid(),
+        req.method,
+        req.path,
+        resp.status_code,
+    )
 
 
 def worker_abort(worker: Worker):
     """gunicorn server hook called when a worker received the SIGABRT signal."""
-    logger.debug("gunicorn worker_abort from worker {} (OS PID {})", worker.pid, os.getpid())
+    logger.debug(
+        "gunicorn worker_abort from worker {} (OS PID {})", worker.pid, os.getpid()
+    )

--- a/monitoring/atproxy/oauth.py
+++ b/monitoring/atproxy/oauth.py
@@ -5,4 +5,5 @@ from .app import webapp
 
 requires_scope = auth_validation.requires_scope_decorator(
     webapp.config.get(config.KEY_TOKEN_PUBLIC_KEY),
-    webapp.config.get(config.KEY_TOKEN_AUDIENCE))
+    webapp.config.get(config.KEY_TOKEN_AUDIENCE),
+)

--- a/monitoring/atproxy/requests.py
+++ b/monitoring/atproxy/requests.py
@@ -3,7 +3,8 @@ from enum import Enum
 from monitoring.monitorlib.rid_automated_testing import injection_api
 from implicitdict import ImplicitDict
 from uas_standards.interuss.automated_testing.scd.v1.api import (
-    ClearAreaRequest, InjectFlightRequest,
+    ClearAreaRequest,
+    InjectFlightRequest,
 )
 
 
@@ -19,7 +20,13 @@ class RequestType(str, Enum):
     SCD_CreateClearAreaRequest = "scd.createClearAreaRequest"
 
 
-SCD_REQUESTS = {RequestType.SCD_GetStatus, RequestType.SCD_GetCapabilities, RequestType.SCD_PutFlight, RequestType.SCD_DeleteFlight, RequestType.SCD_CreateClearAreaRequest}
+SCD_REQUESTS = {
+    RequestType.SCD_GetStatus,
+    RequestType.SCD_GetCapabilities,
+    RequestType.SCD_PutFlight,
+    RequestType.SCD_DeleteFlight,
+    RequestType.SCD_CreateClearAreaRequest,
+}
 
 
 # Each request descriptor in this file is expected to implement a static

--- a/monitoring/atproxy/routes.py
+++ b/monitoring/atproxy/routes.py
@@ -9,20 +9,20 @@ from monitoring.monitorlib import auth_validation, versioning
 from .app import webapp, basic_auth, users
 
 
-@webapp.route('/')
+@webapp.route("/")
 def root() -> Tuple[str, int]:
-    return 'ok', 200
+    return "ok", 200
 
 
-@webapp.route('/favicon.ico')
+@webapp.route("/favicon.ico")
 def favicon():
-  flask.abort(404)
+    flask.abort(404)
 
 
-@webapp.route('/status')
+@webapp.route("/status")
 @basic_auth.login_required
 def status():
-    return 'atproxy ok {}'.format(versioning.get_code_version())
+    return "atproxy ok {}".format(versioning.get_code_version())
 
 
 @webapp.errorhandler(Exception)
@@ -31,17 +31,31 @@ def handle_exception(e):
     if isinstance(e, HTTPException):
         return e
     elif isinstance(e, auth_validation.InvalidScopeError):
-        return flask.jsonify({
-            'message': 'Invalid scope; expected one of {%s}, but received only {%s}' % (' '.join(e.permitted_scopes),
-                                                                                        ' '.join(e.provided_scopes))}), 403
+        return (
+            flask.jsonify(
+                {
+                    "message": "Invalid scope; expected one of {%s}, but received only {%s}"
+                    % (" ".join(e.permitted_scopes), " ".join(e.provided_scopes))
+                }
+            ),
+            403,
+        )
     elif isinstance(e, auth_validation.InvalidAccessTokenError):
-        return flask.jsonify({'message': e.message}), 401
+        return flask.jsonify({"message": e.message}), 401
     elif isinstance(e, auth_validation.ConfigurationError):
-        return flask.jsonify({'message': 'Auth validation configuration error: ' + e.message}), 500
+        return (
+            flask.jsonify(
+                {"message": "Auth validation configuration error: " + e.message}
+            ),
+            500,
+        )
     elif isinstance(e, ValueError):
-        return flask.jsonify({'message': str(e)}), 400
+        return flask.jsonify({"message": str(e)}), 400
 
-    return flask.jsonify({'message': 'Unhandled {}: {}'.format(type(e).__name__, str(e))}), 500
+    return (
+        flask.jsonify({"message": "Unhandled {}: {}".format(type(e).__name__, str(e))}),
+        500,
+    )
 
 
 @basic_auth.verify_password

--- a/monitoring/atproxy/routes_handler.py
+++ b/monitoring/atproxy/routes_handler.py
@@ -12,7 +12,7 @@ from .database import db, Query, QueryState
 from .handling import ListQueriesResponse, PendingRequest, PutQueryRequest
 
 
-@webapp.route('/handler/queries', methods=['GET'])
+@webapp.route("/handler/queries", methods=["GET"])
 @basic_auth.login_required
 def list_queries() -> Tuple[str, int]:
     """Lists outstanding queries to be handled.
@@ -20,45 +20,56 @@ def list_queries() -> Tuple[str, int]:
     See ListQueriesResponse for response body schema.
     """
     t_start = datetime.utcnow()
-    logger.debug('Handler requesting queries from worker {}', os.getpid())
+    logger.debug("Handler requesting queries from worker {}", os.getpid())
     max_timeout = timedelta(seconds=5)
     while datetime.utcnow() < t_start + max_timeout:
         with db as tx:
-            response = ListQueriesResponse(requests=[
-                PendingRequest(id=id, type=q.type, request=q.request)
-                for id, q in tx.queries.items()
-                if q.state == QueryState.Queued])
+            response = ListQueriesResponse(
+                requests=[
+                    PendingRequest(id=id, type=q.type, request=q.request)
+                    for id, q in tx.queries.items()
+                    if q.state == QueryState.Queued
+                ]
+            )
             if response.requests:
-                logger.debug('Provided handler {} queries'.format(len(response.requests)))
+                logger.debug(
+                    "Provided handler {} queries".format(len(response.requests))
+                )
                 return flask.jsonify(response)
         time.sleep(0.1)
-    logger.debug('No queries available for handler from worker {}', os.getpid())
+    logger.debug("No queries available for handler from worker {}", os.getpid())
     return flask.jsonify(ListQueriesResponse(requests=[]))
 
 
-@webapp.route('/handler/queries/<id>', methods=['PUT'])
+@webapp.route("/handler/queries/<id>", methods=["PUT"])
 @basic_auth.login_required
 def put_query_result(id: str) -> Tuple[str, int]:
     """Fulfills an outstanding query.
 
     See PutQueryRequest for request body schema.
     """
-    logger.debug('Handler instructed to fulfill request {} from worker {}', id, os.getpid())
+    logger.debug(
+        "Handler instructed to fulfill request {} from worker {}", id, os.getpid()
+    )
     try:
-        request: PutQueryRequest = ImplicitDict.parse(flask.request.json, PutQueryRequest)
+        request: PutQueryRequest = ImplicitDict.parse(
+            flask.request.json, PutQueryRequest
+        )
     except ValueError as e:
-        msg = f'Could not parse PutQueryRequest due to {type(e).__name__} on worker {os.getpid()}: {str(e)}'
+        msg = f"Could not parse PutQueryRequest due to {type(e).__name__} on worker {os.getpid()}: {str(e)}"
         logger.error(msg)
-        return flask.jsonify({'message': msg}), 400
+        return flask.jsonify({"message": msg}), 400
     with db as tx:
         if id not in tx.queries:
-            msg = f'No outstanding request with ID {id} exists on worker {os.getpid()}'
+            msg = f"No outstanding request with ID {id} exists on worker {os.getpid()}"
             logger.error(msg)
-            return flask.jsonify({'message': msg}), 400
+            return flask.jsonify({"message": msg}), 400
         query: Query = tx.queries[id]
-        logger.debug('{} query {} handled with code {}', query.type, id, request.return_code)
+        logger.debug(
+            "{} query {} handled with code {}", query.type, id, request.return_code
+        )
         query.return_code = request.return_code
         query.response = request.response
         query.state = QueryState.Complete
-    logger.debug('Handler fulfilled request {} from worker {}', id, os.getpid())
-    return '', 204
+    logger.debug("Handler fulfilled request {} from worker {}", id, os.getpid())
+    return "", 204

--- a/monitoring/atproxy/routes_rid_injection.py
+++ b/monitoring/atproxy/routes_rid_injection.py
@@ -14,24 +14,30 @@ from implicitdict import ImplicitDict
 timeout = timedelta(seconds=webapp.config[KEY_QUERY_TIMEOUT])
 
 
-@webapp.route('/ridsp/injection/tests/<test_id>', methods=['PUT'])
+@webapp.route("/ridsp/injection/tests/<test_id>", methods=["PUT"])
 @requires_scope([injection_api.SCOPE_RID_QUALIFIER_INJECT])
 def rid_injection_create_test(test_id: str) -> Tuple[str, int]:
     """Implements test creation in RID automated testing injection API."""
     try:
         json = flask.request.json
         if json is None:
-            raise ValueError('Request did not contain a JSON payload')
-        req_body: injection_api.CreateTestParameters = ImplicitDict.parse(json, injection_api.CreateTestParameters)
+            raise ValueError("Request did not contain a JSON payload")
+        req_body: injection_api.CreateTestParameters = ImplicitDict.parse(
+            json, injection_api.CreateTestParameters
+        )
     except ValueError as e:
-        msg = 'Create test {} unable to parse JSON: {}'.format(test_id, e)
+        msg = "Create test {} unable to parse JSON: {}".format(test_id, e)
         return msg, 400
 
-    return handling.fulfill_query(RIDInjectionCreateTestRequest(test_id=test_id, request_body=req_body), timeout)
+    return handling.fulfill_query(
+        RIDInjectionCreateTestRequest(test_id=test_id, request_body=req_body), timeout
+    )
 
 
-@webapp.route('/ridsp/injection/tests/<test_id>/<version>', methods=['DELETE'])
+@webapp.route("/ridsp/injection/tests/<test_id>/<version>", methods=["DELETE"])
 @requires_scope([injection_api.SCOPE_RID_QUALIFIER_INJECT])
 def rid_injection_delete_test(test_id: str, version: str) -> Tuple[str, int]:
     """Implements test deletion in RID automated testing injection API."""
-    return handling.fulfill_query(RIDInjectionDeleteTestRequest(test_id=test_id, version=version), timeout)
+    return handling.fulfill_query(
+        RIDInjectionDeleteTestRequest(test_id=test_id, version=version), timeout
+    )

--- a/monitoring/atproxy/routes_rid_observation.py
+++ b/monitoring/atproxy/routes_rid_observation.py
@@ -8,20 +8,27 @@ from . import handling
 from .app import webapp
 from .config import KEY_QUERY_TIMEOUT
 from .oauth import requires_scope
-from .requests import RIDObservationGetDisplayDataRequest, RIDObservationGetDetailsRequest
+from .requests import (
+    RIDObservationGetDisplayDataRequest,
+    RIDObservationGetDetailsRequest,
+)
 
 timeout = timedelta(seconds=webapp.config[KEY_QUERY_TIMEOUT])
 
 
-@webapp.route('/riddp/observation/display_data', methods=['GET'])
+@webapp.route("/riddp/observation/display_data", methods=["GET"])
 @requires_scope([Scope.Read])
 def rid_observation_display_data() -> Tuple[str, int]:
     """Implements retrieval of current display data per automated testing API."""
-    return handling.fulfill_query(RIDObservationGetDisplayDataRequest(view=flask.request.args['view']), timeout)
+    return handling.fulfill_query(
+        RIDObservationGetDisplayDataRequest(view=flask.request.args["view"]), timeout
+    )
 
 
-@webapp.route('/riddp/observation/display_data/<flight_id>', methods=['GET'])
+@webapp.route("/riddp/observation/display_data/<flight_id>", methods=["GET"])
 @requires_scope([Scope.Read])
 def rid_observation_flight_details(flight_id: str) -> Tuple[str, int]:
     """Implements get flight details endpoint per automated testing API."""
-    return handling.fulfill_query(RIDObservationGetDetailsRequest(id=flight_id), timeout)
+    return handling.fulfill_query(
+        RIDObservationGetDetailsRequest(id=flight_id), timeout
+    )

--- a/monitoring/atproxy/routes_scd.py
+++ b/monitoring/atproxy/routes_scd.py
@@ -3,69 +3,84 @@ from typing import Tuple
 
 import flask
 from implicitdict import ImplicitDict
-from uas_standards.interuss.automated_testing.scd.v1.api import \
-    InjectFlightRequest, ClearAreaRequest
+from uas_standards.interuss.automated_testing.scd.v1.api import (
+    InjectFlightRequest,
+    ClearAreaRequest,
+)
 
 from . import handling
 from .app import webapp
 from .config import KEY_QUERY_TIMEOUT
 from .oauth import requires_scope
-from .requests import SCDInjectionStatusRequest, \
-    SCDInjectionCapabilitiesRequest, SCDInjectionPutFlightRequest, \
-    SCDInjectionDeleteFlightRequest, SCDInjectionClearAreaRequest
-from monitoring.monitorlib.scd_automated_testing.scd_injection_api import SCOPE_SCD_QUALIFIER_INJECT
+from .requests import (
+    SCDInjectionStatusRequest,
+    SCDInjectionCapabilitiesRequest,
+    SCDInjectionPutFlightRequest,
+    SCDInjectionDeleteFlightRequest,
+    SCDInjectionClearAreaRequest,
+)
+from monitoring.monitorlib.scd_automated_testing.scd_injection_api import (
+    SCOPE_SCD_QUALIFIER_INJECT,
+)
 
 
 timeout = timedelta(seconds=webapp.config[KEY_QUERY_TIMEOUT])
 
 
-@webapp.route('/scd/v1/status', methods=['GET'])
+@webapp.route("/scd/v1/status", methods=["GET"])
 @requires_scope([SCOPE_SCD_QUALIFIER_INJECT])
 def scd_injection_status() -> Tuple[str, int]:
     """Implements status in SCD automated testing injection API."""
     return handling.fulfill_query(SCDInjectionStatusRequest(), timeout)
 
 
-@webapp.route('/scd/v1/capabilities', methods=['GET'])
+@webapp.route("/scd/v1/capabilities", methods=["GET"])
 @requires_scope([SCOPE_SCD_QUALIFIER_INJECT])
 def scd_injection_capabilities() -> Tuple[str, int]:
     """Implements capabilities in SCD automated testing injection API."""
     return handling.fulfill_query(SCDInjectionCapabilitiesRequest(), timeout)
 
 
-@webapp.route('/scd/v1/flights/<flight_id>', methods=['PUT'])
+@webapp.route("/scd/v1/flights/<flight_id>", methods=["PUT"])
 @requires_scope([SCOPE_SCD_QUALIFIER_INJECT])
 def scd_injection_put_flight(flight_id: str) -> Tuple[str, int]:
     """Implements PUT flight in SCD automated testing injection API."""
     try:
         json = flask.request.json
         if json is None:
-            raise ValueError('Request did not contain a JSON payload')
+            raise ValueError("Request did not contain a JSON payload")
         req_body: InjectFlightRequest = ImplicitDict.parse(json, InjectFlightRequest)
     except ValueError as e:
-        msg = 'Upsert flight {} unable to parse JSON: {}'.format(flight_id, e)
+        msg = "Upsert flight {} unable to parse JSON: {}".format(flight_id, e)
         return msg, 400
-    return handling.fulfill_query(SCDInjectionPutFlightRequest(flight_id=flight_id, request_body=req_body), timeout)
+    return handling.fulfill_query(
+        SCDInjectionPutFlightRequest(flight_id=flight_id, request_body=req_body),
+        timeout,
+    )
 
 
-@webapp.route('/scd/v1/flights/<flight_id>', methods=['DELETE'])
+@webapp.route("/scd/v1/flights/<flight_id>", methods=["DELETE"])
 @requires_scope([SCOPE_SCD_QUALIFIER_INJECT])
 def scd_injection_delete_flight(flight_id: str) -> Tuple[str, int]:
     """Implements flight deletion in SCD automated testing injection API."""
-    return handling.fulfill_query(SCDInjectionDeleteFlightRequest(flight_id=flight_id), timeout)
+    return handling.fulfill_query(
+        SCDInjectionDeleteFlightRequest(flight_id=flight_id), timeout
+    )
 
 
-@webapp.route('/scd/v1/clear_area_requests', methods=['POST'])
+@webapp.route("/scd/v1/clear_area_requests", methods=["POST"])
 @requires_scope([SCOPE_SCD_QUALIFIER_INJECT])
 def scd_injection_clear_area() -> Tuple[str, int]:
     """Implements area clearing in RID automated testing injection API."""
     try:
         json = flask.request.json
         if json is None:
-            raise ValueError('Request did not contain a JSON payload')
+            raise ValueError("Request did not contain a JSON payload")
         req_body: ClearAreaRequest = ImplicitDict.parse(json, ClearAreaRequest)
     except ValueError as e:
-        msg = 'Clear area request unable to parse JSON: {}'.format(e)
+        msg = "Clear area request unable to parse JSON: {}".format(e)
         return msg, 400
 
-    return handling.fulfill_query(SCDInjectionClearAreaRequest(request_body=req_body), timeout)
+    return handling.fulfill_query(
+        SCDInjectionClearAreaRequest(request_body=req_body), timeout
+    )

--- a/monitoring/deployment_manager/actions/dss/v1/common.py
+++ b/monitoring/deployment_manager/actions/dss/v1/common.py
@@ -5,9 +5,11 @@ from monitoring.deployment_manager.infrastructure import Context
 
 def requires_v1_dss(func):
     """Make sure v1 DSS is well-specified"""
+
     @functools.wraps(func)
     def wrapper_v1_dss_required(context: Context, *args, **kwargs):
-        if 'dss' not in context.spec:
-            raise ValueError('DSS system is not defined in deployment configuration')
+        if "dss" not in context.spec:
+            raise ValueError("DSS system is not defined in deployment configuration")
         return func(context, *args, **kwargs)
+
     return wrapper_v1_dss_required

--- a/monitoring/deployment_manager/actions/dss/v1/crdb.py
+++ b/monitoring/deployment_manager/actions/dss/v1/crdb.py
@@ -7,7 +7,9 @@ import yaml
 
 from monitoring.deployment_manager.deploylib.crdb_cluster_api import ClusterAPI
 from monitoring.deployment_manager.deploylib import crdb_sql
-from monitoring.deployment_manager.deploylib.port_forwarding import get_requests_session_for_pod
+from monitoring.deployment_manager.deploylib.port_forwarding import (
+    get_requests_session_for_pod,
+)
 from monitoring.deployment_manager.infrastructure import deployment_action, Context
 from monitoring.deployment_manager.actions.dss.v1.common import requires_v1_dss
 
@@ -21,62 +23,92 @@ import cryptography.x509
 def _public_key_bytes(public_key) -> bytes:
     return public_key.public_bytes(
         cryptography.hazmat.primitives.serialization.Encoding.PEM,
-        cryptography.hazmat.primitives.serialization.PublicFormat.SubjectPublicKeyInfo)
+        cryptography.hazmat.primitives.serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
 
 
-@deployment_action('dss/crdb/print_ca_public_certs')
+@deployment_action("dss/crdb/print_ca_public_certs")
 @requires_v1_dss
 def print_ca_public_certs(context: Context):
     """Print the accepted CA certificates accepted by the cluster."""
     backend = cryptography.hazmat.backends.default_backend()
 
     # Read the list of accepted CA certificates
-    ca_crt: V1Secret = context.clients.core.read_namespaced_secret(name='cockroachdb.ca.crt', namespace=context.spec.dss.v1.namespace)
-    ca_crt_content = base64.b64decode(ca_crt.data['ca.crt'])
-    certs = [cryptography.x509.load_pem_x509_certificate(str(c).encode('utf-8'), backend)
-             for c in pem.parse(ca_crt_content)]
-    context.log.msg('ca.crt:\n' + ca_crt_content.decode('utf-8'))
+    ca_crt: V1Secret = context.clients.core.read_namespaced_secret(
+        name="cockroachdb.ca.crt", namespace=context.spec.dss.v1.namespace
+    )
+    ca_crt_content = base64.b64decode(ca_crt.data["ca.crt"])
+    certs = [
+        cryptography.x509.load_pem_x509_certificate(str(c).encode("utf-8"), backend)
+        for c in pem.parse(ca_crt_content)
+    ]
+    context.log.msg("ca.crt:\n" + ca_crt_content.decode("utf-8"))
 
     # Read the private key to determine which certificate belongs to this instance
-    ca_key: V1Secret = context.clients.core.read_namespaced_secret(name='cockroachdb.ca.key', namespace=context.spec.dss.v1.namespace)
-    ca_key_content = base64.b64decode(ca_key.data['ca.key']).decode('utf-8')
+    ca_key: V1Secret = context.clients.core.read_namespaced_secret(
+        name="cockroachdb.ca.key", namespace=context.spec.dss.v1.namespace
+    )
+    ca_key_content = base64.b64decode(ca_key.data["ca.key"]).decode("utf-8")
     private_key = cryptography.hazmat.primitives.serialization.load_pem_private_key(
-        ca_key_content.encode('utf-8'), password=None, backend=backend)
+        ca_key_content.encode("utf-8"), password=None, backend=backend
+    )
     public_key_bytes = _public_key_bytes(private_key.public_key())
 
-    matches = [i for i in range(len(certs))
-               if public_key_bytes == _public_key_bytes(certs[i].public_key())]
-    match_words = ['first', 'second', 'third'] + ['{}th'.format(i) for i in range(4, 50)]
+    matches = [
+        i
+        for i in range(len(certs))
+        if public_key_bytes == _public_key_bytes(certs[i].public_key())
+    ]
+    match_words = ["first", "second", "third"] + [
+        "{}th".format(i) for i in range(4, 50)
+    ]
     if not matches:
-        context.log.warn('This DSS instance\'s public key does not appear in any of the listed certificates')
+        context.log.warn(
+            "This DSS instance's public key does not appear in any of the listed certificates"
+        )
     else:
-        context.log.msg('This DSS instance\'s public key matches the {} certificate{} in those above'.format(', '.join(match_words[m] for m in matches), 's' if len(matches) > 1 else ''))
+        context.log.msg(
+            "This DSS instance's public key matches the {} certificate{} in those above".format(
+                ", ".join(match_words[m] for m in matches),
+                "s" if len(matches) > 1 else "",
+            )
+        )
 
 
-@deployment_action('dss/crdb/status')
+@deployment_action("dss/crdb/status")
 @requires_v1_dss
 def crdb_status(context: Context):
     """Retrieve and print information about the CockroachDB cluster."""
     username, password = crdb_sql.get_monitoring_user(
-        context.clients.core, context.spec.dss.v1.namespace, context.spec.cluster.name)
-    pod_name = 'cockroachdb-0'
-    pod_session, host_port = get_requests_session_for_pod(pod_name, context.spec.dss.v1.namespace, 8080, context.clients.core)
-    cluster = ClusterAPI(pod_session, base_url='https://{}/api/v2'.format(host_port), username=username, password=password)
+        context.clients.core, context.spec.dss.v1.namespace, context.spec.cluster.name
+    )
+    pod_name = "cockroachdb-0"
+    pod_session, host_port = get_requests_session_for_pod(
+        pod_name, context.spec.dss.v1.namespace, 8080, context.clients.core
+    )
+    cluster = ClusterAPI(
+        pod_session,
+        base_url="https://{}/api/v2".format(host_port),
+        username=username,
+        password=password,
+    )
     up = cluster.is_up()
     ready = cluster.is_ready()
-    source = '{} ({}, {})'.format(pod_name, 'up' if up else 'DOWN', 'ready' if ready else 'NOT READY')
+    source = "{} ({}, {})".format(
+        pod_name, "up" if up else "DOWN", "ready" if ready else "NOT READY"
+    )
     if up and ready:
         nodes = cluster.get_nodes()
         summary = dict()
         for n in nodes:
             k, v = n.summarize()
             summary[k] = v
-        context.log.msg('{} reports:\n'.format(source) + yaml.dump(summary))
+        context.log.msg("{} reports:\n".format(source) + yaml.dump(summary))
     else:
-        context.log.msg('{} not ready to query nodes'.format(source))
+        context.log.msg("{} not ready to query nodes".format(source))
 
 
-@deployment_action('dss/crdb/print_monitoring_user')
+@deployment_action("dss/crdb/print_monitoring_user")
 @requires_v1_dss
 def print_monitoring_user(context: Context):
     """Print the username and password of the CRDB monitoring user.
@@ -87,6 +119,7 @@ def print_monitoring_user(context: Context):
     applicable deployment_manager action is taken.
     """
     username, password = crdb_sql.get_monitoring_user(
-        context.clients.core, context.spec.dss.v1.namespace, context.spec.cluster.name)
-    context.log.msg('Username: {} Password: {}'.format(username, password))
+        context.clients.core, context.spec.dss.v1.namespace, context.spec.cluster.name
+    )
+    context.log.msg("Username: {} Password: {}".format(username, password))
     return

--- a/monitoring/deployment_manager/actions/k8s.py
+++ b/monitoring/deployment_manager/actions/k8s.py
@@ -4,17 +4,27 @@ from monitoring.deployment_manager.infrastructure import deployment_action
 from monitoring.deployment_manager.infrastructure import Context
 
 
-@deployment_action('list_pods')
+@deployment_action("list_pods")
 def list_pods(context: Context):
     """List all Kubernetes pods"""
     ret = context.clients.core.list_pod_for_all_namespaces(watch=False)
-    msg = '\n'.join(['{}\t{}\t{}'.format(i.status.pod_ip, i.metadata.namespace, i.metadata.name) for i in ret.items])
-    context.log.msg('Pods:\n' + msg)
+    msg = "\n".join(
+        [
+            "{}\t{}\t{}".format(i.status.pod_ip, i.metadata.namespace, i.metadata.name)
+            for i in ret.items
+        ]
+    )
+    context.log.msg("Pods:\n" + msg)
 
 
-@deployment_action('list_ingress_controllers')
+@deployment_action("list_ingress_controllers")
 def list_ingress_controllers(context: Context):
     """List all available ingress controllers"""
     class_list = context.clients.networking.list_ingress_class()
-    msg = '\n'.join(['{}\t{}\t{}'.format(c.metadata.name, c.spec.controller, c.spec.parameters) for c in class_list.items])
-    context.log.msg('Ingress controllers:\n' + msg)
+    msg = "\n".join(
+        [
+            "{}\t{}\t{}".format(c.metadata.name, c.spec.controller, c.spec.parameters)
+            for c in class_list.items
+        ]
+    )
+    context.log.msg("Ingress controllers:\n" + msg)

--- a/monitoring/deployment_manager/actions/test/hello_world.py
+++ b/monitoring/deployment_manager/actions/test/hello_world.py
@@ -7,37 +7,59 @@ from monitoring.deployment_manager.infrastructure import deployment_action, Cont
 from monitoring.deployment_manager.systems.test import hello_world
 
 
-@deployment_action('test/hello_world/deploy')
+@deployment_action("test/hello_world/deploy")
 def deploy(context: Context) -> None:
     """Bring up the hello_world system"""
     namespace = hello_world.define_namespace(context.spec.test.v1.namespace)
     resources = hello_world.define_resources()
 
-    active_namespace = deploylib.namespaces.upsert(context.clients.core, context.log, namespace)
-    deploylib.systems.upsert_resources(resources, active_namespace, context.clients, context.log)
+    active_namespace = deploylib.namespaces.upsert(
+        context.clients.core, context.log, namespace
+    )
+    deploylib.systems.upsert_resources(
+        resources, active_namespace, context.clients, context.log
+    )
 
-    context.log.msg('hello_world system deployment complete.  Run `minikube tunnel` and then navigate to http://localhost in a browser to see the web content.')
+    context.log.msg(
+        "hello_world system deployment complete.  Run `minikube tunnel` and then navigate to http://localhost in a browser to see the web content."
+    )
 
 
-@deployment_action('test/hello_world/destroy')
+@deployment_action("test/hello_world/destroy")
 def destroy(context: Context) -> None:
     """Tear down the hello_world system"""
-    namespace = deploylib.namespaces.get(context.clients.core, context.log, hello_world.define_namespace(context.spec.test.v1.namespace))
+    namespace = deploylib.namespaces.get(
+        context.clients.core,
+        context.log,
+        hello_world.define_namespace(context.spec.test.v1.namespace),
+    )
     if namespace is None:
-        context.log.warn('Namespace `{}` does not exist in `{}` cluster'.format(context.spec.test.v1.namespace, context.spec.cluster.name))
+        context.log.warn(
+            "Namespace `{}` does not exist in `{}` cluster".format(
+                context.spec.test.v1.namespace, context.spec.cluster.name
+            )
+        )
         return
 
     resources = hello_world.define_resources()
     resources.reverse()
-    existing_resources = deploylib.systems.get_resources(resources, namespace, context.clients, context.log, context.spec.cluster.name)
+    existing_resources = deploylib.systems.get_resources(
+        resources, namespace, context.clients, context.log, context.spec.cluster.name
+    )
 
-    context.log.warn('Destroying hello_world system in `{}` namespace of `{}` cluster in 15 seconds...'.format(namespace.metadata.name, context.spec.cluster.name))
+    context.log.warn(
+        "Destroying hello_world system in `{}` namespace of `{}` cluster in 15 seconds...".format(
+            namespace.metadata.name, context.spec.cluster.name
+        )
+    )
     time.sleep(15)
 
-    deploylib.systems.delete_resources(existing_resources, namespace, context.clients, context.log)
+    deploylib.systems.delete_resources(
+        existing_resources, namespace, context.clients, context.log
+    )
 
-    context.log.msg('Deleting namespace')
+    context.log.msg("Deleting namespace")
     status = context.clients.core.delete_namespace(name=namespace.metadata.name)
-    context.log.msg('Namespace deleted', name=status.message)
+    context.log.msg("Namespace deleted", name=status.message)
 
-    context.log.msg('hello_world system removal complete')
+    context.log.msg("hello_world system removal complete")

--- a/monitoring/deployment_manager/deploylib/common_k8s.py
+++ b/monitoring/deployment_manager/deploylib/common_k8s.py
@@ -5,29 +5,49 @@ from structlog import BoundLogger
 from monitoring.deployment_manager.deploylib import comparisons
 
 
-def get_resource(list_resources: Callable[[], Any], log: BoundLogger, resource_type: str, resource_name: str) -> Optional[Any]:
-    log.msg('Checking for existing {}'.format(resource_type), name=resource_name)
+def get_resource(
+    list_resources: Callable[[], Any],
+    log: BoundLogger,
+    resource_type: str,
+    resource_name: str,
+) -> Optional[Any]:
+    log.msg("Checking for existing {}".format(resource_type), name=resource_name)
     resource_list = list_resources()
-    matching_resources = [d for d in resource_list.items
-                         if d.metadata.name == resource_name]
+    matching_resources = [
+        d for d in resource_list.items if d.metadata.name == resource_name
+    ]
     if len(matching_resources) > 2:
-        raise ValueError('Found {} {}s matching `{}`'.format(len(matching_resources), resource_type, resource_name))
+        raise ValueError(
+            "Found {} {}s matching `{}`".format(
+                len(matching_resources), resource_type, resource_name
+            )
+        )
     if not matching_resources:
         return None
     return matching_resources[0]
 
 
-def upsert_resource(existing_resource: Optional[Any], target_resource: Any, log: BoundLogger, resource_type: str, create: Callable[[], Any], patch: Callable[[], Any]) -> Any:
+def upsert_resource(
+    existing_resource: Optional[Any],
+    target_resource: Any,
+    log: BoundLogger,
+    resource_type: str,
+    create: Callable[[], Any],
+    patch: Callable[[], Any],
+) -> Any:
     if existing_resource is not None:
         if comparisons.specs_are_the_same(existing_resource, target_resource):
-            log.msg('Existing {} does not need to be updated'.format(resource_type), name=existing_resource.metadata.name)
+            log.msg(
+                "Existing {} does not need to be updated".format(resource_type),
+                name=existing_resource.metadata.name,
+            )
             new_resource = existing_resource
         else:
-            log.msg('Updating existing {}'.format(resource_type))
+            log.msg("Updating existing {}".format(resource_type))
             new_resource = patch()
-            log.msg('Updated {}'.format(resource_type), name=new_resource.metadata.name)
+            log.msg("Updated {}".format(resource_type), name=new_resource.metadata.name)
     else:
-        log.msg('Creating new {}'.format(resource_type))
+        log.msg("Creating new {}".format(resource_type))
         new_resource = create()
-        log.msg('Created {}'.format(resource_type), name=new_resource.metadata.name)
+        log.msg("Created {}".format(resource_type), name=new_resource.metadata.name)
     return new_resource

--- a/monitoring/deployment_manager/deploylib/comparisons.py
+++ b/monitoring/deployment_manager/deploylib/comparisons.py
@@ -1,12 +1,21 @@
 from typing import Any, Callable, Dict, List, Optional, Type
 
-from kubernetes.client import V1ObjectMeta, V1Deployment, V1Ingress, V1Namespace, V1Service, V1Secret
+from kubernetes.client import (
+    V1ObjectMeta,
+    V1Deployment,
+    V1Ingress,
+    V1Namespace,
+    V1Service,
+    V1Secret,
+)
 
 
 _special_comparisons: Dict[Type, Callable[[Any, Any], bool]] = {}
 
 
-def specs_are_the_same(obj1: Any, obj2: Any, field_paths: Optional[List[str]]=None) -> bool:
+def specs_are_the_same(
+    obj1: Any, obj2: Any, field_paths: Optional[List[str]] = None
+) -> bool:
     """Determine if the specifications for two Kubernetes objects are equivalent
 
     Only the relevant parts of the two objects will be compared to see if they
@@ -27,10 +36,14 @@ def specs_are_the_same(obj1: Any, obj2: Any, field_paths: Optional[List[str]]=No
         special_are_the_same = _special_comparisons.get(obj1.__class__, None)
         if special_are_the_same is not None:
             return special_are_the_same(obj1, obj2)
-        elif hasattr(obj1, 'attribute_map'):
-            return specs_are_the_same(obj1, obj2, list(getattr(obj1, 'attribute_map').keys))
+        elif hasattr(obj1, "attribute_map"):
+            return specs_are_the_same(
+                obj1, obj2, list(getattr(obj1, "attribute_map").keys)
+            )
         elif isinstance(obj1, dict) and isinstance(obj2, dict):
-            return all(obj2[k] == v for k, v in obj1.items()) and all(obj1[k] == v for k, v in obj2.items())
+            return all(obj2[k] == v for k, v in obj1.items()) and all(
+                obj1[k] == v for k, v in obj2.items()
+            )
         elif isinstance(obj1, list) and isinstance(obj2, list):
             return all(v1 == v2 for v1, v2 in zip(obj1, obj2))
         else:
@@ -38,14 +51,16 @@ def specs_are_the_same(obj1: Any, obj2: Any, field_paths: Optional[List[str]]=No
 
     sub_paths: Dict[str, Optional[List[str]]] = {}
     for field_path in field_paths:
-        parts = field_path.split('.')
+        parts = field_path.split(".")
         if len(parts) == 1:
             if parts[0] in sub_paths:
-                raise ValueError('Cannot compare {} and its subfield {}'.format(parts[0], field_path))
+                raise ValueError(
+                    "Cannot compare {} and its subfield {}".format(parts[0], field_path)
+                )
             sub_paths[parts[0]] = None
         else:
             sub_fields = sub_paths.get(parts[0], [])
-            sub_fields.append('.'.join(parts[1:]))
+            sub_fields.append(".".join(parts[1:]))
             sub_paths[parts[0]] = sub_fields
 
     for field_name, paths in sub_paths.items():
@@ -67,34 +82,37 @@ def _special_comparison(type: Type):
         global _special_comparisons
         _special_comparisons[type] = compare
         return compare
+
     return decorator_declare_comparison
 
 
 @_special_comparison(V1Namespace)
 def _v1namespace_are_the_same(namespace1: V1Namespace, namespace2: V1Namespace) -> bool:
-    return specs_are_the_same(namespace1, namespace2, ['metadata'])
+    return specs_are_the_same(namespace1, namespace2, ["metadata"])
 
 
 @_special_comparison(V1ObjectMeta)
 def _v1objectmeta_are_the_same(meta1: V1ObjectMeta, meta2: V1ObjectMeta) -> bool:
-    return specs_are_the_same(meta1, meta2, ['annotations', 'labels', 'name', 'namespace'])
+    return specs_are_the_same(
+        meta1, meta2, ["annotations", "labels", "name", "namespace"]
+    )
 
 
 @_special_comparison(V1Deployment)
 def _v1deployment_are_the_same(dep1: V1Deployment, dep2: V1Deployment) -> bool:
-    return specs_are_the_same(dep1, dep2, ['metadata', 'spec'])
+    return specs_are_the_same(dep1, dep2, ["metadata", "spec"])
 
 
 @_special_comparison(V1Service)
 def _v1service_are_the_same(svc1: V1Service, svc2: V1Service) -> bool:
-    return specs_are_the_same(svc1, svc2, ['metadata', 'spec'])
+    return specs_are_the_same(svc1, svc2, ["metadata", "spec"])
 
 
 @_special_comparison(V1Ingress)
 def _v1ingress_are_the_same(ingress1: V1Ingress, ingress2: V1Ingress) -> bool:
-    return specs_are_the_same(ingress1, ingress2, ['metadata', 'spec'])
+    return specs_are_the_same(ingress1, ingress2, ["metadata", "spec"])
 
 
 @_special_comparison(V1Secret)
 def _v1secret_are_the_same(secret1: V1Secret, secret2: V1Secret) -> bool:
-    return specs_are_the_same(secret1, secret2, ['metadata', 'data'])
+    return specs_are_the_same(secret1, secret2, ["metadata", "data"])

--- a/monitoring/deployment_manager/deploylib/conversion.py
+++ b/monitoring/deployment_manager/deploylib/conversion.py
@@ -5,20 +5,23 @@ import kubernetes
 
 
 def to_openapi_object(value: Any, type_name: str) -> Any:
-    primitives = {'int', 'str'}
+    primitives = {"int", "str"}
 
     # Do not convert primitives
     if type_name in primitives:
         return value
 
     # Convert dicts
-    dict_regex = r'dict\(([^,]+), ([^,]+)\)'
+    dict_regex = r"dict\(([^,]+), ([^,]+)\)"
     m = re.fullmatch(dict_regex, type_name)
     if m:
-        return {to_openapi_object(k, m.group(1)): to_openapi_object(v, m.group(2)) for k, v in value.items()}
+        return {
+            to_openapi_object(k, m.group(1)): to_openapi_object(v, m.group(2))
+            for k, v in value.items()
+        }
 
     # Convert lists
-    list_regex = r'list\[([^]]+)\]'
+    list_regex = r"list\[([^]]+)\]"
     m = re.fullmatch(list_regex, type_name)
     if m:
         return [to_openapi_object(v, m.group(1)) for v in value]

--- a/monitoring/deployment_manager/deploylib/crdb_cluster_api.py
+++ b/monitoring/deployment_manager/deploylib/crdb_cluster_api.py
@@ -39,11 +39,15 @@ class Node(ImplicitDict):
     liveness_status: int
 
     def summarize(self) -> Tuple[str, Dict[str, str]]:
-        key = 'Node {} ({})'.format(self.node_id, self.address.address_field)
+        key = "Node {} ({})".format(self.node_id, self.address.address_field)
         t0 = arrow.get(math.floor(self.started_at / 1e9))
         values = {
-            'locality': ' '.join('{}:{}'.format(t['key'], t['value']) for t in self.locality.tiers),
-            'status': 'Running {} since {}, liveness {}'.format(self.build_tag, t0.to('local').isoformat(),self.liveness_status)
+            "locality": " ".join(
+                "{}:{}".format(t["key"], t["value"]) for t in self.locality.tiers
+            ),
+            "status": "Running {} since {}, liveness {}".format(
+                self.build_tag, t0.to("local").isoformat(), self.liveness_status
+            ),
         }
         return key, values
 
@@ -53,7 +57,14 @@ class ClusterAPI(object):
 
     API: https://www.cockroachlabs.com/docs/api/cluster/v2
     """
-    def __init__(self, session: requests.Session, base_url: str='https://localhost:8080/api/v2', username: Optional[str]=None, password: Optional[str]=None):
+
+    def __init__(
+        self,
+        session: requests.Session,
+        base_url: str = "https://localhost:8080/api/v2",
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+    ):
         self._session = session
         self._base_url = base_url
         self._username = username
@@ -64,52 +75,83 @@ class ClusterAPI(object):
         self.log_out()
 
     def is_ready(self) -> bool:
-        resp = self._session.get('{}/health/?ready=true'.format(self._base_url))
+        resp = self._session.get("{}/health/?ready=true".format(self._base_url))
         if resp.status_code == 200:
             return True
         elif resp.status_code == 500:
             return False
         else:
-            raise ValueError('Call to {} returned unexpected status code {}: {}'.format(resp.url, resp.status_code, resp.content.decode('utf-8')))
+            raise ValueError(
+                "Call to {} returned unexpected status code {}: {}".format(
+                    resp.url, resp.status_code, resp.content.decode("utf-8")
+                )
+            )
 
     def is_up(self) -> bool:
-        resp = self._session.get('{}/health/'.format(self._base_url))
+        resp = self._session.get("{}/health/".format(self._base_url))
         if resp.status_code == 200:
             return True
         elif resp.status_code == 500:
             return False
         else:
-            raise ValueError('Call to {} returned unexpected status code {}: {}'.format(resp.url, resp.status_code, resp.content.decode('utf-8')))
+            raise ValueError(
+                "Call to {} returned unexpected status code {}: {}".format(
+                    resp.url, resp.status_code, resp.content.decode("utf-8")
+                )
+            )
 
     def log_in(self) -> str:
         if self._username is None:
-            raise ValueError('Cannot log in to CockroachDB cluster at {} when username is not specified'.format(self._base_url))
+            raise ValueError(
+                "Cannot log in to CockroachDB cluster at {} when username is not specified".format(
+                    self._base_url
+                )
+            )
         if self._password is None:
-            raise ValueError('Cannot log in to CockroachDB cluster at {} when password is not specified'.format(self._base_url))
-        resp = self._session.post('{}/login/'.format(self._base_url), data={'username': self._username, 'password': self._password})
+            raise ValueError(
+                "Cannot log in to CockroachDB cluster at {} when password is not specified".format(
+                    self._base_url
+                )
+            )
+        resp = self._session.post(
+            "{}/login/".format(self._base_url),
+            data={"username": self._username, "password": self._password},
+        )
         resp.raise_for_status()
-        session = resp.json().get('session', None)
+        session = resp.json().get("session", None)
         if session is None:
-            raise ValueError('Invalid CockroachDB cluster response: `session` not specified: {}'.format(resp.content.decode('utf-8')))
+            raise ValueError(
+                "Invalid CockroachDB cluster response: `session` not specified: {}".format(
+                    resp.content.decode("utf-8")
+                )
+            )
         self._session_auth = session
         return session
 
     def _get_headers(self) -> Dict[str, str]:
         if self._session_auth is None:
             self.log_in()
-        return {'X-Cockroach-API-Session': self._session_auth}
+        return {"X-Cockroach-API-Session": self._session_auth}
 
     def log_out(self) -> None:
         if self._session_auth is None:
             return
-        resp = self._session.post('{}/logout/'.format(self._base_url), headers=self._get_headers())
+        resp = self._session.post(
+            "{}/logout/".format(self._base_url), headers=self._get_headers()
+        )
         resp.raise_for_status()
         self._session_auth = None
 
     def get_nodes(self) -> List[Node]:
-        resp = self._session.get('{}/nodes/'.format(self._base_url), headers=self._get_headers())
+        resp = self._session.get(
+            "{}/nodes/".format(self._base_url), headers=self._get_headers()
+        )
         resp.raise_for_status()
-        nodes = resp.json().get('nodes', None)
+        nodes = resp.json().get("nodes", None)
         if nodes is None:
-            raise ValueError('Invalid CockroachDB cluster response: `nodes` not specified: {}'.format(resp.content.decode('utf-8')))
+            raise ValueError(
+                "Invalid CockroachDB cluster response: `nodes` not specified: {}".format(
+                    resp.content.decode("utf-8")
+                )
+            )
         return [ImplicitDict.parse(n, Node) for n in nodes]

--- a/monitoring/deployment_manager/deploylib/crdb_sql.py
+++ b/monitoring/deployment_manager/deploylib/crdb_sql.py
@@ -23,32 +23,40 @@ def execute_sql(client: k8s.CoreV1Api, namespace: str, sql_commands: List[str]) 
     :param sql_commands: SQL commands to be executed (no semicolons)
     :return: stdout of console from executing `cockroach sql`
     """
-    exec_command = ['./cockroach', 'sql', '--certs-dir=cockroach-certs/']
-    exec_command += ['--execute=' + cmd for cmd in sql_commands]
-    resp = kubernetes.stream.stream(client.connect_get_namespaced_pod_exec,
-                  'cockroachdb-0',
-                  namespace,
-                  command=exec_command,
-                  stderr=True, stdin=False,
-                  stdout=True, tty=False)
-    if 'Failed running' in resp:
-        raise ValueError('SQL error: ' + resp)
+    exec_command = ["./cockroach", "sql", "--certs-dir=cockroach-certs/"]
+    exec_command += ["--execute=" + cmd for cmd in sql_commands]
+    resp = kubernetes.stream.stream(
+        client.connect_get_namespaced_pod_exec,
+        "cockroachdb-0",
+        namespace,
+        command=exec_command,
+        stderr=True,
+        stdin=False,
+        stdout=True,
+        tty=False,
+    )
+    if "Failed running" in resp:
+        raise ValueError("SQL error: " + resp)
     return resp
 
 
 def list_users(client: k8s.CoreV1Api, namespace: str) -> List[User]:
-    lines = execute_sql(client, namespace, ['SHOW USERS']).split('\n')
+    lines = execute_sql(client, namespace, ["SHOW USERS"]).split("\n")
     lines = [line for line in lines[1:] if line]
     users = []
     for line in lines:
-        username, options_text, member_of_text = [col.strip() for col in line.split('\t')]
-        options = [opt.strip() for opt in options_text.split(',')]
-        member_of = [group.strip() for group in member_of_text[1:-1].split(',')]
+        username, options_text, member_of_text = [
+            col.strip() for col in line.split("\t")
+        ]
+        options = [opt.strip() for opt in options_text.split(",")]
+        member_of = [group.strip() for group in member_of_text[1:-1].split(",")]
         users.append(User(username=username, options=options, member_of=member_of))
     return users
 
 
-def get_monitoring_user(client: k8s.CoreV1Api, namespace: str, cluster_name: str) -> Tuple[str, str]:
+def get_monitoring_user(
+    client: k8s.CoreV1Api, namespace: str, cluster_name: str
+) -> Tuple[str, str]:
     """Get the username and password for a CRDB user intended for monitoring.
 
     Whenever this routine is called, it sets the validity of the user to 1-2
@@ -63,20 +71,31 @@ def get_monitoring_user(client: k8s.CoreV1Api, namespace: str, cluster_name: str
         * Password
     """
     # Create username according to cluster_name
-    prefix = 'monitoring_user_'
-    suffix = hashlib.md5(cluster_name.encode('utf-8')).hexdigest()[-8:]
+    prefix = "monitoring_user_"
+    suffix = hashlib.md5(cluster_name.encode("utf-8")).hexdigest()[-8:]
     username = prefix + suffix
 
     # Create a new password
     r = random.Random()
-    password = ''.join(random.choice('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-=_+[]\\{}|;:",./<>?') for _ in range(32))
+    password = "".join(
+        random.choice(
+            'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-=_+[]\\{}|;:",./<>?'
+        )
+        for _ in range(32)
+    )
 
     # Compute validity
     valid_until = (datetime.datetime.utcnow() + datetime.timedelta(days=2)).isoformat()
     execute_sql(
-        client, namespace,
-        ['CREATE USER IF NOT EXISTS {}'.format(username),
-         'GRANT admin TO {}'.format(username),
-         'ALTER USER {} WITH LOGIN PASSWORD \'{}\' VALID UNTIL \'{}\''.format(username, password, valid_until)])
+        client,
+        namespace,
+        [
+            "CREATE USER IF NOT EXISTS {}".format(username),
+            "GRANT admin TO {}".format(username),
+            "ALTER USER {} WITH LOGIN PASSWORD '{}' VALID UNTIL '{}'".format(
+                username, password, valid_until
+            ),
+        ],
+    )
 
     return username, password

--- a/monitoring/deployment_manager/deploylib/deployments.py
+++ b/monitoring/deployment_manager/deploylib/deployments.py
@@ -6,17 +6,30 @@ from structlog import BoundLogger
 from monitoring.deployment_manager.deploylib import common_k8s
 
 
-def get(client: AppsV1Api, log: BoundLogger, namespace: V1Namespace, dep: V1Deployment) -> Optional[V1Deployment]:
+def get(
+    client: AppsV1Api, log: BoundLogger, namespace: V1Namespace, dep: V1Deployment
+) -> Optional[V1Deployment]:
     return common_k8s.get_resource(
         lambda: client.list_namespaced_deployment(namespace=namespace.metadata.name),
-        log, 'deployment', dep.metadata.name)
+        log,
+        "deployment",
+        dep.metadata.name,
+    )
 
 
-def upsert(client: AppsV1Api, log: BoundLogger, namespace: V1Namespace, dep: V1Deployment) -> V1Deployment:
+def upsert(
+    client: AppsV1Api, log: BoundLogger, namespace: V1Namespace, dep: V1Deployment
+) -> V1Deployment:
     existing_dep = get(client, log, namespace, dep)
     return common_k8s.upsert_resource(
-        existing_dep, dep, log, 'deployment',
+        existing_dep,
+        dep,
+        log,
+        "deployment",
         lambda: client.create_namespaced_deployment(
-            body=dep, namespace=namespace.metadata.name),
+            body=dep, namespace=namespace.metadata.name
+        ),
         lambda: client.patch_namespaced_deployment(
-            existing_dep.metadata.name, namespace.metadata.name, dep))
+            existing_dep.metadata.name, namespace.metadata.name, dep
+        ),
+    )

--- a/monitoring/deployment_manager/deploylib/ingresses.py
+++ b/monitoring/deployment_manager/deploylib/ingresses.py
@@ -6,17 +6,36 @@ from structlog import BoundLogger
 from monitoring.deployment_manager.deploylib import common_k8s
 
 
-def get(client: NetworkingV1Api, log: BoundLogger, namespace: V1Namespace, ingress: V1Ingress) -> Optional[V1Ingress]:
+def get(
+    client: NetworkingV1Api,
+    log: BoundLogger,
+    namespace: V1Namespace,
+    ingress: V1Ingress,
+) -> Optional[V1Ingress]:
     return common_k8s.get_resource(
         lambda: client.list_namespaced_ingress(namespace=namespace.metadata.name),
-        log, 'ingress', ingress.metadata.name)
+        log,
+        "ingress",
+        ingress.metadata.name,
+    )
 
 
-def upsert(client: NetworkingV1Api, log: BoundLogger, namespace: V1Namespace, ingress: V1Ingress) -> V1Ingress:
+def upsert(
+    client: NetworkingV1Api,
+    log: BoundLogger,
+    namespace: V1Namespace,
+    ingress: V1Ingress,
+) -> V1Ingress:
     existing_ingress = get(client, log, namespace, ingress)
     return common_k8s.upsert_resource(
-        existing_ingress, ingress, log, 'ingress',
+        existing_ingress,
+        ingress,
+        log,
+        "ingress",
         lambda: client.create_namespaced_ingress(
-            body=ingress, namespace=namespace.metadata.name),
+            body=ingress, namespace=namespace.metadata.name
+        ),
         lambda: client.patch_namespaced_ingress(
-            existing_ingress.metadata.name, namespace.metadata.name, ingress))
+            existing_ingress.metadata.name, namespace.metadata.name, ingress
+        ),
+    )

--- a/monitoring/deployment_manager/deploylib/namespaces.py
+++ b/monitoring/deployment_manager/deploylib/namespaces.py
@@ -6,13 +6,20 @@ from structlog import BoundLogger
 from monitoring.deployment_manager.deploylib import common_k8s
 
 
-def get(client: CoreV1Api, log: BoundLogger, namespace: V1Namespace) -> Optional[V1Namespace]:
+def get(
+    client: CoreV1Api, log: BoundLogger, namespace: V1Namespace
+) -> Optional[V1Namespace]:
     return common_k8s.get_resource(
-        lambda: client.list_namespace(), log, 'namespace', namespace.metadata.name)
+        lambda: client.list_namespace(), log, "namespace", namespace.metadata.name
+    )
 
 
 def upsert(client: CoreV1Api, log: BoundLogger, namespace: V1Namespace) -> V1Namespace:
     return common_k8s.upsert_resource(
-        get(client, log, namespace), namespace, log, 'namespace',
+        get(client, log, namespace),
+        namespace,
+        log,
+        "namespace",
         lambda: client.create_namespace(body=namespace),
-        lambda: client.patch_namespace(namespace.metadata.name, body=namespace))
+        lambda: client.patch_namespace(namespace.metadata.name, body=namespace),
+    )

--- a/monitoring/deployment_manager/deploylib/secrets.py
+++ b/monitoring/deployment_manager/deploylib/secrets.py
@@ -6,17 +6,30 @@ from structlog import BoundLogger
 from monitoring.deployment_manager.deploylib import common_k8s
 
 
-def get(client: CoreV1Api, log: BoundLogger, namespace: V1Namespace, name: str) -> Optional[V1Secret]:
+def get(
+    client: CoreV1Api, log: BoundLogger, namespace: V1Namespace, name: str
+) -> Optional[V1Secret]:
     return common_k8s.get_resource(
         lambda: client.list_namespaced_secret(namespace=namespace.metadata.name),
-        log, 'secret', name)
+        log,
+        "secret",
+        name,
+    )
 
 
-def upsert(client: CoreV1Api, log: BoundLogger, namespace: V1Namespace, secret: V1Secret) -> V1Secret:
+def upsert(
+    client: CoreV1Api, log: BoundLogger, namespace: V1Namespace, secret: V1Secret
+) -> V1Secret:
     existing_secret = get(client, log, namespace, secret.metadata.name)
     return common_k8s.upsert_resource(
-        existing_secret, secret, log, 'secret',
+        existing_secret,
+        secret,
+        log,
+        "secret",
         lambda: client.create_namespaced_secret(
-            body=secret, namespace=namespace.metadata.name),
+            body=secret, namespace=namespace.metadata.name
+        ),
         lambda: client.patch_namespaced_secret(
-            existing_secret.metadata.name, namespace.metadata.name, secret))
+            existing_secret.metadata.name, namespace.metadata.name, secret
+        ),
+    )

--- a/monitoring/deployment_manager/deploylib/services.py
+++ b/monitoring/deployment_manager/deploylib/services.py
@@ -6,17 +6,30 @@ from structlog import BoundLogger
 from monitoring.deployment_manager.deploylib import common_k8s
 
 
-def get(client: CoreV1Api, log: BoundLogger, namespace: V1Namespace, svc: V1Service) -> Optional[V1Service]:
+def get(
+    client: CoreV1Api, log: BoundLogger, namespace: V1Namespace, svc: V1Service
+) -> Optional[V1Service]:
     return common_k8s.get_resource(
         lambda: client.list_namespaced_service(namespace=namespace.metadata.name),
-        log, 'service', svc.metadata.name)
+        log,
+        "service",
+        svc.metadata.name,
+    )
 
 
-def upsert(client: CoreV1Api, log: BoundLogger, namespace: V1Namespace, svc: V1Service) -> V1Service:
+def upsert(
+    client: CoreV1Api, log: BoundLogger, namespace: V1Namespace, svc: V1Service
+) -> V1Service:
     existing_svc = get(client, log, namespace, svc)
     return common_k8s.upsert_resource(
-        existing_svc, svc, log, 'service',
+        existing_svc,
+        svc,
+        log,
+        "service",
         lambda: client.create_namespaced_service(
-            body=svc, namespace=namespace.metadata.name),
+            body=svc, namespace=namespace.metadata.name
+        ),
         lambda: client.patch_namespaced_service(
-            existing_svc.metadata.name, namespace.metadata.name, svc))
+            existing_svc.metadata.name, namespace.metadata.name, svc
+        ),
+    )

--- a/monitoring/deployment_manager/deploylib/systems.py
+++ b/monitoring/deployment_manager/deploylib/systems.py
@@ -11,59 +11,104 @@ import monitoring.deployment_manager.deploylib.namespaces
 import monitoring.deployment_manager.deploylib.services
 
 
-def upsert_resources(target_resources: List[Any], namespace: V1Namespace, clients: Clients, log: BoundLogger) -> None:
+def upsert_resources(
+    target_resources: List[Any],
+    namespace: V1Namespace,
+    clients: Clients,
+    log: BoundLogger,
+) -> None:
     for target_resource in target_resources:
         if target_resource.__class__ == V1Deployment:
             deploylib.deployments.upsert(clients.apps, log, namespace, target_resource)
         elif target_resource.__class__ == V1Ingress:
-            deploylib.ingresses.upsert(clients.networking, log, namespace, target_resource)
+            deploylib.ingresses.upsert(
+                clients.networking, log, namespace, target_resource
+            )
         elif target_resource.__class__ == V1Namespace:
             deploylib.namespaces.upsert(clients.core, log, target_resource)
         elif target_resource.__class__ == V1Service:
             deploylib.services.upsert(clients.core, log, namespace, target_resource)
         else:
-            raise NotImplementedError('Upserting {} is not yet supported'.format(target_resource.__class__))
+            raise NotImplementedError(
+                "Upserting {} is not yet supported".format(target_resource.__class__)
+            )
 
 
-def get_resources(target_resources: List[Any], namespace: V1Namespace, clients: Clients, log: BoundLogger, cluster_name: str) -> List[Any]:
+def get_resources(
+    target_resources: List[Any],
+    namespace: V1Namespace,
+    clients: Clients,
+    log: BoundLogger,
+    cluster_name: str,
+) -> List[Any]:
     existing_resources = []
     for target_resource in target_resources:
         if target_resource.__class__ == V1Deployment:
-            existing_resource = deploylib.deployments.get(clients.apps, log, namespace, target_resource)
+            existing_resource = deploylib.deployments.get(
+                clients.apps, log, namespace, target_resource
+            )
         elif target_resource.__class__ == V1Ingress:
-            existing_resource = deploylib.ingresses.get(clients.networking, log, namespace, target_resource)
+            existing_resource = deploylib.ingresses.get(
+                clients.networking, log, namespace, target_resource
+            )
         elif target_resource.__class__ == V1Namespace:
-            existing_resource = deploylib.namespaces.get(clients.core, log, target_resource)
+            existing_resource = deploylib.namespaces.get(
+                clients.core, log, target_resource
+            )
         elif target_resource.__class__ == V1Service:
-            existing_resource = deploylib.services.get(clients.core, log, namespace, target_resource)
+            existing_resource = deploylib.services.get(
+                clients.core, log, namespace, target_resource
+            )
         else:
-            raise NotImplementedError('Getting {} is not yet supported'.format(target_resource.__class__))
+            raise NotImplementedError(
+                "Getting {} is not yet supported".format(target_resource.__class__)
+            )
 
         if existing_resource is None:
-            log.warn('No existing {} {} found in `{}` namespace of `{}` cluster'.format(target_resource.metadata.name, target_resource.__class__.__name__, namespace.metadata.name, cluster_name))
+            log.warn(
+                "No existing {} {} found in `{}` namespace of `{}` cluster".format(
+                    target_resource.metadata.name,
+                    target_resource.__class__.__name__,
+                    namespace.metadata.name,
+                    cluster_name,
+                )
+            )
         existing_resources.append(existing_resource)
     return existing_resources
 
 
-def delete_resources(existing_resources: List[Any], namespace: V1Namespace, clients: Clients, log: BoundLogger):
+def delete_resources(
+    existing_resources: List[Any],
+    namespace: V1Namespace,
+    clients: Clients,
+    log: BoundLogger,
+):
     for existing_resource in existing_resources:
         if existing_resource is None:
             pass
         elif existing_resource.__class__ == V1Deployment:
-            log.msg('Deleting deployment')
-            status = clients.apps.delete_namespaced_deployment(name=existing_resource.metadata.name, namespace=namespace.metadata.name)
-            log.msg('Deployment deleted', message=status.message)
+            log.msg("Deleting deployment")
+            status = clients.apps.delete_namespaced_deployment(
+                name=existing_resource.metadata.name, namespace=namespace.metadata.name
+            )
+            log.msg("Deployment deleted", message=status.message)
         elif existing_resource.__class__ == V1Ingress:
-            log.msg('Deleting ingress')
-            status = clients.networking.delete_namespaced_ingress(name=existing_resource.metadata.name, namespace=namespace.metadata.name)
-            log.msg('Ingress deleted', message=status.message)
+            log.msg("Deleting ingress")
+            status = clients.networking.delete_namespaced_ingress(
+                name=existing_resource.metadata.name, namespace=namespace.metadata.name
+            )
+            log.msg("Ingress deleted", message=status.message)
         elif existing_resource.__class__ == V1Namespace:
-            log.msg('Deleting namespace')
+            log.msg("Deleting namespace")
             status = clients.core.delete_namespace(name=namespace.metadata.name)
-            log.msg('Namespace deleted', name=status.message)
+            log.msg("Namespace deleted", name=status.message)
         elif existing_resource.__class__ == V1Service:
-            log.msg('Deleting service')
-            svc = clients.core.delete_namespaced_service(name=existing_resource.metadata.name, namespace=namespace.metadata.name)
-            log.msg('Service deleted', message=svc.metadata.name)
+            log.msg("Deleting service")
+            svc = clients.core.delete_namespaced_service(
+                name=existing_resource.metadata.name, namespace=namespace.metadata.name
+            )
+            log.msg("Service deleted", message=svc.metadata.name)
         else:
-            raise NotImplementedError('Deleting {} is not yet supported'.format(existing_resource.__class__))
+            raise NotImplementedError(
+                "Deleting {} is not yet supported".format(existing_resource.__class__)
+            )

--- a/monitoring/deployment_manager/deployment_manager.py
+++ b/monitoring/deployment_manager/deployment_manager.py
@@ -14,13 +14,17 @@ from monitoring.monitorlib.inspection import import_submodules
 
 
 def _parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description='Manage an InterUSS deployment')
+    parser = argparse.ArgumentParser(description="Manage an InterUSS deployment")
 
-    actions = parser.add_subparsers(title='available deployment actions', dest='action', metavar='ACTION')
+    actions = parser.add_subparsers(
+        title="available deployment actions", dest="action", metavar="ACTION"
+    )
     for name, func in infrastructure.actions.items():
         actions.add_parser(name, help=func.__doc__)
 
-    parser.add_argument('deployment_spec', metavar='SPEC', type=str, help='specification for deployment')
+    parser.add_argument(
+        "deployment_spec", metavar="SPEC", type=str, help="specification for deployment"
+    )
 
     return parser.parse_args()
 
@@ -35,27 +39,35 @@ def main() -> int:
     # Retrieve action function
     action_method = infrastructure.actions.get(args.action, None)
     if action_method is None:
-        raise ValueError('Could not find definition for action `{}`'.format(args.action))
+        raise ValueError(
+            "Could not find definition for action `{}`".format(args.action)
+        )
 
     # Parse deployment spec
-    with open(args.deployment_spec, 'r') as f:
+    with open(args.deployment_spec, "r") as f:
         spec = ImplicitDict.parse(json.load(f), DeploymentSpec)
     original_spec = json.dumps(spec)
     context = make_context(spec)
 
     # Execute action
-    context.log.msg('Executing action', action=args.action, spec_file=args.deployment_spec)
+    context.log.msg(
+        "Executing action", action=args.action, spec_file=args.deployment_spec
+    )
     action_method(context)
 
     # Check if the deployment spec was updated
     new_spec = json.dumps(context.spec)
     if new_spec != original_spec:
-        context.log.msg('Deployment spec updated; writing changes to {}'.format(args.deployment_spec))
-        with open(args.deployment_spec, 'w') as f:
+        context.log.msg(
+            "Deployment spec updated; writing changes to {}".format(
+                args.deployment_spec
+            )
+        )
+        with open(args.deployment_spec, "w") as f:
             json.dump(context.spec, f, indent=2)
 
     return os.EX_OK
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/monitoring/deployment_manager/infrastructure.py
+++ b/monitoring/deployment_manager/infrastructure.py
@@ -25,18 +25,31 @@ def make_context(spec: DeploymentSpec):
     if spec.cluster is not None:
         contexts, active_context = kubernetes.config.list_kube_config_contexts()
         if not contexts:
-            raise ValueError('Cannot find any context in kube-config file.')
-        matching_contexts = [c['name'] for c in contexts if c['name'] == spec.cluster.name]
+            raise ValueError("Cannot find any context in kube-config file.")
+        matching_contexts = [
+            c["name"] for c in contexts if c["name"] == spec.cluster.name
+        ]
         if not matching_contexts:
-            raise ValueError('Cannot find definition for context `{}` in kube-config file'.format(spec.cluster.name))
+            raise ValueError(
+                "Cannot find definition for context `{}` in kube-config file".format(
+                    spec.cluster.name
+                )
+            )
         if len(matching_contexts) > 1:
-            raise ValueError('Found multiple context definitions with the name `{}` in kube-config file'.format(spec.cluster.name))
+            raise ValueError(
+                "Found multiple context definitions with the name `{}` in kube-config file".format(
+                    spec.cluster.name
+                )
+            )
 
-        api_client = kubernetes.config.new_client_from_config(context=matching_contexts[0])
+        api_client = kubernetes.config.new_client_from_config(
+            context=matching_contexts[0]
+        )
         clients = Clients(
             core=kubernetes.client.CoreV1Api(api_client=api_client),
             apps=kubernetes.client.AppsV1Api(api_client=api_client),
-            networking=kubernetes.client.NetworkingV1Api(api_client=api_client))
+            networking=kubernetes.client.NetworkingV1Api(api_client=api_client),
+        )
     else:
         clients = None
 
@@ -53,4 +66,5 @@ def deployment_action(name: str):
         global actions
         actions[name] = action
         return action
+
     return decorator_declare_action

--- a/monitoring/deployment_manager/systems/dss/v1/configuration.py
+++ b/monitoring/deployment_manager/systems/dss/v1/configuration.py
@@ -9,5 +9,5 @@ class V1DSS(ImplicitDict):
     Kubernetes cluster with Tanka.
     """
 
-    namespace: str = 'default'
+    namespace: str = "default"
     """Namespace in which all DSS components are located"""

--- a/monitoring/deployment_manager/systems/test/configuration.py
+++ b/monitoring/deployment_manager/systems/test/configuration.py
@@ -3,7 +3,7 @@ from implicitdict import ImplicitDict
 
 
 class TestV1(ImplicitDict):
-    namespace: str = 'test'
+    namespace: str = "test"
 
 
 class Test(ImplicitDict):

--- a/monitoring/deployment_manager/systems/test/hello_world.py
+++ b/monitoring/deployment_manager/systems/test/hello_world.py
@@ -3,15 +3,15 @@ from typing import Any, List
 from kubernetes import client as k8s
 
 
-DEPLOYMENT_NAME = 'webserver-deployment'
+DEPLOYMENT_NAME = "webserver-deployment"
 CONTAINER_PORT = 8001
-APP_NAME = 'webbserver-app'
+APP_NAME = "webbserver-app"
 
-SERVICE_NAME = 'webserver-service'
+SERVICE_NAME = "webserver-service"
 SERVICE_PORT = 8002
-SERVICE_PORT_NAME = 'webserver-port'
+SERVICE_PORT_NAME = "webserver-port"
 
-INGRESS_NAME = 'webserver-ingress'
+INGRESS_NAME = "webserver-ingress"
 
 
 def define_namespace(name: str) -> k8s.V1Namespace:
@@ -21,25 +21,32 @@ def define_namespace(name: str) -> k8s.V1Namespace:
 def _define_webserver_deployment() -> k8s.V1Deployment:
     # Define Pod container template
     container = k8s.V1Container(
-        name='echo',
-        image='hashicorp/http-echo',
-        command=['/http-echo', '-listen=:{}'.format(CONTAINER_PORT), '-text="Echo server on port {}"'.format(CONTAINER_PORT)],
+        name="echo",
+        image="hashicorp/http-echo",
+        command=[
+            "/http-echo",
+            "-listen=:{}".format(CONTAINER_PORT),
+            '-text="Echo server on port {}"'.format(CONTAINER_PORT),
+        ],
         ports=[k8s.V1ContainerPort(container_port=CONTAINER_PORT)],
         resources=k8s.V1ResourceRequirements(
-            requests={'cpu': '100m', 'memory': '200Mi'},
-            limits={'cpu': '500m', 'memory': '500Mi'},
+            requests={"cpu": "100m", "memory": "200Mi"},
+            limits={"cpu": "500m", "memory": "500Mi"},
         ),
     )
 
     # Create and configure a spec section
     template = k8s.V1PodTemplateSpec(
-        metadata=k8s.V1ObjectMeta(labels={'app': APP_NAME}),
+        metadata=k8s.V1ObjectMeta(labels={"app": APP_NAME}),
         spec=k8s.V1PodSpec(containers=[container]),
     )
 
     # Create the specification of deployment
     spec = k8s.V1DeploymentSpec(
-        replicas=1, template=template, selector=k8s.V1LabelSelector(match_labels={'app': APP_NAME}))
+        replicas=1,
+        template=template,
+        selector=k8s.V1LabelSelector(match_labels={"app": APP_NAME}),
+    )
 
     # Instantiate the deployment object
     deployment = k8s.V1Deployment(
@@ -52,15 +59,15 @@ def _define_webserver_deployment() -> k8s.V1Deployment:
 
 def _define_webserver_service() -> k8s.V1Service:
     spec = k8s.V1ServiceSpec(
-        selector={'app': APP_NAME},
-        type='LoadBalancer',
+        selector={"app": APP_NAME},
+        type="LoadBalancer",
         ports=[
             k8s.V1ServicePort(
                 name=SERVICE_PORT_NAME,
                 port=SERVICE_PORT,
                 target_port=CONTAINER_PORT,
             )
-        ]
+        ],
     )
 
     svc = k8s.V1Service(
@@ -78,12 +85,17 @@ def _define_webserver_ingress() -> k8s.V1Ingress:
                 http=k8s.V1HTTPIngressRuleValue(
                     paths=[
                         k8s.V1HTTPIngressPath(
-                            path='/',
-                            path_type='Prefix',
+                            path="/",
+                            path_type="Prefix",
                             backend=k8s.V1IngressBackend(
                                 service=k8s.V1IngressServiceBackend(
                                     name=SERVICE_NAME,
-                                    port=k8s.V1ServiceBackendPort(name=SERVICE_PORT_NAME))))
+                                    port=k8s.V1ServiceBackendPort(
+                                        name=SERVICE_PORT_NAME
+                                    ),
+                                )
+                            ),
+                        )
                     ]
                 )
             )

--- a/monitoring/get_access_token.py
+++ b/monitoring/get_access_token.py
@@ -6,25 +6,36 @@ from monitoring.monitorlib import auth
 
 
 def parse_args(argv: List[str]):
-  parser = argparse.ArgumentParser(description='Retrieve an access token')
-  parser.add_argument(
-    '--spec', action='store', dest='spec', type=str,
-    help='The auth spec for which to retrieve the token.  See README.md in this folder for examples.')
-  parser.add_argument(
-    '--scopes', action='store', dest='scopes', type=str,
-    help='The scope or scopes to request.  Multiple scopes should be space-separated (so, included in quotes on the command line).')
-  parser.add_argument(
-    '--audience', action='store', dest='audience', type=str,
-    help='The audience to request.')
-  return parser.parse_args(argv)
+    parser = argparse.ArgumentParser(description="Retrieve an access token")
+    parser.add_argument(
+        "--spec",
+        action="store",
+        dest="spec",
+        type=str,
+        help="The auth spec for which to retrieve the token.  See README.md in this folder for examples.",
+    )
+    parser.add_argument(
+        "--scopes",
+        action="store",
+        dest="scopes",
+        type=str,
+        help="The scope or scopes to request.  Multiple scopes should be space-separated (so, included in quotes on the command line).",
+    )
+    parser.add_argument(
+        "--audience",
+        action="store",
+        dest="audience",
+        type=str,
+        help="The audience to request.",
+    )
+    return parser.parse_args(argv)
 
 
 def get_access_token(spec: str, scopes: str, audience: str):
-  adapter = auth.make_auth_adapter(spec)
-  return adapter.issue_token(audience, scopes.split(' '))
+    adapter = auth.make_auth_adapter(spec)
+    return adapter.issue_token(audience, scopes.split(" "))
 
 
-if __name__ == '__main__':
-  args = parse_args(sys.argv[1:])
-  print(get_access_token(args.spec, args.scopes, args.audience))
-
+if __name__ == "__main__":
+    args = parse_args(sys.argv[1:])
+    print(get_access_token(args.spec, args.scopes, args.audience))

--- a/monitoring/loadtest/locust_files/ISA.py
+++ b/monitoring/loadtest/locust_files/ISA.py
@@ -9,6 +9,7 @@ from monitoring.monitorlib import rid_v1
 from monitoring.prober.rid.v1 import common
 from locust import task, between
 
+
 class ISA(client.USS):
     wait_time = between(0.01, 1)
     lock = threading.Lock()
@@ -70,7 +71,9 @@ class ISA(client.USS):
 
     @task(100)
     def get_isa(self):
-        target_isa = random.choice(list(self.isa_dict.keys())) if self.isa_dict else None
+        target_isa = (
+            random.choice(list(self.isa_dict.keys())) if self.isa_dict else None
+        )
         if not target_isa:
             print("Nothing to pick from isa_dict for GET")
             return
@@ -88,7 +91,9 @@ class ISA(client.USS):
 
     def checkout_isa(self):
         self.lock.acquire()
-        target_isa = random.choice(list(self.isa_dict.keys())) if self.isa_dict else None
+        target_isa = (
+            random.choice(list(self.isa_dict.keys())) if self.isa_dict else None
+        )
         target_version = self.isa_dict.pop(target_isa, None)
         self.lock.release()
         return target_isa, target_version
@@ -99,4 +104,3 @@ class ISA(client.USS):
 
     def on_stop(self):
         self.isa_dict = {}
-

--- a/monitoring/loadtest/locust_files/Sub.py
+++ b/monitoring/loadtest/locust_files/Sub.py
@@ -16,22 +16,10 @@ class Sub(client.USS):
         base_lng = random.randint(0, 180)
         base_lat = random.randint(-90, 90)
         return [
-            {
-                'lng': base_lng + 0.6205,
-                'lat': base_lat + 0.6558
-            },
-            {
-                'lng': base_lng + 0.6301,
-                'lat': base_lat + 0.6898
-            },
-            {
-                'lng': base_lng + 0.6700,
-                'lat': base_lat + 0.6709
-            },
-            {
-                'lng': base_lng + 0.6466,
-                'lat': base_lat + 0.6407
-            },
+            {"lng": base_lng + 0.6205, "lat": base_lat + 0.6558},
+            {"lng": base_lng + 0.6301, "lat": base_lat + 0.6898},
+            {"lng": base_lng + 0.6700, "lat": base_lat + 0.6709},
+            {"lng": base_lng + 0.6466, "lat": base_lat + 0.6407},
         ]
 
     @task(100)
@@ -64,7 +52,9 @@ class Sub(client.USS):
 
     @task(20)
     def get_sub(self):
-        target_sub = random.choice(list(self.sub_dict.keys())) if self.sub_dict else None
+        target_sub = (
+            random.choice(list(self.sub_dict.keys())) if self.sub_dict else None
+        )
         if not target_sub:
             print("Nothing to pick from sub_dict for GET")
             return
@@ -111,7 +101,9 @@ class Sub(client.USS):
 
     def checkout_sub(self):
         self.lock.acquire()
-        target_sub = random.choice(list(self.sub_dict.keys())) if self.sub_dict else None
+        target_sub = (
+            random.choice(list(self.sub_dict.keys())) if self.sub_dict else None
+        )
         target_version = self.sub_dict.pop(target_sub, None)
         self.lock.release()
         return target_sub, target_version

--- a/monitoring/loadtest/locust_files/client.py
+++ b/monitoring/loadtest/locust_files/client.py
@@ -40,7 +40,9 @@ class DSSClient(infrastructure.UTMClientSession):
                 )
         return result
 
-    def log_exception(self, real_method: str, name: str, start_time: float, e: Exception):
+    def log_exception(
+        self, real_method: str, name: str, start_time: float, e: Exception
+    ):
         total_time = int((time.time() - start_time) * 1000)
         self._locust_environment.events.request_failure.fire(
             request_type=real_method,
@@ -49,6 +51,7 @@ class DSSClient(infrastructure.UTMClientSession):
             exception=e,
             response_length=0,
         )
+
 
 class USS(User):
     # Suggested by Locust 1.2.2 API Docs https://docs.locust.io/en/stable/api.html#locust.User.abstract
@@ -65,7 +68,9 @@ class USS(User):
         if not auth_spec:
             # logging after creation of client so that we surface the error in the UI
             e = Exception("Missing AUTH_SPEC environment variable, please check README")
-            self.client.log_exception("Initialization", "Create DSS Client", time.time(), e)
+            self.client.log_exception(
+                "Initialization", "Create DSS Client", time.time(), e
+            )
             # raising exception to not allow things to proceed further
             raise e
         # This is a load tester its acceptable to have all the scopes required to operate anything.

--- a/monitoring/validate_access_token.py
+++ b/monitoring/validate_access_token.py
@@ -8,21 +8,29 @@ from monitoring.monitorlib import auth_validation
 
 
 def parse_args(argv: List[str]):
-    parser = argparse.ArgumentParser(description='Validate an access token')
+    parser = argparse.ArgumentParser(description="Validate an access token")
     parser.add_argument(
-        '--token', action='store', dest='token', type=str,
-        help='JWT access token to be validated')
+        "--token",
+        action="store",
+        dest="token",
+        type=str,
+        help="JWT access token to be validated",
+    )
     parser.add_argument(
-        '--key', action='store', dest='key', type=str,
-        help='Public key to validate against.  May be PEM-format text or a URL to a JWKS or plaintext PEM file.')
+        "--key",
+        action="store",
+        dest="key",
+        type=str,
+        help="Public key to validate against.  May be PEM-format text or a URL to a JWKS or plaintext PEM file.",
+    )
     return parser.parse_args(argv)
 
 
 def get_access_token_payload(token: str, public_key: str):
     key = auth_validation.fix_key(public_key)
-    return jwt.decode(token, key, algorithms='RS256', options={'verify_aud': False})
+    return jwt.decode(token, key, algorithms="RS256", options={"verify_aud": False})
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     args = parse_args(sys.argv[1:])
     print(get_access_token_payload(args.token, args.key))

--- a/test/repo_hygiene/md_files/local_links.py
+++ b/test/repo_hygiene/md_files/local_links.py
@@ -5,14 +5,16 @@ import marko.block
 import marko.inline
 
 
-def check_local_links(parent: marko.block.Element, doc_path: str, repo_root: str) -> None:
+def check_local_links(
+    parent: marko.block.Element, doc_path: str, repo_root: str
+) -> None:
     github_base_url = os.environ.get("MONITORING_GITHUB_ROOT", "")
     if not github_base_url:
         github_base_url = "https://github.com/interuss/monitoring"
     repo_content_base_url = github_base_url + "/tree/main/"
     if isinstance(parent, marko.inline.Link):
         if parent.dest.startswith(repo_content_base_url):
-            relative_path = parent.dest[len(repo_content_base_url):]
+            relative_path = parent.dest[len(repo_content_base_url) :]
         elif parent.dest.startswith("http://") or parent.dest.startswith("https://"):
             # Don't check absolute paths to other locations
             relative_path = None
@@ -25,7 +27,9 @@ def check_local_links(parent: marko.block.Element, doc_path: str, repo_root: str
             abs_path = os.path.realpath(os.path.join(repo_root, relative_path))
             if not os.path.exists(abs_path):
                 md_relative_path = os.path.relpath(doc_path, repo_root)
-                raise ValueError(f"Document {md_relative_path} has a link to {parent.dest} but {relative_path} does not exist in the repository ({abs_path} in the repo_hygiene container)")
+                raise ValueError(
+                    f"Document {md_relative_path} has a link to {parent.dest} but {relative_path} does not exist in the repository ({abs_path} in the repo_hygiene container)"
+                )
     else:
         if hasattr(parent, "children") and not isinstance(parent.children, str):
             for child in parent.children:

--- a/test/repo_hygiene/md_files/md_files.py
+++ b/test/repo_hygiene/md_files/md_files.py
@@ -15,5 +15,7 @@ def check_md_file(md_file_path: str, repo_root: str) -> None:
 def check_md_files(path: str, repo_root: str) -> None:
     for md_file in glob.glob(os.path.join(path, "*.md")):
         check_md_file(md_file, repo_root)
-    for subfolder in (f.path for f in os.scandir(path) if f.is_dir() and f.name != "github_pages"):
+    for subfolder in (
+        f.path for f in os.scandir(path) if f.is_dir() and f.name != "github_pages"
+    ):
         check_md_files(subfolder, repo_root)

--- a/test/repo_hygiene/repo_hygiene.py
+++ b/test/repo_hygiene/repo_hygiene.py
@@ -14,7 +14,9 @@ from md_files.md_files import check_md_files
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Check repo hygiene")
 
-    parser.add_argument("repo_location", metavar="REPO", type=str, help="path to repository")
+    parser.add_argument(
+        "repo_location", metavar="REPO", type=str, help="path to repository"
+    )
 
     return parser.parse_args()
 


### PR DESCRIPTION
This PR consists only of the changes made by running the command below:

`docker run --rm -v "$(pwd):/code" -w /code pyfound/black:22.10.0 black . --exclude '^/interfaces'`

This applies `black` formatting to the entire repo in preparation for simplifying Python autoformatting by performing it only once at the root of the repository.