### PR TITLE
[uss_qualifier] Expect correct value of 'owner' in subscription_simple scenario

### DIFF
--- a/monitoring/uss_qualifier/resources/interuss/id_generator.py
+++ b/monitoring/uss_qualifier/resources/interuss/id_generator.py
@@ -25,6 +25,7 @@ class IDGeneratorSpecification(ImplicitDict):
 
 class IDGeneratorResource(Resource[IDGeneratorSpecification]):
     id_factory: IDFactory
+    subscriber: str
 
     def __init__(
         self,
@@ -39,5 +40,5 @@ class IDGeneratorResource(Resource[IDGeneratorSpecification]):
             raise ValueError(
                 f"`sub` claim not found in payload of token using {type(auth_adapter).__name__} requesting {specification.whoami_scope} scope for {specification.whoami_audience} audience: {token}"
             )
-        subscriber = payload["sub"]
-        self.id_factory = IDFactory(subscriber)
+        self.subscriber = payload["sub"]
+        self.id_factory = IDFactory(self.subscriber)

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/subscription_simple.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/subscription_simple.py
@@ -21,9 +21,6 @@ from monitoring.uss_qualifier.suites.suite import ExecutionContext
 
 TIME_TOLERANCE_SEC = 1
 
-# TODO check if this is something that needs to be configurable.
-USS_QUALIFIER_OWNER = "uss_qualifier"
-
 
 class SubscriptionSimple(GenericTestScenario):
     """Based on prober/rid/v2/test_subscription_simple.py from the legacy prober tool."""
@@ -32,6 +29,9 @@ class SubscriptionSimple(GenericTestScenario):
 
     # Base identifier for the subscriptions that will be created
     _base_sub_id: str
+
+    # The value for 'owner' we'll expect the DSS to set on subscriptions
+    _owner: str
 
     _test_subscription_ids: List[str]
 
@@ -73,6 +73,8 @@ class SubscriptionSimple(GenericTestScenario):
         # Used to validate some special-case handling by the DSS
         self._isa_area_loop = self._isa_area.copy()
         self._isa_area_loop.append(self._isa_area_loop[0])
+
+        self._owner = id_generator.subscriber
 
         # Prepare 4 different subscription ids:
         self._test_subscription_ids = [
@@ -631,11 +633,11 @@ class SubscriptionSimple(GenericTestScenario):
         with self.check(
             "Returned subscription owner is correct", [self._dss_wrapper.participant_id]
         ) as check:
-            if sub_under_test.owner != USS_QUALIFIER_OWNER:
+            if sub_under_test.owner != self._owner:
                 check.record_failed(
                     "Returned subscription owner does not match provided one",
                     Severity.High,
-                    f"Provided: {USS_QUALIFIER_OWNER}, Returned: {sub_under_test.owner}",
+                    f"Provided: {self._owner}, Returned: {sub_under_test.owner}",
                     query_timestamps=query_timestamps,
                 )
 


### PR DESCRIPTION
This is an initial quick fix for issue #306: it profits of the fact that the `sub` claim is already made available in the `IDGeneratorResource` and that the `subscription_simple` scenario already depends on it.

A proper fix probably involves defining a new resource, as described in #306 . Discussion on this topic will continue on the issue.

