### PR TITLE
[uss_qualifier/utm/off_nominal_planning] Add 'down USS with equal priority conflicts not permitted' scenario validating SCD0010

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/utm/__init__.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/__init__.py
@@ -9,3 +9,6 @@ from .dss_interoperability import DSSInteroperability
 from .aggregate_checks import AggregateChecks
 from .prep_planners import PrepareFlightPlanners
 from .off_nominal_planning.down_uss import DownUSS
+from .off_nominal_planning.down_uss_equal_priority_not_permitted import (
+    DownUSSEqualPriorityNotPermitted,
+)

--- a/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss.md
@@ -1,9 +1,8 @@
 # Off-Nominal planning: down USS test scenario
 
 ## Description
-This test aims to test the strategic coordination requirements that relate to the down USS mechanism:
+This test aims to test the strategic coordination requirements that relate to the down USS mechanism in the general case:
 - **[astm.f3548.v21.SCD0005](../../../../requirements/astm/f3548/v21.md)**
-- **[astm.f3548.v21.SCD0010](../../../../requirements/astm/f3548/v21.md)**
 
 It involves a single tested USS. The USS qualifier acts as a virtual USS that may have its availability set to down.
 
@@ -17,24 +16,12 @@ FlightIntentsResource that provides the following flight intents:
     <th>Flight name</th>
     <th>Priority</th>
     <th>State</th><!-- TODO: Update with usage_state and uas_state when new flight planning API is adopted -->
-    <th>Must conflict with</th>
-    <th>Must not conflict with</th>
   </tr>
   <tr>
     <td><code>flight_1_planned_vol_A</code></td>
     <td rowspan="2">Flight 1</td>
     <td rowspan="5">Any</td>
     <td>Accepted</td>
-    <td rowspan="2">Flight 2</td>
-    <td rowspan="2">Flight 2m</td>
-  </tr>
-  <tr>
-    <td><code>flight_2_planned_vol_A</code></td>
-    <td rowspan="2">Flight 2</td>
-    <td rowspan="3">Higher than Flight 1*</td>
-    <td>Accepted</td>
-    <td rowspan="2">Flight 1</td>
-    <td rowspan="2">N/A</td>
   </tr>
 </table>
 
@@ -62,11 +49,12 @@ Delete any leftover operational intents created at DSS by virtual USS.
 #### Successful operational intents cleanup check
 If the search for own operational intents or their deletion fail, this check fails per **[astm.f3548.v21.DSS0005](../../../../requirements/astm/f3548/v21.md)**.
 
+
 ## Plan flight in conflict with planned flight managed by down USS test case
 This test case aims at testing requirement **[astm.f3548.v21.SCD0005](../../../../requirements/astm/f3548/v21.md)**.
 
-### Virtual USS plans high-priority flight 2 test step
-The USS qualifier, acting as a virtual USS, creates an operational intent at the DSS with a high priority and a non-working base URL.
+### Virtual USS creates conflicting operational intent test step
+The USS qualifier, acting as a virtual USS, creates an operational intent at the DSS with a non-working base URL.
 The objective is to make the later request by the tested USS to retrieve operational intent details to fail.
 
 #### Operational intent successfully created check
@@ -75,15 +63,15 @@ If the creation of the operational intent reference at the DSS fails, this check
 ### [Declare virtual USS as down at DSS test step](../set_uss_down.md)
 
 ### Tested USS attempts to plan low-priority flight 1 test step
-The low-priority flight 1 of the tested USS conflicts with high-priority flight 2 of the virtual USS.
+The low-priority flight 1 of the tested USS conflicts with the operational intent of the virtual USS.
 However, since:
 - the virtual USS is declared as down at the DSS,
 - it does not respond for operational intent details, and
-- the operational intent for flight 2 is in 'Planned' state,
-The tested USS should evaluate the operational intent of flight 2 as having the lowest bound priority status, i.e. a priority strictly lower than the lowest priority allowed by the local regulation.
+- the conflicting operational intent is in the 'Accepted' state,
+The tested USS should evaluate the conflicting operational intent as having the lowest bound priority status, i.e. a priority strictly lower than the lowest priority allowed by the local regulation.
 
 As such, the tested USS may either:
