### PR TITLE
[uss_qualifier] Make skipped actions first-class actions in report

### DIFF
--- a/monitoring/uss_qualifier/reports/report.py
+++ b/monitoring/uss_qualifier/reports/report.py
@@ -362,8 +362,13 @@ class TestSuiteActionReport(ImplicitDict):
     action_generator: Optional[ActionGeneratorReport]
     """If this action was an action generator, this field will hold its report"""
 
+    skipped_action: Optional[SkippedActionReport]
+    """If this action was skipped, this field will hold its report"""
+
     def get_applicable_report(self) -> Tuple[bool, bool, bool]:
         """Determine which type of report is applicable for this action.
+
+        Note that skipped_action is applicable if none of the other return values are true.
 
         Returns:
             * Whether test_suite is applicable
@@ -375,15 +380,21 @@ class TestSuiteActionReport(ImplicitDict):
         action_generator = (
             "action_generator" in self and self.action_generator is not None
         )
+        skipped_action = "skipped_action" in self and self.skipped_action is not None
         if (
             sum(
                 1 if case else 0
-                for case in [test_suite, test_scenario, action_generator]
+                for case in [
+                    test_suite,
+                    test_scenario,
+                    action_generator,
+                    skipped_action,
+                ]
             )
             != 1
         ):
             raise ValueError(
-                "Exactly one of `test_suite`, `test_scenario`, or `action_generator` must be populated"
+                "Exactly one of `test_suite`, `test_scenario`, `action_generator`, or `skipped_action` must be populated"
             )
         return test_suite, test_scenario, action_generator
 
@@ -392,6 +403,7 @@ class TestSuiteActionReport(ImplicitDict):
         test_suite_func: Union[Callable[[TestSuiteReport], Any], Callable[[Any], Any]],
         test_scenario_func: Optional[Callable[[TestScenarioReport], Any]] = None,
         action_generator_func: Optional[Callable[[ActionGeneratorReport], Any]] = None,
+        skipped_action_func: Optional[Callable[[SkippedActionReport], Any]] = None,
     ) -> Any:
         test_suite, test_scenario, action_generator = self.get_applicable_report()
         if test_suite:
@@ -406,11 +418,10 @@ class TestSuiteActionReport(ImplicitDict):
                 return action_generator_func(self.action_generator)
             else:
                 return test_suite_func(self.action_generator)
-
-        # This line should not be possible to reach
-        raise RuntimeError(
-            "Case selection logic failed for TestSuiteActionReport; none of test_suite, test_scenario, nor action_generator were populated"
-        )
+        if skipped_action_func is not None:
+            return skipped_action_func(self.skipped_action)
+        else:
+            return test_suite_func(self.skipped_action)
 
     def successful(self) -> bool:
         return self._conditional(lambda report: report.successful)
@@ -435,9 +446,7 @@ class TestSuiteActionReport(ImplicitDict):
             report = self.action_generator
             prefix = "action_generator"
         else:
-            raise RuntimeError(
-                "Case selection logic failed for TestSuiteActionReport; none of test_suite, test_scenario, nor action_generator were populated"
-            )
+            return
 
         for path, pc in report.query_passed_checks(participant_id):
             yield f"{prefix}.{path}", pc
@@ -456,9 +465,7 @@ class TestSuiteActionReport(ImplicitDict):
             report = self.action_generator
             prefix = "action_generator"
         else:
-            raise RuntimeError(
-                "Case selection logic failed for TestSuiteActionReport; none of test_suite, test_scenario, nor action_generator were populated"
-            )
+            return
 
         for path, fc in report.query_failed_checks(participant_id):
             yield f"{prefix}.{path}", fc
@@ -621,6 +628,30 @@ class SkippedActionReport(ImplicitDict):
     declaration: TestSuiteActionDeclaration
     """Full declaration of the action that was skipped."""
 
+    @property
+    def successful(self) -> bool:
+        return True
+
+    def has_critical_problem(self) -> bool:
+        return False
+
+    def all_participants(self) -> Set[ParticipantID]:
+        return set()
+
+    def queries(self) -> List[fetch.Query]:
+        return []
+
+    def participant_ids(self) -> Set[ParticipantID]:
+        return set()
+
+    @property
+    def start_time(self) -> Optional[StringBasedDateTime]:
+        return self.timestamp
+
+    @property
+    def end_time(self) -> Optional[StringBasedDateTime]:
+        return self.timestamp
+
 
 class TestSuiteReport(ImplicitDict):
     name: str
@@ -637,9 +668,6 @@ class TestSuiteReport(ImplicitDict):
 
     actions: List[TestSuiteActionReport]
     """Reports from test scenarios and test suites comprising the test suite for this report, in order of execution."""
-
-    skipped_actions: List[SkippedActionReport]
-    """Reports for actions configured but not executed."""
 
     end_time: Optional[StringBasedDateTime]
     """Time at which the test suite completed"""

--- a/monitoring/uss_qualifier/reports/sequence_view.py
+++ b/monitoring/uss_qualifier/reports/sequence_view.py
@@ -497,12 +497,6 @@ def _compute_action_node(report: TestSuiteActionReport, indexer: Indexer) -> Act
         )
     elif is_test_suite:
         children = [_compute_action_node(a, indexer) for a in report.test_suite.actions]
-        for skipped_action in report.test_suite.skipped_actions:
-            i = 0
-            for i, a in enumerate(report.test_suite.actions):
-                if a.start_time.datetime > skipped_action.timestamp.datetime:
-                    break
-            children.insert(i, _skipped_action_of(skipped_action))
         return ActionNode(
             name=report.test_suite.name,
             node_type=ActionNodeType.Suite,
@@ -521,9 +515,7 @@ def _compute_action_node(report: TestSuiteActionReport, indexer: Indexer) -> Act
             ],
         )
     else:
-        raise ValueError(
-            "Invalid TestSuiteActionReport; doesn't specify scenario, suite, or action generator"
-        )
+        return _skipped_action_of(report.skipped_action)
 
 
 def _compute_overview_rows(node: ActionNode) -> Iterator[OverviewRow]:

--- a/monitoring/uss_qualifier/reports/validation/report_validation.py
+++ b/monitoring/uss_qualifier/reports/validation/report_validation.py
@@ -55,17 +55,7 @@ def _validate_action_no_skipped_actions(
     if test_scenario:
         success = True
     elif test_suite:
-        if (
-            "skipped_actions" not in report.test_suite
-            or not report.test_suite.skipped_actions
-        ):
-            success = True
-        else:
-            success = False
-            for sa in report.test_suite.skipped_actions:
-                logger.error(
-                    f"No skipped actions not achieved because {context}.test_suite had a skipped action for action index {sa.action_declaration_index}: {sa.reason}"
-                )
+        success = True
         for i, a in enumerate(report.test_suite.actions):
             success = success and _validate_action_no_skipped_actions(
                 a, JSONAddress(context + f".test_suite.actions[{i}]")
@@ -76,6 +66,11 @@ def _validate_action_no_skipped_actions(
             success = success and _validate_action_no_skipped_actions(
                 a, JSONAddress(context + f".action_generator.actions[{i}]")
             )
+    else:
+        logger.error(
+            f"No skipped actions not achieved because {context}.test_suite had a skipped action for action index {report.skipped_action.action_declaration_index}: {report.skipped_action.reason}"
+        )
+        success = False
     return success
 
 

--- a/schemas/monitoring/uss_qualifier/reports/report/TestSuiteActionReport.json
+++ b/schemas/monitoring/uss_qualifier/reports/report/TestSuiteActionReport.json
@@ -1,23 +1,14 @@
 {
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/uss_qualifier/reports/report/TestSuiteActionReport.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "type": "object",
+  "description": "monitoring.uss_qualifier.reports.report.TestSuiteActionReport, as defined in monitoring/uss_qualifier/reports/report.py",
   "properties": {
     "$ref": {
-      "type": "string",
-      "description": "Path to content that replaces the $ref"
-    },
-    "test_scenario": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "$ref": "TestScenarioReport.json"
-        }
-      ],
-      "description": "If this action was a test scenario, this field will hold its report"
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
     },
     "action_generator": {
+      "description": "If this action was an action generator, this field will hold its report",
       "oneOf": [
         {
           "type": "null"
@@ -25,10 +16,32 @@
         {
           "$ref": "ActionGeneratorReport.json"
         }
-      ],
-      "description": "If this action was an action generator, this field will hold its report"
+      ]
+    },
+    "skipped_action": {
+      "description": "If this action was skipped, this field will hold its report",
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "SkippedActionReport.json"
+        }
+      ]
+    },
+    "test_scenario": {
+      "description": "If this action was a test scenario, this field will hold its report",
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "TestScenarioReport.json"
+        }
+      ]
     },
     "test_suite": {
+      "description": "If this action was a test suite, this field will hold its report",
       "oneOf": [
         {
           "type": "null"
@@ -36,10 +49,8 @@
         {
           "$ref": "TestSuiteReport.json"
         }
-      ],
-      "description": "If this action was a test suite, this field will hold its report"
+      ]
     }
   },
-  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/uss_qualifier/reports/report/TestSuiteActionReport.json",
-  "description": "monitoring.uss_qualifier.reports.report.TestSuiteActionReport, as defined in monitoring/uss_qualifier/reports/report.py"
+  "type": "object"
 }

--- a/schemas/monitoring/uss_qualifier/reports/report/TestSuiteReport.json
+++ b/schemas/monitoring/uss_qualifier/reports/report/TestSuiteReport.json
@@ -37,13 +37,6 @@
       "description": "Name of this test suite",
       "type": "string"
     },
-    "skipped_actions": {
-      "description": "Reports for actions configured but not executed.",
-      "items": {
-        "$ref": "SkippedActionReport.json"
-      },
-      "type": "array"
-    },
     "start_time": {
       "description": "Time at which the test suite started",
       "format": "date-time",
@@ -63,7 +56,6 @@
     "capability_evaluations",
     "documentation_url",
     "name",
-    "skipped_actions",
     "start_time",
     "suite_type"
   ],


### PR DESCRIPTION
Skipped actions were initially introduced as separate things in a report but that introduces a lot of edge cases.  This PR instead makes a skipped action a kind of test suite action and this makes things much cleaner.