### PR TITLE
[uss_qualifier] Split subscription cleanup checks into their "query" and "deletion" parts

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/isa_subscription_interactions.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/isa_subscription_interactions.py
@@ -299,7 +299,7 @@ class ISASubscriptionInteractions(GenericTestScenario):
         )
 
     def _clean_any_sub(self):
-        utils.delete_any_subscription(self, self._dss_wrapper, self._isa.footprint)
+        self._dss_wrapper.cleanup_subs_in_area(self._isa_area)
 
     def cleanup(self):
         self.begin_cleanup()

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/subscription_simple.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/subscription_simple.py
@@ -172,12 +172,7 @@ class SubscriptionSimple(GenericTestScenario):
         which is why we need to explicitly test for their presence.
         """
         for sub_id in self._test_subscription_ids:
-            # TODO migrate this to the two-check pattern when the utility has been migrated
-            with self.check(
-                "Ensure subscription with test ID does not exist",
-                [self._dss_wrapper.participant_id],
-            ) as check:
-                self._dss_wrapper.cleanup_sub(check, sub_id)
+            self._dss_wrapper.cleanup_sub(sub_id)
 
     def _ensure_no_active_subs_exist(self):
         """Ensure that we don't currently have any other active subscriptions at the DSS:

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/utils.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/utils.py
@@ -63,29 +63,3 @@ def delete_isa_if_exists(
                         f"Attempting to notify subscriber for ISA {isa_id} at {subscriber_url} resulted in {notification.status_code}",
                         query_timestamps=[notification.query.request.timestamp],
                     )
-
-
-def delete_any_subscription(
-    scenario: GenericTestScenario,
-    dss_wrapper: DSSWrapper,
-    area: List[LatLngPoint],
-):
-    """
-    Deletes any subscription that is returned for the passed area.
-
-    Args:
-        scenario: the scenario instance that will provide the checks
-        dss_wrapper: the dss on which to delete subscriptions
-        area: the area for which subscriptions are to be deleted
-    """
-    with scenario.check(
-        "Successful subscription query", [dss_wrapper.participant_id]
-    ) as check:
-        fetched = dss_wrapper.search_subs(
-            check, [vertex.as_s2sphere() for vertex in area]
-        )
-    for sub_id in fetched.subscriptions.keys():
-        with scenario.check(
-            "Successful subscription deletion", [dss_wrapper.participant_id]
-        ) as check:
-            dss_wrapper.cleanup_sub(check, sub_id=sub_id)

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss_interoperability.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss_interoperability.py
@@ -768,14 +768,9 @@ class DSSInteroperability(GenericTestScenario):
                     )
 
             elif entity.type == EntityType.Sub:
-                with self.check(
-                    "Subscription deleted with proper response",
-                    [self._dss_primary.participant_id],
-                ) as check:
-                    _ = self._dss_primary.cleanup_sub(
-                        check,
-                        sub_id=entity.uuid,
-                    )
+                _ = self._dss_primary.cleanup_sub(
+                    sub_id=entity.uuid,
+                )
 
             else:
                 raise RuntimeError(f"Unknown Entity type: {entity.type}")

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/isa_subscription_interactions.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/isa_subscription_interactions.md
@@ -38,7 +38,7 @@ If an ISA with the intended ID is already present in the DSS, it needs to be rem
 
 When a pre-existing ISA needs to be deleted to ensure a clean workspace, any subscribers to ISAs in that area must be notified (as specified by the DSS).  If a notification cannot be delivered, then the **[astm.f3411.v19.NET0730](../../../../../requirements/astm/f3411/v19.md)** requirement to implement the POST ISAs endpoint isn't met.
 
-#### Successful subscription query check
+#### Successful subscription search query check
 
 **[astm.f3411.v19.DSS0030,f](../../../../../requirements/astm/f3411/v19.md)** requires the implementation of the DSS endpoint to allow callers to retrieve the subscriptions they created.
 
@@ -139,7 +139,7 @@ If an ISA with the intended ID is already present in the DSS, it needs to be rem
 
 When a pre-existing ISA needs to be deleted to ensure a clean workspace, any subscribers to ISAs in that area must be notified (as specified by the DSS).  If a notification cannot be delivered, then the **[astm.f3411.v19.NET0730](../../../../../requirements/astm/f3411/v19.md)** requirement to implement the POST ISAs endpoint isn't met.
 