-- Successfully plan flight 1 over the higher-priority flight 2, or
+- Successfully plan flight 1 over the conflicting operational intent, or
 - Decide to be more conservative and reject the planning of flight 1.
 
 #### Successful planning check

--- a/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md
@@ -1,0 +1,179 @@
+# Off-Nominal planning: down USS with equal priority conflicts not permitted test scenario
+
+## Description
+This test aims to test the strategic coordination requirements that relate to the down USS mechanism in the case where
+equal priority conflicts are not permitted:
+- **[astm.f3548.v21.SCD0010](../../../../requirements/astm/f3548/v21.md)**
+
+It involves a single tested USS. The USS qualifier acts as a virtual USS that may have its availability set to down.
+
+## Resources
+### flight_intents
+FlightIntentsResource that provides the following flight intents:
+
+<table>
+  <tr>
+    <th>Flight intent ID</th>
+    <th>Flight name</th>
+    <th>Priority</th>
+    <th>State</th><!-- TODO: Update with usage_state and uas_state when new flight planning API is adopted -->
+  </tr>
+  <tr>
+    <td><code>flight_2_planned_vol_A</code></td>
+    <td rowspan="2">Flight 2</td>
+    <td rowspan="3">High priority</td>
+    <td>Accepted</td>
+  </tr>
+</table>
+
+
+### tested_uss
+FlightPlannerResource that is under test and will manage flight 2.
+
+### dss
+DSSInstanceResource that provides access to a DSS instance where:
+- flight creation/sharing can be verified,
+- the USS qualifier acting as a virtual USS can create operational intents, and
+- the USS qualifier can act as an availability arbitrator.
+
+## Setup test case
+### Resolve USS ID of virtual USS test step
+Make a dummy request to the DSS in order to resolve the USS ID of the virtual USS.
+
+#### Successful dummy query check
+
+### [Restore virtual USS availability test step](../set_uss_available.md)
+
+### Clear operational intents created by virtual USS test step
+Delete any leftover operational intents created at DSS by virtual USS.
+
+#### Successful operational intents cleanup check
+If the search for own operational intents or their deletion fail, this check fails per **[astm.f3548.v21.DSS0005](../../../../requirements/astm/f3548/v21.md)**.
+
+## Plan flight in conflict with activated flight managed by down USS test case
+This test case aims at testing requirement **[astm.f3548.v21.SCD0010](../../../../requirements/astm/f3548/v21.md)**.
+
+### Virtual USS creates conflicting operational intent test step
+The USS qualifier, acting as a virtual USS, creates an operational intent at the DSS with a non-working base URL.
+The objective is to make the later request by the tested USS to retrieve operational intent details to fail.
+
+#### Operational intent successfully created check
+If the creation of the operational intent reference at the DSS fails, this check fails per **[astm.f3548.v21.DSS0005](../../../../requirements/astm/f3548/v21.md)**.
+
+### Virtual USS activates conflicting operational intent test step
+The USS qualifier, acting as a virtual USS, activates the operational intent previously created at the DSS with a non-working base URL.
+The objective is to make the later request by the tested USS to retrieve operational intent details to fail.
+
+#### Operational intent successfully activated check
+If the activation of the operational intent reference at the DSS fails, this check fails per **[astm.f3548.v21.DSS0005](../../../../requirements/astm/f3548/v21.md)**.
+
+### [Declare virtual USS as down at DSS test step](../set_uss_down.md)
+
+### Tested USS attempts to plan high-priority flight 2 test step
+The high-priority flight 2 of the tested USS conflicts with the operational intent of the virtual USS.
+However, since:
+- the virtual USS is declared as down at the DSS,
+- it does not respond for operational intent details, and
+- the conflicting operational intent is in the 'Activated' state,
+- the local regulation does not allow for equal priority conflicts at the highest priority level,
+The tested USS should evaluate the conflicting operational intent as having the highest priority status allowed by the local regulation.
+As such, the tested USS should reject the planning of flight 2.
+
+#### Incorrectly planned check
+All flight intent data provided is correct and the USS should have rejected properly the planning per **[astm.f3548.v21.SCD0010](../../../../requirements/astm/f3548/v21.md)**.
+If the USS indicates that the injection attempt failed, this check will fail.
+If the USS successfully plans the flight or otherwise fails to indicate a conflict, this check will fail.
+
+#### Failure check
+All flight intent data provided was complete and correct. It should have been processed successfully, allowing the USS
+to reject or accept the flight. If the USS indicates that the injection attempt failed, this check will fail per
+**[interuss.automated_testing.flight_planning.ExpectedBehavior](../../../../requirements/interuss/automated_testing/flight_planning.md)**.
+
+### [Validate high-priority flight 2 not shared test step](../validate_not_shared_operational_intent.md)
+
+### [Restore virtual USS availability at DSS test step](../set_uss_available.md)
+
+
+## Plan flight in conflict with nonconforming flight managed by down USS test case
+This test case aims at testing requirement **[astm.f3548.v21.SCD0010](../../../../requirements/astm/f3548/v21.md)**.
+
+### Virtual USS transitions to Nonconforming conflicting operational intent test step
+The USS qualifier, acting as a virtual USS, transitions to Nonconforming the operational intent previously created at the DSS with a non-working base URL.
+The objective is to make the later request by the tested USS to retrieve operational intent details to fail.
+
+#### Operational intent successfully transitioned to Nonconforming check
+If the transition of the operational intent reference at the DSS fails, this check fails per **[astm.f3548.v21.DSS0005](../../../../requirements/astm/f3548/v21.md)**.
+
+### [Declare virtual USS as down at DSS test step](../set_uss_down.md)
+
+### Tested USS attempts to plan high-priority flight 2 test step
+The high-priority flight 2 of the tested USS conflicts with the operational intent of the virtual USS.
+However, since:
+- the virtual USS is declared as down at the DSS,
+- it does not respond for operational intent details, and
+- the conflicting operational intent is in the 'Nonconforming' state,
+- the local regulation does not allow for equal priority conflicts at the highest priority level,
+The tested USS should evaluate the conflicting operational intent as having the highest priority status allowed by the local regulation.
+As such, the tested USS should reject the planning of flight 2.
+
+#### Incorrectly planned check
+All flight intent data provided is correct and the USS should have rejected properly the planning per **[astm.f3548.v21.SCD0010](../../../../requirements/astm/f3548/v21.md)**.
+If the USS indicates that the injection attempt failed, this check will fail.
+If the USS successfully plans the flight or otherwise fails to indicate a conflict, this check will fail.
+
+#### Failure check
+All flight intent data provided was complete and correct. It should have been processed successfully, allowing the USS
+to reject or accept the flight. If the USS indicates that the injection attempt failed, this check will fail per
+**[interuss.automated_testing.flight_planning.ExpectedBehavior](../../../../requirements/interuss/automated_testing/flight_planning.md)**.
+
+### [Validate high-priority flight 2 not shared test step](../validate_not_shared_operational_intent.md)
+
+### [Restore virtual USS availability at DSS test step](../set_uss_available.md)
+
+
+## Plan flight in conflict with contingent flight managed by down USS test case
+This test case aims at testing requirement **[astm.f3548.v21.SCD0010](../../../../requirements/astm/f3548/v21.md)**.
+
+### Virtual USS transitions to Contingent conflicting operational intent test step
+The USS qualifier, acting as a virtual USS, transitions to Contingent the operational intent previously created at the DSS with a non-working base URL.
+The objective is to make the later request by the tested USS to retrieve operational intent details to fail.
+
+#### Operational intent successfully transitioned to Contingent check
+If the transition of the operational intent reference at the DSS fails, this check fails per **[astm.f3548.v21.DSS0005](../../../../requirements/astm/f3548/v21.md)**.
+
+### [Declare virtual USS as down at DSS test step](../set_uss_down.md)
+
+### Tested USS attempts to plan high-priority flight 2 test step
+The high-priority flight 2 of the tested USS conflicts with the operational intent of the virtual USS.
+However, since:
+- the virtual USS is declared as down at the DSS,
+- it does not respond for operational intent details, and
+- the conflicting operational intent is in the 'Contingent' state,
+- the local regulation does not allow for equal priority conflicts at the highest priority level,
+The tested USS should evaluate the conflicting operational intent as having the highest priority status allowed by the local regulation.
+As such, the tested USS should reject the planning of flight 2.
+
+#### Incorrectly planned check
+All flight intent data provided is correct and the USS should have rejected properly the planning per **[astm.f3548.v21.SCD0010](../../../../requirements/astm/f3548/v21.md)**.
+If the USS indicates that the injection attempt failed, this check will fail.
+If the USS successfully plans the flight or otherwise fails to indicate a conflict, this check will fail.
+
+#### Failure check
+All flight intent data provided was complete and correct. It should have been processed successfully, allowing the USS
+to reject or accept the flight. If the USS indicates that the injection attempt failed, this check will fail per
+**[interuss.automated_testing.flight_planning.ExpectedBehavior](../../../../requirements/interuss/automated_testing/flight_planning.md)**.
+
+### [Validate high-priority flight 2 not shared test step](../validate_not_shared_operational_intent.md)
+
+
+## Cleanup
+### Availability of virtual USS restored check
+**[astm.f3548.v21.DSS0100](../../../../requirements/astm/f3548/v21.md)**
+
+### Successful flight deletion check
+Delete flights injected at USS through the flight planning interface.
+**[interuss.automated_testing.flight_planning.DeleteFlightSuccess](../../../../requirements/interuss/automated_testing/flight_planning.md)**
+
+### Successful operational intents cleanup check
+Delete operational intents created at DSS by virtual USS.
+If the search for own operational intents or their deletion fail, this check fails per **[astm.f3548.v21.DSS0005](../../../../requirements/astm/f3548/v21.md)**.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.py
@@ -1,0 +1,213 @@
+from typing import Dict
+
+from uas_standards.astm.f3548.v21.api import (
+    OperationalIntentState,
+    OperationalIntentReference,
+)
+from uas_standards.interuss.automated_testing.scd.v1.api import (
+    InjectFlightResponseResult,
+)
+
+from monitoring.uss_qualifier.resources.flight_planning.flight_intent import (
+    FlightIntent,
+)
+
+from monitoring.uss_qualifier.scenarios.astm.utm import DownUSS
+from monitoring.uss_qualifier.scenarios.astm.utm.test_steps import (
+    OpIntentValidator,
+    set_uss_down,
+    set_uss_available,
+)
+from monitoring.uss_qualifier.scenarios.flight_planning.test_steps import (
+    submit_flight_intent,
+)
+from monitoring.uss_qualifier.suites.suite import ExecutionContext
+
+
+class DownUSSEqualPriorityNotPermitted(DownUSS):
+    flight_2_planned_vol_A: FlightIntent
+
+    def _parse_flight_intents(self, flight_intents: Dict[str, FlightIntent]) -> None:
+        try:
+            self.flight_2_planned_vol_A = flight_intents["flight_2_planned_vol_A"]
+
+            assert (
+                self.flight_2_planned_vol_A.request.operational_intent.state
+                == OperationalIntentState.Accepted
+            ), "flight_2_planned_vol_A must have state Accepted"
+
+        except KeyError as e:
+            raise ValueError(
+                f"`{self.me()}` TestScenario requirements for flight_intents not met: missing flight intent {e}"
+            )
+        except AssertionError as e:
+            raise ValueError(
+                f"`{self.me()}` TestScenario requirements for flight_intents not met: {e}"
+            )
+
+    def run(self, context: ExecutionContext):
+        self.begin_test_scenario(context)
+
+        self.record_note(
+            "Tested USS",
+            f"{self.tested_uss.config.participant_id}",
+        )
+
+        self.begin_test_case("Setup")
+        self._setup()
+        self.end_test_case()
+
+        self.begin_test_case(
+            "Plan flight in conflict with activated flight managed by down USS"
+        )
+        oi_ref = self._plan_flight_conflict_activated()
+        self.end_test_case()
+
+        self.begin_test_case(
+            "Plan flight in conflict with nonconforming flight managed by down USS"
+        )
+        oi_ref = self._plan_flight_conflict_nonconforming(oi_ref)
+        self.end_test_case()
+
+        self.begin_test_case(
+            "Plan flight in conflict with contingent flight managed by down USS"
+        )
+        self._plan_flight_conflict_contingent(oi_ref)
+        self.end_test_case()
+
+        self.end_test_scenario()
+
+    def _plan_flight_conflict_activated(self) -> OperationalIntentReference:
+
+        # Virtual USS creates conflicting operational intent test step
+        oi_ref = self._put_conflicting_op_intent_step(
+            self.flight_2_planned_vol_A, OperationalIntentState.Accepted
+        )
+
+        # Virtual USS activates conflicting operational intent test step
+        oi_ref = self._put_conflicting_op_intent_step(
+            self.flight_2_planned_vol_A, OperationalIntentState.Activated, oi_ref
+        )
+
+        # Declare virtual USS as down at DSS test step
+        set_uss_down(
+            self, "Declare virtual USS as down at DSS", self.dss, self.uss_qualifier_sub
+        )
+
+        # Tested USS attempts to plan high-priority flight 2 test step
+        with OpIntentValidator(
+            self,
+            self.tested_uss,
+            self.dss,
+            "Validate high-priority flight 2 not shared",
+            self._intents_extent,
+        ) as validator:
+            submit_flight_intent(
+                self,
+                "Tested USS attempts to plan high-priority flight 2",
+                "Incorrectly planned",
+                {
+                    InjectFlightResponseResult.Rejected,
+                    InjectFlightResponseResult.ConflictWithFlight,
+                },
+                {
+                    InjectFlightResponseResult.Failed: "Failure",
+                },
+                self.tested_uss,
+                self.flight_2_planned_vol_A.request,
+            )
+            validator.expect_not_shared()
+
+        # Restore virtual USS availability at DSS test step
+        set_uss_available(
+            self,
+            "Restore virtual USS availability at DSS",
+            self.dss,
+            self.uss_qualifier_sub,
+        )
+
+        return oi_ref
+
+    def _plan_flight_conflict_nonconforming(
+        self, oi_ref: OperationalIntentReference
+    ) -> OperationalIntentReference:
+
+        # Virtual USS transitions to Nonconforming conflicting operational intent test step
+        oi_ref = self._put_conflicting_op_intent_step(
+            self.flight_2_planned_vol_A, OperationalIntentState.Nonconforming, oi_ref
+        )
+
+        # Declare virtual USS as down at DSS test step
+        set_uss_down(
+            self, "Declare virtual USS as down at DSS", self.dss, self.uss_qualifier_sub
+        )
+
+        # Tested USS attempts to plan high-priority flight 2 test step
+        with OpIntentValidator(
+            self,
+            self.tested_uss,
+            self.dss,
+            "Validate high-priority flight 2 not shared",
+            self._intents_extent,
+        ) as validator:
+            submit_flight_intent(
+                self,
+                "Tested USS attempts to plan high-priority flight 2",
+                "Incorrectly planned",
+                {
+                    InjectFlightResponseResult.Rejected,
+                    InjectFlightResponseResult.ConflictWithFlight,
+                },
+                {
+                    InjectFlightResponseResult.Failed: "Failure",
+                },
+                self.tested_uss,
+                self.flight_2_planned_vol_A.request,
+            )
+            validator.expect_not_shared()
+
+        # Restore virtual USS availability at DSS test step
+        set_uss_available(
+            self,
+            "Restore virtual USS availability at DSS",
+            self.dss,
+            self.uss_qualifier_sub,
+        )
+
+        return oi_ref
+
+    def _plan_flight_conflict_contingent(self, oi_ref: OperationalIntentReference):
+
+        # Virtual USS transitions to Contingent conflicting operational intent test step
+        self._put_conflicting_op_intent_step(
+            self.flight_2_planned_vol_A, OperationalIntentState.Contingent, oi_ref
+        )
+
+        # Declare virtual USS as down at DSS test step
+        set_uss_down(
+            self, "Declare virtual USS as down at DSS", self.dss, self.uss_qualifier_sub
+        )
+
+        # Tested USS attempts to plan high-priority flight 2 test step
+        with OpIntentValidator(
+            self,
+            self.tested_uss,
+            self.dss,
+            "Validate high-priority flight 2 not shared",
+            self._intents_extent,
+        ) as validator:
+            submit_flight_intent(
+                self,
+                "Tested USS attempts to plan high-priority flight 2",
+                "Incorrectly planned",
+                {
+                    InjectFlightResponseResult.Rejected,
+                    InjectFlightResponseResult.ConflictWithFlight,
+                },
+                {
+                    InjectFlightResponseResult.Failed: "Failure",
+                },
+                self.tested_uss,
+                self.flight_2_planned_vol_A.request,
+            )
+            validator.expect_not_shared()

