### PR TITLE
[uss_qualifier] Fix report validation

### DIFF
--- a/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml
@@ -91,7 +91,7 @@ v1:
             participant_id: uss1
             base_url: http://dss.uss1.localutm
 
-        # Mock USS that can be used in tests for flight planning, modifying data sharing behavior and recording interuss interactions
+        # Mock USS that can be used in tests for flight planning, modifying data sharing behavior and recording interactions
         mock_uss:
           resource_type: resources.interuss.mock_uss.client.MockUSSResource
           dependencies:
@@ -108,6 +108,7 @@ v1:
       - v1.test_run.resources.resource_declarations.utm_auth
       - v1.test_run.resources.resource_declarations.flight_planners
       - v1.test_run.resources.resource_declarations.dss
+      - v1.test_run.resources.resource_declarations.mock_uss
 
     # How to execute a test run using this configuration
     execution:

--- a/monitoring/uss_qualifier/configurations/dev/library/environment_containers.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/library/environment_containers.yaml
@@ -184,6 +184,14 @@ mock_uss_instance_uss1:
     participant_id: mock_uss
     mock_uss_base_url: http://scdsc.uss1.localutm
 
+mock_uss_instance_uss6:
+  resource_type: resources.interuss.mock_uss.client.MockUSSResource
+  dependencies:
+    auth_adapter: utm_auth
+  specification:
+    participant_id: mock_uss
+    mock_uss_base_url: http://scdsc.log.uss6.localutm
+
 mock_uss_instances_scdsc:
   $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
   resource_type: resources.interuss.mock_uss.client.MockUSSsResource

--- a/monitoring/uss_qualifier/configurations/dev/library/environment_localhost.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/library/environment_localhost.yaml
@@ -184,6 +184,14 @@ mock_uss_instance_uss1:
     participant_id: mock_uss
     mock_uss_base_url: http://localhost:8074
 
+mock_uss_instance_uss6:
+  resource_type: resources.interuss.mock_uss.client.MockUSSResource
+  dependencies:
+    auth_adapter: utm_auth
+  specification:
+    participant_id: mock_uss
+    mock_uss_base_url: http://localhost:8095
+
 mock_uss_instances_scdsc:
   $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
   resource_type: resources.interuss.mock_uss.client.MockUSSsResource

--- a/monitoring/uss_qualifier/configurations/dev/library/resources.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/library/resources.yaml
@@ -142,6 +142,13 @@ che_general_flight_auth_flights:
     file:
       path: file://./test_data/che/flight_intents/general_flight_auth_flights.yaml
 
+che_non_conflicting_flights:
+  $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
+  resource_type: resources.flight_planning.FlightIntentsResource
+  specification:
+    file:
+      path: test_data.che.flight_intents.non_conflicting
+
 # ===== General flight authorization =====
 
 example_flight_check_table:

--- a/monitoring/uss_qualifier/configurations/dev/library/validation.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/library/validation.yaml
@@ -14,3 +14,9 @@ normal_test:
         elements:
           count:
             equal_to: 0
+    - applicability:
+        skipped_actions: {}
+      pass_condition:
+        elements:
+          count:
+            equal_to: 0

--- a/monitoring/uss_qualifier/configurations/dev/uspace.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/uspace.yaml
@@ -7,6 +7,7 @@ v1:
         che_conflicting_flights: {$ref: 'library/resources.yaml#/che_conflicting_flights'}
         che_invalid_flight_intents: {$ref: 'library/resources.yaml#/che_invalid_flight_intents'}
         che_invalid_flight_auth_flights: {$ref: 'library/resources.yaml#/che_invalid_flight_auth_flights'}
+        che_non_conflicting_flights: {$ref: 'library/resources.yaml#/che_non_conflicting_flights'}
         foca_flights_data: {$ref: 'library/resources.yaml#/foca_flights_data'}
         netrid_observation_evaluation_configuration: {$ref: 'library/resources.yaml#/netrid_observation_evaluation_configuration'}
         id_generator: {$ref: 'library/resources.yaml#/id_generator'}
@@ -15,6 +16,7 @@ v1:
 
         utm_auth: {$ref: 'library/environment.yaml#/utm_auth'}
         mock_uss_instances_scdsc: {$ref: 'library/environment.yaml#/mock_uss_instances_scdsc'}
+        mock_uss_instance_uss6: {$ref: 'library/environment.yaml#/mock_uss_instance_uss6'}
         scd_version_providers: {$ref: 'library/environment.yaml#/scd_version_providers'}
         all_flight_planners: {$ref: 'library/environment.yaml#/all_flight_planners'}
         scd_dss: {$ref: 'library/environment.yaml#/scd_dss'}
@@ -25,6 +27,7 @@ v1:
     non_baseline_inputs:
       - v1.test_run.resources.resource_declarations.utm_auth
       - v1.test_run.resources.resource_declarations.mock_uss_instances_scdsc
