### PR TITLE
[uss_qualifier] Make target that checks if a v19 doc file references v22a or vice-versa (and fix #352)

### DIFF
--- a/monitoring/uss_qualifier/Makefile
+++ b/monitoring/uss_qualifier/Makefile
@@ -2,9 +2,13 @@
 lint: validate-docs
 
 .PHONY: validate-docs
-validate-docs:
+validate-docs: check-no-cross-reference
 	./scripts/validate_test_definitions.sh
 	./scripts/format_test_suite_docs.sh --lint
+
+.PHONY: check-no-cross-reference
+check-no-cross-reference:
+	./scripts/check-netrid-cross-references.sh
 
 .PHONY: format
 format: format-documentation

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/subscription_simple.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/subscription_simple.md
@@ -34,7 +34,7 @@ If the DSS fails to let us search in the area for which test subscriptions will 
 
 #### Subscription can be queried by ID check
 
-If the DSS cannot be queried for the existing test ID, the DSS is likely not implementing **[astm.f3411.v19.DSS0030,e](../../../../../requirements/astm/f3411/v19.md)** correctly.
+If the DSS cannot be queried for the existing test ID, the DSS is likely not implementing **[astm.f3411.v22a.DSS0030,e](../../../../../requirements/astm/f3411/v22a.md)** correctly.
 
 #### Subscription can be deleted check
 
@@ -390,7 +390,7 @@ The cleanup phase of this test scenario removes the subscription with the known 
 
 #### Subscription can be queried by ID check
 
-If the DSS cannot be queried for the existing test ID, the DSS is likely not implementing **[astm.f3411.v19.DSS0030,e](../../../../../requirements/astm/f3411/v19.md)** correctly.
+If the DSS cannot be queried for the existing test ID, the DSS is likely not implementing **[astm.f3411.v22a.DSS0030,e](../../../../../requirements/astm/f3411/v22a.md)** correctly.
 
 #### Subscription can be deleted check
 

--- a/monitoring/uss_qualifier/scripts/check-netrid-cross-references.sh
+++ b/monitoring/uss_qualifier/scripts/check-netrid-cross-references.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Check for 'v19' references in netrid v22a scenario documents
+filesv22a=$(find ./scenarios/astm/netrid/v22a -name '*.md' -exec grep -l 'v19' {} +)
+if [ -n "$filesv22a" ]; then
+    echo "Error: Found netrid v22a scenario document containing a 'v19' reference:"
+    echo "$filesv22a"
+    error_found=true
+fi
+
+# Check for 'v22a' references in netrid v19 scenario documents
+filesv19=$(find ./scenarios/astm/netrid/v19 -name '*.md' -exec grep -l 'v22a' {} +)
+if [ -n "$filesv19" ]; then
+    echo "Error: Found netrid v19 scenario document containing a 'v22a' reference:"
+    echo "$filesv19"
+    error_found=true
+fi
+
+# Error if we found any file
+if [ "$error_found" = true ]; then
+    exit 1
+fi
+# Otherwise all is good
+exit 0

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a.md
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a.md
@@ -21,7 +21,7 @@
     <th><a href="../../README.md#checked-in">Checked in</a></th>
   </tr>
   <tr>
-    <td rowspan="4" style="vertical-align:top;"><a href="../../../requirements/astm/f3411/v19.md">astm<br>.f3411<br>.v19</a></td>
+    <td rowspan="3" style="vertical-align:top;"><a href="../../../requirements/astm/f3411/v19.md">astm<br>.f3411<br>.v19</a></td>
     <td><a href="../../../requirements/astm/f3411/v19.md">DSS0030,a</a></td>
     <td>Implemented</td>
     <td><a href="../../../scenarios/astm/netrid/v19/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a></td>
@@ -30,11 +30,6 @@
     <td><a href="../../../requirements/astm/f3411/v19.md">DSS0030,b</a></td>
     <td>Implemented</td>
     <td><a href="../../../scenarios/astm/netrid/v19/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a></td>
-  </tr>
-  <tr>
-    <td><a href="../../../requirements/astm/f3411/v19.md">DSS0030,e</a></td>
-    <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/netrid/v22a/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3411/v19.md">NET0730</a></td>

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a/dss_probing.md
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a/dss_probing.md
@@ -24,7 +24,7 @@
     <th><a href="../../../README.md#checked-in">Checked in</a></th>
   </tr>
   <tr>
-    <td rowspan="4" style="vertical-align:top;"><a href="../../../../requirements/astm/f3411/v19.md">astm<br>.f3411<br>.v19</a></td>
+    <td rowspan="3" style="vertical-align:top;"><a href="../../../../requirements/astm/f3411/v19.md">astm<br>.f3411<br>.v19</a></td>
     <td><a href="../../../../requirements/astm/f3411/v19.md">DSS0030,a</a></td>
     <td>Implemented</td>
     <td><a href="../../../../scenarios/astm/netrid/v19/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a></td>
@@ -33,11 +33,6 @@
     <td><a href="../../../../requirements/astm/f3411/v19.md">DSS0030,b</a></td>
     <td>Implemented</td>
     <td><a href="../../../../scenarios/astm/netrid/v19/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a></td>
-  </tr>
-  <tr>
-    <td><a href="../../../../requirements/astm/f3411/v19.md">DSS0030,e</a></td>
-    <td>Implemented</td>
-    <td><a href="../../../../scenarios/astm/netrid/v22a/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a></td>
   </tr>
   <tr>
     <td><a href="../../../../requirements/astm/f3411/v19.md">NET0730</a></td>

--- a/monitoring/uss_qualifier/suites/interuss/dss/all_tests.md
+++ b/monitoring/uss_qualifier/suites/interuss/dss/all_tests.md
@@ -42,7 +42,7 @@
   <tr>
     <td><a href="../../../requirements/astm/f3411/v19.md">DSS0030,e</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/netrid/v22a/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a></td>
+    <td><a href="../../../scenarios/astm/netrid/v19/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3411/v19.md">DSS0030,f</a></td>

--- a/monitoring/uss_qualifier/suites/uspace/network_identification.md
+++ b/monitoring/uss_qualifier/suites/uspace/network_identification.md
@@ -16,7 +16,7 @@
     <th><a href="../README.md#checked-in">Checked in</a></th>
   </tr>
   <tr>
-    <td rowspan="4" style="vertical-align:top;"><a href="../../requirements/astm/f3411/v19.md">astm<br>.f3411<br>.v19</a></td>
+    <td rowspan="3" style="vertical-align:top;"><a href="../../requirements/astm/f3411/v19.md">astm<br>.f3411<br>.v19</a></td>
     <td><a href="../../requirements/astm/f3411/v19.md">DSS0030,a</a></td>
     <td>Implemented</td>
     <td><a href="../../scenarios/astm/netrid/v19/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a></td>
@@ -25,11 +25,6 @@
     <td><a href="../../requirements/astm/f3411/v19.md">DSS0030,b</a></td>
     <td>Implemented</td>
     <td><a href="../../scenarios/astm/netrid/v19/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a></td>
-  </tr>
-  <tr>
-    <td><a href="../../requirements/astm/f3411/v19.md">DSS0030,e</a></td>
-    <td>Implemented</td>
-    <td><a href="../../scenarios/astm/netrid/v22a/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3411/v19.md">NET0730</a></td>

--- a/monitoring/uss_qualifier/suites/uspace/required_services.md
+++ b/monitoring/uss_qualifier/suites/uspace/required_services.md
@@ -18,7 +18,7 @@
     <th><a href="../README.md#checked-in">Checked in</a></th>
   </tr>
   <tr>
-    <td rowspan="4" style="vertical-align:top;"><a href="../../requirements/astm/f3411/v19.md">astm<br>.f3411<br>.v19</a></td>
+    <td rowspan="3" style="vertical-align:top;"><a href="../../requirements/astm/f3411/v19.md">astm<br>.f3411<br>.v19</a></td>
     <td><a href="../../requirements/astm/f3411/v19.md">DSS0030,a</a></td>
     <td>Implemented</td>
     <td><a href="../../scenarios/astm/netrid/v19/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a></td>
@@ -27,11 +27,6 @@
     <td><a href="../../requirements/astm/f3411/v19.md">DSS0030,b</a></td>
     <td>Implemented</td>
     <td><a href="../../scenarios/astm/netrid/v19/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a></td>
-  </tr>
-  <tr>
-    <td><a href="../../requirements/astm/f3411/v19.md">DSS0030,e</a></td>
-    <td>Implemented</td>
-    <td><a href="../../scenarios/astm/netrid/v22a/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3411/v19.md">NET0730</a></td>


### PR DESCRIPTION
This occurred to me sufficiently to be worth an automated check. 

This also fixes issue #352 

`monitoring/uss_qualifier/scripts/check-netrid-cross-references.sh` was tested against `main` before fixing the doc, and it also fails if you manually add a mistake in a v19 doc file.