### PR TITLE
[uss_qualifier] Add missing participant attribution in ISA validation scenario

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/aggregate_checks.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/aggregate_checks.py
@@ -150,7 +150,7 @@ class AggregateChecks(ReportEvaluationScenario):
 
         # Check that all queries have been attributed to a participant
         unattr_queries = [
-            query.request.url
+            f"{query.request.method} {query.request.url}"
             for query in self._queries
             if query.get("participant_id") is None
         ]

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/isa_validation.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/isa_validation.py
@@ -252,6 +252,8 @@ class ISAValidation(GenericTestScenario):
             else:
                 raise ValueError(f"Unknown RID version: {self._dss.rid_version}")
 
+            rid_query.set_participant_id(self._dss_wrapper.participant_id)
+
             self._dss_wrapper._handle_query_result(
                 check=check,
                 q=rid_query,
@@ -283,6 +285,8 @@ class ISAValidation(GenericTestScenario):
                 rid_query = ChangedISA(v22a_query=q)
             else:
                 raise ValueError(f"Unknown RID version: {self._dss.rid_version}")
+
+            rid_query.set_participant_id(self._dss_wrapper.participant_id)
 
             self._dss_wrapper._handle_query_result(
                 check=check,


### PR DESCRIPTION
Noticed that `common/isa_validation.py` forgot to set the participant ID on some queries.

This also adds the HTTP method to the recorded note in the aggregated checks: it should help with locating unattributed queries (there are still quite a few but I'll keep fixing these for another time)