### PR TITLE
[uss_qualifier] Add output path override CLI flag

### DIFF
--- a/monitoring/uss_qualifier/configurations/configuration.py
+++ b/monitoring/uss_qualifier/configurations/configuration.py
@@ -198,7 +198,7 @@ class RawReportConfiguration(ImplicitDict):
 
 class ArtifactsConfiguration(ImplicitDict):
     output_path: str
-    """Path to folder where artifacts should be written."""
+    """Path to folder where artifacts should be written.  Note that this value may be overridden at runtime without affecting the test baseline."""
 
     raw_report: Optional[RawReportConfiguration] = None
     """Configuration for raw report generation"""

--- a/monitoring/uss_qualifier/main.py
+++ b/monitoring/uss_qualifier/main.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import os
 import sys
+from typing import Optional
 
 from implicitdict import ImplicitDict
 from loguru import logger
@@ -57,6 +58,12 @@ def parseArgs() -> argparse.Namespace:
         help="If specified, do not validate the format of the provided configuration.",
     )
 
+    parser.add_argument(
+        "--output-path",
+        default=None,
+        help="If specified, override v1.artifacts.output_path with this value.  Overriding in this way does not change the test baseline.",
+    )
+
     return parser.parse_args()
 
 
@@ -108,6 +115,7 @@ def run_config(
     config_output: str,
     skip_validation: bool,
     exit_before_execution: bool,
+    output_path_override: Optional[str],
 ):
     config_src = load_dict_with_references(config_name)
 
@@ -146,7 +154,7 @@ def run_config(
     report = execute_test_run(whole_config)
 
     if config.artifacts:
-        generate_artifacts(report, config.artifacts)
+        generate_artifacts(report, config.artifacts, output_path_override)
 
     if "validation" in config and config.validation:
         logger.info(f"Validating test run report for configuration '{config_name}'")
@@ -182,6 +190,7 @@ def main() -> int:
             config_outputs[idx],
             args.skip_validation,
             args.exit_before_execution,
+            args.output_path,
         )
         if exit_code != os.EX_OK:
             return exit_code

--- a/schemas/monitoring/uss_qualifier/configurations/configuration/ArtifactsConfiguration.json
+++ b/schemas/monitoring/uss_qualifier/configurations/configuration/ArtifactsConfiguration.json
@@ -8,7 +8,7 @@
       "type": "string"
     },
     "output_path": {
-      "description": "Path to folder where artifacts should be written.",
+      "description": "Path to folder where artifacts should be written.  Note that this value may be overridden at runtime without affecting the test baseline.",
       "type": "string"
     },
     "raw_report": {


### PR DESCRIPTION
Some uss_qualifier users may want to define their own container mount points separate from the configuration to run.  Although the output_path parameter that would be overridden to accomplish this is part of the configuration which is an input to the test baseline hash (and therefore a change would affect the baseline hash), the placement of output files in the uss_qualifier container does not reasonably affect the substance of the test.  So, this PR documents that v1.artifacts.output_path may be overridden without affecting the baseline and then overrides it without affecting the baseline.

Verification can be accomplished by running `./monitoring/uss_qualifier/run_locally.sh configurations.dev.noop` then `./monitoring/uss_qualifier/run_locally.sh configurations.dev.noop --output-path output/noop_custom` (baseline hash remains the same in report.json)