--- a/monitoring/uss_qualifier/suites/astm/utm/f3548_21.md
+++ b/monitoring/uss_qualifier/suites/astm/utm/f3548_21.md
@@ -17,7 +17,9 @@
     1. Scenario: [Data Validation of GET operational intents by USS](../../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md) ([`scenarios.astm.utm.data_exchange_validation.GetOpResponseDataValidationByUSS`](../../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.py))
 7. Action generator: [`action_generators.flight_planning.FlightPlannerCombinations`](../../../action_generators/flight_planning/planner_combinations.py)
     1. Scenario: [Off-Nominal planning: down USS](../../../scenarios/astm/utm/off_nominal_planning/down_uss.md) ([`scenarios.astm.utm.DownUSS`](../../../scenarios/astm/utm/off_nominal_planning/down_uss.py))
-8. Scenario: [ASTM F3548 UTM aggregate checks](../../../scenarios/astm/utm/aggregate_checks.md) ([`scenarios.astm.utm.AggregateChecks`](../../../scenarios/astm/utm/aggregate_checks.py))
+8. Action generator: [`action_generators.flight_planning.FlightPlannerCombinations`](../../../action_generators/flight_planning/planner_combinations.py)
+    1. Scenario: [Off-Nominal planning: down USS with equal priority conflicts not permitted](../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md) ([`scenarios.astm.utm.DownUSSEqualPriorityNotPermitted`](../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.py))
+9. Scenario: [ASTM F3548 UTM aggregate checks](../../../scenarios/astm/utm/aggregate_checks.md) ([`scenarios.astm.utm.AggregateChecks`](../../../scenarios/astm/utm/aggregate_checks.py))
 
 ## [Checked requirements](../../README.md#checked-requirements)
 