+      - v1.test_run.resources.resource_declarations.mock_uss_instance_uss6
       - v1.test_run.resources.resource_declarations.scd_version_providers
       - v1.test_run.resources.resource_declarations.all_flight_planners
       - v1.test_run.resources.resource_declarations.scd_dss
@@ -45,7 +48,9 @@ v1:
           priority_preemption_flights: che_conflicting_flights
           invalid_flight_intents: che_invalid_flight_intents
           invalid_flight_auth_flights: che_invalid_flight_auth_flights
+          non_conflicting_flights: che_non_conflicting_flights
           flight_planners: all_flight_planners
+          mock_uss: mock_uss_instance_uss6
           scd_dss: scd_dss
           scd_dss_instances: scd_dss_instances
 
@@ -70,7 +75,9 @@ v1:
                 priority_preemption_flights: priority_preemption_flights
                 invalid_flight_intents: invalid_flight_intents
                 invalid_flight_auth_flights: invalid_flight_auth_flights
+                non_conflicting_flights: non_conflicting_flights
                 flight_planners: flight_planners
+                mock_uss: mock_uss
                 scd_dss: scd_dss
                 scd_dss_instances: scd_dss_instances
 

--- a/monitoring/uss_qualifier/main.py
+++ b/monitoring/uss_qualifier/main.py
@@ -177,12 +177,14 @@ def main() -> int:
         logger.info(
             f"========== Running uss_qualifier for configuration {config_name} =========="
         )
