### PR TITLE
[uss-qualifier] verify that searches for ISAs on the DSS can't be done without proper credentials

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/token_validation.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/token_validation.py
@@ -1,13 +1,15 @@
-from typing import Optional, Dict
+import datetime
+from typing import Optional, Dict, List
 
 import arrow
+import s2sphere
 from uas_standards.astm.f3411 import v19, v22a
 
 from monitoring.monitorlib import fetch, infrastructure
 from monitoring.monitorlib import rid_v1, rid_v2
 from monitoring.monitorlib.auth import InvalidTokenSignatureAuth
 from monitoring.monitorlib.fetch import rid as rid_fetch
-from monitoring.monitorlib.fetch.rid import FetchedISA
+from monitoring.monitorlib.fetch.rid import FetchedISA, FetchedISAs
 from monitoring.monitorlib.mutate import rid as mutate
 from monitoring.monitorlib.mutate.rid import (
     ISAChange,
@@ -78,10 +80,9 @@ class TokenValidation(GenericTestScenario):
         self._create_isa()
         self._wrong_auth_get()
         self._wrong_auth_mutate()
+        self._wrong_auth_search()
         self._wrong_auth_delete()
         self._delete_isa()
-
-        # TODO to potentially be added in a subsequent PR: testing the search endpoint too
 
         self.end_test_step()
         self.end_test_case()
@@ -302,6 +303,67 @@ class TokenValidation(GenericTestScenario):
                     Severity.High,
                     f"Attempting to create ISA {self._isa_id} with a fake token returned {del_fake_token.dss_query.status_code}",
                     query_timestamps=[del_fake_token.dss_query.query.request.timestamp],
+                )
+
+    def _wrong_auth_search(self):
+        # confirm that a search with proper credentials returns a successful http code
+        search_ok = self._search_isas_tweak_auth(
+            utm_client=self._dss.client,
+            area=self._isa_area,
+            start_time=self._isa_start_time,
+            end_time=self._isa_end_time,
+        )
+
+        with self.check(
+            "Proper token is allowed to search for ISAs",
+            participants=[self._dss.participant_id],
+        ) as check:
+            if not search_ok.success:
+                check.record_failed(
+                    "Search request failed although a valid token was used",
+                    Severity.High,
+                    f"Attempting to search ISAs with a valid token returned failure code: {search_ok.query.status_code}",
+                    query_timestamps=[search_ok.query.request.timestamp],
+                )
+
+        # Search for ISAs with an invalid token
+        search_wrong_token = self._search_isas_tweak_auth(
+            utm_client=self._unsigned_token_session,
+            area=self._isa_area,
+            start_time=self._isa_start_time,
+            end_time=self._isa_end_time,
+        )
+
+        with self.check(
+            "Fake token cannot search for ISAs",
+            participants=[self._dss.participant_id],
+        ) as check:
+            if search_wrong_token.success:
+                check.record_failed(
+                    "Search endpoint returned successfully without a token",
+                    Severity.High,
+                    f"Attempting to search ISAs with invalid token returned successful query: {search_wrong_token.query.status_code}",
+                    query_timestamps=[search_wrong_token.query.request.timestamp],
+                )
+
+        # Search for ISAs with a missing token
+        search_no_token = self._search_isas_tweak_auth(
+            utm_client=self._no_token_session,
+            area=self._isa_area,
+            start_time=self._isa_start_time,
+            end_time=self._isa_end_time,
+        )
+
+        with self.check(
+            "Missing token cannot search for ISAs",
+            participants=[self._dss.participant_id],
+        ) as check:
+            if search_no_token.success:
+                check.record_failed(
+                    "Search endpoint returned successfully without a token",
+                    Severity.High,
+                    f"Attempting to search ISAs with no token returned successful query: {search_no_token.query.status_code}",
+                    query_timestamps=[search_no_token.query.request.timestamp],
                 )
 
     def _delete_isa(self):