-#### Successful subscription query check
+#### Successful subscription search query check
 
 **[astm.f3411.v19.DSS0030,f](../../../../../requirements/astm/f3411/v19.md)** requires the implementation of the DSS endpoint to allow callers to retrieve the subscriptions they created.
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/subscription_simple.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/subscription_simple.md
@@ -32,14 +32,13 @@ This step ensures that no subscription with the known test ID exists in the DSS.
 
 If the DSS fails to let us search in the area for which test subscriptions will be created, it is failing to properly implement **[astm.f3411.v19.DSS0030,f](../../../../../requirements/astm/f3411/v19.md)**.
 
+#### Subscription can be queried by ID check
+
+If the DSS cannot be queried for the existing test ID, the DSS is likely not implementing **[astm.f3411.v19.DSS0030,e](../../../../../requirements/astm/f3411/v19.md)** correctly.
+
 #### Subscription can be deleted check
 
 An attempt to delete a subscription when the correct version is provided should succeed, otherwise the DSS is in violation of **[astm.f3411.v19.DSS0030,d](../../../../../requirements/astm/f3411/v19.md)**.
-
-#### Ensure subscription with test ID does not exist check
-
-If the DSS cannot be queried for the existing test ID, or if a subscription with that ID exists and it cannot be removed,
-the DSS is likely not implementing **[astm.f3411.v19.DSS0030,e](../../../../../requirements/astm/f3411/v19.md)** or **[astm.f3411.v19.DSS0030,d](../../../../../requirements/astm/f3411/v19.md)** properly.
 
 ## Subscription Simple test case
 
@@ -396,7 +395,11 @@ If the DSS returns the deleted subscription in a search that covers the area it 
 
 The cleanup phase of this test scenario removes the subscription with the known test ID if it has not been removed before.
 
-#### Ensure subscription with test ID does not exist check
+#### Subscription can be queried by ID check
 
-If the DSS cannot be queried for the existing test ID, or if a subscription with that ID exists and it cannot be removed,
-the DSS is likely not implementing **[astm.f3411.v19.DSS0030,e](../../../../../requirements/astm/f3411/v19.md)** or **[astm.f3411.v19.DSS0030,d](../../../../../requirements/astm/f3411/v19.md)** properly.
+If the DSS cannot be queried for the existing test ID, the DSS is likely not implementing **[astm.f3411.v19.DSS0030,e](../../../../../requirements/astm/f3411/v19.md)** correctly.
+
+#### Subscription can be deleted check
+
+An attempt to delete a subscription when the correct version is provided should succeed, otherwise the DSS is in violation of **[astm.f3411.v19.DSS0030,d](../../../../../requirements/astm/f3411/v19.md)**.
+

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/subscription_validation.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/subscription_validation.md
@@ -24,11 +24,11 @@ Perform basic operations on a single DSS instance to create subscriptions and ch
 
 This step ensures that we remove any subscription that may already exist for the service area.  First, the DSS is queried for any applicable existing subscriptions, and then any subscriptions found are deleted.
 
-#### Successful subscription query check
+#### Successful subscription search query check
 
-If the query for subscriptions fails, **[astm.f3411.v19.DSS0030,f](../../../../../requirements/astm/f3411/v19.md)** was not met.
+If the search query for subscriptions fails, **[astm.f3411.v19.DSS0030,f](../../../../../requirements/astm/f3411/v19.md)** was not met.
 
-#### Successful subscription deletion check
+#### Subscription can be deleted check
 
 If the deletion attempt fails, **[astm.f3411.v19.DSS0030,d](../../../../../requirements/astm/f3411/v19.md)** was not met.
 
