### PR TITLE
[uss_qualifier] dss_wrapper's handle_query_result function is made public

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/isa_validation.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/isa_validation.py
@@ -256,7 +256,7 @@ class ISAValidation(GenericTestScenario):
 
             rid_query.set_participant_id(self._dss_wrapper.participant_id)
 
-            self._dss_wrapper._handle_query_result(
+            self._dss_wrapper.handle_query_result(
                 check=check,
                 q=rid_query,
                 fail_msg="ISA Creation with missing outline has unexpected result code",
@@ -290,7 +290,7 @@ class ISAValidation(GenericTestScenario):
 
             rid_query.set_participant_id(self._dss_wrapper.participant_id)
 
-            self._dss_wrapper._handle_query_result(
+            self._dss_wrapper.handle_query_result(
                 check=check,
                 q=rid_query,
                 fail_msg="ISA Creation with missing outline has unexpected result code",
@@ -319,7 +319,7 @@ class ISAValidation(GenericTestScenario):
             else:
                 raise ValueError(f"Unknown RID version: {self._dss.rid_version}")
 
-            self._dss_wrapper._handle_query_result(
+            self._dss_wrapper.handle_query_result(
                 check=check,
                 q=rid_query,
                 fail_msg="ISA Creation with missing outline has unexpected result code",


### PR DESCRIPTION
This to reflect its use in `isa_validation.py`: most if not all scenarios that have a `DSSWrapper` have access to its internals one way or another, so keeping `handle_query_result` private does not protect much.

If there is an important reason I missed, I'm happy to do the necessary adaptations in `isa_validation.py`