### PR TITLE
[uss_qualifier] Add ability to specify flight intents directly in configuration

### DIFF
--- a/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml
@@ -53,7 +53,6 @@ v1:
         conflicting_flights:
           resource_type: resources.flight_planning.FlightIntentsResource
           specification:
-            planning_time: '0:05:00'
             file:
               path: file://./test_data/che/flight_intents/conflicting_flights.yaml
 
@@ -61,7 +60,6 @@ v1:
         priority_preemption_flights:
           resource_type: resources.flight_planning.FlightIntentsResource
           specification:
-            planning_time: '0:05:00'
             file:
               path: test_data.che.flight_intents.conflicting_flights
 
@@ -69,17 +67,15 @@ v1:
         invalid_flight_intents:
           resource_type: resources.flight_planning.FlightIntentsResource
           specification:
-            planning_time: '0:05:00'
-            file:
-              path: test_data.che.flight_intents.invalid_flight_intents
+            intent_collection:
+              $ref: test_data.che.flight_intents.invalid_flight_intents
 
         # Details of non-conflicting flights (used in data validation scenario)
         non_conflicting_flights:
           resource_type: resources.flight_planning.FlightIntentsResource
           specification:
-            planning_time: '0:05:00'
-            file:
-              path: file://./test_data/usa/kentland/flight_intents/non_conflicting.yaml
+            intent_collection:
+              $ref: file://../../test_data/usa/kentland/flight_intents/non_conflicting.yaml
 
         # Location of DSS instance that can be used to verify flight planning outcomes
         dss:

--- a/monitoring/uss_qualifier/configurations/dev/library/resources.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/library/resources.yaml
@@ -115,8 +115,9 @@ che_invalid_flight_auth_flights:
   $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
   resource_type: resources.flight_planning.FlightIntentsResource
   specification:
-    file:
-      path: file://./test_data/che/flight_intents/invalid_flight_auths.yaml
+    intent_collection:
+      # Note that $refs are relative to the file with the $ref (this one, in this case)
+      $ref: file://../../../test_data/che/flight_intents/invalid_flight_auths.yaml
 
 che_conflicting_flights:
   # Includes flight intents for both equal-priority-not-permitted and higher-priority
@@ -132,14 +133,16 @@ che_invalid_flight_intents:
   $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
   resource_type: resources.flight_planning.FlightIntentsResource
   specification:
-    file:
-      path: test_data.che.flight_intents.invalid_flight_intents
+    intent_collection:
+      # Note that $refs may use package-based paths
+      $ref: test_data.che.flight_intents.invalid_flight_intents
 
 che_general_flight_auth_flights:
   $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
   resource_type: resources.flight_planning.FlightIntentsResource
   specification:
     file:
+      # Note that ExternalFile local file paths are relative to the uss_qualifier folder
       path: file://./test_data/che/flight_intents/general_flight_auth_flights.yaml
 
 che_non_conflicting_flights:
@@ -147,6 +150,7 @@ che_non_conflicting_flights:
   resource_type: resources.flight_planning.FlightIntentsResource
   specification:
     file:
+      # Note that ExternalFile paths may be package-based
       path: test_data.che.flight_intents.non_conflicting
 
 # ===== General flight authorization =====

--- a/monitoring/uss_qualifier/fileio.py
+++ b/monitoring/uss_qualifier/fileio.py
@@ -135,9 +135,19 @@ def _load_dict_with_references_from_file_name(
         and not base_file_name.startswith(HTTPS_PREFIX)
         and not base_file_name.startswith("/")
     ):
-        # This is a relative file path; it should be relative to the context
-        root_path = os.path.dirname(context_file_name)
-        base_file_name = os.path.join(root_path, base_file_name)
+        if (
+            base_file_name.startswith(".")
+            or "/" in base_file_name
+            or "\\" in base_file_name
+            or base_file_name.lower().endswith(".yaml")
+            or base_file_name.lower().endswith(".json")
+        ):
+            # This is a relative file path; it should be relative to the context
+            root_path = os.path.dirname(context_file_name)
+            base_file_name = os.path.join(root_path, base_file_name)
+        else:
+            # This is a package-based file path
+            base_file_name = resolve_filename(base_file_name)
 
     base_file_name = os.path.abspath(base_file_name)
 

