### PR TITLE
[uss_qualifier] Change reusable test steps to reusable test step fragments

### DIFF
--- a/monitoring/uss_qualifier/scenarios/README.md
+++ b/monitoring/uss_qualifier/scenarios/README.md
@@ -10,7 +10,7 @@ A test scenario is separated into of a list of test cases, each of which are sep
 
 ### Test cases
 
-1. A test case is a single wholistic operation or action performed as part of a larger test scenario.
+1. A test case is a single holistic operation or action performed as part of a larger test scenario.
     * Test cases are like acts in the "play" of the test scenario they are a part of.
     * Test cases are typically the "gray headers” of the overview sequence diagrams.
 2. A given test case belongs to exactly one test scenario.
@@ -22,7 +22,7 @@ A test scenario is separated into of a list of test cases, each of which are sep
 1. A test step is a single task that must be performed in order to accomplish its associated test case.
     * Test steps are like scenes in the "play/act" of the test scenario/test case they are a part of.
 2. A given test step belongs to exactly one test case.
-3. A test step may have a list of checks associated with it.
+3. A test step should generally have a list of checks associated with it.
 
 ### Checks
 
@@ -30,6 +30,8 @@ A test scenario is separated into of a list of test cases, each of which are sep
 2. A check evaluates information collected during the actions performed for a test step.
 3. A given check belongs to exactly one test step.
 4. Each check defines which requirement(s) are not met if the check fails.
+5. In nearly all cases, the test participant(s) to which a check pertains should be specified when performing the check.
+    * If the test participant is not specified, then either everyone involved in a test or no one is responsible for meeting the requirements of that check, and this is very rarely appropriate.
 
 ## Creation
 
