### PR TITLE
[uss_qualifier] Change USS_QUALIFIER_STOP_FAST to execution setting

### DIFF
--- a/.github/workflows/CI.md
+++ b/.github/workflows/CI.md
@@ -38,7 +38,7 @@ This check runs unit tests for mock_uss.
 
 ### uss_qualifier tests (`make test` in monitoring/uss_qualifier)
 
-Note: `export USS_QUALIFIER_STOP_FAST=true` is recommended as defining that environment variable will cause testing to stop on the first failure, and this is usually the desired behavior when debugging.
+Note: setting configuration `stop_fast` to `true` is recommended as setting that flag in configuration will cause testing to stop on the first failure, and this is usually the desired behavior when debugging.
 
 This action:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,7 @@ jobs:
     with:
       name: uss_qualifier
       script: |
-        export CONFIG_NAME="" \
-          USS_QUALIFIER_STOP_FAST=true
+        export CONFIG_NAME=""
 
         cd monitoring/uss_qualifier
         make test

--- a/monitoring/uss_qualifier/configurations/configuration.py
+++ b/monitoring/uss_qualifier/configurations/configuration.py
@@ -126,6 +126,9 @@ class ExecutionConfiguration(ImplicitDict):
     skip_action_when: Optional[List[TestSuiteActionSelectionCondition]] = None
     """If specified, do not execute test actions if they are selected by ANY of these conditions."""
 
+    stop_fast: Optional[bool] = False
+    """If true, escalate the Severity of any failed check to Critical in order to end the test run early."""
+
 
 class TestConfiguration(ImplicitDict):
     action: TestSuiteActionDeclaration

--- a/monitoring/uss_qualifier/configurations/dev/dss_probing.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/dss_probing.yaml
@@ -25,6 +25,8 @@ v1:
           id_generator: id_generator
           service_area: kentland_service_area
           problematically_big_area: kentland_problematically_big_area
+    execution:
+      stop_fast: true
   artifacts:
     output_path: output/dss_probing
     raw_report: {}

--- a/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml
@@ -89,6 +89,12 @@ v1:
       - v1.test_run.resources.resource_declarations.flight_planners
       - v1.test_run.resources.resource_declarations.dss
 
+    # How to execute a test run using this configuration
+    execution:
+      # Since we expect no failed checks and want to stop execution immediately if there are any failed checks, we set
+      # this parameter to true.
+      stop_fast: true
+
   # This block defines artifacts related to the test run.  Note that all paths are
   # relative to where uss_qualifier is executed from, and are located inside the
   # Docker container executing uss_qualifier.

--- a/monitoring/uss_qualifier/configurations/dev/general_flight_auth.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/general_flight_auth.yaml
@@ -16,6 +16,8 @@ v1:
         resources:
           table: example_flight_check_table
           planner: uss1_flight_planner
+    execution:
+      stop_fast: true
   artifacts:
     output_path: output/general_flight_auth
     raw_report: {}

--- a/monitoring/uss_qualifier/configurations/dev/generate_rid_test_data.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/generate_rid_test_data.yaml
@@ -61,5 +61,7 @@ v1:
                   kml_flights_data: kml_flights_data
                   kml_storage_config: kml_storage_config
               on_failure: Continue
+    execution:
+      stop_fast: true
   validation:
     "$ref": "./library/validation.yaml#/normal_test"

--- a/monitoring/uss_qualifier/configurations/dev/geoawareness_cis.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/geoawareness_cis.yaml
@@ -12,6 +12,8 @@ v1:
         suite_type: suites.uspace.geo_awareness_cis
         resources:
           source_document: source_document
+    execution:
+      stop_fast: true
   artifacts:
     output_path: output/geoawareness_cis
     raw_report: {}

--- a/monitoring/uss_qualifier/configurations/dev/geospatial_comprehension.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/geospatial_comprehension.yaml
@@ -9,6 +9,8 @@ v1:
         scenario_type: scenarios.interuss.geospatial_map.GeospatialFeatureComprehension
         resources:
           table: example_feature_check_table
+    execution:
+      stop_fast: true
   artifacts:
     output_path: output/geospatial_comprehension
     raw_report: {}

--- a/monitoring/uss_qualifier/configurations/dev/message_signing.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/message_signing.yaml
@@ -48,6 +48,8 @@ v1:
           conflicting_flights: che_conflicting_flights
           priority_preemption_flights: che_conflicting_flights
           dss: scd_dss
+    execution:
+      stop_fast: true
 
   artifacts:
     output_path: output/message_signing

