### PR TITLE
[uss_qualifier] Remove area clearing from individual scenarios

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md
@@ -8,6 +8,8 @@ Notably the following requirements:
 
 - **[astm.f3548.v21.SCD0035](../../../../requirements/astm/f3548/v21.md)**
 
+This scenario assumes that the area used in the scenario is already clear of any pre-existing flights (using, for instance, PrepareFlightPlanners scenario).
+
 ## Resources
 ### flight_intents
 FlightIntentsResource provides the two V-shaped flight intents.
@@ -24,19 +26,6 @@ FlightPlannerResource that will be used for the USS being tested for its data va
 
 ### dss
 DSSInstanceResource that provides access to a DSS instance where flight creation/sharing can be verified.
-
-## Setup test case
-### Check for flight planning readiness test step
-Both USSs are queried for their readiness to ensure this test can proceed.
-
-#### Flight planning USS not ready check
-If either USS does not respond appropriately to the endpoint queried to determine readiness, this check will fail and the USS will have failed to meet **[astm.f3548.v21.GEN0310](../../../../requirements/astm/f3548/v21.md)** as the USS does not support the InterUSS implementation of that requirement.
-
-### Area clearing test step
-Both USSs are requested to remove all flights from the area under test.
-
-#### Area cleared successfully check
-**[interuss.automated_testing.flight_planning.ClearArea](../../../../requirements/interuss/automated_testing/flight_planning.md)**
 
 ## Successfully plan flight near an existing flight test case
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md
@@ -9,6 +9,8 @@ Notably the following requirements:
 - **[astm.f3548.v21.OPIN0040](../../../../requirements/astm/f3548/v21.md)**
 - **[astm.f3548.v21.GEN0500](../../../../requirements/astm/f3548/v21.md)**
 
+It assumes that the area used in the scenario is already clear of any pre-existing flights (using, for instance, PrepareFlightPlanners scenario).
+
 ## Resources
 ### flight_intents
 FlightIntentsResource that provides the following flight intents:
@@ -26,19 +28,6 @@ FlightPlannerResource that will be tested for its validation of operational inte
 
 ### dss
 DSSInstanceResource that provides access to a DSS instance where flight creation/sharing can be verified.
-
-## Setup test case
-### Check for flight planning readiness test step
-Both USSs are queried for their readiness to ensure this test can proceed.
-
-#### Flight planning USS not ready check
-If the USS does not respond appropriately to the endpoint queried to determine readiness, this check will fail and the USS will have failed to meet **[astm.f3548.v21.GEN0310](../../../../requirements/astm/f3548/v21.md)** as the USS does not support the InterUSS implementation of that requirement.
-
-### Area clearing test step
-The tested USS is requested to remove all flights from the area under test.
-
-#### Area cleared successfully check
-**[interuss.automated_testing.flight_planning.ClearArea](../../../../requirements/interuss/automated_testing/flight_planning.md)**
 
 ## Attempt to plan invalid flight intents test case
 ### Attempt to plan flight intent too far ahead of time test step

--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md
@@ -12,6 +12,8 @@ It involves a tested USS and a control USS through which conflicting flights are
 
 This scenario skips execution and completes successfully at the setup case if a resource containing equal priority flight intents where conflicts are not allow is not provided, such as if a jurisdiction does not have any priority levels at which conflicts are not allowed.
 
+It assumes that the area used in the scenario is already clear of any pre-existing flights (using, for instance, PrepareFlightPlanners scenario).
+
 ## Resources
 ### flight_intents
 If the jurisdiction in which these tests are being conducted does not have a priority level at which conflicts are not allowed, the FlightIntentsResource must be None to prevent the
@@ -88,20 +90,6 @@ CMSA role in order to transition some flight intents to the `Nonconforming` stat
 
 ### dss
 DSSInstanceResource that provides access to a DSS instance where flight creation/sharing can be verified.
-
-
-## Setup test case
-### Check for flight planning readiness test step
-Both USSs are queried for their readiness to ensure this test can proceed.
-
-#### 🛑 Flight planning USS not ready check
-If either USS does not respond appropriately to the endpoint queried to determine readiness, this check will fail and the USS will have failed to meet **[astm.f3548.v21.GEN0310](../../../../../requirements/astm/f3548/v21.md)** as the USS does not support the InterUSS implementation of that requirement.
-
-### Area clearing test step
-Both USSs are requested to remove all flights from the area under test.
-
-#### 🛑 Area cleared successfully check
-**[interuss.automated_testing.flight_planning.ClearArea](../../../../../requirements/interuss/automated_testing/flight_planning.md)**
 
 
 ## Attempt to plan flight into conflict test case

