### PR TITLE
[uss_qualifier] Don't use participant notification URLs as participant IDs

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/isa_simple.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/isa_simple.py
@@ -110,15 +110,19 @@ class ISASimple(GenericTestScenario):
                         query_timestamps=[deleted.dss_query.query.request.timestamp],
                     )
             for subscriber_url, notification in deleted.notifications.items():
-                with self.check("Notified subscriber", [subscriber_url]) as check:
-                    # TODO: Find a better way to identify a subscriber who couldn't be notified
-                    if not notification.success:
-                        check.record_failed(
-                            "Could not notify ISA subscriber",
-                            Severity.Medium,
-                            f"Attempting to notify subscriber for ISA {self._isa_id} at {subscriber_url} resulted in {notification.status_code}",
-                            query_timestamps=[notification.query.request.timestamp],
-                        )
+                # For checking the notifications, we ignore the request we made for the subscription that we created.
+                if self._isa.base_url not in subscriber_url:
+                    pid = notification.query.participant_id
+                    with self.check(
+                        "Notified subscriber", [pid] if pid else []
+                    ) as check:
+                        if not notification.success:
+                            check.record_failed(
+                                "Could not notify ISA subscriber",
+                                Severity.Medium,
+                                f"Attempting to notify subscriber for ISA {self._isa_id} at {subscriber_url} resulted in {notification.status_code}",
+                                query_timestamps=[notification.query.request.timestamp],
+                            )
 
     def _get_isa_by_id_step(self):
         self.begin_test_step("Get ISA by ID")

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/utils.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/utils.py
@@ -54,8 +54,8 @@ def delete_isa_if_exists(
                 )
 
         for subscriber_url, notification in deleted.notifications.items():
-            with scenario.check("Notified subscriber", [subscriber_url]) as check:
-                # TODO: Find a better way to identify a subscriber who couldn't be notified
+            pid = notification.query.participant_id
+            with scenario.check("Notified subscriber", [pid] if pid else []) as check:
                 if not notification.success:
                     check.record_failed(
                         "Could not notify ISA subscriber",


### PR DESCRIPTION
Following the discussion [here](https://github.com/interuss/monitoring/pull/291#discussion_r1377851163) on #291 , don't use the subscription notification URL as the participant ID.

Instead, rely on the query's participant_id. Note that currently, this will mostly not be set, and if we run into many failures that can't be attributed, we'll probably want to find a way to attribute those queries properly.