@@ -79,7 +81,23 @@ A scenario must document at least one test case (otherwise the scenario is doing
 
 Each test case in the documentation must document at least one test step (otherwise nothing is happening in the test case).  Each test step must be documented via a subsection of the parent test case named with a " test step" suffix (example: `### Injection test step`).
 
-If the entire test step heading is enclosed in a link, the contents of that linked file will be used to populate the test step (example: `### [Plan flight test step](plan_flight_step.md)`) and any content in this section will be ignored.  The linked file must follow the format requirements for a test step, starting with the first line being a top-level heading ending with " test step" (example: `# Plan flight test step`).
+If the entire test step heading is enclosed in a link, the contents of that linked file will be used to pre-populate the test step (example: `### [Plan flight test step](plan_flight_fragment.md)`) before reading the content in this section.  The linked file must follow the format requirements for a test step, but with the first line being a top-level heading ending with " test step fragment" (example: `# Plan flight test step fragment`).
+
+Multiple test step fragments may be included in a test step by linking to the test step fragment in a heading one level lower than the test step itself, and these lower-level headings may be combined with [checks](#test-checks) specific to the test step; for instance:
+
+```markdown
+### Plan flight test step
+
+This step does (a particular thing).
+
+#### [Actually plan flight](plan_flight_fragment.md)
+
+#### Special check
+
+If the system under test doesn't Foo, then requirement **Bar** will not be met.
+
+#### [Ensure flight baz](check_flight_baz_fragment.md)
+```
 
 ### Test checks
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/test_steps/clean_workspace.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/test_steps/clean_workspace.md
@@ -1,4 +1,4 @@
-# Ensure clean workspace test step
+# Ensure clean workspace test step fragment
 
 This page describes the content of a common test step that ensures a clean workspace for testing interactions with a DSS
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/test_steps/delete_isa.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/test_steps/delete_isa.md
@@ -1,4 +1,4 @@
-# Delete ISA test step
+# Delete ISA test step fragment
 
 This page describes the content of a common test step where a deletion of an ISA should be successful.
 See `DSSWrapper.del_isa` in [`dss_wrapper.py`](../../../dss_wrapper.py).

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/test_steps/put_isa.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/test_steps/put_isa.md
@@ -1,4 +1,4 @@
-# Create or update ISA test step
+# Create or update ISA test step fragment
 
 This page describes the content of a common test step where a creation or an update of an ISA should be successful.
 See `DSSWrapper.put_isa` in [`dss_wrapper.py`](../../../dss_wrapper.py).

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/test_steps/search_isas.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/test_steps/search_isas.md
@@ -1,4 +1,4 @@
-# Search ISAs test step
+# Search ISAs test step fragment
 
 This page describes the content of a common test step where a search for ISAs should be successful.
 See `DSSWrapper.search_isa` in [`dss_wrapper.py`](../../../dss_wrapper.py).

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/test_steps/clean_workspace.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/test_steps/clean_workspace.md
@@ -1,4 +1,4 @@
-# Ensure clean workspace test step
+# Ensure clean workspace test step fragment
 
 This page describes the content of a common test step that ensures a clean workspace for testing interactions with a DSS
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/test_steps/delete_isa.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/test_steps/delete_isa.md
@@ -1,4 +1,4 @@
-# Delete ISA test step
+# Delete ISA test step fragment
 
 This page describes the content of a common test step where a deletion of an ISA should be successful.
 See `DSSWrapper.del_isa` in [`dss_wrapper.py`](../../../dss_wrapper.py).

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/test_steps/put_isa.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/test_steps/put_isa.md
@@ -1,4 +1,4 @@
-# Create or update ISA test step
+# Create or update ISA test step fragment
 
 This page describes the content of a common test step where a creation or an update of an ISA should be successful.
 See `DSSWrapper.put_isa` in [`dss_wrapper.py`](../../../dss_wrapper.py).

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/test_steps/search_isas.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/test_steps/search_isas.md
@@ -1,4 +1,4 @@
-# Search ISAs test step
+# Search ISAs test step fragment
 
 This page describes the content of a common test step where a search for ISAs should be successful.
 See `DSSWrapper.search_isa` in [`dss_wrapper.py`](../../../dss_wrapper.py).

--- a/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/test_steps/plan_flight_intent_expect_failed.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/test_steps/plan_flight_intent_expect_failed.md
@@ -1,4 +1,4 @@
-# Plan flight Expect Failed test step
+# Plan flight Expect Failed test step fragment
 
 This page describes the content of a common test case where a valid user flight intent fails in a flight planner, because of invalid data shared for a nearby flight shared by another USS.  See `plan_flight_intent_expect_failed` in invalid_op_test_steps.py.
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/test_steps/validate_get_operational_intent.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/test_steps/validate_get_operational_intent.md
@@ -1,4 +1,4 @@
-# Validate GET interaction test step
+# Validate GET interaction test step fragment
 
 This step verifies that a USS makes a GET request to get the intent_details of an existing operation when needed as per ASTM F3548-21 by checking the interuss interactions of mock uss
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/test_steps/validate_no_notification_operational_intent.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/test_steps/validate_no_notification_operational_intent.md
@@ -1,4 +1,4 @@
-# Validate no notification test step
+# Validate no notification test step fragment
 
 This step verifies when a flight is not created, it is also not notified by checking the interuss interactions of mock_uss instance.
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/test_steps/validate_notification_operational_intent.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/test_steps/validate_notification_operational_intent.md
@@ -1,4 +1,4 @@
-# Validate notification test step
+# Validate notification test step fragment
 
 This step verifies that, when creating or modifying an operational intent, a USS sent the required notification for a relevant subscription owned by a mock_uss instance by checking the interactions of that mock_uss instance.
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/test_steps/validate_sharing_operational_intent_but_with_invalid_interuss_data.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/test_steps/validate_sharing_operational_intent_but_with_invalid_interuss_data.md
@@ -1,4 +1,4 @@
-# Validate flight sharing invalid data test step
+# Validate flight sharing invalid data test step fragment
 
 This step verifies that a created flight is shared properly per ASTM F3548-21 by querying the DSS for flights in the area of the flight intent, and then retrieving the details from the USS if the operational intent reference is found.  See `expect_shared_with_invalid_data` in invalid_op_test_steps.py.
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md
@@ -95,7 +95,9 @@ DSSInstanceResource that provides access to a DSS instance where flight creation
 ## Attempt to plan flight into conflict test case
 ![Test case summary illustration](assets/attempt_to_plan_flight_into_conflict.svg)
 
-### [Plan flight 2 test step](../../../../flight_planning/plan_flight_intent.md)
+### Plan flight 2 test step
+
+#### [Plan flight 2](../../../../flight_planning/plan_flight_intent.md)
 Flight 2 on time range B should be successfully planned by the control USS.
 
 ### [Validate flight 2 sharing test step](../../validate_shared_operational_intent.md)

--- a/monitoring/uss_qualifier/scenarios/astm/utm/set_uss_available.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/set_uss_available.md
@@ -1,4 +1,4 @@
-# Set USS availability to 'Available' test step
+# Set USS availability to 'Available' test step fragment
 
 This step sets the USS availability to 'Available' at the DSS.
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/set_uss_down.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/set_uss_down.md
@@ -1,4 +1,4 @@
-# Set USS availability to 'Down' test step
+# Set USS availability to 'Down' test step fragment
 
 This step sets the USS availability to 'Down' at the DSS.
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/validate_not_shared_operational_intent.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/validate_not_shared_operational_intent.md
@@ -1,4 +1,4 @@
-# Validate operational intent not shared test step
+# Validate operational intent not shared test step fragment
 
 This step verifies that a previous attempt to create a flight did not result in a flight being shared with the DSS.
 It does so by querying the DSS for operational intents in the area of the flight before and after an attempted creation.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/validate_shared_operational_intent.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/validate_shared_operational_intent.md
@@ -1,4 +1,4 @@
-# Validate flight sharing test step
+# Validate flight sharing test step fragment
 
 This step verifies that a created flight is shared properly per ASTM F3548-21 by querying the DSS for flights in the area of the flight intent, and then retrieving the details from the USS if the operational intent reference is found.  See `OpIntentValidator.expect_shared()` in [test_steps.py](test_steps.py).
 

--- a/monitoring/uss_qualifier/scenarios/flight_planning/activate_conflict_flight_intent.md
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/activate_conflict_flight_intent.md
@@ -1,4 +1,4 @@
-# Activate flight with non-permitted equal priority conflict test step
+# Activate flight with non-permitted equal priority conflict test step fragment
 
 This page describes the content of a common test step where a user flight intent should be denied activation because of
 a non-permitted conflict with an equal priority flight intent.

--- a/monitoring/uss_qualifier/scenarios/flight_planning/activate_flight_intent.md
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/activate_flight_intent.md
@@ -1,4 +1,4 @@
-# Activate flight test step
+# Activate flight test step fragment
 
 This page describes the content of a common test step where a valid user flight intent should be successfully activated by a flight planner.  See `activate_flight_intent` in [test_steps.py](test_steps.py).
 

--- a/monitoring/uss_qualifier/scenarios/flight_planning/activate_permitted_conflict_flight_intent.md
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/activate_permitted_conflict_flight_intent.md
@@ -1,4 +1,4 @@
-# Activate flight with permitted equal priority conflict test step
+# Activate flight with permitted equal priority conflict test step fragment
 
 This page describes the content of a common test step where a user flight intent should be successfully activated by a
 flight planner, given that there exists a permitted conflict with an equal priority flight intent.

--- a/monitoring/uss_qualifier/scenarios/flight_planning/activate_priority_conflict_flight_intent.md
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/activate_priority_conflict_flight_intent.md
@@ -1,4 +1,4 @@
-# Activate flight with higher priority conflict test step
+# Activate flight with higher priority conflict test step fragment
 
 This page describes the content of a common test step where a user flight intent should be denied activation because of
 a conflict with a higher priority flight intent.

--- a/monitoring/uss_qualifier/scenarios/flight_planning/delete_flight_intent.md
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/delete_flight_intent.md
@@ -1,4 +1,4 @@
-# Delete flight test step
+# Delete flight test step fragment
 
 This page describes the content of a common test case where a flight intent should be successfully deleted by a flight planner.
 See `delete_flight_intent` in [test_steps.py](test_steps.py).

--- a/monitoring/uss_qualifier/scenarios/flight_planning/modify_activated_conflict_flight_intent.md
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/modify_activated_conflict_flight_intent.md
@@ -1,4 +1,4 @@
-# Modify activated flight with non-permitted equal priority conflict test step
+# Modify activated flight with non-permitted equal priority conflict test step fragment
 
 This page describes the content of a common test step where a user flight intent should be denied modification because
 of a non-permitted conflict with an equal priority flight intent.

--- a/monitoring/uss_qualifier/scenarios/flight_planning/modify_activated_flight_intent.md
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/modify_activated_flight_intent.md
@@ -1,4 +1,4 @@
-# Modify activated flight test step
+# Modify activated flight test step fragment
 
 This page describes the content of a common test case where a valid user flight intent in activated state is tentatively
 modified by a flight planned. Multiple outcomes may be valid.

--- a/monitoring/uss_qualifier/scenarios/flight_planning/modify_activated_permitted_conflict_flight_intent.md
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/modify_activated_permitted_conflict_flight_intent.md
@@ -1,4 +1,4 @@
-# Modify activated flight with permitted equal priority conflict test step
+# Modify activated flight with permitted equal priority conflict test step fragment
 
 This page describes the content of a common test step where a user flight intent should be successfully modified by a
 flight planner, given that there exists a permitted conflict with an equal priority flight intent.

--- a/monitoring/uss_qualifier/scenarios/flight_planning/modify_activated_priority_conflict_flight_intent.md
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/modify_activated_priority_conflict_flight_intent.md
@@ -1,4 +1,4 @@
-# Modify activated flight with higher priority conflict test step
+# Modify activated flight with higher priority conflict test step fragment
 
 This page describes the content of a common test step where a user flight intent should be denied modification because
 of a conflict with a higher priority flight intent.

--- a/monitoring/uss_qualifier/scenarios/flight_planning/modify_planned_conflict_flight_intent.md
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/modify_planned_conflict_flight_intent.md
@@ -1,4 +1,4 @@
-# Modify planned flight with non-permitted equal priority conflict test step
+# Modify planned flight with non-permitted equal priority conflict test step fragment
 
 This page describes the content of a common test step where a user flight intent should be denied modification because
 of a non-permitted conflict with an equal priority flight intent.

--- a/monitoring/uss_qualifier/scenarios/flight_planning/modify_planned_flight_intent.md
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/modify_planned_flight_intent.md
@@ -1,4 +1,4 @@
-# Modify planned flight test step
+# Modify planned flight test step fragment
 
 This page describes the content of a common test case where a valid user flight intent in planned state should be
 successfully modified by a flight planner.  See `modify_planned_flight_intent` in [test_steps.py](test_steps.py).

--- a/monitoring/uss_qualifier/scenarios/flight_planning/modify_planned_permitted_conflict_flight_intent.md
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/modify_planned_permitted_conflict_flight_intent.md
@@ -1,4 +1,4 @@
-# Modify planned flight with permitted equal priority conflict test step
+# Modify planned flight with permitted equal priority conflict test step fragment
 
 This page describes the content of a common test step where a user flight intent should be successfully modified by a
 flight planner, given that there exists a permitted conflict with an equal priority flight intent.

--- a/monitoring/uss_qualifier/scenarios/flight_planning/modify_planned_priority_conflict_flight_intent.md
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/modify_planned_priority_conflict_flight_intent.md
@@ -1,4 +1,4 @@
-# Modify planned flight with higher priority conflict test step
+# Modify planned flight with higher priority conflict test step fragment
 
 This page describes the content of a common test step where a user flight intent should be denied modification because
 of a conflict with a higher priority flight intent.

--- a/monitoring/uss_qualifier/scenarios/flight_planning/plan_conflict_flight_intent.md
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/plan_conflict_flight_intent.md
@@ -1,4 +1,4 @@
-# Plan flight with non-permitted equal priority conflict test step
+# Plan flight with non-permitted equal priority conflict test step fragment
 
 This page describes the content of a common test step where a user flight intent should be denied planning because of
 a non-permitted conflict with an equal priority flight intent.

--- a/monitoring/uss_qualifier/scenarios/flight_planning/plan_flight_intent.md
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/plan_flight_intent.md
@@ -1,4 +1,4 @@
-# Plan flight test step
+# Plan flight test step fragment
 
 This page describes the content of a common test case where a valid user flight intent should be successfully planned by a flight planner.  See `plan_flight_intent` in [test_steps.py](test_steps.py).
 

--- a/monitoring/uss_qualifier/scenarios/flight_planning/plan_permitted_conflict_flight_intent.md
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/plan_permitted_conflict_flight_intent.md
@@ -1,4 +1,4 @@
-# Plan flight with permitted equal priority conflict test step
+# Plan flight with permitted equal priority conflict test step fragment
 
 This page describes the content of a common test step where a user flight intent should be successfully planned by a
 flight planner, given that there exists a permitted conflict with an equal priority flight intent.

--- a/monitoring/uss_qualifier/scenarios/flight_planning/plan_priority_conflict_flight_intent.md
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/plan_priority_conflict_flight_intent.md
@@ -1,4 +1,4 @@
-# Plan flight with higher priority conflict test step
+# Plan flight with higher priority conflict test step fragment
 
 This page describes the content of a common test step where a user flight intent should be denied planning because of
 a conflict with a higher priority flight intent.


### PR DESCRIPTION
This PR is part 1 to address #380.  It changes reusable test steps into reusable test step fragments and enables these fragments to be linked from lower-level headings within a test step (as well as the legacy way of linking in the test step heading itself).  One test step fragment in conflict_equal_priority_not_permitted.md is updated to use this new ability to verify that it works (though multiple fragments in a single test step is not yet tested).

This PR also takes the opportunity to improve scenarios/README.md slightly outside the PR's main scope.

Part 2 (later PR) will factor out the "begin test step" and "end test step" calls from the reusable Python code so the reusable code fragments are agnostic of what test step they're in.  This is expected to be a fairly wide-ranging change and therefore result in a large PR, so I wanted to separate it into another PR.  This change will be necessary before multiple of any existing reusable test step fragments can be used in a single test step, as far as I'm aware.

Part 3 and beyond will update test steps to be larger so that each step can include its atomic operations -- for instance (and most common), planning a flight and validation of sharing of that flight will occur in one test step rather than two different ones (since part of the sharing validation has to happen before actually planning the flight).