@@ -56,11 +56,11 @@ it will not have performed the Subscription count validation as defined in **[as
 
 Clean up any subscriptions created.
 
-#### Successful subscription query check
+#### Successful subscription search query check
 
 If the query for subscriptions fails, **[astm.f3411.v19.DSS0030,f](../../../../../requirements/astm/f3411/v19.md)** was not met.
 
-#### Successful subscription deletion check
+#### Subscription can be deleted check
 
 If the deletion attempt fails, **[astm.f3411.v19.DSS0030,d](../../../../../requirements/astm/f3411/v19.md)** was not met.
 
@@ -101,10 +101,10 @@ The ability to delete an existing subscription is required in **[astm.f3411.v19.
 
 The cleanup phase of this test scenario will remove any subscription that may have been created during the test and that intersects with the test ISA.
 
-### Successful subscription query check
+### Successful subscription search query check
 
 If the query for subscriptions fails, the "GET Subscriptions" portion of **[astm.f3411.v19.DSS0030,f](../../../../../requirements/astm/f3411/v19.md)** was not met.
 
-### Successful subscription deletion check
+### Subscription can be deleted check
 
 If the deletion attempt fails, the "DELETE Subscription" portion of **[astm.f3411.v19.DSS0030,d](../../../../../requirements/astm/f3411/v19.md)** was not met.

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss_interoperability.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss_interoperability.md
@@ -331,6 +331,10 @@ Any entities (ISAs or Subscriptions) not deleted normally will be deleted here.
 
 **[astm.f3411.v19.DSS0130,A2-6-1,2a](../../../../requirements/astm/f3411/v19.md)**
 
-### Subscription deleted with proper response check
+### Subscription can be queried by ID check
+
+**[astm.f3411.v19.DSS0130,A2-6-1,4a](../../../../requirements/astm/f3411/v19.md)**
+
+### Subscription can be deleted check
 
 **[astm.f3411.v19.DSS0130,A2-6-1,4a](../../../../requirements/astm/f3411/v19.md)**

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/isa_subscription_interactions.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/isa_subscription_interactions.md
@@ -38,7 +38,7 @@ If an ISA with the intended ID is already present in the DSS, it needs to be rem
 
 When a pre-existing ISA needs to be deleted to ensure a clean workspace, any subscribers to ISAs in that area must be notified (as specified by the DSS).  If a notification cannot be delivered, then the **[astm.f3411.v22a.NET0730](../../../../../requirements/astm/f3411/v22a.md)** requirement to implement the POST ISAs endpoint isn't met.
 
-#### Successful subscription query check
+#### Successful subscription search query check
 
 **[astm.f3411.v22a.DSS0030,f](../../../../../requirements/astm/f3411/v22a.md)** requires the implementation of the DSS endpoint to allow callers to retrieve the subscriptions they created.
 
@@ -139,7 +139,7 @@ If an ISA with the intended ID is already present in the DSS, it needs to be rem
 
 When a pre-existing ISA needs to be deleted to ensure a clean workspace, any subscribers to ISAs in that area must be notified (as specified by the DSS).  If a notification cannot be delivered, then the **[astm.f3411.v22a.NET0730](../../../../../requirements/astm/f3411/v22a.md)** requirement to implement the POST ISAs endpoint isn't met.
 
-#### Successful subscription query check
+#### Successful subscription search query check
 
 **[astm.f3411.v22a.DSS0030,f](../../../../../requirements/astm/f3411/v22a.md)** requires the implementation of the DSS endpoint to allow callers to retrieve the subscriptions they created.
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/subscription_simple.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/subscription_simple.md
@@ -32,14 +32,13 @@ This step ensures that no subscription with the known test ID exists in the DSS.
 
 If the DSS fails to let us search in the area for which test subscriptions will be created, it is failing to properly implement **[astm.f3411.v22a.DSS0030,f](../../../../../requirements/astm/f3411/v22a.md)**.
 
+#### Subscription can be queried by ID check
+
+If the DSS cannot be queried for the existing test ID, the DSS is likely not implementing **[astm.f3411.v19.DSS0030,e](../../../../../requirements/astm/f3411/v19.md)** correctly.
+
 #### Subscription can be deleted check
 
 An attempt to delete a subscription when the correct version is provided should succeed, otherwise the DSS is in violation of **[astm.f3411.v22a.DSS0030,d](../../../../../requirements/astm/f3411/v22a.md)**.
-
-#### Ensure subscription with test ID does not exist check
-
-If the DSS cannot be queried for the existing test ID, or if a subscription with that ID exists and it cannot be removed,
-the DSS is likely not implementing **[astm.f3411.v22a.DSS0030,e](../../../../../requirements/astm/f3411/v22a.md)** or **[astm.f3411.v22a.DSS0030,d](../../../../../requirements/astm/f3411/v22a.md)** properly.
 
 ## Subscription Simple test case
 
@@ -389,7 +388,10 @@ If the DSS returns the deleted subscription in a search that covers the area it 
 
 The cleanup phase of this test scenario removes the subscription with the known test ID if it has not been removed before.
 
-#### Ensure subscription with test ID does not exist check
+#### Subscription can be queried by ID check
 
-If the DSS cannot be queried for the existing test ID, or if a subscription with that ID exists and it cannot be removed,
-the DSS is likely not implementing **[astm.f3411.v22a.DSS0030,e](../../../../../requirements/astm/f3411/v22a.md)** or **[astm.f3411.v22a.DSS0030,d](../../../../../requirements/astm/f3411/v22a.md)** properly.
+If the DSS cannot be queried for the existing test ID, the DSS is likely not implementing **[astm.f3411.v19.DSS0030,e](../../../../../requirements/astm/f3411/v19.md)** correctly.
+
+#### Subscription can be deleted check
+
+An attempt to delete a subscription when the correct version is provided should succeed, otherwise the DSS is in violation of **[astm.f3411.v22a.DSS0030,d](../../../../../requirements/astm/f3411/v22a.md)**.

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/subscription_validation.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/subscription_validation.md
@@ -24,11 +24,11 @@ Perform basic operations on a single DSS instance to create subscriptions and ch
 
 This step ensures that we remove any subscription that may already exist for the service area.  First, the DSS is queried for any applicable existing subscriptions, and then any subscriptions found are deleted.
 
-#### Successful subscription query check
+#### Successful subscription search query check
 
-If the query for subscriptions fails, **[astm.f3411.v22a.DSS0030,f](../../../../../requirements/astm/f3411/v22a.md)** was not met.
+If the search query for subscriptions fails, **[astm.f3411.v22a.DSS0030,f](../../../../../requirements/astm/f3411/v22a.md)** was not met.
 
-#### Successful subscription deletion check
+#### Subscription can be deleted check
 
 If the deletion attempt fails, **[astm.f3411.v22a.DSS0030,d](../../../../../requirements/astm/f3411/v22a.md)** was not met.
 
@@ -56,11 +56,11 @@ it will not have performed the Subscription count validation as defined in **[as
 
 Clean up any subscriptions created.
 
-#### Successful subscription query check
+#### Successful subscription search query check
 
 If the query for subscriptions fails, **[astm.f3411.v22a.DSS0030,f](../../../../../requirements/astm/f3411/v22a.md)** was not met.
 
-#### Successful subscription deletion check
+#### Subscription can be deleted check
 
 If the deletion attempt fails, **[astm.f3411.v22a.DSS0030,d](../../../../../requirements/astm/f3411/v22a.md)** was not met.
 
@@ -101,10 +101,10 @@ The ability to delete an existing subscription is required in **[astm.f3411.v22a
 
 The cleanup phase of this test scenario will remove any subscription that may have been created during the test and that intersects with the test ISA.
 
-### Successful subscription query check
+### Successful subscription search query check
 
 If the query for subscriptions fails, the "GET Subscriptions" portion of **[astm.f3411.v22a.DSS0030,f](../../../../../requirements/astm/f3411/v22a.md)** was not met.
 
-### Successful subscription deletion check
+### Subscription can be deleted check
 
 If the deletion attempt fails, the "DELETE Subscription" portion of **[astm.f3411.v22a.DSS0030,d](../../../../../requirements/astm/f3411/v22a.md)** was not met.

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss_interoperability.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss_interoperability.md
@@ -330,6 +330,10 @@ Any entities (ISAs or Subscriptions) not deleted normally will be deleted here.
 
 **[astm.f3411.v22a.DSS0130,A2-6-1,2a](../../../../requirements/astm/f3411/v22a.md)**
 
-### Subscription deleted with proper response check
+### Subscription can be queried by ID check
+
+**[astm.f3411.v22a.DSS0130,A2-6-1,4a](../../../../requirements/astm/f3411/v22a.md)**
+
+### Subscription can be deleted check
 
 **[astm.f3411.v22a.DSS0130,A2-6-1,4a](../../../../requirements/astm/f3411/v22a.md)**

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a.md
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a.md
@@ -21,6 +21,12 @@
     <th><a href="../../README.md#checked-in">Checked in</a></th>
   </tr>
   <tr>
+    <td rowspan="1" style="vertical-align:top;"><a href="../../../requirements/astm/f3411/v19.md">astm<br>.f3411<br>.v19</a></td>
+    <td><a href="../../../requirements/astm/f3411/v19.md">DSS0030,e</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/netrid/v22a/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a></td>
+  </tr>
+  <tr>
     <td rowspan="87" style="vertical-align:top;"><a href="../../../requirements/astm/f3411/v22a.md">astm<br>.f3411<br>.v22a</a></td>
     <td><a href="../../../requirements/astm/f3411/v22a.md">DSS0030</a></td>
     <td>Implemented</td>

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a/dss_probing.md
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a/dss_probing.md
@@ -23,6 +23,12 @@
     <th><a href="../../../README.md#checked-in">Checked in</a></th>
   </tr>
   <tr>
+    <td rowspan="1" style="vertical-align:top;"><a href="../../../../requirements/astm/f3411/v19.md">astm<br>.f3411<br>.v19</a></td>
+    <td><a href="../../../../requirements/astm/f3411/v19.md">DSS0030,e</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../../scenarios/astm/netrid/v22a/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a></td>
+  </tr>
+  <tr>
     <td rowspan="39" style="vertical-align:top;"><a href="../../../../requirements/astm/f3411/v22a.md">astm<br>.f3411<br>.v22a</a></td>
     <td><a href="../../../../requirements/astm/f3411/v22a.md">DSS0030</a></td>
     <td>Implemented</td>

--- a/monitoring/uss_qualifier/suites/interuss/dss/all_tests.md
+++ b/monitoring/uss_qualifier/suites/interuss/dss/all_tests.md
@@ -42,7 +42,7 @@
   <tr>
     <td><a href="../../../requirements/astm/f3411/v19.md">DSS0030,e</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/netrid/v19/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a></td>
+    <td><a href="../../../scenarios/astm/netrid/v22a/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3411/v19.md">DSS0030,f</a></td>

--- a/monitoring/uss_qualifier/suites/uspace/network_identification.md
+++ b/monitoring/uss_qualifier/suites/uspace/network_identification.md
@@ -16,6 +16,12 @@
     <th><a href="../README.md#checked-in">Checked in</a></th>
   </tr>
   <tr>
+    <td rowspan="1" style="vertical-align:top;"><a href="../../requirements/astm/f3411/v19.md">astm<br>.f3411<br>.v19</a></td>
+    <td><a href="../../requirements/astm/f3411/v19.md">DSS0030,e</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/netrid/v22a/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a></td>
+  </tr>
+  <tr>
     <td rowspan="87" style="vertical-align:top;"><a href="../../requirements/astm/f3411/v22a.md">astm<br>.f3411<br>.v22a</a></td>
     <td><a href="../../requirements/astm/f3411/v22a.md">DSS0030</a></td>
     <td>Implemented</td>

--- a/monitoring/uss_qualifier/suites/uspace/required_services.md
+++ b/monitoring/uss_qualifier/suites/uspace/required_services.md
@@ -18,6 +18,12 @@
     <th><a href="../README.md#checked-in">Checked in</a></th>
   </tr>
   <tr>
+    <td rowspan="1" style="vertical-align:top;"><a href="../../requirements/astm/f3411/v19.md">astm<br>.f3411<br>.v19</a></td>
+    <td><a href="../../requirements/astm/f3411/v19.md">DSS0030,e</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/netrid/v22a/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a></td>
+  </tr>
+  <tr>
     <td rowspan="87" style="vertical-align:top;"><a href="../../requirements/astm/f3411/v22a.md">astm<br>.f3411<br>.v22a</a></td>
     <td><a href="../../requirements/astm/f3411/v22a.md">DSS0030</a></td>
     <td>Implemented</td>


### PR DESCRIPTION
As [pointed out](https://github.com/interuss/monitoring/pull/295#discussion_r1375303789) in #295 the subscription cleanups require two checks.

This updates the helper function on `dss_wrapper` to reflect that fact, and fixes the documentation of `subscription_validation` and `dss_interoperability`

The redundant `delete_any_subscription` function in `utils.py` is removed as well and the two existing call-sites are now using the cleanup function on the `DSSWrapper` 