### PR TITLE
[uss_qualifier] Fix aggregate queries stats for #343

### DIFF
--- a/monitoring/monitorlib/fetch/evaluation_test.py
+++ b/monitoring/monitorlib/fetch/evaluation_test.py
@@ -1,0 +1,37 @@
+from datetime import datetime
+
+from implicitdict import StringBasedDateTime
+
+from monitoring.monitorlib.fetch import (
+    Query,
+    RequestDescription,
+    ResponseDescription,
+    evaluation,
+)
+
+
+def _fq(ts: int, elapsed: float):
+    """returns a fake query with the specified epoch timestamp as 'initiated_at'"""
+    return Query(
+        request=RequestDescription(
+            method=None,
+            url=None,
+            initiated_at=StringBasedDateTime(datetime.fromtimestamp(ts)),
+        ),
+        response=ResponseDescription(elapsed_s=elapsed, reported=None),
+    )
+
+
+def test_get_init_subsequent_queries_durations():
+    dummy_queries = [_fq(10, 2), _fq(12, 1), _fq(13, 0.9), _fq(14, 0.8)]
+    query_dict = {"some-url": dummy_queries}
+    (init_d, subseq_d) = evaluation.get_init_subsequent_queries_durations(5, query_dict)
+
+    assert init_d == [2]
+    assert subseq_d == [1, 0.9, 0.8]
+
+    query_dict = {"some-url": dummy_queries, "another-url": dummy_queries}
+
+    (init_d, subseq_d) = evaluation.get_init_subsequent_queries_durations(5, query_dict)
+    assert init_d == [2, 2]
+    assert subseq_d == [1, 0.9, 0.8, 1, 0.9, 0.8]

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/aggregate_checks.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/aggregate_checks.py
@@ -79,10 +79,10 @@ class AggregateChecks(GenericTestScenario):
 
         for query in self._queries:
             for base_url, participant in self._participants_by_base_url.items():
-                if query.request.url.startswith(base_url):
-                    self._queries_by_participant[participant].append(query)
-                    # TODO opportunity here to set the participant_id on the query if it's not already there
-                    #  maybe do so after most/all queries have been tagged at the call site where possible
+                if query.request.url.startswith(
+                    base_url
+                ) and not query.has_field_with_value("participant_id"):
+                    query.participant_id = participant
                     break
 
             # Only consider queries with the participant/server explicitly identified
@@ -371,4 +371,9 @@ class AggregateChecks(GenericTestScenario):
             self.record_note(
                 f"{participant}/display_data",
                 f"percentiles on {len(relevant_queries)} relevant queries ({len(relevant_queries_by_url)} different URLs, {len(init_durations)} initial queries, {len(subsequent_durations)} subsequent queries): init 95th: {init_95th}; init 99th: {init_99th}; subsequent 95th: {subsequent_95th}; subsequent 99th: {subsequent_99th}",
+            )
+
+            self.record_note(
+                f"{participant}/display_data details",
+                f"Initial durations: {init_durations} subsequent durations: {subsequent_durations}",
             )


### PR DESCRIPTION
Initial investigation into, and subsequent fix for #343.

This also:
 * adds a simple unit test to confirm that the basic thing is working as expected (although the issue was unrelated to the method being tested).
 * adds an additional `record_note` with the exact times that were used to compute the statistic (with the hope that it might help troubleshoot any future bugs and give more information to USS's that fail this check)

Before the fix we would have duplicate times being considered in the statistics computation:
```
Computed durations: 
init=
[0.009221, 0.017303, 0.006969, 0.015645, 0.019991, 0.020171, 0.019669, 0.022012, 0.024948, 0.024175, 0.023265, 0.022342, 0.02261, 0.026369, 0.02529, 0.024384, 0.024189, 0.024016, 0.022973, 0.020148, 0.016649, 0.010734, 0.007285, 0.010437, 0.007551]
subsequent=
[0.009221, 0.017303, 0.006969, 0.015645, 0.019991, 0.020171, 0.019669, 0.022012, 0.024948, 0.024175, 0.023265, 0.022342, 0.024381, 0.024381, 0.02261, 0.026369, 0.024578, 0.024578, 0.02336, 0.02336, 0.022722, 0.022722, 0.02529, 0.019169, 0.019169, 0.021319, 0.021319, 0.024384, 0.024189, 0.023463, 0.023463, 0.020018, 0.020018, 0.024016, 0.02004, 0.02004, 0.019751, 0.019751, 0.020949, 0.020949, 0.022973, 0.019569, 0.019569, 0.021984, 0.021984, 0.020148, 0.016649, 0.010734, 0.007285, 0.010437, 0.007551]

```

After the fix, we now have:

```
 Note: uss3/display_data details -> 
 Initial durations: 
 [0.01803, 0.02747, 0.006678, 0.015086, 0.020754, 0.017331, 0.022996, 0.019715, 0.024693, 0.023738, 0.024164, 0.037216, 0.023981, 0.024089, 0.024049, 0.024908, 0.025497, 0.025069, 0.025, 0.051053, 0.024023, 0.023673, 0.018797, 0.017193, 0.021442, 0.007035, 0.011693, 0.006912] 
 subsequent durations: 
 [0.033204, 0.025565, 0.03087, 0.02483, 0.021935, 0.021839, 0.023704, 0.025428, 0.018601, 0.019487]
```

These are clearly different. 

