### PR TITLE
[docs] Fix GitHub Pages links

### DIFF
--- a/github_pages/make_site_content.sh
+++ b/github_pages/make_site_content.sh
@@ -11,4 +11,4 @@ mkdir ./public
 cp -r ./monitoring/github_pages/static/* ./public
 
 mkdir -p ./public/artifacts/uss_qualifier/reports
-cp -r ./artifacts/uss_qualifier/output ./public/artifacts/uss_qualifier/reports
+cp -r ./artifacts/uss_qualifier/output/* ./public/artifacts/uss_qualifier/reports


### PR DESCRIPTION
The links on the index of the GitHub Pages site that receives and publishes CI artifacts expects the reports to simply be in the `reports` folder rather than the `reports/output` folder.  This PR fixes the content to match that expectation.