### PR TITLE
[uss_qualifier] Fix schema generation logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ lint: shell-lint python-lint
 	cd schemas && make lint
 
 .PHONY: check-hygiene
-check-hygiene: python-lint hygiene validate-uss-qualifier-docs shell-lint
+check-hygiene: python-lint hygiene validate-uss-qualifier-docs shell-lint json-schema-lint
 
 .PHONY: python-lint
 python-lint:

--- a/schemas/manage_type_schemas.sh
+++ b/schemas/manage_type_schemas.sh
@@ -22,6 +22,7 @@ action=${1:?The action must be specified as --check or --generate}
 # shellcheck disable=SC2086
 docker run --name type_schema_manager \
   --rm \
+  -u "$(id -u):$(id -g)" \
   -v "$(pwd):/app" \
   interuss/monitoring \
   python /app/schemas/manage_type_schemas.py "${action}"


### PR DESCRIPTION
There are two issues with our JSON Schema generation logic currently: 1) `make check-hygiene` doesn't check schemas, and therefore generated schema verification is actually not part of our CI currently, and 2) `make format` uses the default docker user to create schema files and this normally means the resulting files are owned by root rather than the invoking user.  This PR resolves both of those issues.