--- a/monitoring/uss_qualifier/configurations/dev/netrid_v19.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/netrid_v19.yaml
@@ -30,6 +30,8 @@ v1:
           id_generator: id_generator
           service_area: kentland_service_area
           problematically_big_area: au_problematically_big_area
+    execution:
+      stop_fast: true
   artifacts:
     output_path: output/netrid_v19
     raw_report: {}

--- a/monitoring/uss_qualifier/configurations/dev/netrid_v22a.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/netrid_v22a.yaml
@@ -30,6 +30,8 @@ v1:
           id_generator: id_generator
           service_area: kentland_service_area
           problematically_big_area: au_problematically_big_area
+    execution:
+      stop_fast: true
   artifacts:
     output_path: output/netrid_v22a
     raw_report: {}

--- a/monitoring/uss_qualifier/configurations/dev/uspace.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/uspace.yaml
@@ -82,6 +82,8 @@ v1:
                 id_generator: id_generator
                 service_area: service_area
                 problematically_big_area: problematically_big_area
+    execution:
+      stop_fast: true
   artifacts:
     output_path: output/uspace
     raw_report: {}

--- a/monitoring/uss_qualifier/local_testing.md
+++ b/monitoring/uss_qualifier/local_testing.md
@@ -32,7 +32,7 @@ To tear down the complete set of local mocks (or ensure it is completely torn do
 
 Once the local interoperability ecosystem infrastructure and complete set of local mocks are deployed, execute uss_qualifier with [`./monitoring/uss_qualifier/run_locally.sh [CONFIG_NAME]`](run_locally.sh).  If no `CONFIG_NAME` is specified, all configurations used for the [continuous integration](../../.github/workflows) are executed; this involves multiple invocations of uss_qualifier.  Otherwise, a specific [configuration name](configurations/README.md#specifying) can be specified; e.g., [`configurations.dev.uspace`](configurations/dev/uspace.yaml).
 
-To cause uss_qualifier to stop at the first test failure (this is often useful when attempting to debug a test that should run fully successfully), set the USS_QUALIFIER_STOP_FAST environment variable with `export USS_QUALIFIER_STOP_FAST=true`.  To disable this behavior, `unset USS_QUALIFIER_STOP_FAST`.
+To cause uss_qualifier to stop at the first test failure (this is often useful when attempting to debug a test that should run fully successfully), set the `stop_fast` flag in the `execution` portion of the configuration.
 
 ## Presubmit testing
 

--- a/monitoring/uss_qualifier/run_locally.sh
+++ b/monitoring/uss_qualifier/run_locally.sh
@@ -66,7 +66,6 @@ docker run ${docker_args} --name uss_qualifier \
   -u "$(id -u):$(id -g)" \
   -e PYTHONBUFFERED=1 \
   -e AUTH_SPEC=${AUTH_SPEC} \
-  -e USS_QUALIFIER_STOP_FAST=${USS_QUALIFIER_STOP_FAST:-} \
   -e MONITORING_GITHUB_ROOT=${MONITORING_GITHUB_ROOT:-} \
   -v "$(pwd)/$OUTPUT_DIR:/app/$OUTPUT_DIR" \
   -v "$(pwd)/$CACHE_DIR:/app/$CACHE_DIR" \

--- a/monitoring/uss_qualifier/scenarios/astm/dss/crdb_access.py
+++ b/monitoring/uss_qualifier/scenarios/astm/dss/crdb_access.py
@@ -7,6 +7,6 @@ class CRDBAccess(GenericTestScenario):
         super().__init__()
 
     def run(self, context: ExecutionContext):
-        self.begin_test_scenario()
+        self.begin_test_scenario(context)
         # TODO: Implement
         self.end_test_scenario()

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/aggregate_checks.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/aggregate_checks.py
@@ -96,7 +96,7 @@ class AggregateChecks(GenericTestScenario):
     def run(self, context: ExecutionContext):
         self._init_queries(context)
 
-        self.begin_test_scenario()
+        self.begin_test_scenario(context)
 
         self.record_note("participants", str(self._participants_by_base_url))
         self.record_note("nb_queries", str(len(self._queries)))

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/isa_expiry.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/isa_expiry.py
@@ -45,7 +45,7 @@ class ISAExpiry(GenericTestScenario):
         self._isa_area = [vertex.as_s2sphere() for vertex in self._isa.footprint]
 
     def run(self, context: ExecutionContext):
-        self.begin_test_scenario()
+        self.begin_test_scenario(context)
 
         self._setup_case()
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/isa_simple.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/isa_simple.py
@@ -49,7 +49,7 @@ class ISASimple(GenericTestScenario):
         ]
 
     def run(self, context: ExecutionContext):
-        self.begin_test_scenario()
+        self.begin_test_scenario(context)
 
         self._setup_case()
         self._create_and_check_isa_case()

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/isa_subscription_interactions.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/isa_subscription_interactions.py
@@ -44,7 +44,7 @@ class ISASubscriptionInteractions(GenericTestScenario):
         self._isa_area = [vertex.as_s2sphere() for vertex in self._isa.footprint]
 
     def run(self, context: ExecutionContext):
-        self.begin_test_scenario()
+        self.begin_test_scenario(context)
 
         self._setup_case()
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/isa_validation.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/isa_validation.py
@@ -72,7 +72,7 @@ class ISAValidation(GenericTestScenario):
             ValueError(f"Unsupported RID version '{self._dss.rid_version}'")
 
     def run(self, context: ExecutionContext):
-        self.begin_test_scenario()
+        self.begin_test_scenario(context)
 
         self._setup_case()
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/subscription_simple.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/subscription_simple.py
@@ -95,7 +95,7 @@ class SubscriptionSimple(GenericTestScenario):
         ]
 
     def run(self, context: ExecutionContext):
