### PR TITLE
[uss_qualifier] Add local test suite resources

### DIFF
--- a/monitoring/uss_qualifier/configurations/dev/library/resources.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/library/resources.yaml
@@ -365,11 +365,3 @@ locality_che:
   resource_type: resources.interuss.mock_uss.locality.LocalityResource
   specification:
     locality_code: CHE
-
-# ===== System versioning =====
-
-uspace_system_identity:
-  $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
-  resource_type: resources.versioning.SystemIdentityResource
-  specification:
-    system_identity: uspace.ussp

--- a/monitoring/uss_qualifier/configurations/dev/uspace.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/uspace.yaml
@@ -4,7 +4,6 @@ v1:
     resources:
       resource_declarations:
         locality_che: {$ref: 'library/resources.yaml#/locality_che'}
-        uspace_system_identity: {$ref: 'library/resources.yaml#/uspace_system_identity'}
         che_conflicting_flights: {$ref: 'library/resources.yaml#/che_conflicting_flights'}
         che_invalid_flight_intents: {$ref: 'library/resources.yaml#/che_invalid_flight_intents'}
         che_invalid_flight_auth_flights: {$ref: 'library/resources.yaml#/che_invalid_flight_auth_flights'}
@@ -41,7 +40,6 @@ v1:
           locality: locality_che
 
           version_providers: scd_version_providers
-          system_identity: uspace_system_identity
 
           conflicting_flights: che_conflicting_flights
           priority_preemption_flights: che_conflicting_flights
@@ -67,7 +65,6 @@ v1:
               suite_type: suites.uspace.required_services
               resources:
                 version_providers: version_providers
-                system_identity: system_identity
 
                 conflicting_flights: conflicting_flights
                 priority_preemption_flights: priority_preemption_flights

--- a/monitoring/uss_qualifier/suites/suite.py
+++ b/monitoring/uss_qualifier/suites/suite.py
@@ -38,6 +38,7 @@ from monitoring.uss_qualifier.resources.resource import (
     ResourceType,
     make_child_resources,
     MissingResourceError,
+    create_resources,
 )
 from monitoring.uss_qualifier.scenarios.scenario import (
     TestScenario,
@@ -185,10 +186,18 @@ class TestSuite(object):
 
         self.declaration = declaration
         self.definition = TestSuiteDefinition.load_from_declaration(declaration)
-        self.local_resources = {
-            local_resource_id: resources[parent_resource_id]
-            for local_resource_id, parent_resource_id in declaration.resources.items()
-        }
+        if "resources" in declaration and declaration.resources:
+            self.local_resources = {
+                local_resource_id: resources[parent_resource_id]
+                for local_resource_id, parent_resource_id in declaration.resources.items()
+            }
+        else:
+            self.local_resources = {}
+        if "local_resources" in self.definition and self.definition.local_resources:
+            local_resources = create_resources(self.definition.local_resources)
+            for local_resource_id, resource in local_resources.items():
+                self.local_resources[local_resource_id] = resource
+
         for resource_id, resource_type in self.definition.resources.items():
             is_optional = resource_type.endswith("?")
             if is_optional:

--- a/monitoring/uss_qualifier/suites/uspace/required_services.yaml
+++ b/monitoring/uss_qualifier/suites/uspace/required_services.yaml
@@ -1,7 +1,6 @@
 name: U-space required services
 resources:
   version_providers: resources.versioning.VersionProvidersResource
-  system_identity: resources.versioning.SystemIdentityResource
 
   conflicting_flights: resources.flight_planning.FlightIntentsResource
   priority_preemption_flights: resources.flight_planning.FlightIntentsResource
@@ -19,6 +18,11 @@ resources:
   id_generator: resources.interuss.IDGeneratorResource
   service_area: resources.netrid.ServiceAreaResource
   problematically_big_area: resources.VerticesResource
+local_resources:
+  system_identity:
+    resource_type: resources.versioning.SystemIdentityResource
+    specification:
+      system_identity: uspace.ussp
 actions:
 - test_scenario:
     scenario_type: scenarios.versioning.GetSystemVersions

--- a/schemas/monitoring/uss_qualifier/suites/definitions/TestSuiteDeclaration.json
+++ b/schemas/monitoring/uss_qualifier/suites/definitions/TestSuiteDeclaration.json
@@ -1,12 +1,30 @@
 {
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/uss_qualifier/suites/definitions/TestSuiteDeclaration.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "type": "object",
+  "description": "monitoring.uss_qualifier.suites.definitions.TestSuiteDeclaration, as defined in monitoring/uss_qualifier/suites/definitions.py",
   "properties": {
     "$ref": {
-      "type": "string",
-      "description": "Path to content that replaces the $ref"
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "resources": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Mapping of the ID a resource will be known by in the child test suite -> the ID a resource is known by in the parent test suite.\n\nThe child suite resource <key> is supplied by the parent suite resource <value>.",
+      "properties": {
+        "$ref": {
+          "description": "Path to content that replaces the $ref",
+          "type": "string"
+        }
+      },
+      "type": [
+        "object",
+        "null"
+      ]
     },
     "suite_definition": {
+      "description": "Definition of test suite internal to the configuration -- specified instead of `suite_type`.",
       "oneOf": [
         {
           "type": "null"
@@ -14,33 +32,15 @@
         {
           "$ref": "TestSuiteDefinition.json"
         }
-      ],
-      "description": "Definition of test suite internal to the configuration -- specified instead of `suite_type`."
-    },
-    "resources": {
-      "type": "object",
-      "properties": {
-        "$ref": {
-          "type": "string",
-          "description": "Path to content that replaces the $ref"
-        }
-      },
-      "additionalProperties": {
-        "type": "string"
-      },
-      "description": "Mapping of the ID a resource will be known by in the child test suite -> the ID a resource is known by in the parent test suite.\n\nThe child suite resource <key> is supplied by the parent suite resource <value>."
+      ]
     },
     "suite_type": {
+      "description": "Type/location of test suite.  Usually expressed as the file name of the suite definition (without extension) qualified relative to the `uss_qualifier` folder",
       "type": [
         "string",
         "null"
-      ],
-      "description": "Type/location of test suite.  Usually expressed as the file name of the suite definition (without extension) qualified relative to the `uss_qualifier` folder"
+      ]
     }
   },
-  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/uss_qualifier/suites/definitions/TestSuiteDeclaration.json",
-  "description": "monitoring.uss_qualifier.suites.definitions.TestSuiteDeclaration, as defined in monitoring/uss_qualifier/suites/definitions.py",
-  "required": [
-    "resources"
-  ]
+  "type": "object"
 }

