### PR TITLE
[mock_uss] Add flight_planning API implementation to mock_uss

### DIFF
--- a/monitoring/mock_uss/__init__.py
+++ b/monitoring/mock_uss/__init__.py
@@ -13,6 +13,7 @@ SERVICE_MESSAGESIGNING = "msgsigning"
 SERVICE_TRACER = "tracer"
 SERVICE_INTERACTION_LOGGING = "interaction_logging"
 SERVICE_VERSIONING = "versioning"
+SERVICE_FLIGHT_PLANNING = "flight_planning"
 
 webapp = MockUSS(__name__)
 enabled_services = set()
@@ -101,6 +102,10 @@ if SERVICE_TRACER in webapp.config[config.KEY_SERVICES]:
 if SERVICE_VERSIONING in webapp.config[config.KEY_SERVICES]:
     enabled_services.add(SERVICE_VERSIONING)
     from monitoring.mock_uss.versioning import routes as versioning_routes
+
+if SERVICE_FLIGHT_PLANNING in webapp.config[config.KEY_SERVICES]:
+    enabled_services.add(SERVICE_FLIGHT_PLANNING)
+    from monitoring.mock_uss.flight_planning import routes as flight_planning_routes
 
 msg = (
     "################################################################################\n"

--- a/monitoring/mock_uss/docker-compose.yaml
+++ b/monitoring/mock_uss/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
       - MOCK_USS_TOKEN_AUDIENCE=scdsc.uss1.localutm,localhost,host.docker.internal
       - MOCK_USS_BASE_URL=http://scdsc.uss1.localutm
       # TODO: remove interaction_logging once dedicated mock_uss is involved in tests
-      - MOCK_USS_SERVICES=scdsc,versioning,interaction_logging
+      - MOCK_USS_SERVICES=scdsc,versioning,interaction_logging,flight_planning
       - MOCK_USS_INTERACTIONS_LOG_DIR=output/scdsc_a_interaction_logs
       - MOCK_USS_PORT=80
     expose:
@@ -47,7 +47,7 @@ services:
       - MOCK_USS_PUBLIC_KEY=/var/test-certs/auth2.pem
       - MOCK_USS_TOKEN_AUDIENCE=scdsc.uss2.localutm,localhost,host.docker.internal
       - MOCK_USS_BASE_URL=http://scdsc.uss2.localutm
-      - MOCK_USS_SERVICES=scdsc,versioning
+      - MOCK_USS_SERVICES=scdsc,versioning,flight_planning
       - MOCK_USS_PORT=80
     expose:
       - 80

--- a/monitoring/mock_uss/flight_planning/routes.py
+++ b/monitoring/mock_uss/flight_planning/routes.py
@@ -1,0 +1,182 @@
+import os
+from datetime import timedelta
+from typing import Tuple
+
+import flask
+from implicitdict import ImplicitDict
+from loguru import logger
+
+from monitoring.mock_uss.scdsc.routes_injection import (
+    inject_flight,
+    lock_flight,
+    release_flight_lock,
+    delete_flight,
+    clear_area,
+)
+from monitoring.monitorlib.clients.flight_planning.flight_info import (
+    FlightInfo,
+    AirspaceUsageState,
+)
+from monitoring.monitorlib.clients.mock_uss.mock_uss_scd_injection_api import (
+    MockUSSInjectFlightRequest,
+    MockUssFlightBehavior,
+)
+from uas_standards.interuss.automated_testing.flight_planning.v1 import api
+from uas_standards.interuss.automated_testing.flight_planning.v1.constants import Scope
+from uas_standards.interuss.automated_testing.scd.v1 import api as scd_api
+
+from monitoring.mock_uss import webapp, require_config_value
+from monitoring.mock_uss.auth import requires_scope
+from monitoring.mock_uss.config import KEY_BASE_URL
+from monitoring.monitorlib.idempotency import idempotent_request
+
+
+require_config_value(KEY_BASE_URL)
+
+DEADLOCK_TIMEOUT = timedelta(seconds=5)
+
+
+@webapp.route("/flight_planning/v1/status", methods=["GET"])
+@requires_scope(Scope.DirectAutomatedTest)
+def flight_planning_v1_status() -> Tuple[str, int]:
+    json, code = injection_status()
+    return flask.jsonify(json), code
+
+
+def injection_status() -> Tuple[dict, int]:
+    return (
+        api.StatusResponse(
+            status=api.StatusResponseStatus.Ready,
+            api_name="Flight Planning Automated Testing Interface",
+            api_version="v0.3.0",
+        ),
+        200,
+    )
+
+
+@webapp.route("/flight_planning/v1/flight_plans/<flight_plan_id>", methods=["PUT"])
+@requires_scope(Scope.Plan)
+@idempotent_request()
+def flight_planning_v1_upsert_flight_plan(flight_plan_id: str) -> Tuple[str, int]:
+    def log(msg: str) -> None:
+        logger.debug(f"[upsert_plan/{os.getpid()}:{flight_plan_id}] {msg}")
+
+    log("Starting handler")
+    try:
+        json = flask.request.json
+        if json is None:
+            raise ValueError("Request did not contain a JSON payload")
+        req_body: api.UpsertFlightPlanRequest = ImplicitDict.parse(
+            json, api.UpsertFlightPlanRequest
+        )
+    except ValueError as e:
+        msg = "Create flight {} unable to parse JSON: {}".format(flight_plan_id, e)
+        return msg, 400
+    info = FlightInfo.from_flight_plan(req_body.flight_plan)
+    req = MockUSSInjectFlightRequest(info.to_scd_inject_flight_request())
+    if "behavior" in json:
+        try:
+            req.behavior = ImplicitDict.parse(json["behavior"], MockUssFlightBehavior)
+        except ValueError as e:
+            msg = f"Create flight {flight_plan_id} unable to parse `behavior` field: {str(e)}"
+            return msg, 400
+
+    existing_flight = lock_flight(flight_plan_id, log)
+    try:
+        if existing_flight:
+            usage_state = existing_flight.flight_info.basic_information.usage_state
+            if usage_state == AirspaceUsageState.Planned:
+                old_status = api.FlightPlanStatus.Planned
+            elif usage_state == AirspaceUsageState.InUse:
+                old_status = api.FlightPlanStatus.OkToFly
+            else:
+                raise ValueError(f"Unrecognized usage_state '{usage_state}'")
+        else:
+            old_status = api.FlightPlanStatus.NotPlanned
+
+        scd_resp, code = inject_flight(flight_plan_id, req, existing_flight)
+    finally:
+        release_flight_lock(flight_plan_id, log)
+
+    if scd_resp.result == scd_api.InjectFlightResponseResult.Planned:
+        result = api.PlanningActivityResult.Completed
+        plan_status = api.FlightPlanStatus.Planned
+        notes = None
+    elif scd_resp.result == scd_api.InjectFlightResponseResult.ReadyToFly:
+        result = api.PlanningActivityResult.Completed
+        plan_status = api.FlightPlanStatus.OkToFly
+        notes = None
+    elif (
+        scd_resp.result == scd_api.InjectFlightResponseResult.ConflictWithFlight
+        or scd_resp.result == scd_api.InjectFlightResponseResult.Rejected
+    ):
+        result = api.PlanningActivityResult.Rejected
+        plan_status = old_status
+        notes = scd_resp.notes if "notes" in scd_resp else None
+    elif scd_resp.result == scd_api.InjectFlightResponseResult.Failed:
+        result = api.PlanningActivityResult.Failed
+        plan_status = old_status
+        notes = scd_resp.notes if "notes" in scd_resp else None
+    else:
+        raise ValueError(f"Unexpected scd inject_flight result '{scd_resp.result}'")
+
+    resp = api.UpsertFlightPlanResponse(
+        planning_result=result,
+        notes=notes,
+        flight_plan_status=plan_status,
+    )
+    for k, v in scd_resp.items():
+        if k not in {"result", "notes", "operational_intent_id"}:
+            resp[k] = v
+    return flask.jsonify(resp), code
+
+
+@webapp.route("/flight_planning/v1/flight_plans/<flight_plan_id>", methods=["DELETE"])
+@requires_scope(Scope.Plan)
+def flight_planning_v1_delete_flight(flight_plan_id: str) -> Tuple[str, int]:
+    """Implements flight deletion in SCD automated testing injection API."""
+    scd_resp, code = delete_flight(flight_plan_id)
+    if code != 200:
+        raise RuntimeError(
+            f"DELETE flight plan endpoint expected code 200 from scd handler but received {code} instead"
+        )
+
+    if scd_resp.result == scd_api.DeleteFlightResponseResult.Closed:
+        result = api.PlanningActivityResult.Completed
+        status = api.FlightPlanStatus.Closed
+    else:
+        result = api.PlanningActivityResult.Failed
+        status = (
+            api.FlightPlanStatus.NotPlanned
+        )  # delete_flight only fails like this when the flight doesn't exist
+    kwargs = {"planning_result": result, "flight_plan_status": status}
+    if "notes" in scd_resp:
+        kwargs["notes"] = scd_resp.notes
+    resp = api.DeleteFlightPlanResponse(**kwargs)
+
+    return flask.jsonify(resp), code
+
+
+@webapp.route("/flight_planning/v1/clear_area_requests", methods=["POST"])
+@requires_scope(Scope.DirectAutomatedTest)
+@idempotent_request()
+def flight_planning_v1_clear_area() -> Tuple[str, int]:
+    try:
+        json = flask.request.json
+        if json is None:
+            raise ValueError("Request did not contain a JSON payload")
+        req: api.ClearAreaRequest = ImplicitDict.parse(json, api.ClearAreaRequest)
+    except ValueError as e:
+        msg = "Unable to parse ClearAreaRequest JSON request: {}".format(e)
+        return msg, 400
+
+    scd_req = scd_api.ClearAreaRequest(
+        request_id=req.request_id,
+        extent=ImplicitDict.parse(req.extent, scd_api.Volume4D),
+    )
+
+    scd_resp, code = clear_area(scd_req)
+
+    resp = ImplicitDict.parse(scd_resp, api.ClearAreaResponse)
+
+    return flask.jsonify(resp), code

--- a/monitoring/mock_uss/scdsc/routes_injection.py
+++ b/monitoring/mock_uss/scdsc/routes_injection.py
@@ -222,11 +222,11 @@ def release_flight_lock(flight_id: str, log: Callable[[str], None]) -> None:
         if flight_id in tx.flights:
             if tx.flights[flight_id]:
                 # FlightRecord was a true existing flight
-                log(f"Releasing placeholder for flight_id {flight_id}")
+                log(f"Releasing lock on existing flight_id {flight_id}")
                 tx.flights[flight_id].locked = False
             else:
                 # FlightRecord was just a placeholder for a new flight
-                log(f"Releasing lock on existing flight_id {flight_id}")
+                log(f"Releasing placeholder for existing flight_id {flight_id}")
                 del tx.flights[flight_id]
 
 

--- a/monitoring/mock_uss/scdsc/routes_injection.py
+++ b/monitoring/mock_uss/scdsc/routes_injection.py
@@ -2,7 +2,7 @@ import os
 import traceback
 from datetime import datetime, timedelta
 import time
-from typing import List, Tuple, Optional
+from typing import List, Tuple, Callable, Optional
 import uuid
 
 import flask
@@ -37,7 +37,7 @@ from monitoring.mock_uss.auth import requires_scope
 from monitoring.mock_uss.config import KEY_BASE_URL
 from monitoring.mock_uss.dynamic_configuration.configuration import get_locality
 from monitoring.mock_uss.scdsc import database, utm_client
-from monitoring.mock_uss.scdsc.database import db
+from monitoring.mock_uss.scdsc.database import db, FlightRecord
 from monitoring.mock_uss.scdsc.flight_planning import (
     validate_request,
     check_for_disallowed_conflicts,
@@ -158,7 +158,11 @@ def scd_capabilities() -> Tuple[dict, int]:
 @idempotent_request()
 def scdsc_inject_flight(flight_id: str) -> Tuple[str, int]:
     """Implements flight injection in SCD automated testing injection API."""
-    logger.debug(f"[inject_flight/{os.getpid()}:{flight_id}] Starting handler")
+
+    def log(msg):
+        logger.debug(f"[inject_flight/{os.getpid()}:{flight_id}] {msg}")
+
+    log("Starting handler")
     try:
         json = flask.request.json
         if json is None:
@@ -167,7 +171,11 @@ def scdsc_inject_flight(flight_id: str) -> Tuple[str, int]:
     except ValueError as e:
         msg = "Create flight {} unable to parse JSON: {}".format(flight_id, e)
         return msg, 400
-    json, code = inject_flight(flight_id, req_body)
+    existing_flight = lock_flight(flight_id, log)
+    try:
+        json, code = inject_flight(flight_id, req_body, existing_flight)
+    finally:
+        release_flight_lock(flight_id, log)
     return flask.jsonify(json), code
 
 
@@ -180,29 +188,9 @@ def _mock_uss_flight_behavior_in_req(
         return None
 
 
-def inject_flight(
-    flight_id: str, req_body: MockUSSInjectFlightRequest
-) -> Tuple[dict, int]:
-    pid = os.getpid()
-    locality = get_locality()
-
-    def log(msg: str):
-        logger.debug(f"[inject_flight/{pid}:{flight_id}] {msg}")
-
-    # Validate request
-    log("Validating request")
-    try:
-        validate_request(req_body, locality)
-    except PlanningError as e:
-        return (
-            InjectFlightResponse(
-                result=InjectFlightResponseResult.Rejected, notes=str(e)
-            ),
-            200,
-        )
-
+def lock_flight(flight_id: str, log: Callable[[str], None]) -> FlightRecord:
     # If this is a change to an existing flight, acquire lock to that flight
-    log("Acquiring lock for flight")
+    log(f"Acquiring lock for flight {flight_id}")
     deadline = datetime.utcnow() + DEADLOCK_TIMEOUT
     while True:
         with db as tx:
@@ -221,14 +209,49 @@ def inject_flight(
         # We found an existing flight but it was locked; wait for it to become
         # available
         time.sleep(0.5)
-        log(
-            f"Waiting for flight lock resolution; now: {datetime.utcnow()} deadline: {deadline}"
-        )
+
         if datetime.utcnow() > deadline:
-            log(f"Deadlock (now: {datetime.utcnow()}, deadline: {deadline})")
             raise RuntimeError(
                 f"Deadlock in inject_flight while attempting to gain access to flight {flight_id}"
             )
+    return existing_flight
+
+
+def release_flight_lock(flight_id: str, log: Callable[[str], None]) -> None:
+    with db as tx:
+        if flight_id in tx.flights:
+            if tx.flights[flight_id]:
+                # FlightRecord was a true existing flight
+                log(f"Releasing placeholder for flight_id {flight_id}")
+                tx.flights[flight_id].locked = False
+            else:
+                # FlightRecord was just a placeholder for a new flight
+                log(f"Releasing lock on existing flight_id {flight_id}")
+                del tx.flights[flight_id]
+
+
+def inject_flight(
+    flight_id: str,
+    req_body: MockUSSInjectFlightRequest,
+    existing_flight: Optional[FlightRecord],
+) -> Tuple[InjectFlightResponse, int]:
+    pid = os.getpid()
+    locality = get_locality()
+
+    def log(msg: str):
+        logger.debug(f"[inject_flight/{pid}:{flight_id}] {msg}")
+
+    # Validate request
+    log("Validating request")
+    try:
+        validate_request(req_body, locality)
+    except PlanningError as e:
+        return (
+            InjectFlightResponse(
+                result=InjectFlightResponseResult.Rejected, notes=str(e)
+            ),
+            200,
+        )
 
     step_name = "performing unknown operation"
     try:
@@ -390,16 +413,6 @@ def inject_flight(
         response["queries"] = e.queries
         response["stacktrace"] = e.stacktrace
         return response, 200
-    finally:
-        with db as tx:
-            if tx.flights[flight_id]:
-                # FlightRecord was a true existing flight
-                log(f"Releasing placeholder for flight_id {flight_id}")
-                tx.flights[flight_id].locked = False
-            else:
-                # FlightRecord was just a placeholder for a new flight
-                log("Releasing lock on existing flight_id {flight_id}")
-                del tx.flights[flight_id]
 
 
 @webapp.route("/scdsc/v1/flights/<flight_id>", methods=["DELETE"])
@@ -410,7 +423,7 @@ def scdsc_delete_flight(flight_id: str) -> Tuple[str, int]:
     return flask.jsonify(json), code
 
 
-def delete_flight(flight_id) -> Tuple[dict, int]:
+def delete_flight(flight_id) -> Tuple[DeleteFlightResponse, int]:
     pid = os.getpid()
     logger.debug(f"[delete_flight/{pid}:{flight_id}] Acquiring flight")
     deadline = datetime.utcnow() + DEADLOCK_TIMEOUT
@@ -519,7 +532,7 @@ def scdsc_clear_area() -> Tuple[str, int]:
     return flask.jsonify(json), code
 
 
-def clear_area(req: ClearAreaRequest) -> Tuple[dict, int]:
+def clear_area(req: ClearAreaRequest) -> Tuple[ClearAreaResponse, int]:
     def make_result(success: bool, msg: str) -> ClearAreaResponse:
         return ClearAreaResponse(
             outcome=ClearAreaOutcome(

--- a/monitoring/mock_uss/scdsc/routes_scdsc.py
+++ b/monitoring/mock_uss/scdsc/routes_scdsc.py
@@ -27,7 +27,7 @@ def scdsc_get_operational_intent_details(entityid: str):
     tx = db.value
     flight = None
     for f in tx.flights.values():
-        if f.op_intent.reference.id == entityid:
+        if f and f.op_intent.reference.id == entityid:
             flight = f
             break
 

--- a/monitoring/monitorlib/clients/flight_planning/client_v1.py
+++ b/monitoring/monitorlib/clients/flight_planning/client_v1.py
@@ -1,3 +1,4 @@
+import json
 import uuid
 from typing import Optional
 
@@ -39,7 +40,7 @@ class V1FlightPlannerClient(FlightPlannerClient):
         execution_style: ExecutionStyle,
         additional_fields: Optional[dict] = None,
     ) -> PlanningActivityResponse:
-        flight_plan = ImplicitDict.parse(flight_info, api.FlightPlan)
+        flight_plan = flight_info.to_flight_plan()
         req = api.UpsertFlightPlanRequest(
             flight_plan=flight_plan,
             execution_style=execution_style,

--- a/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml
@@ -42,10 +42,10 @@ v1:
             flight_planners:
               # uss1 is the mock_uss directly exposing flight planning functionality
               - participant_id: uss1
-                scd_injection_base_url: http://scdsc.uss1.localutm/scdsc
+                v1_base_url: http://scdsc.uss1.localutm/flight_planning/v1
               # uss2 is another mock_uss directly exposing flight planning functionality
               - participant_id: uss2
-                scd_injection_base_url: http://scdsc.uss2.localutm/scdsc
+                v1_base_url: http://scdsc.uss2.localutm/flight_planning/v1
 
         # Details of conflicting flights (used in nominal planning scenario)
         conflicting_flights:

--- a/monitoring/uss_qualifier/configurations/dev/library/environment_containers.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/library/environment_containers.yaml
@@ -119,7 +119,7 @@ all_flight_planners:
   specification:
     flight_planners:
       - participant_id: uss1
-        scd_injection_base_url: http://scdsc.uss1.localutm/scdsc
+        v1_base_url: http://scdsc.uss1.localutm/flight_planning/v1
         local_debug: true
 
       - participant_id: uss2
@@ -134,7 +134,7 @@ uss1_flight_planner:
   specification:
     flight_planner:
       participant_id: uss1
-      scd_injection_base_url: http://scdsc.uss1.localutm/scdsc
+      v1_base_url: http://scdsc.uss1.localutm/flight_planning/v1
       local_debug: true
 
 uss2_flight_planner:


### PR DESCRIPTION
This PR adds an implementation of [the flight_planning automated testing API](https://github.com/interuss/automated_testing_interfaces/tree/main/flight_planning) to mock_uss by simply calling the existing flight planning handlers for [the legacy scd interface](https://github.com/interuss/automated_testing_interfaces/tree/main/scd).  The interface used in uss_qualifier's CI automated tests is switched to this new API for all but one of the mock_uss instances.

The overall state of mock_uss flight planning handling is still left in need of some attention after this PR, but I hope to follow up with some improvements.