-        run_config(
+        exit_code = run_config(
             config_name,
             config_outputs[idx],
             args.skip_validation,
             args.exit_before_execution,
         )
+        if exit_code != os.EX_OK:
+            return exit_code
         logger.info(
             f"========== Completed uss_qualifier for configuration {config_name} =========="
         )

--- a/monitoring/uss_qualifier/scenarios/interuss/geospatial_map/geospatial_feature_comprehension.py
+++ b/monitoring/uss_qualifier/scenarios/interuss/geospatial_map/geospatial_feature_comprehension.py
@@ -1,5 +1,6 @@
 import arrow
 
+from monitoring.monitorlib.temporal import Time
 from monitoring.uss_qualifier.resources.interuss.geospatial_map import (
     FeatureCheckTableResource,
 )
@@ -72,7 +73,7 @@ class GeospatialFeatureComprehension(TestScenario):
             self.begin_dynamic_test_step(doc)
 
             if row.volumes:
-                concrete_volumes = [v.resolve(start_time) for v in row.volumes]
+                concrete_volumes = [v.resolve(Time(start_time)) for v in row.volumes]
 
             # TODO: Query USSs under test
             self.record_note(

--- a/monitoring/uss_qualifier/scenarios/scenario.py
+++ b/monitoring/uss_qualifier/scenarios/scenario.py
@@ -192,7 +192,7 @@ class GenericTestScenario(ABC):
     _step_report: Optional[TestStepReport] = None
     _allow_undocumented_checks = False  # When this variable is set to True, it allows undocumented checks to be executed by the scenario. This is primarly intended to simplify internal unit testing.
 
-    _context = None
+    context = None
     """Execution context; set at begin_test_scenario."""
 
     def __init__(self):
@@ -293,7 +293,7 @@ class GenericTestScenario(ABC):
             context: Execution context with type monitoring.uss_qualifier.suites.suite.ExecutionContext.  Type hint is
                 not annotated because doing so would create a circular reference.
         """
-        self._context = context
+        self.context = context
         self._expect_phase(ScenarioPhase.NotStarted)
         self._make_scenario_report()
         self._phase = ScenarioPhase.ReadyForTestCase
@@ -409,7 +409,7 @@ class GenericTestScenario(ABC):
             documentation=check_documentation,
             participants=[] if participants is None else participants,
             step_report=self._step_report,
-            stop_fast=self._context.stop_fast,
+            stop_fast=self.context.stop_fast,
             on_failed_check=self.on_failed_check,
         )
 

--- a/monitoring/uss_qualifier/suites/uspace/flight_auth.yaml
+++ b/monitoring/uss_qualifier/suites/uspace/flight_auth.yaml
@@ -4,7 +4,9 @@ resources:
   priority_preemption_flights: resources.flight_planning.FlightIntentsResource
   invalid_flight_auth_flights: resources.flight_planning.FlightIntentsResource
   invalid_flight_intents: resources.flight_planning.FlightIntentsResource
+  non_conflicting_flights: resources.flight_planning.FlightIntentsResource
   flight_planners: resources.flight_planning.FlightPlannersResource
+  mock_uss: resources.interuss.mock_uss.client.MockUSSResource
   dss: resources.astm.f3548.v21.DSSInstanceResource
   dss_instances: resources.astm.f3548.v21.DSSInstancesResource?
 
@@ -15,7 +17,9 @@ actions:
       conflicting_flights: conflicting_flights
       priority_preemption_flights: priority_preemption_flights
       invalid_flight_intents: invalid_flight_intents
+      non_conflicting_flights: non_conflicting_flights
       flight_planners: flight_planners
+      mock_uss: mock_uss
       dss: dss
       dss_instances: dss_instances
   on_failure: Continue

--- a/monitoring/uss_qualifier/suites/uspace/required_services.yaml
+++ b/monitoring/uss_qualifier/suites/uspace/required_services.yaml
@@ -6,7 +6,9 @@ resources:
   priority_preemption_flights: resources.flight_planning.FlightIntentsResource
   invalid_flight_intents: resources.flight_planning.FlightIntentsResource
   invalid_flight_auth_flights: resources.flight_planning.FlightIntentsResource
+  non_conflicting_flights: resources.flight_planning.FlightIntentsResource
   flight_planners: resources.flight_planning.FlightPlannersResource
+  mock_uss: resources.interuss.mock_uss.client.MockUSSResource
   scd_dss: resources.astm.f3548.v21.DSSInstanceResource
   scd_dss_instances: resources.astm.f3548.v21.DSSInstancesResource?
 
@@ -37,7 +39,9 @@ actions:
       priority_preemption_flights: priority_preemption_flights
       invalid_flight_intents: invalid_flight_intents
       invalid_flight_auth_flights: invalid_flight_auth_flights
+      non_conflicting_flights: non_conflicting_flights
       flight_planners: flight_planners
+      mock_uss: mock_uss
       dss: scd_dss
       dss_instances: scd_dss_instances
   on_failure: Continue

--- a/monitoring/uss_qualifier/test_data/che/flight_intents/non_conflicting.yaml
+++ b/monitoring/uss_qualifier/test_data/che/flight_intents/non_conflicting.yaml
@@ -7,14 +7,14 @@ intents:
         area:
           - outline_polygon:
               vertices:
-                - lat: 37.20642344604623
-                  lng: -80.58508994131496
-                - lat: 37.21359527809636
-                  lng: -80.5767365824006
-                - lat: 37.215812746083586
-                  lng: -80.58144645497978
-                - lat: 37.2146332499489
-                  lng: -80.58408279875103
+                - lat: 47.20642344604623
+                  lng: 7.58508994131496
+                - lat: 47.21359527809636
+                  lng: 7.5767365824006
+                - lat: 47.215812746083586
+                  lng: 7.58144645497978
+                - lat: 47.2146332499489
+                  lng: 7.58408279875103
             altitude_lower:
               value: 474
               reference: W84
@@ -33,7 +33,6 @@ intents:
       astm_f3548_21:
         priority: 0
 
-      # TODO: Remove flight_authorisation section when it is optional
       uspace_flight_authorisation:
         uas_serial_number: 1AF49UL5CC5J6K
         operation_category: Open
@@ -58,16 +57,16 @@ intents:
         area:
           - outline_polygon:
               vertices:
-                - lat: 37.214119359044275
-                  lng: -80.58443600701524
-                - lat: 37.212388260776436
-                  lng: -80.58824885811198
-                - lat: 37.20211436858821
-                  lng: -80.5856832012991
-                - lat: 37.21394908884487
-                  lng: -80.57474352572189
-                - lat: 37.206173006943104
-                  lng: -80.5852199577081
+                - lat: 47.214119359044275
+                  lng: 7.58443600701524
+                - lat: 47.212388260776436
+                  lng: 7.58824885811198
+                - lat: 47.20211436858821
+                  lng: 7.5856832012991
+                - lat: 47.21394908884487
+                  lng: 7.57474352572189
+                - lat: 47.206173006943104
+                  lng: 7.5852199577081
             altitude_lower:
               value: 483
               reference: W84
@@ -86,7 +85,6 @@ intents:
       astm_f3548_21:
         priority: 0
 
-      # TODO: Remove flight_authorisation section when it is optional
       uspace_flight_authorisation:
         uas_serial_number: 1AF49UL5CC5J6K
         operation_category: Open


### PR DESCRIPTION
Our current main branch is failing to detect most test failures in CI runs because the exit code from an inner function in main.py is being discarded in favor of always returning EX_OK.  This PR fixes the bug in main.py and then fixes the errors revealed when that bug is fixed, along with some cleanup noticed while making these fixes.  The bulk of the changes in this PR provide a mock_uss instance and the new flight intents resource to the ASTM F3548-21 suite when called from the U-space suite.  An additional validation criterion is added for most reports that no actions may be skipped (though this is intentionally not applied to f3548_self_contained).  The new flight intents file is copied into Switzerland test data and the lat/lng coordinates are adjusted to be in Switzerland for that file.