-        self.begin_test_scenario()
+        self.begin_test_scenario(context)
 
         loguru.logger.info("setup")
         self._setup_case()

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/subscription_validation.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/subscription_validation.py
@@ -48,7 +48,7 @@ class SubscriptionValidation(GenericTestScenario):
         self._isa_area = [vertex.as_s2sphere() for vertex in self._isa.footprint]
 
     def run(self, context: ExecutionContext):
-        self.begin_test_scenario()
+        self.begin_test_scenario(context)
 
         self._setup_case()
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss_interoperability.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss_interoperability.py
@@ -90,7 +90,7 @@ class DSSInteroperability(GenericTestScenario):
         return all_entities
 
     def run(self, context: ExecutionContext):
-        self.begin_test_scenario()
+        self.begin_test_scenario(context)
 
         self.begin_test_case("Prerequisites")
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/misbehavior.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/misbehavior.py
@@ -71,7 +71,7 @@ class Misbehavior(GenericTestScenario):
         )
 
     def run(self, context: ExecutionContext):
-        self.begin_test_scenario()
+        self.begin_test_scenario(context)
         self.begin_test_case("Unauthenticated requests")
 
         self.begin_test_step("Injection")

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/nominal_behavior.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/nominal_behavior.py
@@ -63,7 +63,7 @@ class NominalBehavior(GenericTestScenario):
         )
 
     def run(self, context: ExecutionContext):
-        self.begin_test_scenario()
+        self.begin_test_scenario(context)
         self.begin_test_case("Nominal flight")
 
         self.begin_test_step("Injection")

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/operator_interactions.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/operator_interactions.py
@@ -7,6 +7,6 @@ class OperatorInteractions(GenericTestScenario):
         super().__init__()
 
     def run(self, context: ExecutionContext):
-        self.begin_test_scenario()
+        self.begin_test_scenario(context)
         # TODO: Implement
         self.end_test_scenario()

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/store_flight_data.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/store_flight_data.py
@@ -26,7 +26,7 @@ class StoreFlightData(TestScenario):
         self._storage_config = storage_configuration
 
     def run(self, context: ExecutionContext):
-        self.begin_test_scenario()
+        self.begin_test_scenario(context)
         self.record_note(
             "Flight count",
             f"{len(self._flights_data.flight_collection.flights)} flights",

--- a/monitoring/uss_qualifier/scenarios/astm/utm/aggregate_checks.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/aggregate_checks.py
@@ -52,7 +52,7 @@ class AggregateChecks(TestScenario):
 
     def run(self, context: ExecutionContext):
         self._init_queries(context)
-        self.begin_test_scenario()
+        self.begin_test_scenario(context)
 
         self.record_note("all_queries", f"{len(self._queries)}")
         for participant, queries_by_type in self._attributed_queries.items():

--- a/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/get_op_data_validation.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/get_op_data_validation.py
@@ -47,6 +47,6 @@ class GetOpResponseDataValidationByUSS(TestScenario):
         self.dss = dss.dss
 
     def run(self):
-        self.begin_test_scenario()
+        self.begin_test_scenario(context)
         pass
         self.end_test_scenario()

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss_interoperability.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss_interoperability.py
@@ -42,7 +42,7 @@ class DSSInteroperability(TestScenario):
 
     def run(self, context: ExecutionContext):
 
-        self.begin_test_scenario()
+        self.begin_test_scenario(context)
 
         self.begin_test_case("Prerequisites")
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/flight_intent_validation/flight_intent_validation.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/flight_intent_validation/flight_intent_validation.py
@@ -143,7 +143,7 @@ class FlightIntentValidation(TestScenario):
             )
 
     def run(self, context: ExecutionContext):
