### PR TITLE
[uss_qualifier] Make execution error critical

### DIFF
--- a/monitoring/uss_qualifier/reports/report.py
+++ b/monitoring/uss_qualifier/reports/report.py
@@ -245,9 +245,13 @@ class TestScenarioReport(ImplicitDict):
     """If there was an error while executing this test scenario, this field describes the error"""
 
     def has_critical_problem(self) -> bool:
-        return any(c.has_critical_problem() for c in self.cases) or (
-            "cleanup" in self and self.cleanup and self.cleanup.has_critical_problem()
-        )
+        if any(c.has_critical_problem() for c in self.cases):
+            return True
+        if "cleanup" in self and self.cleanup and self.cleanup.has_critical_problem():
+            return True
+        if "execution_error" in self and self.execution_error:
+            return True
+        return False
 
     def all_participants(self) -> Set[ParticipantID]:
         participants = set()


### PR DESCRIPTION
Currently, an execution error (a raised Exception during scenario execution) is not considered a critical error and therefore execution continues.  This small PR makes it a critical error, which will therefore (gracefully) stop test execution.