### PR TITLE
[uss_qualifier] Fix non-cached sub information

### DIFF
--- a/monitoring/monitorlib/auth.py
+++ b/monitoring/monitorlib/auth.py
@@ -174,10 +174,6 @@ class DummyOAuth(AuthAdapter):
             )
         return response.json()["access_token"]
 
-    def get_sub(self) -> Optional[str]:
-        """directly return the configured `sub` value"""
-        return self._sub
-
 
 class _SessionIssuer:
     """Helper for issuing tokens using a pre-configured Google session."""

--- a/monitoring/uss_qualifier/resources/communications/client_identity.py
+++ b/monitoring/uss_qualifier/resources/communications/client_identity.py
@@ -53,10 +53,10 @@ class ClientIdentityResource(Resource[ClientIdentitySpecification]):
             # sub might be none because no authentication has happened yet:
             # we force one using the client identify audience and scopes
 
-            # Do an initial token request so that adapter.get_sub() will return something
-            token = self._adapter.issue_token(
-                intended_audience=self.specification.whoami_audience,
-                scopes=[self.specification.whoami_scope],
+            # Trigger a caching initial token request so that adapter.get_sub() will return something
+            headers = self._adapter.get_headers(
+                f"https://{self.specification.whoami_audience}",
+                [self.specification.whoami_scope],
             )
 
             sub = self._adapter.get_sub()
@@ -65,7 +65,7 @@ class ClientIdentityResource(Resource[ClientIdentitySpecification]):
                 raise ValueError(
                     f"subscriber is None, meaning `sub` claim was not found in payload of token, "
                     f"using {type(self._adapter).__name__} requesting {self.specification.whoami_scope} scope "
-                    f"for {self.specification.whoami_audience} audience: {token}"
+                    f"for {self.specification.whoami_audience} audience: {headers['Authorization'][len('Bearer: '):]}"
                 )
 
         return sub


### PR DESCRIPTION
A recent IDGenerator change to more properly separate out obtaining of subscriber information into another resource introduced a bug because `issue_token` does not cache tokens whereas `get_sub` depends on cached tokens.  This PR fixes that issue by triggering a token cache update with `get_headers` rather than `issue_token`.  It also removes the special `get_sub` implementation for DummyOAuth because, while it is more efficient, it exercises less of the standard code paths.