### PR TITLE
[uss_qualifier/artifacts] Supplement tested requirements artifact with additional information

### DIFF
--- a/monitoring/uss_qualifier/reports/templates/tested_requirements/participant_tested_requirements.html
+++ b/monitoring/uss_qualifier/reports/templates/tested_requirements/participant_tested_requirements.html
@@ -2,7 +2,7 @@
 <head>
   <style>
     body {
-      margin: 0;
+      margin: 1em;
       color: #24292f;
       background-color: #ffffff;
       font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
@@ -80,6 +80,12 @@
       <td>Participant</td>
       <td>{{ participant_id }}</td>
     </tr>
+    {% if system_version != None %}
+      <tr>
+        <td>System version</td>
+        <td>{{ system_version }}</td>
+      </tr>
+    {% endif %}
     <tr>
       <td>Other participants</td>
       <td>{{ other_participants }}</td>
@@ -107,6 +113,20 @@
     <tr>
       <td>Environment identifier</td>
       <td>TE-{{ test_run.environment[0:7] }}</td>
+    </tr>
+    <tr>
+      <td>Requirement verification status</td>
+      <td class="{{ overall_status.get_class() }}">
+        {% if overall_status == ParticipantVerificationStatus.Pass %}
+          Pass
+        {% elif overall_status == ParticipantVerificationStatus.Fail %}
+          Fail
+        {% elif overall_status == ParticipantVerificationStatus.Incomplete %}
+          Not fully verified
+        {% else %}
+          ???
+        {% endif %}
+      </td>
     </tr>
   </table>
 </div>

--- a/monitoring/uss_qualifier/reports/templates/tested_requirements/test_run_report.html
+++ b/monitoring/uss_qualifier/reports/templates/tested_requirements/test_run_report.html
@@ -7,6 +7,8 @@
       <li><a href="./{{ participant_id }}.html">{{ participant_id }}</a></li>
     {% endfor %}
   </ul>
+  <h2>Programmatic verification statuses</h2>
+  <a href="status.json">status.json</a>
 </div>
 </body>
 </html>


### PR DESCRIPTION
This PR adds a bit of additional information to the tested_requirements uss_qualifier artifact:
* System version, from the first instance of a GetSystemVersions test scenario, if one exists
* Overall status of requirements verification (rolling up all requirements identified for the artifact)

This PR also outputs a small JSON file with the top-level information included in the human-readable tested_requirements report.