@@ -29,15 +31,15 @@
     <th><a href="../../README.md#checked-in">Checked in</a></th>
   </tr>
   <tr>
-    <td rowspan="23" style="vertical-align:top;"><a href="../../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
+    <td rowspan="24" style="vertical-align:top;"><a href="../../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0100</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a></td>
+    <td><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0300</a></td>
@@ -83,6 +85,11 @@
     <td><a href="../../../requirements/astm/f3548/v21.md">SCD0005</a></td>
     <td>Implemented</td>
     <td><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">SCD0010</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">SCD0015</a></td>
@@ -153,12 +160,12 @@
   <tr>
     <td><a href="../../../requirements/interuss/automated_testing/flight_planning.md">DeleteFlightSuccess</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/interuss/automated_testing/flight_planning.md">ExpectedBehavior</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/interuss/automated_testing/flight_planning.md">FlightCoveredByOperationalIntent</a></td>

--- a/monitoring/uss_qualifier/suites/astm/utm/f3548_21.yaml
+++ b/monitoring/uss_qualifier/suites/astm/utm/f3548_21.yaml
@@ -145,6 +145,28 @@ actions:
       roles:
         - uss1
   on_failure: Continue
+- action_generator:
+    generator_type: action_generators.flight_planning.FlightPlannerCombinations
+    resources:
+      flight_planners: flight_planners
+      nominal_planning_selector: nominal_planning_selector?
+      conflicting_flights: conflicting_flights
+      dss: dss
+    specification:
+      action_to_repeat:
+        test_scenario:
+          # TODO: ability for this scenario to be skipped
+          scenario_type: scenarios.astm.utm.DownUSSEqualPriorityNotPermitted
+          resources:
+            flight_intents: conflicting_flights
+            tested_uss: uss1
+            dss: dss
+        on_failure: Continue
+      combination_selector_source: nominal_planning_selector
+      flight_planners_source: flight_planners
+      roles:
+        - uss1
+  on_failure: Continue
 - test_scenario:
     scenario_type: scenarios.astm.utm.AggregateChecks
     resources:

--- a/monitoring/uss_qualifier/suites/faa/uft/message_signing.md
+++ b/monitoring/uss_qualifier/suites/faa/uft/message_signing.md
@@ -18,15 +18,15 @@
     <th><a href="../../README.md#checked-in">Checked in</a></th>
   </tr>
   <tr>
-    <td rowspan="23" style="vertical-align:top;"><a href="../../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
+    <td rowspan="24" style="vertical-align:top;"><a href="../../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0100</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a></td>
+    <td><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0300</a></td>
@@ -72,6 +72,11 @@
     <td><a href="../../../requirements/astm/f3548/v21.md">SCD0005</a></td>
     <td>Implemented</td>
     <td><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">SCD0010</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">SCD0015</a></td>
@@ -142,12 +147,12 @@
   <tr>
     <td><a href="../../../requirements/interuss/automated_testing/flight_planning.md">DeleteFlightSuccess</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/interuss/automated_testing/flight_planning.md">ExpectedBehavior</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/interuss/automated_testing/flight_planning.md">FlightCoveredByOperationalIntent</a></td>

--- a/monitoring/uss_qualifier/suites/uspace/flight_auth.md
+++ b/monitoring/uss_qualifier/suites/uspace/flight_auth.md
@@ -19,15 +19,15 @@
     <th><a href="../README.md#checked-in">Checked in</a></th>
   </tr>
   <tr>
