### PR TITLE
[uss_qualifier] Improve dynamic time specification

### DIFF
--- a/monitoring/monitorlib/geotemporal.py
+++ b/monitoring/monitorlib/geotemporal.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import math
 from datetime import datetime, timedelta
-from typing import Optional, List, Tuple, Iterator
+from typing import Optional, List, Tuple, Dict
 
 import arrow
 from implicitdict import ImplicitDict, StringBasedTimeDelta
@@ -13,7 +13,7 @@ from uas_standards.interuss.automated_testing.scd.v1 import api as interuss_scd_
 
 from monitoring.monitorlib import geo
 from monitoring.monitorlib.geo import LatLngPoint, Circle, Altitude, Volume3D, Polygon
-from monitoring.monitorlib.temporal import TestTime, Time
+from monitoring.monitorlib.temporal import TestTime, Time, TimeDuringTest
 
 
 class Volume4DTemplate(ImplicitDict):
@@ -38,7 +38,7 @@ class Volume4DTemplate(ImplicitDict):
     altitude_upper: Optional[Altitude] = None
     """The maximum altitude at which the virtual user will fly while using this volume for their flight."""
 
-    def resolve(self, start_of_test: Time) -> Volume4D:
+    def resolve(self, times: Dict[TimeDuringTest, Time]) -> Volume4D:
         """Resolve Volume4DTemplate into concrete Volume4D."""
         # Make 3D volume
         kwargs = {}
@@ -56,12 +56,12 @@ class Volume4DTemplate(ImplicitDict):
         kwargs = {"volume": volume}
 
         if self.start_time is not None:
-            time_start = self.start_time.resolve(start_of_test)
+            time_start = self.start_time.resolve(times)
         else:
             time_start = None
 
         if self.end_time is not None:
-            time_end = self.end_time.resolve(start_of_test)
+            time_end = self.end_time.resolve(times)
         else:
             time_end = None
 

--- a/monitoring/uss_qualifier/configurations/dev/library/resources.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/library/resources.yaml
@@ -211,14 +211,14 @@ example_feature_check_table:
                 units: M
                 reference: SFC
               start_time:
-                start_of_test: { }
+                time_during_test: StartOfTestRun
               end_time:
                 offset_from:
                   starting_from:
                     next_day:
                       time_zone: Europe/Zurich
                       starting_from:
-                        start_of_test: { }
+                        time_during_test: StartOfTestRun
                       days_of_the_week: [ "Mo", "Fr" ]
                   offset: 12h
           expected_result: Block
@@ -252,7 +252,7 @@ example_feature_check_table:
                   starting_from:
                     offset_from:
                       starting_from:
-                        start_of_test: { }
+                        time_during_test: StartOfTestRun
                       offset: 12h
                 use_timezone: +01:00
               duration: 5m
@@ -289,7 +289,7 @@ example_feature_check_table:
                         next_day:
                           time_zone: Europe/Zurich
                           starting_from:
-                            start_of_test: { }
+                            time_during_test: StartOfTestRun
                       offset: 12h
               duration: 5m
           expected_result: Advise

--- a/monitoring/uss_qualifier/configurations/dev/library/resources.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/library/resources.yaml
@@ -127,7 +127,7 @@ che_conflicting_flights:
     file:
       path: file://./test_data/che/flight_intents/conflicting_flights.yaml
       # Note that this hash_sha512 field can be safely deleted if the content changes
-      hash_sha512: 381b6a75e66f2f4ead4cc637744a3c6594d0cdcabf80e13acef087acf3d9195a8dfb521b1f997824b5c0f9dd83167263695b99bdb4fd3e604ac6ac513dad54ab
+      hash_sha512: ac109b89c95381ba4685d6db5f7064dac64875a8875e58989aad19d91d2e7b10e568d5091749b5ea2b0892191a84486971d999b63ac8c73fd4249131111a6c58
 
 che_invalid_flight_intents:
   $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json

--- a/monitoring/uss_qualifier/resources/flight_planning/flight_intent.py
+++ b/monitoring/uss_qualifier/resources/flight_planning/flight_intent.py
@@ -9,7 +9,7 @@ from implicitdict import ImplicitDict, StringBasedDateTime
 from monitoring.monitorlib.clients.flight_planning.flight_info_template import (
     FlightInfoTemplate,
 )
-from monitoring.monitorlib.temporal import Time
+from monitoring.monitorlib.temporal import Time, TimeDuringTest
 
 from monitoring.uss_qualifier.resources.files import ExternalFile
 from monitoring.uss_qualifier.resources.overrides import apply_overrides
@@ -27,9 +27,14 @@ class FlightIntent(ImplicitDict):
 
     @staticmethod
     def from_flight_info_template(info_template: FlightInfoTemplate) -> FlightIntent:
-        t = Time(arrow.utcnow().datetime)
-        request = info_template.to_scd_inject_request(t)
-        return FlightIntent(reference_time=StringBasedDateTime(t), request=request)
+        t_now = Time(arrow.utcnow().datetime)
+        times = {
+            TimeDuringTest.StartOfTestRun: t_now,
+            TimeDuringTest.StartOfScenario: t_now,
+            TimeDuringTest.TimeOfEvaluation: t_now,
+        }  # Not strictly correct, but this class is deprecated
+        request = info_template.to_scd_inject_request(times)
+        return FlightIntent(reference_time=StringBasedDateTime(t_now), request=request)
 
 
 FlightIntentID = str

--- a/monitoring/uss_qualifier/scenarios/flight_planning/prep_planners.py
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/prep_planners.py
@@ -8,7 +8,7 @@ from monitoring.monitorlib.clients.flight_planning.client import (
     PlanningActivityError,
 )
 from monitoring.monitorlib.geotemporal import Volume4DCollection, Volume4D
-from monitoring.monitorlib.temporal import Time
+from monitoring.monitorlib.temporal import Time, TimeDuringTest
 from monitoring.uss_qualifier.common_data_definitions import Severity
 from monitoring.uss_qualifier.configurations.configuration import ParticipantID
 from monitoring.uss_qualifier.resources.flight_planning import (
@@ -35,7 +35,9 @@ class PrepareFlightPlanners(TestScenario):
     ):
         super().__init__()
         now = Time(arrow.utcnow().datetime)
+        times_now = {t: now for t in TimeDuringTest}
         later = now.offset(MAX_TEST_DURATION)
+        times_later = {t: later for t in TimeDuringTest}
         self.areas = []
         for intents in (
             flight_intents,
@@ -48,14 +50,10 @@ class PrepareFlightPlanners(TestScenario):
             v4c = Volume4DCollection([])
             for flight_info_template in intents.get_flight_intents().values():
                 v4c.extend(
-                    flight_info_template.resolve(
-                        start_of_test=now
-                    ).basic_information.area
+                    flight_info_template.resolve(times_now).basic_information.area
                 )
                 v4c.extend(
-                    flight_info_template.resolve(
-                        start_of_test=later
-                    ).basic_information.area
+                    flight_info_template.resolve(times_later).basic_information.area
                 )
             self.areas.append(v4c.bounding_volume)
         self.flight_planners = {

--- a/monitoring/uss_qualifier/suites/suite.py
+++ b/monitoring/uss_qualifier/suites/suite.py
@@ -379,6 +379,7 @@ class ActionStackFrame(object):
 
 
 class ExecutionContext(object):
+    start_time: datetime
     config: Optional[ExecutionConfiguration]
     top_frame: Optional[ActionStackFrame]
     current_frame: Optional[ActionStackFrame]
@@ -387,6 +388,7 @@ class ExecutionContext(object):
         self.config = config
         self.top_frame = None
         self.current_frame = None
+        self.start_time = arrow.utcnow().datetime
 
     def sibling_queries(self) -> Iterator[Query]:
         if self.current_frame.parent is None:

--- a/monitoring/uss_qualifier/test_data/che/flight_intents/conflicting_flights.yaml
+++ b/monitoring/uss_qualifier/test_data/che/flight_intents/conflicting_flights.yaml
@@ -27,12 +27,12 @@ intents:
             start_time:
               offset_from:
                 starting_from:
-                  start_of_test: {}
+                  time_during_test: StartOfTestRun
                 offset: -1s
             end_time:
               offset_from:
                 starting_from:
-                  start_of_test: {}
+                  time_during_test: StartOfTestRun
                 offset: 8m
 
       astm_f3548_21:
@@ -131,12 +131,12 @@ intents:
             start_time:
               offset_from:
                 starting_from:
-                  start_of_test: {}
+                  time_during_test: StartOfTestRun
                 offset: -1s
             end_time:
               offset_from:
                 starting_from:
-                  start_of_test: {}
+                  time_during_test: StartOfTestRun
                 offset: 8m
 
       astm_f3548_21:

--- a/monitoring/uss_qualifier/test_data/che/flight_intents/general_flight_auth_flights.yaml
+++ b/monitoring/uss_qualifier/test_data/che/flight_intents/general_flight_auth_flights.yaml
@@ -24,7 +24,7 @@ intents:
               # TODO: Change to SFC once mock_uss can process that datum
               reference: W84
             start_time:
-              start_of_test: {}
+              time_during_test: StartOfTestRun
               use_timezone: Europe/Berlin
             end_time:
               offset_from:
@@ -32,7 +32,7 @@ intents:
                   next_day:
                     time_zone: Europe/Zurich
                     starting_from:
-                      start_of_test: {}
+                      time_during_test: StartOfTestRun
                     days_of_the_week: ["Tu", "Th"]
                 offset: 12h
       additional_information:
@@ -81,7 +81,7 @@ intents:
                 starting_from:
                   offset_from:
                     starting_from:
-                      start_of_test: {}
+                      time_during_test: StartOfTestRun
                     offset: 12h
             duration: 5m
       additional_information:

--- a/monitoring/uss_qualifier/test_data/che/flight_intents/invalid_flight_auths.yaml
+++ b/monitoring/uss_qualifier/test_data/che/flight_intents/invalid_flight_auths.yaml
@@ -25,7 +25,7 @@ intents:
             start_time:
               offset_from:
                 starting_from:
-                  start_of_test: {}
+                  time_during_test: StartOfTestRun
                 offset: -1s
             duration: 5m
 

--- a/monitoring/uss_qualifier/test_data/che/flight_intents/invalid_flight_intents.yaml
+++ b/monitoring/uss_qualifier/test_data/che/flight_intents/invalid_flight_intents.yaml
@@ -25,7 +25,7 @@ intents:
             start_time:
               offset_from:
                 starting_from:
-                  start_of_test: {}
+                  time_during_test: StartOfTestRun
                 offset: -1s
             duration: 5m
 
@@ -62,7 +62,7 @@ intents:
             - start_time:
                 offset_from:
                   starting_from:
-                    start_of_test: { }
+                    time_during_test: StartOfTestRun
                   offset: 32d
 
   valid_conflict_tiny_overlap:

--- a/monitoring/uss_qualifier/test_data/che/flight_intents/non_conflicting.yaml
+++ b/monitoring/uss_qualifier/test_data/che/flight_intents/non_conflicting.yaml
@@ -26,7 +26,7 @@ intents:
             start_time:
               offset_from:
                 starting_from:
-                  start_of_test: { }
+                  time_during_test: StartOfTestRun
                 offset: -1s
             duration: 5m
 
@@ -78,7 +78,7 @@ intents:
             start_time:
               offset_from:
                 starting_from:
-                  start_of_test: { }
+                  time_during_test: StartOfTestRun
                 offset: -1s
             duration: 5m
 

--- a/monitoring/uss_qualifier/test_data/usa/kentland/flight_intents/non_conflicting.yaml
+++ b/monitoring/uss_qualifier/test_data/usa/kentland/flight_intents/non_conflicting.yaml
@@ -26,7 +26,7 @@ intents:
             start_time:
               offset_from:
                 starting_from:
-                  start_of_test: { }
+                  time_during_test: StartOfTestRun
                 offset: -1s
             duration: 5m
 
@@ -79,7 +79,7 @@ intents:
             start_time:
               offset_from:
                 starting_from:
-                  start_of_test: { }
+                  time_during_test: StartOfTestRun
                 offset: -1s
             duration: 5m
 
@@ -101,8 +101,3 @@ intents:
         operator_id: CHEo5kut30e0mt01-qwe
         uas_id: ''
         uas_type_certificate: ''
-
-
-
-
-

--- a/schemas/monitoring/monitorlib/temporal/TestTime.json
+++ b/schemas/monitoring/monitorlib/temporal/TestTime.json
@@ -48,10 +48,15 @@
         }
       ]
     },
