### PR TITLE
[uss_qualifier] Display execution errors in sequence view artifact

### DIFF
--- a/monitoring/uss_qualifier/reports/sequence_view.py
+++ b/monitoring/uss_qualifier/reports/sequence_view.py
@@ -27,6 +27,7 @@ from monitoring.uss_qualifier.reports.report import (
     PassedCheck,
     FailedCheck,
     SkippedActionReport,
+    ErrorReport,
 )
 from monitoring.uss_qualifier.reports.tested_requirements import (
     compute_test_run_information,
@@ -153,7 +154,8 @@ class TestedParticipant(object):
     has_queries: bool = False
 
 
-class TestedScenario(ImplicitDict):
+@dataclass
+class TestedScenario(object):
     type: TestScenarioTypeName
     name: str
     url: str
@@ -161,6 +163,7 @@ class TestedScenario(ImplicitDict):
     duration: str
     epochs: List[Epoch]
     participants: Dict[ParticipantID, TestedParticipant]
+    execution_error: Optional[ErrorReport]
 
     @property
     def rows(self) -> int:
@@ -421,6 +424,7 @@ def _compute_tested_scenario(
         epochs=epochs,
         scenario_index=indexer.scenario_index,
         participants=scenario_participants,
+        execution_error=report.execution_error if "execution_error" in report else None,
     )
     indexer.scenario_index += 1
     return scenario

--- a/monitoring/uss_qualifier/reports/templates/sequence_view/overview.html
+++ b/monitoring/uss_qualifier/reports/templates/sequence_view/overview.html
@@ -120,7 +120,7 @@
 </div>
 
 <div id="configuration_section" class="collapseable">
-  <div class="node_key" onclick="showHide(document.getElementById('configuration_section'))"><h2>Configuration</h2></div>
+  <div class="node_key" onclick="showHide(document.getElementById('configuration_section'))"><h2>Resources configuration</h2></div>
   <div class="node_value">
     {% for is_baseline in (True, False) %}
       <h3>{{ "Baseline" if is_baseline else "Environment" }}</h3>
@@ -182,9 +182,13 @@
           {% endif %}
         {% endfor %}
         {% if row.scenario_node %}
-          <td>
-            <a href="s{{ row.scenario_node.scenario.scenario_index }}.html">{{ row.scenario_node.scenario.name }}</a>
-          </td>
+          {% if row.scenario_node.scenario.execution_error %}
+            <td class="fail_result">
+          {% else %}
+            <td>
+          {% endif %}
+              <a href="s{{ row.scenario_node.scenario.scenario_index }}.html">{{ row.scenario_node.scenario.name }}</a>
+            </td>
         {% endif %}
         {% if row.skipped_action_node %}
           <td>

--- a/monitoring/uss_qualifier/reports/templates/sequence_view/scenario.html
+++ b/monitoring/uss_qualifier/reports/templates/sequence_view/scenario.html
@@ -202,6 +202,16 @@
       {% endif %}
     {% endfor %}
   </table>
+  {% if test_scenario.execution_error %}
+    <div id="execution_error">
+      <h4 class="fail_result"><code>{{ test_scenario.execution_error.type }}</code> at {{ test_scenario.execution_error.timestamp }}</h4>
+      <p><b>Message</b>: {{ test_scenario.execution_error.message }}</p>
+      <p>
+        <b>Stack trace</b>:<br>
+        <pre>{{ test_scenario.execution_error.stacktrace }}</pre>
+      </p>
+    </div>
+  {% endif %}
 </div>
 {{ explorer_footer(collapsible.queries) }}
 </body>


### PR DESCRIPTION
Currently, the sequence view artifact does not visualize execution errors.  This can lead to confusion when viewing the artifact for a test run that had execution errors (everything will appear normal, but truncated).  This PR fixes that by displaying execution error information when present and visually indicating that one happened for a particular scenario on the overview page.

Since `TestedScenario` is only an in-memory object and is not serialized or deserialized, there is no reason for it to be an ImplicitDict so it is changed to a dataclass while already modifying it for the reason above.

A heading title in the artifact is also adjusted for clarity.