### PR TITLE
[mock_uss/flight_planning] Do not fail op intent injection or deletion when a notification fail

### DIFF
--- a/monitoring/mock_uss/f3548v21/flight_planning.py
+++ b/monitoring/mock_uss/f3548v21/flight_planning.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from typing import Optional, List, Callable, Dict, Tuple
 
 import arrow
+import requests
 
 from monitoring.mock_uss import webapp
 from monitoring.mock_uss.config import KEY_BASE_URL
@@ -573,7 +574,12 @@ def notify_subscribers(
             scd_client.notify_operational_intent_details_changed(
                 utm_client, subscriber.uss_base_url, update
             )
-        except Exception as e:
+        except (
+            ValueError,
+            ConnectionError,
+            requests.exceptions.ConnectionError,
+            QueryError,
+        ) as e:
             log(f"Failed to notify {subscriber.uss_base_url}: {str(e)}")
             notif_errors[subscriber.uss_base_url] = e
 


### PR DESCRIPTION
Currently if a notification to an USS fails after the mock USS shares or deletes an op intent, the entire call fails.
That is not compatible with notably the expected behavior when a USS is down. And in general I do not believe those calls are expected to fail if a notification fails.

This PR changes this behavior to attempt all notifications, and if some of them do fail, the error is returned up the stack and returned as notes in the response.