--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md
@@ -10,6 +10,8 @@ exists a conflict with a higher priority flight:
 
 It involves a tested USS and a control USS through which conflicting flights are injected.
 
+It assumes that the area used in the scenario is already clear of any pre-existing flights (using, for instance, PrepareFlightPlanners scenario).
+
 ## Resources
 ### flight_intents
 FlightIntentsResource that provides the following flight intents:
@@ -85,21 +87,6 @@ FlightPlannerResource that will manage conflicting flight 2.
 
 ### dss
 DSSInstanceResource that provides access to a DSS instance where flight creation/sharing can be verified.
-
-## Setup test case
-
-### Check for flight planning readiness test step
-Both USSs are queried for their readiness to ensure this test can proceed.
-
-#### Flight planning USS not ready check
-If either USS does not respond appropriately to the endpoint queried to determine readiness, this check will fail and the USS will have failed to meet **[astm.f3548.v21.GEN0310](../../../../../requirements/astm/f3548/v21.md)** as the USS does not support the InterUSS implementation of that requirement.
-
-### Area clearing test step
-Both USSs are requested to remove all flights from the area under test.
-
-#### Area cleared successfully check
-**[interuss.automated_testing.flight_planning.ClearArea](../../../../../requirements/interuss/automated_testing/flight_planning.md)**
-
 
 ## Attempt to plan flight in conflict test case
 ![Test case summary illustration](assets/attempt_to_plan_flight_into_conflict.svg)

--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.py
@@ -8,7 +8,6 @@ from uas_standards.astm.f3548.v21.api import (
 )
 
 from monitoring.monitorlib.geotemporal import Volume4DCollection
-from monitoring.uss_qualifier.common_data_definitions import Severity
 from uas_standards.astm.f3548.v21.api import OperationalIntentState
 from uas_standards.interuss.automated_testing.scd.v1.api import (
     InjectFlightResponseResult,
@@ -39,7 +38,6 @@ from monitoring.uss_qualifier.scenarios.flight_planning.prioritization_test_step
 )
 from monitoring.uss_qualifier.scenarios.scenario import TestScenario
 from monitoring.uss_qualifier.scenarios.flight_planning.test_steps import (
-    clear_area,
     plan_flight_intent,
     cleanup_flights,
     activate_flight_intent,
@@ -206,11 +204,6 @@ class ConflictHigherPriority(TestScenario):
             f"{self.control_uss.config.participant_id}",
         )
 
-        self.begin_test_case("Setup")
-        if not self._setup():
-            return
-        self.end_test_case()
-
         self.begin_test_case("Attempt to plan flight in conflict")
         self._attempt_plan_flight_conflict()
         self.end_test_case()
@@ -235,43 +228,6 @@ class ConflictHigherPriority(TestScenario):
         self.end_test_case()
 
         self.end_test_scenario()