@@ -561,6 +623,65 @@ class TokenValidation(GenericTestScenario):
             self.record_query(notification_query.query)
 
         return ISAChange(dss_query=dss_response, notifications=notifications)
+
+    def _search_isas_tweak_auth(
+        self,
+        utm_client: infrastructure.UTMClientSession,
+        area: List[s2sphere.LatLng],
+        start_time: Optional[datetime.datetime],
+        end_time: Optional[datetime.datetime],
+    ) -> FetchedISAs:
+
+        url_time_params = ""
+        if start_time is not None:
+            url_time_params += (
+                f"&earliest_time={self._dss.rid_version.format_time(start_time)}"
+            )
+        if end_time is not None:
+            url_time_params += (
+                f"&latest_time={self._dss.rid_version.format_time(end_time)}"
+            )
+
+        query_scope = self._query_scope_for_auth_params(utm_client, "read")
+
+        """A local version of fetch.rid.isas that lets us control authentication parameters"""
+        if self._dss.rid_version == RIDVersion.f3411_19:
+            op = v19.api.OPERATIONS[
+                v19.api.OperationID.SearchIdentificationServiceAreas
+            ]
+            area_str = rid_v1.geo_polygon_string_from_s2(area)
+            url = f"{self._dss.base_url}{op.path}?area={area_str}{url_time_params}"
+            response = FetchedISAs(
+                v19_query=fetch.query_and_describe(
+                    utm_client,
+                    op.verb,
+                    url,
+                    participant_id=self._dss.participant_id,
+                    **({} if query_scope is None else {"scope": query_scope}),
+                )
+            )
+        elif self._dss.rid_version == RIDVersion.f3411_22a:
+            op = v22a.api.OPERATIONS[
+                v22a.api.OperationID.SearchIdentificationServiceAreas
+            ]
+            area_str = rid_v2.geo_polygon_string_from_s2(area)
+            url = f"{self._dss.base_url}{op.path}?area={area_str}{url_time_params}"
+            response = FetchedISAs(
+                v22a_query=fetch.query_and_describe(
+                    utm_client,
+                    op.verb,
+                    url,
+                    participant_id=self._dss.participant_id,
+                    **({} if query_scope is None else {"scope": query_scope}),
+                )
+            )
+        else:
+            raise NotImplementedError(
+                f"Cannot query DSS for ISAs using RID version {self._dss.rid_version}"
+            )
+
+        self.record_query(response.query)
+        return response
 
     def _query_scope_for_auth_params(
         self, utm_client: infrastructure.UTMClientSession, scope_intent: str

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/token_validation.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/token_validation.md
@@ -79,9 +79,21 @@ If the existing ISA can be mutated by using a read-only scope, the DSS is in vio
 
 If the existing ISA can be mutated without a token being provided, the DSS is in violation of **[astm.f3411.v19.DSS0030,a](../../../../../requirements/astm/f3411/v19.md)**
 
+#### Proper token is allowed to search for ISAs check
+
+If a valid token is presented as part of the search request, and the search parameters are valid, the DSS must return a 200 response, or be in violation of **[interuss.f3411.dss_endpoints.SearchISAs](../../../../../requirements/interuss/f3411/dss_endpoints.md)**.
+
 #### Fake token cannot mutate an ISA check
 
 If the existing ISA can be mutated by using an invalid token, the DSS is in violation of **[astm.f3411.v19.DSS0030,a](../../../../../requirements/astm/f3411/v19.md)**
+
+#### Fake token cannot search for ISAs check
+
+If the DSS accepts search queries with an invalid token, it is in violation of **[interuss.f3411.dss_endpoints.SearchISAs](../../../../../requirements/interuss/f3411/dss_endpoints.md)**.
+
+#### Missing token cannot search for ISAs check
+
+If the DSS accepts search queries without a token, it is in violation of **[interuss.f3411.dss_endpoints.SearchISAs](../../../../../requirements/interuss/f3411/dss_endpoints.md)**.
 
 #### Read scope cannot delete an ISA check
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/token_validation.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/token_validation.md
@@ -27,7 +27,7 @@ part of the test.
 
 #### Successful ISA query check
 
-While F3411-19 does not explicitly require the implementation of a specific ISA retrieval endpoint, Annex A4 specifies the explicit format for this endpoint.  If this format is not followed and the error isn't a 404, this check will fail per **[interuss.f3411.dss_endpoints.GetISA](../../../../../requirements/interuss/f3411/dss_endpoints.md)**.
+While F3411-22a does not explicitly require the implementation of a specific ISA retrieval endpoint, Annex A4 specifies the explicit format for this endpoint.  If this format is not followed and the error isn't a 404, this check will fail per **[interuss.f3411.dss_endpoints.GetISA](../../../../../requirements/interuss/f3411/dss_endpoints.md)**.
 
 #### Removed pre-existing ISA check
 
@@ -51,6 +51,10 @@ If an ISA can be created with a scope that does not provide write permission, th
 #### Missing token prevents creating an ISA check
 
 If an ISA can be created without a token being present in the request, the DSS is in violation of **[astm.f3411.v22a.DSS0030,a](../../../../../requirements/astm/f3411/v22a.md)**.
+
+#### Proper token is allowed to search for ISAs check
+
+If a valid token is presented as part of the search request, and the search parameters are valid, the DSS must return a 200 response, or be in violation of **[interuss.f3411.dss_endpoints.SearchISAs](../../../../../requirements/interuss/f3411/dss_endpoints.md)**.
 
 #### Fake token prevents creating an ISA check
 
@@ -82,6 +86,14 @@ If the existing ISA can be mutated without a token being provided, the DSS is in
 #### Fake token cannot mutate an ISA check
 
 If the existing ISA can be mutated by using an invalid token, the DSS is in violation of **[astm.f3411.v22a.DSS0030,a](../../../../../requirements/astm/f3411/v22a.md)**
+
+#### Fake token cannot search for ISAs check
+
+If the DSS accepts search queries with an invalid token, it is in violation of **[interuss.f3411.dss_endpoints.SearchISAs](../../../../../requirements/interuss/f3411/dss_endpoints.md)**.
+
+#### Missing token cannot search for ISAs check
+
+If the DSS accepts search queries without a token, it is in violation of **[interuss.f3411.dss_endpoints.SearchISAs](../../../../../requirements/interuss/f3411/dss_endpoints.md)**.
 
 #### Read scope cannot delete an ISA check
 

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_19.md
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_19.md
@@ -372,6 +372,6 @@
   <tr>
     <td><a href="../../../requirements/interuss/f3411/dss_endpoints.md">SearchISAs</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/netrid/v19/dss/isa_expiry.md">ASTM NetRID DSS: ISA Expiry</a><br><a href="../../../scenarios/astm/netrid/v19/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../../scenarios/astm/netrid/v19/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
+    <td><a href="../../../scenarios/astm/netrid/v19/dss/isa_expiry.md">ASTM NetRID DSS: ISA Expiry</a><br><a href="../../../scenarios/astm/netrid/v19/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../../scenarios/astm/netrid/v19/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a><br><a href="../../../scenarios/astm/netrid/v19/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
   </tr>
 </table>

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_19/dss_probing.md
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_19/dss_probing.md
@@ -218,6 +218,6 @@
   <tr>
     <td><a href="../../../../requirements/interuss/f3411/dss_endpoints.md">SearchISAs</a></td>
     <td>Implemented</td>
-    <td><a href="../../../../scenarios/astm/netrid/v19/dss/isa_expiry.md">ASTM NetRID DSS: ISA Expiry</a><br><a href="../../../../scenarios/astm/netrid/v19/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a></td>
+    <td><a href="../../../../scenarios/astm/netrid/v19/dss/isa_expiry.md">ASTM NetRID DSS: ISA Expiry</a><br><a href="../../../../scenarios/astm/netrid/v19/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../../../scenarios/astm/netrid/v19/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a></td>
   </tr>
 </table>

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a.md
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a.md
@@ -513,6 +513,6 @@
   <tr>
     <td><a href="../../../requirements/interuss/f3411/dss_endpoints.md">SearchISAs</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/netrid/v22a/dss/isa_expiry.md">ASTM NetRID DSS: ISA Expiry</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../../scenarios/astm/netrid/v22a/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
+    <td><a href="../../../scenarios/astm/netrid/v22a/dss/isa_expiry.md">ASTM NetRID DSS: ISA Expiry</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../../scenarios/astm/netrid/v19/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a><br><a href="../../../scenarios/astm/netrid/v22a/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
   </tr>
 </table>

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a/dss_probing.md
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a/dss_probing.md
@@ -244,6 +244,6 @@
   <tr>
     <td><a href="../../../../requirements/interuss/f3411/dss_endpoints.md">SearchISAs</a></td>
     <td>Implemented</td>
-    <td><a href="../../../../scenarios/astm/netrid/v22a/dss/isa_expiry.md">ASTM NetRID DSS: ISA Expiry</a><br><a href="../../../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a></td>
+    <td><a href="../../../../scenarios/astm/netrid/v22a/dss/isa_expiry.md">ASTM NetRID DSS: ISA Expiry</a><br><a href="../../../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../../../scenarios/astm/netrid/v19/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a></td>
   </tr>
 </table>

--- a/monitoring/uss_qualifier/suites/interuss/dss/all_tests.md
+++ b/monitoring/uss_qualifier/suites/interuss/dss/all_tests.md
@@ -409,6 +409,6 @@
   <tr>
     <td><a href="../../../requirements/interuss/f3411/dss_endpoints.md">SearchISAs</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/netrid/v22a/dss/isa_expiry.md">ASTM NetRID DSS: ISA Expiry</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a></td>
+    <td><a href="../../../scenarios/astm/netrid/v22a/dss/isa_expiry.md">ASTM NetRID DSS: ISA Expiry</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../../scenarios/astm/netrid/v19/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a></td>
   </tr>
 </table>

--- a/monitoring/uss_qualifier/suites/uspace/network_identification.md
+++ b/monitoring/uss_qualifier/suites/uspace/network_identification.md
@@ -508,6 +508,6 @@
   <tr>
     <td><a href="../../requirements/interuss/f3411/dss_endpoints.md">SearchISAs</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/netrid/v22a/dss/isa_expiry.md">ASTM NetRID DSS: ISA Expiry</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../scenarios/astm/netrid/v22a/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
+    <td><a href="../../scenarios/astm/netrid/v22a/dss/isa_expiry.md">ASTM NetRID DSS: ISA Expiry</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../scenarios/astm/netrid/v19/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a><br><a href="../../scenarios/astm/netrid/v22a/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
   </tr>
 </table>

--- a/monitoring/uss_qualifier/suites/uspace/required_services.md
+++ b/monitoring/uss_qualifier/suites/uspace/required_services.md
@@ -647,7 +647,7 @@
   <tr>
     <td><a href="../../requirements/interuss/f3411/dss_endpoints.md">SearchISAs</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/netrid/v22a/dss/isa_expiry.md">ASTM NetRID DSS: ISA Expiry</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../scenarios/astm/netrid/v22a/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
+    <td><a href="../../scenarios/astm/netrid/v22a/dss/isa_expiry.md">ASTM NetRID DSS: ISA Expiry</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../scenarios/astm/netrid/v19/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a><br><a href="../../scenarios/astm/netrid/v22a/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
   </tr>
   <tr>
     <td rowspan="1" style="vertical-align:top;"><a href="../../requirements/interuss/f3548/notification_requirements.md">interuss<br>.f3548<br>.notification_requirements</a></td>


### PR DESCRIPTION
Extends the `TokenValidation` generic test scenario to also try out the ISA search endpoint.