-        self.begin_test_scenario()
+        self.begin_test_scenario(context)
         self.record_note(
             "Tested USS",
             f"{self.tested_uss.config.participant_id}",

--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.py
@@ -216,7 +216,7 @@ class ConflictEqualPriorityNotPermitted(TestScenario):
             )
 
     def run(self, context: ExecutionContext):
-        self.begin_test_scenario()
+        self.begin_test_scenario(context)
 
         self.record_note(
             "Tested USS",

--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.py
@@ -195,7 +195,7 @@ class ConflictHigherPriority(TestScenario):
             )
 
     def run(self, context: ExecutionContext):
-        self.begin_test_scenario()
+        self.begin_test_scenario(context)
 
         self.record_note(
             "Tested USS",

--- a/monitoring/uss_qualifier/scenarios/dev/noop.py
+++ b/monitoring/uss_qualifier/scenarios/dev/noop.py
@@ -12,7 +12,7 @@ class NoOp(TestScenario):
         self.sleep_secs = noop_config.sleep_secs
 
     def run(self, context: ExecutionContext):
-        self.begin_test_scenario()
+        self.begin_test_scenario(context)
         self.begin_test_case("Sleep")
         self.begin_test_step("Sleep")
 

--- a/monitoring/uss_qualifier/scenarios/eurocae/ed269/source_data_model.py
+++ b/monitoring/uss_qualifier/scenarios/eurocae/ed269/source_data_model.py
@@ -25,7 +25,7 @@ class SourceDataModelValidation(TestScenario):
         self.source_document = source_document
 
     def run(self, context: ExecutionContext):
-        self.begin_test_scenario()
+        self.begin_test_scenario(context)
 
         self.record_note(
             "Document",

--- a/monitoring/uss_qualifier/scenarios/faa/uft/message_signing_finalize.py
+++ b/monitoring/uss_qualifier/scenarios/faa/uft/message_signing_finalize.py
@@ -15,7 +15,7 @@ class FinalizeMessageSigningReport(TestScenario):
         self._mock_uss = mock_uss.mock_uss
 
     def run(self, context: ExecutionContext):
-        self.begin_test_scenario()
+        self.begin_test_scenario(context)
 
         self.begin_test_case("Finalize message signing")
 

--- a/monitoring/uss_qualifier/scenarios/faa/uft/message_signing_start.py
+++ b/monitoring/uss_qualifier/scenarios/faa/uft/message_signing_start.py
@@ -15,7 +15,7 @@ class StartMessageSigningReport(TestScenario):
         self._mock_uss = mock_uss.mock_uss
 
     def run(self, context: ExecutionContext):
-        self.begin_test_scenario()
+        self.begin_test_scenario(context)
 
         self.begin_test_case("Start message signing")
 

--- a/monitoring/uss_qualifier/scenarios/flight_planning/record_planners.py
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/record_planners.py
@@ -11,7 +11,7 @@ class RecordPlanners(TestScenario):
         self._flight_planners = flight_planners
 
     def run(self, context: ExecutionContext):
-        self.begin_test_scenario()
+        self.begin_test_scenario(context)
 
         self.record_note(
             "Available flight planners",

--- a/monitoring/uss_qualifier/scenarios/interuss/flight_authorization/general_flight_authorization.py
+++ b/monitoring/uss_qualifier/scenarios/interuss/flight_authorization/general_flight_authorization.py
@@ -60,7 +60,7 @@ class GeneralFlightAuthorization(TestScenario):
         self.participant_id = planner.participant_id
 
     def run(self, context: ExecutionContext):
-        self.begin_test_scenario()
+        self.begin_test_scenario(context)
 
         self.begin_test_case("Flight planning")
         self._plan_flights()

--- a/monitoring/uss_qualifier/scenarios/interuss/geospatial_map/geospatial_feature_comprehension.py
+++ b/monitoring/uss_qualifier/scenarios/interuss/geospatial_map/geospatial_feature_comprehension.py
@@ -36,7 +36,7 @@ class GeospatialFeatureComprehension(TestScenario):
         self.table = table.table
 
     def run(self, context: ExecutionContext):
-        self.begin_test_scenario()
+        self.begin_test_scenario(context)
 
         self.begin_test_case("Map query")
         self._map_query()

--- a/monitoring/uss_qualifier/scenarios/interuss/mock_uss/configure_locality.py
+++ b/monitoring/uss_qualifier/scenarios/interuss/mock_uss/configure_locality.py
@@ -31,7 +31,7 @@ class ConfigureLocality(TestScenario):
         self.to_unconfigure = []
 
     def run(self, context: ExecutionContext):
-        self.begin_test_scenario()
+        self.begin_test_scenario(context)
 
         self.begin_test_case("Set locality")
 

--- a/monitoring/uss_qualifier/scenarios/interuss/mock_uss/unconfigure_locality.py
+++ b/monitoring/uss_qualifier/scenarios/interuss/mock_uss/unconfigure_locality.py
@@ -22,7 +22,7 @@ UnconfigureLocality will reset localities according to the most recent stack add
 
 class UnconfigureLocality(TestScenario):
     def run(self, context: ExecutionContext):
-        self.begin_test_scenario()
+        self.begin_test_scenario(context)
 
         if not unconfigure_stack:
             raise ValueError(

--- a/monitoring/uss_qualifier/scenarios/interuss/unit_test.py
+++ b/monitoring/uss_qualifier/scenarios/interuss/unit_test.py
@@ -14,7 +14,7 @@ class UnitTestScenario(GenericTestScenario):
         super().__init__()
 
     def run(self, context: ExecutionContext):
-        self.begin_test_scenario()
+        self.begin_test_scenario(context)
         self.begin_test_case("Case under test")
         self.begin_test_step("Step under test")
         self.step_under_test(self)

--- a/monitoring/uss_qualifier/scenarios/uspace/flight_auth/validation.py
+++ b/monitoring/uss_qualifier/scenarios/uspace/flight_auth/validation.py
@@ -69,7 +69,7 @@ class Validation(TestScenario):
                     )
 
     def run(self, context: ExecutionContext):
-        self.begin_test_scenario()
+        self.begin_test_scenario(context)
 
         self.record_note("Planner", self.ussp.participant_id)
 

--- a/monitoring/uss_qualifier/scenarios/versioning/get_system_versions.py
+++ b/monitoring/uss_qualifier/scenarios/versioning/get_system_versions.py
@@ -19,7 +19,7 @@ class GetSystemVersions(TestScenario):
         self._system_identity = system_identity.system_identity
 
     def run(self, context: ExecutionContext):
-        self.begin_test_scenario()
+        self.begin_test_scenario(context)
         self.begin_test_case("Get versions")
         self.begin_test_step("Get versions")
 

--- a/monitoring/uss_qualifier/suites/suite.py
+++ b/monitoring/uss_qualifier/suites/suite.py
@@ -396,6 +396,16 @@ class ExecutionContext(object):
                 for q in child.report.queries():
                     yield q
 
+    @property
+    def stop_fast(self) -> bool:
+        if (
+            self.config is not None
+            and "stop_fast" in self.config
+            and self.config.stop_fast is not None
+        ):
+            return self.config.stop_fast
+        return False
+
     def _compute_n_of(
         self, target: TestSuiteAction, condition: TestSuiteActionSelectionCondition
     ) -> int:

--- a/schemas/monitoring/uss_qualifier/configurations/configuration/ExecutionConfiguration.json
+++ b/schemas/monitoring/uss_qualifier/configurations/configuration/ExecutionConfiguration.json
@@ -26,6 +26,13 @@
         "array",
         "null"
       ]
+    },
+    "stop_fast": {
+      "description": "If true, escalate the Severity of any failed check to Critical in order to end the test run early.",
+      "type": [
+        "boolean",
+        "null"
+      ]
     }
   },
   "type": "object"


### PR DESCRIPTION
Currently, we short-circuit test run execution on the first failed check (by escalating it to Critical severity) according to an environment variable named USS_QUALIFIER_STOP_FAST.  This PR moves control of this behavior into the configuration; specifically, under `execution`.

Since the ExecutionContext already has the execution configuration in order to control execution, this PR makes the context available to the base GenericTestScenario by requiring it as a parameter to begin_test_scenario.  With the context (containing the stop_fast setting) available to the base GenericTestScenario, it simply constructs its PendingChecks with that setting.