-    <td rowspan="23" style="vertical-align:top;"><a href="../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
+    <td rowspan="24" style="vertical-align:top;"><a href="../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0005</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0100</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a></td>
+    <td><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0300</a></td>
@@ -73,6 +73,11 @@
     <td><a href="../../requirements/astm/f3548/v21.md">SCD0005</a></td>
     <td>Implemented</td>
     <td><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3548/v21.md">SCD0010</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">SCD0015</a></td>
@@ -143,12 +148,12 @@
   <tr>
     <td><a href="../../requirements/interuss/automated_testing/flight_planning.md">DeleteFlightSuccess</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../scenarios/uspace/flight_auth/validation.md">Flight authorisation validation</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../scenarios/uspace/flight_auth/validation.md">Flight authorisation validation</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/interuss/automated_testing/flight_planning.md">ExpectedBehavior</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../scenarios/uspace/flight_auth/validation.md">Flight authorisation validation</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../scenarios/uspace/flight_auth/validation.md">Flight authorisation validation</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/interuss/automated_testing/flight_planning.md">FlightCoveredByOperationalIntent</a></td>

--- a/monitoring/uss_qualifier/suites/uspace/required_services.md
+++ b/monitoring/uss_qualifier/suites/uspace/required_services.md
@@ -449,15 +449,15 @@
     <td><a href="../../scenarios/astm/netrid/v22a/dss/isa_expiry.md">ASTM NetRID DSS: ISA Expiry</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_subscription_interactions.md">ASTM NetRID DSS: ISA Subscription Interactions</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_validation.md">ASTM NetRID DSS: Submitted ISA Validations</a><br><a href="../../scenarios/astm/netrid/v22a/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a></td>
   </tr>
   <tr>
