### PR TITLE
[uss_qualifier] Fix NetRID automated testing issues

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/isa_simple.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/isa_simple.py
@@ -361,7 +361,7 @@ class ISASimple(GenericTestScenario):
             ) as check:
                 _ = self._dss_wrapper.search_isas_expect_response_code(
                     check,
-                    expected_error_codes={413},
+                    expected_error_codes={400, 413},
                     area=self._huge_area,
                 )
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/subscription_simple.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/subscription_simple.py
@@ -441,7 +441,7 @@ class SubscriptionSimple(GenericTestScenario):
         ) as check:
             self._dss_wrapper.search_subs_expect_response_code(
                 check=check,
-                expected_codes={413},
+                expected_codes={400, 413},
                 area=self._problematically_big_area,
             )
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/display_data_evaluator.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/display_data_evaluator.py
@@ -574,7 +574,7 @@ class RIDObservationEvaluator(object):
         with self._test_scenario.check(
             "Area too large", [observer.participant_id]
         ) as check:
-            if query.status_code != 413:
+            if query.status_code not in (400, 413):
                 check.record_failed(
                     summary="Did not receive expected error code for too-large area request",
                     details=f"{observer.participant_id} was queried for flights in {_rect_str(rect)} with a diagonal of {diagonal} which is larger than the maximum allowed diagonal of {self._rid_version.max_diagonal_km}.  The expected error code is 413, but instead code {query.status_code} was received.",

--- a/monitoring/uss_qualifier/test_data/che/rid/foca.kml
+++ b/monitoring/uss_qualifier/test_data/che/rid/foca.kml
@@ -315,7 +315,7 @@
 			<description>serial_number: 36ZN8ZAJFH6N3
 operation_description: Bend west
 operator_id: OP-000002che
-registration_number: CHE2h6zwko1y0xr6
+registration_number: HB.2h6zwko1y0xr6
 aircraft_type: HybridLift
 operator_name: Participant 2
 timestamp_accuracy: 1.0
@@ -417,7 +417,7 @@ accuracy_v: VAUnknown</description>
 			<description>serial_number: VF0M3GRU
 operation_description: Bend west
 operator_id: OP-000001che
-registration_number: CHE5jwwg00t0vfhc
+registration_number: HB.5jwwg00t0vfhc
 aircraft_type: HybridLift
 operator_name: Participant 1
 timestamp_accuracy: 1.0

--- a/monitoring/uss_qualifier/test_data/usa/kentland/rid.kml
+++ b/monitoring/uss_qualifier/test_data/usa/kentland/rid.kml
@@ -317,7 +317,7 @@
 			<description>serial_number: EXPL3123
 operation_description: U-turn south of takeoff
 operator_id: EXAMPLE_OPERATOR2
-registration_number: EXAMPLE_REGISTRATION2
+registration_number: N.123456
 aircraft_type: HybridLift
 operator_name: UFT Participant 2
 timestamp_accuracy: 1.0
@@ -434,7 +434,7 @@ accuracy_v: VAUnknown</description>
 			<description>serial_number: EXAMPLE_SERIAL1
 operation_description: Circle around dairy complex
 operator_id: EXAMPLE_OPERATOR1
-registration_number: EXAMPLE_REGISTRATION1
+registration_number: N.123456
 aircraft_type: Helicopter
 operator_name: UFT Participant 1
 timestamp_accuracy: 1.0

--- a/monitoring/uss_qualifier/test_data/usa/netrid/dcdemo.kml
+++ b/monitoring/uss_qualifier/test_data/usa/netrid/dcdemo.kml
@@ -101,7 +101,7 @@
 			<description>serial_number: EXMPLx31bclx2guk
 operation_description: Traffic Monitoring
 operator_id: OP-d7p4o3l2
-registration_number: FA-atqbGtF5FFc
+registration_number: N.123456
 aircraft_type: Helicopter
 operator_name: Johnson Group
 timestamp_accuracy: 1.0


### PR DESCRIPTION
Two issues were discovered by a NetRID automated testing user, both of which are addressed by this PR:

1. The registration_number values used in NetRID test data (which are put into [the registration_id field](https://github.com/uastech/standards/blob/astm_rid_api_2.1/remoteid/canonical.yaml#L1628)) do not follow the prescribed format, and therefore should fail validation in a fully-compliant USS.  This issue was not noticed previously because we [don't yet check registration_id format](https://github.com/interuss/monitoring/blob/89aaa4bba65b0bde664bed817e2968c855cc5658/monitoring/uss_qualifier/scenarios/astm/netrid/common_dictionary_evaluator.py#L306).
2. The HTTP response code for "area too large" in [a number of ASTM F3411-22a endpoints](https://github.com/uastech/standards/blob/astm_rid_api_2.1/remoteid/canonical.yaml#L504) is 413, but the 400 response is usually described as one or more parameters being invalid, and this is also the case when an area that is too large is specified.  Therefore, we should not fail checks if a USS responds with 400 rather than 413 in these situations.