-    "start_of_test": {
-      "description": "Time option field to, if specified, use the timestamp at which the current test run started.",
+    "time_during_test": {
+      "description": "Time option field to, if specified, use a timestamp relating to the current test run.",
+      "enum": [
+        "StartOfTestRun",
+        "StartOfScenario",
+        "TimeOfEvaluation"
+      ],
       "type": [
-        "object",
+        "string",
         "null"
       ]
     },

--- a/schemas/monitoring/uss_qualifier/resources/interuss/mock_uss/client/MockUSSSpecification.json
+++ b/schemas/monitoring/uss_qualifier/resources/interuss/mock_uss/client/MockUSSSpecification.json
@@ -14,6 +14,13 @@
     "participant_id": {
       "description": "Test participant responsible for this mock USS.",
       "type": "string"
+    },
+    "timeout_seconds": {
+      "description": "Number of seconds to allow for requests to this mock_uss instance.  If None, use default.",
+      "type": [
+        "number",
+        "null"
+      ]
     }
   },
   "required": [


### PR DESCRIPTION
Currently, uss_qualifier produces dynamic times (for telemetry, flight intents, etc) relevant to the current test run from static definitions in just one way: specifying times relative to "start of test".  However, it is unclear when the "test" starts (test run?  test scenario?  test step?) and this does not provide enough flexibility for many use cases.  For instance, a test designer may  want to activate flights "now" and not at a particular time relative to the start of the "test".

This PR replaces start_of_test with a more flexible TimeDuringTest construct that allows the specification of many potentially-relevant dynamic times, initially including start of test run, start of test scenario, and "time of evaluation" (as close to "now" as is feasible).