### PR TITLE
[mock_uss/gunicorn] Use gevent worker type to mitigate #28

### DIFF
--- a/monitoring/mock_uss/start.sh
+++ b/monitoring/mock_uss/start.sh
@@ -23,7 +23,8 @@ export PYTHONUNBUFFERED=TRUE
 gunicorn \
     --preload \
     --config ./gunicorn.conf.py \
+    --worker-class="gevent" \
     --workers=4 \
-    --threads=2 \
+    --worker-tmp-dir="/dev/shm" \
     "--bind=0.0.0.0:${port}" \
     monitoring.mock_uss:webapp

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ faker===8.1.0  # uss_qualifier
 flask==1.1.2
 Flask-HTTPAuth==4.7.0  # atproxy
 geojson===2.5.0  # uss_qualifier
+gevent==22.10.2  # mock_uss / gunicorn worker
 google-auth==1.6.3
 graphviz==0.20.1  # uss_qualifier
 gunicorn==20.1.0


### PR DESCRIPTION
See https://github.com/interuss/monitoring/issues/28#issuecomment-1764586324 for context.
This may or may not fix the issue.

This also sets the worker tmp dir to a RAM-based storage. See those links for insight as to why that may help the #28 situation, and will improve performances in any case: 
- https://pythonspeed.com/articles/gunicorn-in-docker/
- https://docs.gunicorn.org/en/stable/faq.html#blocking-os-fchmod