### PR TITLE
[mock_uss] Remove API objects from flight planning routines

### DIFF
--- a/monitoring/mock_uss/f3548v21/flight_planning.py
+++ b/monitoring/mock_uss/f3548v21/flight_planning.py
@@ -242,10 +242,15 @@ def op_intent_from_flightinfo(
         uss_base_url="{}/mock/scd".format(webapp.config[KEY_BASE_URL]),
         subscription_id="UNKNOWN",
     )
+    if "astm_f3548_21" in flight_info and flight_info.astm_f3548_21:
+        priority = flight_info.astm_f3548_21.priority
+    else:
+        # TODO: Ensure this function is only called when sufficient information is available, or raise ValueError
+        priority = 0
     details = f3548_v21.OperationalIntentDetails(
         volumes=volumes,
         off_nominal_volumes=off_nominal_volumes,
-        priority=flight_info.astm_f3548_21.priority,
+        priority=priority,
     )
     return f3548_v21.OperationalIntent(
         reference=reference,

--- a/monitoring/mock_uss/f3548v21/flight_planning.py
+++ b/monitoring/mock_uss/f3548v21/flight_planning.py
@@ -8,8 +8,6 @@ from monitoring.mock_uss import webapp
 from monitoring.mock_uss.config import KEY_BASE_URL
 from monitoring.monitorlib.clients.flight_planning.flight_info import (
     FlightInfo,
-    AirspaceUsageState,
-    UasState,
 )
 from monitoring.uss_qualifier.resources.overrides import apply_overrides
 from uas_standards.astm.f3548.v21 import api as f3548_v21
@@ -27,18 +25,15 @@ class PlanningError(Exception):
     pass
 
 
-def validate_request(req_body: scd_api.InjectFlightRequest) -> None:
+def validate_request(op_intent: f3548_v21.OperationalIntent) -> None:
     """Raise a PlannerError if the request is not valid.
 
     Args:
-        req_body: Information about the requested flight.
+        op_intent: Information about the requested flight.
     """
     # Validate max number of vertices
     nb_vertices = 0
-    for volume in (
-        req_body.operational_intent.volumes
-        + req_body.operational_intent.off_nominal_volumes
-    ):
+    for volume in op_intent.details.volumes + op_intent.details.off_nominal_volumes:
         if volume.volume.has_field_with_value("outline_polygon"):
             nb_vertices += len(volume.volume.outline_polygon.vertices)
         if volume.volume.has_field_with_value("outline_circle"):
@@ -51,34 +46,32 @@ def validate_request(req_body: scd_api.InjectFlightRequest) -> None:
 
     # Validate max planning horizon for creation
     start_time = Volume4DCollection.from_interuss_scd_api(
-        req_body.operational_intent.volumes
-        + req_body.operational_intent.off_nominal_volumes
+        op_intent.details.volumes + op_intent.details.off_nominal_volumes
     ).time_start.datetime
     time_delta = start_time - datetime.now(tz=start_time.tzinfo)
     if (
         time_delta.days > OiMaxPlanHorizonDays
-        and req_body.operational_intent.state == scd_api.OperationalIntentState.Accepted
+        and op_intent.reference.state == scd_api.OperationalIntentState.Accepted
     ):
         raise PlanningError(
             f"Operational intent to plan is too far away in time (max OiMaxPlanHorizonDays={OiMaxPlanHorizonDays})"
         )
 
     # Validate no off_nominal_volumes if in Accepted or Activated state
-    if len(req_body.operational_intent.off_nominal_volumes) > 0 and (
-        req_body.operational_intent.state == scd_api.OperationalIntentState.Accepted
-        or req_body.operational_intent.state == scd_api.OperationalIntentState.Activated
+    if len(op_intent.details.off_nominal_volumes) > 0 and (
+        op_intent.reference.state == scd_api.OperationalIntentState.Accepted
+        or op_intent.reference.state == scd_api.OperationalIntentState.Activated
     ):
         raise PlanningError(
-            f"Operational intent specifies an off-nominal volume while being in {req_body.operational_intent.state} state"
+            f"Operational intent specifies an off-nominal volume while being in {op_intent.reference.state} state"
         )
 
     # Validate intent is currently active if in Activated state
     # I.e. at least one volume has start time in the past and end time in the future
-    if req_body.operational_intent.state == scd_api.OperationalIntentState.Activated:
+    if op_intent.reference.state == scd_api.OperationalIntentState.Activated:
         now = arrow.utcnow().datetime
         active_volume = Volume4DCollection.from_interuss_scd_api(
-            req_body.operational_intent.volumes
-            + req_body.operational_intent.off_nominal_volumes
+            op_intent.details.volumes + op_intent.details.off_nominal_volumes
         ).has_active_volume(now)
         if not active_volume:
             raise PlanningError(
@@ -438,3 +431,38 @@ def share_op_intent(
             utm_client, subscriber.uss_base_url, update
         )
     return record
+
+
+def delete_op_intent(
+    op_intent_ref: f3548_v21.OperationalIntentReference, log: Callable[[str], None]
+):
+    """Remove the operational intent reference from the DSS in compliance with ASTM F3548-21.
+
+    Args:
+        op_intent_ref: Operational intent reference to remove.
+        log: Means of indicating debugging information.
+
+    Raises:
+        * QueryError
+        * ConnectionError
+        * requests.exceptions.ConnectionError
+    """
+    result = scd_client.delete_operational_intent_reference(
+        utm_client,
+        op_intent_ref.id,
+        op_intent_ref.ovn,
+    )
+
+    base_url = "{}/mock/scd".format(webapp.config[KEY_BASE_URL])
+    for subscriber in result.subscribers:
+        if subscriber.uss_base_url == base_url:
+            # Do not notify ourselves
+            continue
+        update = f3548_v21.PutOperationalIntentDetailsParameters(
+            operational_intent_id=result.operational_intent_reference.id,
+            subscriptions=subscriber.subscriptions,
+        )
+        log(f"Notifying {subscriber.uss_base_url}")
+        scd_client.notify_operational_intent_details_changed(
+            utm_client, subscriber.uss_base_url, update
+        )

--- a/monitoring/mock_uss/flight_planning/routes.py
+++ b/monitoring/mock_uss/flight_planning/routes.py
@@ -96,7 +96,7 @@ def flight_planning_v1_upsert_flight_plan(flight_plan_id: str) -> Tuple[str, int
         flight_plan_status=api.FlightPlanStatus(inject_resp.flight_plan_status),
     )
     for k, v in inject_resp.items():
-        if k not in {"activity_result", "flight_plan_status"}:
+        if k not in {"planning_result", "flight_plan_status"}:
             resp[k] = v
     return flask.jsonify(resp), 200
 
@@ -111,9 +111,9 @@ def flight_planning_v1_delete_flight(flight_plan_id: str) -> Tuple[str, int]:
         planning_result=api.PlanningActivityResult(del_resp.activity_result),
         flight_plan_status=api.FlightPlanStatus(del_resp.flight_plan_status),
     )
-    if "notes" in del_resp and del_resp.notes:
-        resp.notes = del_resp.notes
-
+    for k, v in del_resp.items():
+        if k not in {"planning_result", "flight_plan_status"}:
+            resp[k] = v
     return flask.jsonify(resp), 200
 
 

--- a/monitoring/mock_uss/flight_planning/routes.py
+++ b/monitoring/mock_uss/flight_planning/routes.py
@@ -1,4 +1,5 @@
 import os
+import uuid
 from datetime import timedelta
 from typing import Tuple
 
@@ -6,6 +7,8 @@ import flask
 from implicitdict import ImplicitDict
 from loguru import logger
 
+from monitoring.mock_uss.f3548v21.flight_planning import op_intent_from_flightinfo
+from monitoring.mock_uss.flights.database import FlightRecord
 from monitoring.mock_uss.scd_injection.routes_injection import (
     inject_flight,
     lock_flight,
@@ -15,11 +18,9 @@ from monitoring.mock_uss.scd_injection.routes_injection import (
 )
 from monitoring.monitorlib.clients.flight_planning.flight_info import (
     FlightInfo,
-    AirspaceUsageState,
 )
 from monitoring.monitorlib.clients.mock_uss.mock_uss_scd_injection_api import (
-    MockUSSInjectFlightRequest,
-    MockUssFlightBehavior,
+    MockUSSUpsertFlightPlanRequest,
 )
 from uas_standards.interuss.automated_testing.flight_planning.v1 import api
 from uas_standards.interuss.automated_testing.flight_planning.v1.constants import Scope
@@ -66,95 +67,53 @@ def flight_planning_v1_upsert_flight_plan(flight_plan_id: str) -> Tuple[str, int
         json = flask.request.json
         if json is None:
             raise ValueError("Request did not contain a JSON payload")
-        req_body: api.UpsertFlightPlanRequest = ImplicitDict.parse(
-            json, api.UpsertFlightPlanRequest
+        req_body: MockUSSUpsertFlightPlanRequest = ImplicitDict.parse(
+            json, MockUSSUpsertFlightPlanRequest
         )
     except ValueError as e:
         msg = "Create flight {} unable to parse JSON: {}".format(flight_plan_id, e)
         return msg, 400
-    info = FlightInfo.from_flight_plan(req_body.flight_plan)
-    req = MockUSSInjectFlightRequest(info.to_scd_inject_flight_request())
-    if "behavior" in json:
-        try:
-            req.behavior = ImplicitDict.parse(json["behavior"], MockUssFlightBehavior)
-        except ValueError as e:
-            msg = f"Create flight {flight_plan_id} unable to parse `behavior` field: {str(e)}"
-            return msg, 400
 
     existing_flight = lock_flight(flight_plan_id, log)
     try:
-        if existing_flight:
-            usage_state = existing_flight.flight_info.basic_information.usage_state
-            if usage_state == AirspaceUsageState.Planned:
-                old_status = api.FlightPlanStatus.Planned
-            elif usage_state == AirspaceUsageState.InUse:
-                old_status = api.FlightPlanStatus.OkToFly
-            else:
-                raise ValueError(f"Unrecognized usage_state '{usage_state}'")
-        else:
-            old_status = api.FlightPlanStatus.NotPlanned
+        info = FlightInfo.from_flight_plan(req_body.flight_plan)
+        op_intent = op_intent_from_flightinfo(info, str(uuid.uuid4()))
+        new_flight = FlightRecord(
+            flight_info=info,
+            op_intent=op_intent,
+            mod_op_sharing_behavior=req_body.behavior
+            if "behavior" in req_body and req_body.behavior
+            else None,
+        )
 
-        scd_resp, code = inject_flight(flight_plan_id, req, existing_flight)
+        inject_resp = inject_flight(flight_plan_id, new_flight, existing_flight)
     finally:
         release_flight_lock(flight_plan_id, log)
 
-    if scd_resp.result == scd_api.InjectFlightResponseResult.Planned:
-        result = api.PlanningActivityResult.Completed
-        plan_status = api.FlightPlanStatus.Planned
-        notes = None
-    elif scd_resp.result == scd_api.InjectFlightResponseResult.ReadyToFly:
-        result = api.PlanningActivityResult.Completed
-        plan_status = api.FlightPlanStatus.OkToFly
-        notes = None
-    elif (
-        scd_resp.result == scd_api.InjectFlightResponseResult.ConflictWithFlight
-        or scd_resp.result == scd_api.InjectFlightResponseResult.Rejected
-    ):
-        result = api.PlanningActivityResult.Rejected
-        plan_status = old_status
-        notes = scd_resp.notes if "notes" in scd_resp else None
-    elif scd_resp.result == scd_api.InjectFlightResponseResult.Failed:
-        result = api.PlanningActivityResult.Failed
-        plan_status = old_status
-        notes = scd_resp.notes if "notes" in scd_resp else None
-    else:
-        raise ValueError(f"Unexpected scd inject_flight result '{scd_resp.result}'")
-
     resp = api.UpsertFlightPlanResponse(
-        planning_result=result,
-        notes=notes,
-        flight_plan_status=plan_status,
+        planning_result=api.PlanningActivityResult(inject_resp.activity_result),
+        flight_plan_status=api.FlightPlanStatus(inject_resp.flight_plan_status),
     )
-    for k, v in scd_resp.items():
-        if k not in {"result", "notes", "operational_intent_id"}:
+    for k, v in inject_resp.items():
+        if k not in {"activity_result", "flight_plan_status"}:
             resp[k] = v
-    return flask.jsonify(resp), code
+    return flask.jsonify(resp), 200
 
 
 @webapp.route("/flight_planning/v1/flight_plans/<flight_plan_id>", methods=["DELETE"])
 @requires_scope(Scope.Plan)
 def flight_planning_v1_delete_flight(flight_plan_id: str) -> Tuple[str, int]:
     """Implements flight deletion in SCD automated testing injection API."""
-    scd_resp, code = delete_flight(flight_plan_id)
-    if code != 200:
-        raise RuntimeError(
-            f"DELETE flight plan endpoint expected code 200 from scd handler but received {code} instead"
-        )
+    del_resp = delete_flight(flight_plan_id)
 
-    if scd_resp.result == scd_api.DeleteFlightResponseResult.Closed:
-        result = api.PlanningActivityResult.Completed
-        status = api.FlightPlanStatus.Closed
-    else:
-        result = api.PlanningActivityResult.Failed
-        status = (
-            api.FlightPlanStatus.NotPlanned
-        )  # delete_flight only fails like this when the flight doesn't exist
-    kwargs = {"planning_result": result, "flight_plan_status": status}
-    if "notes" in scd_resp:
-        kwargs["notes"] = scd_resp.notes
-    resp = api.DeleteFlightPlanResponse(**kwargs)
+    resp = api.DeleteFlightPlanResponse(
+        planning_result=api.PlanningActivityResult(del_resp.activity_result),
+        flight_plan_status=api.FlightPlanStatus(del_resp.flight_plan_status),
+    )
+    if "notes" in del_resp and del_resp.notes:
+        resp.notes = del_resp.notes
 
-    return flask.jsonify(resp), code
+    return flask.jsonify(resp), 200
 
 
 @webapp.route("/flight_planning/v1/clear_area_requests", methods=["POST"])

--- a/monitoring/mock_uss/scd_injection/routes_injection.py
+++ b/monitoring/mock_uss/scd_injection/routes_injection.py
@@ -395,9 +395,12 @@ def clear_area(extent: Volume4D) -> ClearAreaResponse:
                     notes += ": " + del_resp.notes
                 flight_deletion_errors[flight_id] = {"notes": notes}
 
-        # Try to delete every remaining operational intent
+        # Try to delete every remaining operational intent that we manage
+        self_sub = utm_client.auth_adapter.get_sub()
         op_intent_refs = [
-            oi for oi in op_intent_refs if oi.id not in op_intents_removed
+            oi
+            for oi in op_intent_refs
+            if oi.id not in op_intents_removed and oi.manager == self_sub
         ]
         op_intent_ids_str = ", ".join(
             op_intent_ref.id for op_intent_ref in op_intent_refs

--- a/monitoring/mock_uss/uspace/flight_auth.py
+++ b/monitoring/mock_uss/uspace/flight_auth.py
@@ -9,6 +9,8 @@ def validate_request(flight_info: FlightInfo) -> None:
     Args:
         flight_info: Information about the requested flight.
     """
-    problems = problems_with_flight_authorisation(flight_info.flight_authorisation)
+    problems = problems_with_flight_authorisation(
+        flight_info.uspace_flight_authorisation
+    )
     if problems:
         raise PlanningError(", ".join(problems))

--- a/monitoring/mock_uss/uspace/flight_auth.py
+++ b/monitoring/mock_uss/uspace/flight_auth.py
@@ -1,14 +1,14 @@
 from monitoring.mock_uss.f3548v21.flight_planning import PlanningError
+from monitoring.monitorlib.clients.flight_planning.flight_info import FlightInfo
 from monitoring.monitorlib.uspace import problems_with_flight_authorisation
-from uas_standards.interuss.automated_testing.scd.v1 import api as scd_api
 
 
-def validate_request(req_body: scd_api.InjectFlightRequest) -> None:
+def validate_request(flight_info: FlightInfo) -> None:
     """Raise a PlannerError if the request is not valid.
 
     Args:
-        req_body: Information about the requested flight.
+        flight_info: Information about the requested flight.
     """
-    problems = problems_with_flight_authorisation(req_body.flight_authorisation)
+    problems = problems_with_flight_authorisation(flight_info.flight_authorisation)
     if problems:
         raise PlanningError(", ".join(problems))

--- a/monitoring/monitorlib/clients/flight_planning/planning.py
+++ b/monitoring/monitorlib/clients/flight_planning/planning.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 from enum import Enum
-from typing import Optional, List
+from typing import Optional, List, Dict
 
 from implicitdict import ImplicitDict
+from uas_standards.astm.f3548.v21 import api as f3548v21
 from uas_standards.interuss.automated_testing.scd.v1 import api as scd_api
 
 from monitoring.monitorlib.clients.flight_planning.flight_info import (
@@ -122,3 +123,28 @@ class PlanningActivityResponse(ImplicitDict):
             )
         notes = {"notes": self.notes} if "notes" in self else {}
         return scd_api.InjectFlightResponse(result=result, **notes)
+
+
+class ClearAreaResponse(ImplicitDict):
+    flights_deleted: List[FlightID]
+    """List of IDs of flights that were deleted during this area clearing operation."""
+
+    flight_deletion_errors: Dict[FlightID, dict]
+    """When an error was encountered deleting a particular flight, information about that error."""
+
+    op_intents_removed: List[f3548v21.EntityOVN]
+    """List of IDs of ASTM F3548-21 operational intent references that were removed during this area clearing operation."""
+
+    op_intent_removal_errors: Dict[f3548v21.EntityOVN, dict]
+    """When an error was encountered removing a particular operational intent reference, information about that error."""
+
+    error: Optional[dict] = None
+    """If an error was encountered that could not be linked to a specific flight or operational intent, information about it will be populated here."""
+
+    @property
+    def success(self) -> bool:
+        return (
+            not self.flight_deletion_errors
+            and not self.op_intent_removal_errors
+            and self.error is None
+        )

--- a/monitoring/monitorlib/clients/mock_uss/mock_uss_scd_injection_api.py
+++ b/monitoring/monitorlib/clients/mock_uss/mock_uss_scd_injection_api.py
@@ -1,5 +1,9 @@
 from implicitdict import ImplicitDict
 from typing import List, Optional
+
+from uas_standards.interuss.automated_testing.flight_planning.v1.api import (
+    UpsertFlightPlanRequest,
+)
 from uas_standards.interuss.automated_testing.scd.v1.api import InjectFlightRequest
 
 
@@ -26,5 +30,11 @@ class MockUssFlightBehavior(ImplicitDict):
 
 class MockUSSInjectFlightRequest(InjectFlightRequest):
     """InjectFlightRequest sent to mock_uss, which looks for the optional additional fields below."""
+
+    behavior: Optional[MockUssFlightBehavior]
+
+
+class MockUSSUpsertFlightPlanRequest(UpsertFlightPlanRequest):
+    """UpsertFlightPlanRequest sent to mock_uss, which looks for the optional additional fields below."""
 
     behavior: Optional[MockUssFlightBehavior]

--- a/monitoring/uss_qualifier/reports/tested_requirements.py
+++ b/monitoring/uss_qualifier/reports/tested_requirements.py
@@ -185,8 +185,8 @@ class TestedBreakdown(ImplicitDict):
 
 class TestRunInformation(ImplicitDict):
     test_run_id: str
-    start_time: Optional[str]
-    end_time: Optional[str]
+    start_time: Optional[str] = None
+    end_time: Optional[str] = None
     baseline: str
     environment: str
 


### PR DESCRIPTION
Historically, mock_uss's core flight planning handler routines used API objects from the [now-deprecated scd injection API](https://github.com/interuss/automated_testing_interfaces/tree/main/scd) for both the input/request and output/response.  This PR does most of the work to switch these routines to use business objects instead.  The clear_area routine is also adjusted to target deletion of known flights first before following up with cleanup of straggling operational intents.