### PR TITLE
[uss_qualifier] Wire additional resources into certain configurations to avoid warnings

### DIFF
--- a/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml
@@ -19,6 +19,7 @@ v1:
           invalid_flight_intents: invalid_flight_intents
           non_conflicting_flights: non_conflicting_flights
           dss: dss
+          dss_instances: dss_instances
           mock_uss: mock_uss
 
     # This block defines all the resources available in the resource pool.
@@ -86,6 +87,19 @@ v1:
             # A USS that hosts a DSS instance is also a participant in the test, even if they don't fulfill any other roles
             participant_id: uss1
             base_url: http://dss.uss1.localutm
+
+        dss_instances:
+            resource_type: resources.astm.f3548.v21.DSSInstancesResource
+            dependencies:
+                auth_adapter: utm_auth
+            specification:
+              dss_instances:
+                - participant_id: uss1
+                  base_url: http://dss.uss1.localutm
+                  has_private_address: true
+                - participant_id: uss2
+                  base_url: http://dss.uss2.localutm
+                  has_private_address: true
 
         # Mock USS that can be used in tests for flight planning, modifying data sharing behavior and recording interactions
         mock_uss:

--- a/monitoring/uss_qualifier/configurations/dev/message_signing.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/message_signing.yaml
@@ -4,6 +4,7 @@ v1:
       resource_declarations:
         che_conflicting_flights: {$ref: 'library/resources.yaml#/che_conflicting_flights'}
         che_invalid_flight_intents: {$ref: 'library/resources.yaml#/che_invalid_flight_intents'}
+        che_non_conflicting_flights: {$ref: 'library/resources.yaml#/che_non_conflicting_flights'}
         combination_selector:
           resource_type: resources.flight_planning.FlightPlannerCombinationSelectorResource
           specification:
@@ -14,6 +15,7 @@ v1:
 
         utm_auth: {$ref: 'library/environment.yaml#/utm_auth'}
         scd_dss: {$ref: 'library/environment.yaml#/scd_dss'}
+        scd_dss_instances: {$ref: 'library/environment.yaml#/scd_dss_instances'}
         flight_planners:
           resource_type: resources.flight_planning.FlightPlannersResource
           dependencies:
@@ -46,8 +48,11 @@ v1:
           flight_planners: flight_planners
           combination_selector: combination_selector
           conflicting_flights: che_conflicting_flights
+          invalid_flight_intents: che_invalid_flight_intents
+          non_conflicting_flights: che_non_conflicting_flights
           priority_preemption_flights: che_conflicting_flights
           dss: scd_dss
+          dss_instances: scd_dss_instances
     execution:
       stop_fast: true
 

--- a/monitoring/uss_qualifier/suites/faa/uft/message_signing.yaml
+++ b/monitoring/uss_qualifier/suites/faa/uft/message_signing.yaml
@@ -4,8 +4,11 @@ resources:
   flight_planners: resources.flight_planning.FlightPlannersResource
   combination_selector: resources.flight_planning.FlightPlannerCombinationSelectorResource
   dss: resources.astm.f3548.v21.DSSInstanceResource
+  dss_instances: resources.astm.f3548.v21.DSSInstancesResource?
   conflicting_flights: resources.flight_planning.FlightIntentsResource
+  non_conflicting_flights: resources.flight_planning.FlightIntentsResource
   priority_preemption_flights: resources.flight_planning.FlightIntentsResource
+  invalid_flight_intents: resources.flight_planning.FlightIntentsResource
 actions:
 - test_scenario:
     scenario_type: scenarios.faa.uft.StartMessageSigningReport
@@ -15,12 +18,16 @@ actions:
 - test_suite:
     suite_type: suites.astm.utm.f3548_21
     resources:
+      mock_uss: mock_uss
       conflicting_flights: conflicting_flights
+      non_conflicting_flights: non_conflicting_flights
       priority_preemption_flights: priority_preemption_flights
       flight_planners: flight_planners
       nominal_planning_selector: combination_selector
+      invalid_flight_intents: invalid_flight_intents
       priority_planning_selector: combination_selector
       dss: dss
+      dss_instances: dss_instances
   on_failure: Continue
 - test_scenario:
     scenario_type: scenarios.faa.uft.FinalizeMessageSigningReport


### PR DESCRIPTION
Ran into some warnings about missing resources when troubleshooting the builds for #362: I do not know if this is actually a problem or if it needs fixing.

Warnings I got when running eg `./run_locally.sh configurations.dev.message_signing` locally on master (or when running _all_ the configurations) – it's only one of them, as I had to iteratively fix them until it worked,

```
2023-11-22 14:02:00.993 | WARNING  | monitoring.uss_qualifier.suites.suite:__init__:259 - Skipping action 1 (test_suite suites.astm.utm.f3548_21) because Test suite "ASTM F3548-21" is missing resource invalid_flight_intents (resources.flight_planning.FlightIntentsResource)

```