-    <td rowspan="23" style="vertical-align:top;"><a href="../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
+    <td rowspan="24" style="vertical-align:top;"><a href="../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0005</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0100</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a></td>
+    <td><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0300</a></td>
@@ -503,6 +503,11 @@
     <td><a href="../../requirements/astm/f3548/v21.md">SCD0005</a></td>
     <td>Implemented</td>
     <td><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3548/v21.md">SCD0010</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">SCD0015</a></td>
@@ -573,12 +578,12 @@
   <tr>
     <td><a href="../../requirements/interuss/automated_testing/flight_planning.md">DeleteFlightSuccess</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../scenarios/uspace/flight_auth/validation.md">Flight authorisation validation</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../scenarios/uspace/flight_auth/validation.md">Flight authorisation validation</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/interuss/automated_testing/flight_planning.md">ExpectedBehavior</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../scenarios/uspace/flight_auth/validation.md">Flight authorisation validation</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../scenarios/uspace/flight_auth/validation.md">Flight authorisation validation</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/interuss/automated_testing/flight_planning.md">FlightCoveredByOperationalIntent</a></td>


### PR DESCRIPTION
This scenario, which only applies when the local regulation does not allow equal priority conflicts at the highest level, is built on top of the SCD0005 scenario, which see its implementation slightly refactored in this PR (and has a few cosmetic enhancements)

Do note:
- given that this scenario inherits from the SCD0005 scenario, this PR depends on #382 for the CI to pass
- in the configuration of the F3548 suite I've included this scenario, and I've left a TODO there to remember to include the mechanism enabling the test designer to skip it. I've done so because I was not sure how to do that properly. I will happily update this PR if I have some pointers/examples, otherwise that can be left for the future. Up to the reviewer.