--- a/schemas/monitoring/uss_qualifier/suites/definitions/TestSuiteDefinition.json
+++ b/schemas/monitoring/uss_qualifier/suites/definitions/TestSuiteDefinition.json
@@ -1,16 +1,51 @@
 {
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/uss_qualifier/suites/definitions/TestSuiteDefinition.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "type": "object",
+  "description": "Schema for the definition of a test suite, analogous to the Python TestScenario subclass for scenarios\n\nmonitoring.uss_qualifier.suites.definitions.TestSuiteDefinition, as defined in monitoring/uss_qualifier/suites/definitions.py",
   "properties": {
     "$ref": {
-      "type": "string",
-      "description": "Path to content that replaces the $ref"
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "actions": {
+      "description": "The actions to take when running the test suite.  Components will be executed in order.",
+      "items": {
+        "$ref": "TestSuiteActionDeclaration.json"
+      },
+      "type": "array"
+    },
+    "local_resources": {
+      "additionalProperties": {
+        "$ref": "../../resources/definitions/ResourceDeclaration.json"
+      },
+      "description": "Declarations of resources originating in this test suite.",
+      "properties": {
+        "$ref": {
+          "description": "Path to content that replaces the $ref",
+          "type": "string"
+        }
+      },
+      "type": [
+        "object",
+        "null"
+      ]
     },
     "name": {
-      "type": "string",
-      "description": "Name of the test suite"
+      "description": "Name of the test suite",
+      "type": "string"
+    },
+    "participant_verifiable_capabilities": {
+      "description": "Definitions of capabilities verified by this test suite for individual participants.",
+      "items": {
+        "$ref": "../../reports/capability_definitions/ParticipantCapabilityDefinition.json"
+      },
+      "type": [
+        "array",
+        "null"
+      ]
     },
     "report_evaluation_scenario": {
+      "description": "The scenario executed after all the actions that evaluates the test suite report. Must be a ReportEvaluationScenario.",
       "oneOf": [
         {
           "type": "null"
@@ -18,45 +53,26 @@
         {
           "$ref": "../../scenarios/definitions/TestScenarioDeclaration.json"
         }
-      ],
-      "description": "The scenario executed after all the actions that evaluates the test suite report. Must be a ReportEvaluationScenario."
-    },
-    "participant_verifiable_capabilities": {
-      "type": [
-        "array",
-        "null"
-      ],
-      "items": {
-        "$ref": "../../reports/capability_definitions/ParticipantCapabilityDefinition.json"
-      },
-      "description": "Definitions of capabilities verified by this test suite for individual participants."
+      ]
     },
     "resources": {
-      "type": "object",
-      "properties": {
-        "$ref": {
-          "type": "string",
-          "description": "Path to content that replaces the $ref"
-        }
-      },
       "additionalProperties": {
         "type": "string"
       },
-      "description": "Enumeration of the resources used by this test suite"
-    },
-    "actions": {
-      "type": "array",
-      "items": {
-        "$ref": "TestSuiteActionDeclaration.json"
+      "description": "Enumeration of the resources used by this test suite",
+      "properties": {
+        "$ref": {
+          "description": "Path to content that replaces the $ref",
+          "type": "string"
+        }
       },
-      "description": "The actions to take when running the test suite.  Components will be executed in order."
+      "type": "object"
     }
   },
-  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/uss_qualifier/suites/definitions/TestSuiteDefinition.json",
-  "description": "Schema for the definition of a test suite, analogous to the Python TestScenario subclass for scenarios\n\nmonitoring.uss_qualifier.suites.definitions.TestSuiteDefinition, as defined in monitoring/uss_qualifier/suites/definitions.py",
   "required": [
     "actions",
     "name",
     "resources"
-  ]
+  ],
+  "type": "object"
 }


### PR DESCRIPTION
When we have a test tool that can be used in many different kinds of tests, the use in one particular test suite may require customization that doesn't really make sense to have the user configure.  For instance, U-space is likely to be sufficiently harmonized that the U-space-certified-system should be the same across member states.  So, it makes sense to pick a single identifier for a U-space system for the purpose of obtaining version information rather than specifying that identifier in each member state's configuration.

This PR adds the ability to define resources within a test suite rather than requiring all resources to come from the parent resource pool.  This capability is exercised on the system identifier for versioning in the U-space test suite.