### PR TITLE
[tooling] Ignore venv directory in root `make format` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ USER_GROUP := $(shell id -u):$(shell id -g)
 UPSTREAM_OWNER := $(shell scripts/git/upstream_owner.sh)
 COMMIT := $(shell scripts/git/commit.sh)
 
+BLACK_EXCLUDES := "/interfaces|/venv"
+
 ifeq ($(OS),Windows_NT)
   detected_OS := Windows
 else
@@ -11,7 +13,7 @@ endif
 
 .PHONY: format
 format: json-schema
-	docker run --rm -v "$(CURDIR):/code" -w /code pyfound/black:22.10.0 black --exclude /interfaces .
+	docker run --rm -v "$(CURDIR):/code" -w /code pyfound/black:22.10.0 black --exclude=$(BLACK_EXCLUDES) .
 	cd monitoring && make format
 
 .PHONY: lint
@@ -24,7 +26,7 @@ check-hygiene: python-lint hygiene validate-uss-qualifier-docs shell-lint
 
 .PHONY: python-lint
 python-lint:
-	docker run --rm -v "$(CURDIR):/code" -w /code pyfound/black:22.10.0 black --check --exclude /interfaces . || (echo "Linter didn't succeed. You can use the following command to fix python linter issues: make format" && exit 1)
+	docker run --rm -v "$(CURDIR):/code" -w /code pyfound/black:22.10.0 black --check --exclude=$(BLACK_EXCLUDES) . || (echo "Linter didn't succeed. You can use the following command to fix python linter issues: make format" && exit 1)
 
 .PHONY: hygiene
 hygiene:


### PR DESCRIPTION
`black` was happily descending into my local `venv` directory when running `make format` at the root: such a setup seems common enough to warrant an exclusion by default.

This was tested on a fresh `venv` installed in the repository root.