--- a/monitoring/uss_qualifier/resources/flight_planning/flight_intent.py
+++ b/monitoring/uss_qualifier/resources/flight_planning/flight_intent.py
@@ -113,5 +113,10 @@ class FlightIntentCollection(ImplicitDict):
 
 
 class FlightIntentsSpecification(ImplicitDict):
-    file: ExternalFile
+    """Exactly one field must be specified."""
+
+    intent_collection: Optional[FlightIntentCollection]
+    """Full flight intent collection, or a $ref to an external file containing a FlightIntentCollection."""
+
+    file: Optional[ExternalFile]
     """Location of file to load, containing a FlightIntentCollection"""

--- a/monitoring/uss_qualifier/resources/flight_planning/flight_intents_resource.py
+++ b/monitoring/uss_qualifier/resources/flight_planning/flight_intents_resource.py
@@ -19,9 +19,24 @@ class FlightIntentsResource(Resource[FlightIntentsSpecification]):
     _intent_collection: FlightIntentCollection
 
     def __init__(self, specification: FlightIntentsSpecification):
-        self._intent_collection = ImplicitDict.parse(
-            load_dict(specification.file), FlightIntentCollection
+        has_file = "file" in specification and specification.file
+        has_literal = (
+            "intent_collection" in specification and specification.intent_collection
         )
+        if has_file and has_literal:
+            raise ValueError(
+                "Only one of `file` or `intent_collection` may be specified in FlightIntentsSpecification"
+            )
+        if not has_file and not has_literal:
+            raise ValueError(
+                "One of `file` or `intent_collection` must be specified in FlightIntentsSpecification"
+            )
+        if has_file:
+            self._intent_collection = ImplicitDict.parse(
+                load_dict(specification.file), FlightIntentCollection
+            )
+        elif has_literal:
+            self._intent_collection = specification.intent_collection
 
     def get_flight_intents(self) -> Dict[FlightIntentID, FlightInfoTemplate]:
         return self._intent_collection.resolve()

--- a/schemas/monitoring/monitorlib/clients/flight_planning/flight_info/ASTMF354821OpIntentInformation.json
+++ b/schemas/monitoring/monitorlib/clients/flight_planning/flight_info/ASTMF354821OpIntentInformation.json
@@ -1,0 +1,18 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/monitorlib/clients/flight_planning/flight_info/ASTMF354821OpIntentInformation.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Information provided about a flight plan that is necessary for ASTM F3548-21.\n\nmonitoring.monitorlib.clients.flight_planning.flight_info.ASTMF354821OpIntentInformation, as defined in monitoring/monitorlib/clients/flight_planning/flight_info.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "priority": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    }
+  },
+  "type": "object"
+}

