### PR TITLE
[build] Exclude pyc files from image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 build/workspace
+*.pyc

--- a/monitoring/Makefile
+++ b/monitoring/Makefile
@@ -6,7 +6,7 @@ lint:
 format:
 	cd uss_qualifier && make format
 
-image: ../requirements.txt $(shell find . -type f ! -path "*/output/*" ! -name image) $(shell find ../interfaces -type f)
+image: ../requirements.txt $(shell find . -type f ! -path "*/output/*" ! -name image ! -name *.pyc) $(shell find ../interfaces -type f)
 	# Building image due to changes in the following files: $?
 	./build.sh
 


### PR DESCRIPTION
Currently, *.pyc files affect whether the monitoring image is rebuilt or not, so if someone using the repository has a tool that manipulates *.pyc files (e.g., a full-featured IDE like IntelliJ), they will build the monitoring image far more frequently than is necessary.  This PR excludes prebuilt *.pyc files from the image and removes them as a make dependency.  Removing prebuilt *.pyc files is also desirable generally as the host machine on which they are built may build them differently than the container in which the image is run.