-
-    def _setup(self) -> bool:
-        self.begin_test_step("Check for flight planning readiness")
-
-        for uss in (self.tested_uss, self.control_uss):
-            error, query = uss.get_readiness()
-            self.record_query(query)
-            with self.check(
-                "Flight planning USS not ready", [uss.participant_id]
-            ) as check:
-                if error:
-                    check.record_failed(
-                        "Error determining readiness",
-                        Severity.High,
-                        "Error: " + error,
-                        query_timestamps=[query.request.timestamp],
-                    )
-
-        self.end_test_step()
-
-        clear_area(
-            self,
-            "Area clearing",
-            [
-                self.flight_1_planned_vol_A,
-                self.flight_1_planned_vol_A_extended,
-                self.flight_1_activated_vol_A,
-                self.flight_1_activated_vol_A_extended,
-                self.flight_1_activated_vol_B,
-                self.flight_2_planned_vol_A,
-                self.flight_2_activated_vol_A,
-                self.flight_2_activated_vol_B,
-            ],
-            [self.tested_uss, self.control_uss],
-        )
-
-        return True
 
     def _attempt_plan_flight_conflict(self):
         with OpIntentValidator(

--- a/monitoring/uss_qualifier/scenarios/flight_planning/test_steps.py
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/test_steps.py
@@ -1,7 +1,6 @@
 import inspect
-from typing import List, Optional, Tuple, Iterable, Set, Dict, Union
+from typing import Optional, Tuple, Iterable, Set, Dict, Union
 
-from monitoring.monitorlib.geotemporal import Volume4DCollection
 from uas_standards.astm.f3548.v21.api import OperationalIntentState
 
 from monitoring.monitorlib.fetch import QueryError
@@ -13,65 +12,10 @@ from uas_standards.interuss.automated_testing.scd.v1.api import (
     DeleteFlightResponse,
 )
 from monitoring.uss_qualifier.common_data_definitions import Severity
-from monitoring.uss_qualifier.resources.flight_planning.flight_intent import (
-    FlightIntent,
-)
 from monitoring.uss_qualifier.resources.flight_planning.flight_planner import (
     FlightPlanner,
 )
 from monitoring.uss_qualifier.scenarios.scenario import TestScenarioType
-
-
-def clear_area(
-    scenario: TestScenarioType,
-    test_step: str,
-    flight_intents: List[FlightIntent],
-    flight_planners: List[FlightPlanner],
-) -> None:
-    """Perform a test step to clear the area that will be used in the scenario.
-
-    This function assumes:
-    * `scenario` is ready to execute a test step
-    * "Area cleared successfully" check declared for specified test step in `scenario`'s documentation
-
-    Args:
-      scenario: Scenario in which this step is being executed
-      test_step: Name of this test step (according to scenario's documentation)
-      flight_intents: Flight intents to be used in this test case (defines bounds of area to be cleared)
-      flight_planners: Flight planners to which clear area requests should be issued
-    """
-    scenario.begin_test_step(test_step)
-
-    volumes = []
-    for flight_intent in flight_intents:
-        volumes += flight_intent.request.operational_intent.volumes
-        volumes += flight_intent.request.operational_intent.off_nominal_volumes
-    extent = Volume4DCollection.from_f3548v21(volumes).bounding_volume
-    for uss in flight_planners:
-        with scenario.check("Area cleared successfully", [uss.participant_id]) as check:
-            try:
-                resp, query = uss.clear_area(extent)
-            except QueryError as e:
-                for q in e.queries:
-                    scenario.record_query(q)
-                check.record_failed(
-                    summary=f"Error from {uss.participant_id} when attempting to clear area",
-                    severity=Severity.High,
-                    details=f"{str(e)}\n\nStack trace:\n{e.stacktrace}",
-                    query_timestamps=[q.request.timestamp for q in e.queries],
-                )
-            scenario.record_query(query)
-            if not resp.outcome.success:
-                check.record_failed(
-                    summary="Area could not be cleared",
-                    severity=Severity.High,
-                    details=f'Participant indicated "{resp.outcome.message}"'
-                    if "message" in resp.outcome
-                    else "See query",
-                    query_timestamps=[query.request.timestamp],
-                )
-
-    scenario.end_test_step()
 
 
 def expect_flight_intent_state(

--- a/monitoring/uss_qualifier/scenarios/uspace/flight_auth/validation.md
+++ b/monitoring/uss_qualifier/scenarios/uspace/flight_auth/validation.md
@@ -6,6 +6,9 @@ This test attempts to create flights with invalid values provided for various
 fields needed for a U-space flight authorisation, followed by successful flight
 creation when all fields are valid.
 
+It assumes that the area used in the scenario is already clear of any
+pre-existing flights (using, for instance, PrepareFlightPlanners scenario).
+
 ## Sequence
 
 ![Sequence diagram](sequence.png)
@@ -19,22 +22,6 @@ FlightIntentsResource that provides at least two flight intents. The flight inte
 ### flight_planner
 
 FlightPlannerResource that provides the flight planner (USSP) which should be tested.
-
-## Setup test case
-
-### Check for flight planning readiness test step
-Both USSs are queried for their readiness to ensure this test can proceed.
-
-#### Flight planning USSP ready check
-If the USS does not respond appropriately to the endpoint queried to determine readiness, this check will fail and the test cannot proceed.
-
-### Area clearing test step
-
-The USSP is requested to remove all flights from the area under test.
-
-#### Area cleared successfully check
-
-If the USSP does not respond appropriately or fails to clear the area of operations, this check will fail.
 
 ## Attempt invalid flights test case
 

--- a/monitoring/uss_qualifier/scenarios/uspace/flight_auth/validation.py
+++ b/monitoring/uss_qualifier/scenarios/uspace/flight_auth/validation.py
@@ -21,7 +21,6 @@ from monitoring.uss_qualifier.resources.flight_planning.flight_planners import (
 )
 from monitoring.uss_qualifier.scenarios.scenario import TestScenario
 from monitoring.uss_qualifier.scenarios.flight_planning.test_steps import (
-    clear_area,
     plan_flight_intent,
     cleanup_flights,
 )
@@ -73,11 +72,6 @@ class Validation(TestScenario):
 
         self.record_note("Planner", self.ussp.participant_id)
 
-        self.begin_test_case("Setup")
-        if not self._setup():
-            return
-        self.end_test_case()
-
         self.begin_test_case("Attempt invalid flights")
         if not self._attempt_invalid_flights():
             return
@@ -89,33 +83,6 @@ class Validation(TestScenario):
         self.end_test_case()
 
         self.end_test_scenario()
-
-    def _setup(self) -> bool:
-        self.begin_test_step("Check for flight planning readiness")
-
-        error, query = self.ussp.get_readiness()
-        self.record_query(query)
-        with self.check(
-            "Flight planning USSP ready", [self.ussp.participant_id]
-        ) as check:
-            if error:
-                check.record_failed(
-                    "Error determining readiness",
-                    Severity.High,
-                    "Error: " + error,
-                    query_timestamps=[query.request.timestamp],
-                )
-
-        self.end_test_step()
-
-        clear_area(
-            self,
-            "Area clearing",
-            [self.valid_flight_intent, *self.invalid_flight_intents],
-            [self.ussp],
-        )
-
-        return True
 
     def _attempt_invalid_flights(self) -> bool:
         self.begin_test_step("Inject invalid flight intents")

--- a/monitoring/uss_qualifier/suites/astm/utm/f3548_21.md
+++ b/monitoring/uss_qualifier/suites/astm/utm/f3548_21.md
@@ -40,7 +40,7 @@
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">GEN0310</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">GEN0500</a></td>
@@ -136,7 +136,7 @@
     <td rowspan="6" style="vertical-align:top;"><a href="../../../requirements/interuss/automated_testing/flight_planning.md">interuss<br>.automated_testing<br>.flight_planning</a></td>
     <td><a href="../../../requirements/interuss/automated_testing/flight_planning.md">ClearArea</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/interuss/automated_testing/flight_planning.md">DeleteFlightSuccess</a></td>

--- a/monitoring/uss_qualifier/suites/faa/uft/message_signing.md
+++ b/monitoring/uss_qualifier/suites/faa/uft/message_signing.md
@@ -31,7 +31,7 @@
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">GEN0310</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">GEN0500</a></td>
@@ -127,7 +127,7 @@
     <td rowspan="6" style="vertical-align:top;"><a href="../../../requirements/interuss/automated_testing/flight_planning.md">interuss<br>.automated_testing<br>.flight_planning</a></td>
     <td><a href="../../../requirements/interuss/automated_testing/flight_planning.md">ClearArea</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/interuss/automated_testing/flight_planning.md">DeleteFlightSuccess</a></td>

--- a/monitoring/uss_qualifier/suites/uspace/flight_auth.md
+++ b/monitoring/uss_qualifier/suites/uspace/flight_auth.md
@@ -32,7 +32,7 @@
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">GEN0310</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">GEN0500</a></td>
@@ -128,7 +128,7 @@
     <td rowspan="6" style="vertical-align:top;"><a href="../../requirements/interuss/automated_testing/flight_planning.md">interuss<br>.automated_testing<br>.flight_planning</a></td>
     <td><a href="../../requirements/interuss/automated_testing/flight_planning.md">ClearArea</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../scenarios/flight_planning/prep_planners.md">Generic flight planners preparation</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/flight_planning/prep_planners.md">Generic flight planners preparation</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/interuss/automated_testing/flight_planning.md">DeleteFlightSuccess</a></td>

--- a/monitoring/uss_qualifier/suites/uspace/required_services.md
+++ b/monitoring/uss_qualifier/suites/uspace/required_services.md
@@ -473,7 +473,7 @@
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">GEN0310</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">GEN0500</a></td>
@@ -569,7 +569,7 @@
     <td rowspan="6" style="vertical-align:top;"><a href="../../requirements/interuss/automated_testing/flight_planning.md">interuss<br>.automated_testing<br>.flight_planning</a></td>
     <td><a href="../../requirements/interuss/automated_testing/flight_planning.md">ClearArea</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../scenarios/flight_planning/prep_planners.md">Generic flight planners preparation</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/flight_planning/prep_planners.md">Generic flight planners preparation</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/interuss/automated_testing/flight_planning.md">DeleteFlightSuccess</a></td>


### PR DESCRIPTION
As a follow-up to #331, this PR removes area clearing from individual test scenarios in favor of (existing, per #331) invocations of the PrepareFlightPlanners scenario.