--- a/schemas/monitoring/monitorlib/clients/flight_planning/flight_info/FlightAuthorisationData.json
+++ b/schemas/monitoring/monitorlib/clients/flight_planning/flight_info/FlightAuthorisationData.json
@@ -1,0 +1,98 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/monitorlib/clients/flight_planning/flight_info/FlightAuthorisationData.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "The details of a UAS flight authorization request, as received from the user.\n\nNote that a full description of a flight authorisation must include mandatory information required by ANNEX IV of COMMISSION IMPLEMENTING REGULATION (EU) 2021/664 for an UAS flight authorisation request. Reference: https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32021R0664&from=EN#d1e32-178-1\n\nmonitoring.monitorlib.clients.flight_planning.flight_info.FlightAuthorisationData, as defined in monitoring/monitorlib/clients/flight_planning/flight_info.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "connectivity_methods": {
+      "description": "Connectivity methods. Required by ANNEX IV of COMMISSION IMPLEMENTING REGULATION (EU) 2021/664, paragraph 7.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "emergency_procedure_url": {
+      "description": "The URL at which the applicable emergency procedure in case of a loss of command and control link may be retrieved. Required by ANNEX IV of COMMISSION IMPLEMENTING REGULATION (EU) 2021/664, paragraph 9.",
+      "type": "string"
+    },
+    "endurance_minutes": {
+      "description": "Endurance of the UAS. This is expressed in minutes. Required by ANNEX IV of COMMISSION IMPLEMENTING REGULATION (EU) 2021/664, paragraph 8.",
+      "type": "integer"
+    },
+    "identification_technologies": {
+      "description": "Technology used to identify the UAS. Required by ANNEX IV of COMMISSION IMPLEMENTING REGULATION (EU) 2021/664, paragraph 6.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "operation_category": {
+      "description": "Category of UAS operation (\u2018open\u2019, \u2018specific\u2019, \u2018certified\u2019) as defined in COMMISSION DELEGATED REGULATION (EU) 2019/945. Required by ANNEX IV of COMMISSION IMPLEMENTING REGULATION (EU) 2021/664, paragraph 4.",
+      "enum": [
+        "Unknown",
+        "Open",
+        "Specific",
+        "Certified"
+      ],
+      "type": "string"
+    },
+    "operation_mode": {
+      "enum": [
+        "Undeclared",
+        "Vlos",
+        "Bvlos"
+      ],
+      "type": "string"
+    },
+    "operator_id": {
+      "description": "Registration number of the UAS operator.\nThe format is defined in EASA Easy Access Rules for Unmanned Aircraft Systems GM1 to AMC1\nArticle 14(6) Registration of UAS operators and \u2018certified\u2019 UAS.\nRequired by ANNEX IV of COMMISSION IMPLEMENTING REGULATION (EU) 2021/664, paragraph 10.",
+      "type": "string"
+    },
+    "uas_class": {
+      "enum": [
+        "Other",
+        "C0",
+        "C1",
+        "C2",
+        "C3",
+        "C4",
+        "C5",
+        "C6"
+      ],
+      "type": "string"
+    },
+    "uas_id": {
+      "description": "When applicable, the registration number of the unmanned aircraft.\nThis is expressed using the nationality and registration mark of the unmanned aircraft in\nline with ICAO Annex 7.\nSpecified by ANNEX IV of COMMISSION IMPLEMENTING REGULATION (EU) 2021/664, paragraph 10.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "uas_serial_number": {
+      "description": "Unique serial number of the unmanned aircraft or, if the unmanned aircraft is privately built, the unique serial number of the add-on. This is expressed in the ANSI/CTA-2063 Physical Serial Number format. Required by ANNEX IV of COMMISSION IMPLEMENTING REGULATION (EU) 2021/664, paragraph 1.",
+      "type": "string"
+    },
+    "uas_type_certificate": {
+      "description": "Provisional field. Not applicable as of September 2021. Required only if `uas_class` is set to `other` by ANNEX IV of COMMISSION IMPLEMENTING REGULATION (EU) 2021/664, paragraph 4.",
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "required": [
+    "connectivity_methods",
+    "emergency_procedure_url",
+    "endurance_minutes",
+    "identification_technologies",
+    "operation_category",
+    "operation_mode",
+    "operator_id",
+    "uas_class",
+    "uas_serial_number"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/monitorlib/clients/flight_planning/flight_info/RPAS26FlightDetails.json
+++ b/schemas/monitoring/monitorlib/clients/flight_planning/flight_info/RPAS26FlightDetails.json
@@ -1,0 +1,102 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/monitorlib/clients/flight_planning/flight_info/RPAS26FlightDetails.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Information about a flight necessary to plan successfully using the RPAS Platform Operating Rules version 2.6.\n\nmonitoring.monitorlib.clients.flight_planning.flight_info.RPAS26FlightDetails, as defined in monitoring/monitorlib/clients/flight_planning/flight_info.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "aircraft_type": {
+      "description": "Type of vehicle being used as per ASTM F3411-22a.",
+      "enum": [
+        "NotDeclared",
+        "Aeroplane",
+        "Helicopter",
+        "Gyroplane",
+        "HybridLift",
+        "Ornithopter",
+        "Glider",
+        "Kite",
+        "FreeBalloon",
+        "CaptiveBalloon",
+        "Airship",
+        "FreeFallOrParachute",
+        "Rocket",
+        "TetheredPoweredAircraft",
+        "GroundObstacle",
+        "Other"
+      ],
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "flight_profile": {
+      "description": "Type of flight profile.",
+      "enum": [
+        "AutomatedGrid",
+        "AutomatedWaypoint",
+        "Manual"
+      ],
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "operator_number": {
+      "description": "Operator number.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "operator_type": {
+      "description": "The type of operator.",
+      "enum": [
+        "Recreational",
+        "CommercialExcluded",
+        "ReOC"
+      ],
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "pilot_license_number": {
+      "description": "License number for the pilot.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "pilot_phone_number": {
+      "description": "Contact phone number for the pilot.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "uas_registration_numbers": {
+      "description": "The list of UAS/drone registration numbers that will be operated during the operation.",
+      "items": {
+        "type": "string"
+      },
+      "type": [
+        "array",
+        "null"
+      ]
+    },
+    "uas_serial_numbers": {
+      "description": "The list of UAS/drone serial numbers that will be operated during the operation.",
+      "items": {
+        "type": "string"
+      },
+      "type": [
+        "array",
+        "null"
+      ]
+    }
+  },
+  "type": "object"
+}

--- a/schemas/monitoring/monitorlib/clients/flight_planning/flight_info_template/BasicFlightPlanInformationTemplate.json
+++ b/schemas/monitoring/monitorlib/clients/flight_planning/flight_info_template/BasicFlightPlanInformationTemplate.json
@@ -1,0 +1,33 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/monitorlib/clients/flight_planning/flight_info_template/BasicFlightPlanInformationTemplate.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Template to provide (at runtime) basic information about a flight plan that an operator and/or UAS can be expected to provide in most flight planning scenarios.\n\nmonitoring.monitorlib.clients.flight_planning.flight_info_template.BasicFlightPlanInformationTemplate, as defined in monitoring/monitorlib/clients/flight_planning/flight_info_template.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "uas_state": {
+      "description": "State of the user's UAS associated with this flight plan.",
+      "enum": [
+        "Nominal",
+        "OffNominal",
+        "Contingent"
+      ],
+      "type": "string"
+    },
+    "usage_state": {
+      "description": "User's current usage of the airspace specified in the flight plan.",
+      "enum": [
+        "Planned",
+        "InUse"
+      ],
+      "type": "string"
+    }
+  },
+  "required": [
+    "uas_state",
+    "usage_state"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/monitorlib/clients/flight_planning/flight_info_template/FlightInfoTemplate.json
+++ b/schemas/monitoring/monitorlib/clients/flight_planning/flight_info_template/FlightInfoTemplate.json
@@ -1,0 +1,55 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/monitorlib/clients/flight_planning/flight_info_template/FlightInfoTemplate.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Template to provide (at runtime) details of user's intent to create or modify a flight plan.\n\nmonitoring.monitorlib.clients.flight_planning.flight_info_template.FlightInfoTemplate, as defined in monitoring/monitorlib/clients/flight_planning/flight_info_template.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "additional_information": {
+      "description": "Any information relevant to a particular jurisdiction or use case not described in the standard schema. The keys and values must be agreed upon between the test designers and USSs under test.",
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "astm_f3548_21": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "../flight_info/ASTMF354821OpIntentInformation.json"
+        }
+      ]
+    },
+    "basic_information": {
+      "$ref": "BasicFlightPlanInformationTemplate.json"
+    },
+    "rpas_operating_rules_2_6": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "../flight_info/RPAS26FlightDetails.json"
+        }
+      ]
+    },
+    "uspace_flight_authorisation": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "../flight_info/FlightAuthorisationData.json"
+        }
+      ]
+    }
+  },
+  "required": [
+    "basic_information"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/uss_qualifier/resources/flight_planning/flight_intent/DeltaFlightIntent.json
+++ b/schemas/monitoring/uss_qualifier/resources/flight_planning/flight_intent/DeltaFlightIntent.json
@@ -1,0 +1,26 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/uss_qualifier/resources/flight_planning/flight_intent/DeltaFlightIntent.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Represents an intent expressed as identical to another intent except for some specific changes.\n\nmonitoring.uss_qualifier.resources.flight_planning.flight_intent.DeltaFlightIntent, as defined in monitoring/uss_qualifier/resources/flight_planning/flight_intent.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "mutation": {
+      "description": "For each leaf subfield specified in this object, override the value in the corresponding subfield of the flight intent for this element with the specified value.\n\nConsider subfields prefixed with + as leaf subfields.",
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "source": {
+      "description": "Base the flight intent for this element of a FlightIntentCollection on the element of the collection identified by this field.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "source"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/uss_qualifier/resources/flight_planning/flight_intent/FlightIntentCollection.json
+++ b/schemas/monitoring/uss_qualifier/resources/flight_planning/flight_intent/FlightIntentCollection.json
@@ -1,0 +1,28 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/uss_qualifier/resources/flight_planning/flight_intent/FlightIntentCollection.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Specification for a collection of flight intents, each identified by a FlightIntentID.\n\nmonitoring.uss_qualifier.resources.flight_planning.flight_intent.FlightIntentCollection, as defined in monitoring/uss_qualifier/resources/flight_planning/flight_intent.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "intents": {
+      "additionalProperties": {
+        "$ref": "FlightIntentCollectionElement.json"
+      },
+      "description": "Flight planning actions that users want to perform.",
+      "properties": {
+        "$ref": {
+          "description": "Path to content that replaces the $ref",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "required": [
+    "intents"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/uss_qualifier/resources/flight_planning/flight_intent/FlightIntentCollectionElement.json
+++ b/schemas/monitoring/uss_qualifier/resources/flight_planning/flight_intent/FlightIntentCollectionElement.json
@@ -1,0 +1,34 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/uss_qualifier/resources/flight_planning/flight_intent/FlightIntentCollectionElement.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Definition of a single flight intent within a FlightIntentCollection.  Exactly one field must be specified.\n\nmonitoring.uss_qualifier.resources.flight_planning.flight_intent.FlightIntentCollectionElement, as defined in monitoring/uss_qualifier/resources/flight_planning/flight_intent.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "delta": {
+      "description": "If specified, a flight planning intent based on another flight intent, but with some changes.",
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "DeltaFlightIntent.json"
+        }
+      ]
+    },
+    "full": {
+      "description": "If specified, the full definition of the flight planning intent.",
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "../../../../monitorlib/clients/flight_planning/flight_info_template/FlightInfoTemplate.json"
+        }
+      ]
+    }
+  },
+  "type": "object"
+}

--- a/schemas/monitoring/uss_qualifier/resources/flight_planning/flight_intent/FlightIntentsSpecification.json
+++ b/schemas/monitoring/uss_qualifier/resources/flight_planning/flight_intent/FlightIntentsSpecification.json
@@ -1,19 +1,34 @@
 {
   "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/uss_qualifier/resources/flight_planning/flight_intent/FlightIntentsSpecification.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "description": "monitoring.uss_qualifier.resources.flight_planning.flight_intent.FlightIntentsSpecification, as defined in monitoring/uss_qualifier/resources/flight_planning/flight_intent.py",
+  "description": "Only one field may be specified.\n\nmonitoring.uss_qualifier.resources.flight_planning.flight_intent.FlightIntentsSpecification, as defined in monitoring/uss_qualifier/resources/flight_planning/flight_intent.py",
   "properties": {
     "$ref": {
       "description": "Path to content that replaces the $ref",
       "type": "string"
     },
     "file": {
-      "$ref": "../../files/ExternalFile.json",
-      "description": "Location of file to load, containing a FlightIntentCollection"
+      "description": "Location of file to load, containing a FlightIntentCollection",
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "../../files/ExternalFile.json"
+        }
+      ]
+    },
+    "intent_collection": {
+      "description": "Full flight intent collection, or a $ref to an external file containing a FlightIntentCollection.",
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "FlightIntentCollection.json"
+        }
+      ]
     }
   },
-  "required": [
-    "file"
-  ],
   "type": "object"
 }


### PR DESCRIPTION
Some users may want to embed flight intent information directly in a configuration (and therefore the final report); this PR adds that flexibility rather than forcing the user to specify an external file containing the flight intent information.  This change should be backwards-compatible for configurations.

Also, the $ref loading structure is updated to allow package-based $ref locations when specified.

Note that most of the lines changed in this PR are auto-generated files in response to embedding the FlightIntentCollection type within the resource specification object.