### PR TITLE
[uss_qualifier] Update flight intent names

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md
@@ -31,7 +31,7 @@ Otherwise, the FlightIntentsResource must provide the following flight intents:
     <th>Must not conflict with</th>
   </tr>
   <tr>
-    <td><code>flight_1_planned_vol_A</code></td>
+    <td><code>flight1_planned</code></td>
     <td rowspan="2">Flight 1</td>
     <td rowspan="8">Any (but all the same)</td>
     <td>Accepted</td>
@@ -39,40 +39,40 @@ Otherwise, the FlightIntentsResource must provide the following flight intents:
     <td rowspan="2">N/A</td>
   </tr>
   <tr>
-    <td><code>flight_1_activated_vol_A</code></td>
+    <td><code>flight1_activated</code></td>
     <td>Activated</td>
   </tr>
   <tr>
-    <td><code>flight_1_activated_vol_A_extended</code></td>
+    <td><code>flight1m_activated</code></td>
     <td>Flight 1m</td>
     <td>Activated</td>
     <td>Flight 2</td>
     <td>N/A</td>
   </tr>
   <tr>
-    <td><code>flight_1_planned_vol_B</code></td>
+    <td><code>flight1c_planned</code></td>
     <td rowspan="2">Flight 1c</td>
     <td>Planned</td>
     <td rowspan="2">N/A</td>
     <td rowspan="2">Flight 2</td>
   </tr>
   <tr>
-    <td><code>flight_1_activated_vol_B</code></td>
+    <td><code>flight1c_activated</code></td>
     <td>Activated</td>
   </tr>
   <tr>
-    <td><code>flight_2_equal_prio_planned_vol_B</code></td>
+    <td><code>equal_prio_flight2_planned</code></td>
     <td rowspan="3">Flight 2</td>
     <td>Planned</td>
     <td rowspan="3">Flight 1, Flight 1m</td>
     <td rowspan="3">Flight 1c</td>
   </tr>
   <tr>
-    <td><code>flight_2_equal_prio_activated_vol_B</code></td>
+    <td><code>equal_prio_flight2_activated</code></td>
     <td>Activated</td>
   </tr>
   <tr>
-    <td><code>flight_2_equal_prio_nonconforming_vol_A</code></td>
+    <td><code>equal_prio_flight2_nonconforming</code></td>
     <td>Nonconforming</td>
   </tr>
 </table>

--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.py
@@ -48,17 +48,17 @@ from uas_standards.interuss.automated_testing.scd.v1.api import (
 
 
 class ConflictEqualPriorityNotPermitted(TestScenario):
-    flight_1_id: Optional[str] = None
-    flight_1_planned_vol_A: FlightIntent
-    flight_1_activated_vol_A: FlightIntent
-    flight_1_activated_vol_A_extended: FlightIntent
-    flight_1_planned_vol_B: FlightIntent
-    flight_1_activated_vol_B: FlightIntent
+    flight1_id: Optional[str] = None
+    flight1_planned: FlightIntent
+    flight1_activated: FlightIntent
+    flight1m_activated: FlightIntent
+    flight1c_planned: FlightIntent
+    flight1c_activated: FlightIntent
 
-    flight_2_id: Optional[str] = None
-    flight_2_equal_prio_planned_vol_B: FlightIntent
-    flight_2_equal_prio_activated_vol_B: FlightIntent
-    flight_2_equal_prio_nonconforming_vol_A: FlightIntent
+    flight2_id: Optional[str] = None
+    flight2_planned: FlightIntent
+    flight2_activated: FlightIntent
+    flight2_nonconforming: FlightIntent
 
     tested_uss: FlightPlanner
     control_uss: FlightPlanner
@@ -99,23 +99,23 @@ class ConflictEqualPriorityNotPermitted(TestScenario):
 
         try:
             (
-                self.flight_1_planned_vol_A,
-                self.flight_1_activated_vol_A,
-                self.flight_1_activated_vol_A_extended,
-                self.flight_1_planned_vol_B,
-                self.flight_1_activated_vol_B,
-                self.flight_2_equal_prio_planned_vol_B,
-                self.flight_2_equal_prio_activated_vol_B,
-                self.flight_2_equal_prio_nonconforming_vol_A,
+                self.flight1_planned,
+                self.flight1_activated,
+                self.flight1m_activated,
+                self.flight1c_planned,
+                self.flight1c_activated,
+                self.flight2_planned,
+                self.flight2_activated,
+                self.flight2_nonconforming,
             ) = (
-                _flight_intents["flight_1_planned_vol_A"],
-                _flight_intents["flight_1_activated_vol_A"],
-                _flight_intents["flight_1_activated_vol_A_extended"],
-                _flight_intents["flight_1_planned_vol_B"],
-                _flight_intents["flight_1_activated_vol_B"],
-                _flight_intents["flight_2_equal_prio_planned_vol_B"],
-                _flight_intents["flight_2_equal_prio_activated_vol_B"],
-                _flight_intents["flight_2_equal_prio_nonconforming_vol_A"],
+                _flight_intents["flight1_planned"],
+                _flight_intents["flight1_activated"],
+                _flight_intents["flight1m_activated"],
+                _flight_intents["flight1c_planned"],
+                _flight_intents["flight1c_activated"],
+                _flight_intents["equal_prio_flight2_planned"],
+                _flight_intents["equal_prio_flight2_activated"],
+                _flight_intents["equal_prio_flight2_nonconforming"],
             )
 
             now = arrow.utcnow().datetime
@@ -132,77 +132,77 @@ class ConflictEqualPriorityNotPermitted(TestScenario):
                     ), f"at least one volume of activated intent {intent_name} must be active now (now is {now})"
 
             assert (
-                self.flight_1_planned_vol_A.request.operational_intent.state
+                self.flight1_planned.request.operational_intent.state
                 == OperationalIntentState.Accepted
-            ), "flight_1_planned_vol_A must have state Accepted"
+            ), "flight1_planned must have state Accepted"
             assert (
-                self.flight_1_activated_vol_A.request.operational_intent.state
+                self.flight1_activated.request.operational_intent.state
                 == OperationalIntentState.Activated
-            ), "flight_1_activated_vol_A must have state Activated"
+            ), "flight1_activated must have state Activated"
             assert (
-                self.flight_1_activated_vol_A_extended.request.operational_intent.state
+                self.flight1m_activated.request.operational_intent.state
                 == OperationalIntentState.Activated
-            ), "flight_1_activated_vol_A_extended must have state Activated"
+            ), "flight1m_activated must have state Activated"
             assert (
-                self.flight_1_planned_vol_B.request.operational_intent.state
+                self.flight1c_planned.request.operational_intent.state
                 == OperationalIntentState.Accepted
-            ), "flight_1_planned_vol_B must have state Accepted"
+            ), "flight1c_planned must have state Accepted"
             assert (
-                self.flight_1_activated_vol_B.request.operational_intent.state
+                self.flight1c_activated.request.operational_intent.state
                 == OperationalIntentState.Activated
-            ), "flight_1_activated_vol_B must have state Activated"
+            ), "flight1c_activated must have state Activated"
             assert (
-                self.flight_2_equal_prio_planned_vol_B.request.operational_intent.state
+                self.flight2_planned.request.operational_intent.state
                 == OperationalIntentState.Accepted
-            ), "flight_2_equal_prio_planned_vol_B must have state Accepted"
+            ), "equal_prio_flight2_planned must have state Accepted"
             assert (
-                self.flight_2_equal_prio_activated_vol_B.request.operational_intent.state
+                self.flight2_activated.request.operational_intent.state
                 == OperationalIntentState.Activated
-            ), "flight_2_equal_prio_activated_vol_B must have state Activated"
+            ), "equal_prio_flight2_activated must have state Activated"
             assert (
-                self.flight_2_equal_prio_nonconforming_vol_A.request.operational_intent.state
+                self.flight2_nonconforming.request.operational_intent.state
                 == OperationalIntentState.Nonconforming
-            ), "flight_2_equal_prio_nonconforming_vol_A must have state Nonconforming"
+            ), "equal_prio_flight2_nonconforming must have state Nonconforming"
 
             assert (
-                self.flight_2_equal_prio_planned_vol_B.request.operational_intent.priority
-                == self.flight_1_planned_vol_A.request.operational_intent.priority
+                self.flight2_planned.request.operational_intent.priority
+                == self.flight1_planned.request.operational_intent.priority
             ), "flight_2 must have priority equal to flight_1"
             assert not Volume4DCollection.from_interuss_scd_api(
-                self.flight_1_planned_vol_A.request.operational_intent.volumes
+                self.flight1_planned.request.operational_intent.volumes
             ).intersects_vol4s(
                 Volume4DCollection.from_interuss_scd_api(
-                    self.flight_2_equal_prio_planned_vol_B.request.operational_intent.volumes
+                    self.flight2_planned.request.operational_intent.volumes
                 )
-            ), "flight_1_planned_vol_A and flight_2_equal_prio_planned_vol_B must not intersect"
+            ), "flight1_planned and equal_prio_flight2_planned must not intersect"
             assert not Volume4DCollection.from_interuss_scd_api(
-                self.flight_1_planned_vol_A.request.operational_intent.volumes
+                self.flight1_planned.request.operational_intent.volumes
             ).intersects_vol4s(
                 Volume4DCollection.from_interuss_scd_api(
-                    self.flight_1_activated_vol_B.request.operational_intent.volumes
+                    self.flight1c_activated.request.operational_intent.volumes
                 )
-            ), "flight_1_planned_vol_A and flight_1_activated_vol_B must not intersect"
+            ), "flight1_planned and flight1c_activated must not intersect"
             assert Volume4DCollection.from_interuss_scd_api(
-                self.flight_1_activated_vol_B.request.operational_intent.volumes
+                self.flight1c_activated.request.operational_intent.volumes
             ).intersects_vol4s(
                 Volume4DCollection.from_interuss_scd_api(
-                    self.flight_2_equal_prio_activated_vol_B.request.operational_intent.volumes
+                    self.flight2_activated.request.operational_intent.volumes
                 )
-            ), "flight_1_activated_vol_B and flight_2_equal_prio_activated_vol_B must intersect"
+            ), "flight1c_activated and equal_prio_flight2_activated must intersect"
             assert Volume4DCollection.from_interuss_scd_api(
-                self.flight_1_activated_vol_A.request.operational_intent.volumes
+                self.flight1_activated.request.operational_intent.volumes
             ).intersects_vol4s(
                 Volume4DCollection.from_interuss_scd_api(
-                    self.flight_2_equal_prio_nonconforming_vol_A.request.operational_intent.off_nominal_volumes
+                    self.flight2_nonconforming.request.operational_intent.off_nominal_volumes
                 )
-            ), "flight_1_activated_vol_A.volumes and flight_2_equal_prio_nonconforming_vol_A.off_nominal_volumes must intersect"
+            ), "flight1_activated.volumes and equal_prio_flight2_nonconforming.off_nominal_volumes must intersect"
 
             assert (
                 len(
-                    self.flight_2_equal_prio_nonconforming_vol_A.request.operational_intent.off_nominal_volumes
+                    self.flight2_nonconforming.request.operational_intent.off_nominal_volumes
                 )
                 > 0
-            ), "flight_2_equal_prio_nonconforming_vol_A must have off-nominal volume"
+            ), "equal_prio_flight2_nonconforming must have off-nominal volume"
 
         except KeyError as e:
             raise ValueError(
@@ -259,15 +259,13 @@ class ConflictEqualPriorityNotPermitted(TestScenario):
             "Validate flight 2 sharing",
             self._intents_extent,
         ) as validator:
-            _, self.flight_2_id = plan_flight_intent(
+            _, self.flight2_id = plan_flight_intent(
                 self,
                 "Plan flight 2",
                 self.control_uss,
-                self.flight_2_equal_prio_planned_vol_B.request,
+                self.flight2_planned.request,
             )
-            flight_2_oi_ref = validator.expect_shared(
-                self.flight_2_equal_prio_planned_vol_B.request
-            )
+            flight_2_oi_ref = validator.expect_shared(self.flight2_planned.request)
 
         with OpIntentValidator(
             self,
@@ -281,12 +279,10 @@ class ConflictEqualPriorityNotPermitted(TestScenario):
                 self,
                 "Activate flight 2",
                 self.control_uss,
-                self.flight_2_equal_prio_activated_vol_B.request,
-                self.flight_2_id,
+                self.flight2_activated.request,
+                self.flight2_id,
             )
-            flight_2_oi_ref = validator.expect_shared(
-                self.flight_2_equal_prio_activated_vol_B.request
-            )
+            flight_2_oi_ref = validator.expect_shared(self.flight2_activated.request)
 
         with OpIntentValidator(
             self,
@@ -299,7 +295,7 @@ class ConflictEqualPriorityNotPermitted(TestScenario):
                 self,
                 "Attempt to plan flight 1",
                 self.tested_uss,
-                self.flight_1_planned_vol_B.request,
+                self.flight1c_planned.request,
             )
             validator.expect_not_shared()
 
@@ -317,8 +313,8 @@ class ConflictEqualPriorityNotPermitted(TestScenario):
                 self,
                 "Attempt to directly activate conflicting flight 1",
                 self.tested_uss,
-                self.flight_1_activated_vol_B.request,
-                self.flight_1_id,
+                self.flight1c_activated.request,
+                self.flight1_id,
             )
             validator.expect_not_shared()
 
@@ -332,15 +328,13 @@ class ConflictEqualPriorityNotPermitted(TestScenario):
             "Validate flight 1 sharing",
             self._intents_extent,
         ) as validator:
-            _, self.flight_1_id = plan_flight_intent(
+            _, self.flight1_id = plan_flight_intent(
                 self,
                 "Plan flight 1",
                 self.tested_uss,
-                self.flight_1_planned_vol_A.request,
+                self.flight1_planned.request,
             )
-            flight_1_oi_ref = validator.expect_shared(
-                self.flight_1_planned_vol_A.request
-            )
+            flight_1_oi_ref = validator.expect_shared(self.flight1_planned.request)
 
         with OpIntentValidator(
             self,
@@ -354,11 +348,11 @@ class ConflictEqualPriorityNotPermitted(TestScenario):
                 self,
                 "Attempt to modify planned flight 1 into conflict",
                 self.tested_uss,
-                self.flight_1_planned_vol_B.request,
-                self.flight_1_id,
+                self.flight1c_planned.request,
+                self.flight1_id,
             )
             flight_1_oi_ref = validator.expect_shared(
-                self.flight_1_planned_vol_A.request, skip_if_not_found=True
+                self.flight1_planned.request, skip_if_not_found=True
             )
 
         return flight_1_oi_ref
@@ -378,12 +372,10 @@ class ConflictEqualPriorityNotPermitted(TestScenario):
                 self,
                 "Activate flight 1",
                 self.tested_uss,
-                self.flight_1_activated_vol_A.request,
-                self.flight_1_id,
+                self.flight1_activated.request,
+                self.flight1_id,
             )
-            flight_1_oi_ref = validator.expect_shared(
-                self.flight_1_activated_vol_A.request
-            )
+            flight_1_oi_ref = validator.expect_shared(self.flight1_activated.request)
 
         with OpIntentValidator(
             self,
@@ -397,11 +389,11 @@ class ConflictEqualPriorityNotPermitted(TestScenario):
                 self,
                 "Attempt to modify activated flight 1 into conflict",
                 self.tested_uss,
-                self.flight_1_activated_vol_B.request,
-                self.flight_1_id,
+                self.flight1c_activated.request,
+                self.flight1_id,
             )
             flight_1_oi_ref = validator.expect_shared(
-                self.flight_1_activated_vol_A.request, skip_if_not_found=True
+                self.flight1_activated.request, skip_if_not_found=True
             )
 
         return flight_1_oi_ref
@@ -423,12 +415,10 @@ class ConflictEqualPriorityNotPermitted(TestScenario):
                 self,
                 "Activate flight 1",
                 self.tested_uss,
-                self.flight_1_activated_vol_A.request,
-                self.flight_1_id,
+                self.flight1_activated.request,
+                self.flight1_id,
             )
-            flight_1_oi_ref = validator.expect_shared(
-                self.flight_1_activated_vol_A.request
-            )
+            flight_1_oi_ref = validator.expect_shared(self.flight1_activated.request)
 
         with OpIntentValidator(
             self,
@@ -448,17 +438,15 @@ class ConflictEqualPriorityNotPermitted(TestScenario):
                 },
                 {InjectFlightResponseResult.Failed: "Failure"},
                 self.control_uss,
-                self.flight_2_equal_prio_nonconforming_vol_A.request,
-                self.flight_2_id,
+                self.flight2_nonconforming.request,
+                self.flight2_id,
             )
             if resp_flight_2.result == InjectFlightResponseResult.NotSupported:
                 msg = f"{self.control_uss.config.participant_id} does not support the transition to a Nonconforming state; execution of the scenario was stopped without failure"
                 self.record_note("Control USS does not support CMSA role", msg)
                 raise ScenarioCannotContinueError(msg)
 
-            validator.expect_shared(
-                self.flight_2_equal_prio_nonconforming_vol_A.request
-            )
+            validator.expect_shared(self.flight2_nonconforming.request)
 
         with OpIntentValidator(
             self,
@@ -478,15 +466,15 @@ class ConflictEqualPriorityNotPermitted(TestScenario):
                 },
                 {InjectFlightResponseResult.Failed: "Failure"},
                 self.tested_uss,
-                self.flight_1_activated_vol_A_extended.request,
-                self.flight_1_id,
+                self.flight1m_activated.request,
+                self.flight1_id,
             )
 
             if resp_flight_1.result == InjectFlightResponseResult.ReadyToFly:
-                validator.expect_shared(self.flight_1_activated_vol_A_extended.request)
+                validator.expect_shared(self.flight1m_activated.request)
             elif resp_flight_1.result == InjectFlightResponseResult.Rejected:
                 validator.expect_shared(
-                    self.flight_1_activated_vol_A.request, skip_if_not_found=True
+                    self.flight1_activated.request, skip_if_not_found=True
                 )
 
     def cleanup(self):

--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md
@@ -26,7 +26,7 @@ FlightIntentsResource that provides the following flight intents:
     <th>Must not conflict with</th>
   </tr>
   <tr>
-    <td><code>flight_1_planned_vol_A</code></td>
+    <td><code>flight1_planned</code></td>
     <td rowspan="2">Flight 1</td>
     <td rowspan="5">Any</td>
     <td>Accepted</td>
@@ -34,29 +34,29 @@ FlightIntentsResource that provides the following flight intents:
     <td rowspan="2">Flight 2m</td>
   </tr>
   <tr>
-    <td><code>flight_1_activated_vol_A</code></td>
+    <td><code>flight1_activated</code></td>
     <td>Activated</td>
   </tr>
   <tr>
-    <td><code>flight_1_planned_vol_A_extended</code></td>
+    <td><code>flight1m_planned</code></td>
     <td rowspan="2">Flight 1m</td>
     <td>Accepted</td>
     <td rowspan="2">Flight 2</td>
     <td rowspan="2">N/A</td>
   </tr>
   <tr>
-    <td><code>flight_1_activated_vol_A_extended</code></td>
+    <td><code>flight1m_activated</code></td>
     <td>Activated</td>
   </tr>
   <tr>
-    <td><code>flight_1_activated_vol_B</code></td>
+    <td><code>flight1c_activated</code></td>
     <td>Flight 1c</td>
     <td>Activated</td>
     <td>Flight 2</td>
     <td>N/A</td>
   </tr>
   <tr>
-    <td><code>flight_2_planned_vol_A</code></td>
+    <td><code>flight2_planned</code></td>
     <td rowspan="2">Flight 2</td>
     <td rowspan="3">Higher than Flight 1*</td>
     <td>Accepted</td>
@@ -64,11 +64,11 @@ FlightIntentsResource that provides the following flight intents:
     <td rowspan="2">N/A</td>
   </tr>
   <tr>
-    <td><code>flight_2_activated_vol_A</code></td>
+    <td><code>flight2_activated</code></td>
     <td>Activated</td>
   </tr>
   <tr>
-    <td><code>flight_2_activated_vol_B</code></td>
+    <td><code>flight2m_activated</code></td>
     <td>Flight 2m</td>
     <td>Activated</td>
     <td>Flight 1c</td>

--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.py
@@ -47,17 +47,17 @@ from monitoring.uss_qualifier.scenarios.flight_planning.test_steps import (
 
 
 class ConflictHigherPriority(TestScenario):
-    flight_1_id: Optional[str] = None
-    flight_1_planned_vol_A: FlightIntent
-    flight_1_planned_vol_A_extended: FlightIntent
-    flight_1_activated_vol_A: FlightIntent
-    flight_1_activated_vol_A_extended: FlightIntent
-    flight_1_activated_vol_B: FlightIntent
+    flight1_id: Optional[str] = None
+    flight1_planned: FlightIntent
+    flight1m_planned: FlightIntent
+    flight1_activated: FlightIntent
+    flight1m_activated: FlightIntent
+    flight1c_activated: FlightIntent
 
-    flight_2_id: Optional[str] = None
-    flight_2_planned_vol_A: FlightIntent
-    flight_2_activated_vol_A: FlightIntent
-    flight_2_activated_vol_B: FlightIntent
+    flight2_id: Optional[str] = None
+    flight2_planned: FlightIntent
+    flight2_activated: FlightIntent
+    flight2m_activated: FlightIntent
 
     tested_uss: FlightPlanner
     control_uss: FlightPlanner
@@ -90,23 +90,23 @@ class ConflictHigherPriority(TestScenario):
 
         try:
             (
-                self.flight_1_planned_vol_A,
-                self.flight_1_planned_vol_A_extended,
-                self.flight_1_activated_vol_A,
-                self.flight_1_activated_vol_A_extended,
-                self.flight_1_activated_vol_B,
-                self.flight_2_planned_vol_A,
-                self.flight_2_activated_vol_A,
-                self.flight_2_activated_vol_B,
+                self.flight1_planned,
+                self.flight1m_planned,
+                self.flight1_activated,
+                self.flight1m_activated,
+                self.flight1c_activated,
+                self.flight2_planned,
+                self.flight2_activated,
+                self.flight2m_activated,
             ) = (
-                _flight_intents["flight_1_planned_vol_A"],
-                _flight_intents["flight_1_planned_vol_A_extended"],
-                _flight_intents["flight_1_activated_vol_A"],
-                _flight_intents["flight_1_activated_vol_A_extended"],
-                _flight_intents["flight_1_activated_vol_B"],
-                _flight_intents["flight_2_planned_vol_A"],
-                _flight_intents["flight_2_activated_vol_A"],
-                _flight_intents["flight_2_activated_vol_B"],
+                _flight_intents["flight1_planned"],
+                _flight_intents["flight1m_planned"],
+                _flight_intents["flight1_activated"],
+                _flight_intents["flight1m_activated"],
+                _flight_intents["flight1c_activated"],
+                _flight_intents["flight2_planned"],
+                _flight_intents["flight2_activated"],
+                _flight_intents["flight2m_activated"],
             )
 
             now = arrow.utcnow().datetime
@@ -123,65 +123,65 @@ class ConflictHigherPriority(TestScenario):
                     ), f"at least one volume of activated intent {intent_name} must be active now (now is {now})"
 
             assert (
-                self.flight_1_planned_vol_A.request.operational_intent.state
+                self.flight1_planned.request.operational_intent.state
                 == OperationalIntentState.Accepted
-            ), "flight_1_planned_vol_A must have state Accepted"
+            ), "flight1_planned must have state Accepted"
             assert (
-                self.flight_1_planned_vol_A_extended.request.operational_intent.state
+                self.flight1m_planned.request.operational_intent.state
                 == OperationalIntentState.Accepted
-            ), "flight_1_planned_vol_A_extended must have state Accepted"
+            ), "flight1m_planned must have state Accepted"
             assert (
-                self.flight_1_activated_vol_A.request.operational_intent.state
+                self.flight1_activated.request.operational_intent.state
                 == OperationalIntentState.Activated
-            ), "flight_1_activated_vol_A must have state Activated"
+            ), "flight1_activated must have state Activated"
             assert (
-                self.flight_1_activated_vol_A_extended.request.operational_intent.state
+                self.flight1m_activated.request.operational_intent.state
                 == OperationalIntentState.Activated
-            ), "flight_1_activated_vol_A_extended must have state Activated"
+            ), "flight1m_activated must have state Activated"
             assert (
-                self.flight_1_activated_vol_B.request.operational_intent.state
+                self.flight1c_activated.request.operational_intent.state
                 == OperationalIntentState.Activated
-            ), "flight_1_activated_vol_B must have state Activated"
+            ), "flight1c_activated must have state Activated"
             assert (
-                self.flight_2_planned_vol_A.request.operational_intent.state
+                self.flight2_planned.request.operational_intent.state
                 == OperationalIntentState.Accepted
-            ), "flight_2_planned_vol_A must have state Accepted"
+            ), "flight2_planned must have state Accepted"
             assert (
-                self.flight_2_activated_vol_A.request.operational_intent.state
+                self.flight2_activated.request.operational_intent.state
                 == OperationalIntentState.Activated
-            ), "flight_2_activated_vol_A must have state Activated"
+            ), "flight2_activated must have state Activated"
             assert (
-                self.flight_2_activated_vol_B.request.operational_intent.state
+                self.flight2m_activated.request.operational_intent.state
                 == OperationalIntentState.Activated
-            ), "flight_2_activated_vol_B must have state Activated"
+            ), "flight2m_activated must have state Activated"
 
             # TODO: check that flight data is the same across the different versions of the flight
 
             assert (
-                self.flight_2_planned_vol_A.request.operational_intent.priority
-                > self.flight_1_planned_vol_A.request.operational_intent.priority
+                self.flight2_planned.request.operational_intent.priority
+                > self.flight1_planned.request.operational_intent.priority
             ), "flight_2 must have higher priority than flight_1"
             assert Volume4DCollection.from_interuss_scd_api(
-                self.flight_1_planned_vol_A.request.operational_intent.volumes
+                self.flight1_planned.request.operational_intent.volumes
             ).intersects_vol4s(
                 Volume4DCollection.from_interuss_scd_api(
-                    self.flight_2_planned_vol_A.request.operational_intent.volumes
+                    self.flight2_planned.request.operational_intent.volumes
                 )
-            ), "flight_1_planned_vol_A and flight_2_planned_vol_A must intersect"
+            ), "flight1_planned and flight2_planned must intersect"
             assert Volume4DCollection.from_interuss_scd_api(
-                self.flight_1_planned_vol_A.request.operational_intent.volumes
+                self.flight1_planned.request.operational_intent.volumes
             ).intersects_vol4s(
                 Volume4DCollection.from_interuss_scd_api(
-                    self.flight_1_planned_vol_A_extended.request.operational_intent.volumes
+                    self.flight1m_planned.request.operational_intent.volumes
                 )
-            ), "flight_1_planned_vol_A and flight_1_planned_vol_A_extended must intersect"
+            ), "flight1_planned and flight1m_planned must intersect"
             assert not Volume4DCollection.from_interuss_scd_api(
-                self.flight_1_planned_vol_A.request.operational_intent.volumes
+                self.flight1_planned.request.operational_intent.volumes
             ).intersects_vol4s(
                 Volume4DCollection.from_interuss_scd_api(
-                    self.flight_1_activated_vol_B.request.operational_intent.volumes
+                    self.flight1c_activated.request.operational_intent.volumes
                 )
-            ), "flight_1_planned_vol_A and flight_1_activated_vol_B must not intersect"
+            ), "flight1_planned and flight1c_activated must not intersect"
 
         except KeyError as e:
             raise ValueError(
@@ -237,13 +237,13 @@ class ConflictHigherPriority(TestScenario):
             "Validate flight 2 sharing",
             self._intents_extent,
         ) as validator:
-            resp_flight_2, self.flight_2_id = plan_flight_intent(
+            resp_flight_2, self.flight2_id = plan_flight_intent(
                 self,
                 "Plan flight 2",
                 self.control_uss,
-                self.flight_2_planned_vol_A.request,
+                self.flight2_planned.request,
             )
-            validator.expect_shared(self.flight_2_planned_vol_A.request)
+            validator.expect_shared(self.flight2_planned.request)
 
         with OpIntentValidator(
             self,
@@ -256,14 +256,14 @@ class ConflictHigherPriority(TestScenario):
                 self,
                 "Attempt to plan flight 1",
                 self.tested_uss,
-                self.flight_1_planned_vol_A.request,
+                self.flight1_planned.request,
             )
             validator.expect_not_shared()
 
         _ = delete_flight_intent(
-            self, "Delete flight 2", self.control_uss, self.flight_2_id
+            self, "Delete flight 2", self.control_uss, self.flight2_id
         )
-        self.flight_2_id = None
+        self.flight2_id = None
 
     def _attempt_modify_planned_flight_conflict(
         self,
@@ -275,15 +275,13 @@ class ConflictHigherPriority(TestScenario):
             "Validate flight 1 sharing",
             self._intents_extent,
         ) as validator:
-            resp_flight_1, self.flight_1_id = plan_flight_intent(
+            resp_flight_1, self.flight1_id = plan_flight_intent(
                 self,
                 "Plan flight 1",
                 self.tested_uss,
-                self.flight_1_planned_vol_A.request,
+                self.flight1_planned.request,
             )
-            flight_1_oi_ref = validator.expect_shared(
-                self.flight_1_planned_vol_A.request
-            )
+            flight_1_oi_ref = validator.expect_shared(self.flight1_planned.request)
 
         with OpIntentValidator(
             self,
@@ -292,13 +290,13 @@ class ConflictHigherPriority(TestScenario):
             "Validate flight 2 sharing",
             self._intents_extent,
         ) as validator:
-            resp_flight_2, self.flight_2_id = plan_flight_intent(
+            resp_flight_2, self.flight2_id = plan_flight_intent(
                 self,
                 "Plan flight 2",
                 self.control_uss,
-                self.flight_2_planned_vol_A.request,
+                self.flight2_planned.request,
             )
-            validator.expect_shared(self.flight_2_planned_vol_A.request)
+            validator.expect_shared(self.flight2_planned.request)
 
         with OpIntentValidator(
             self,
@@ -312,11 +310,11 @@ class ConflictHigherPriority(TestScenario):
                 self,
                 "Attempt to modify planned flight 1 in conflict",
                 self.tested_uss,
-                self.flight_1_planned_vol_A_extended.request,
-                self.flight_1_id,
+                self.flight1m_planned.request,
+                self.flight1_id,
             )
             flight_1_oi_ref = validator.expect_shared(
-                self.flight_1_planned_vol_A.request, skip_if_not_found=True
+                self.flight1_planned.request, skip_if_not_found=True
             )
 
         return flight_1_oi_ref
@@ -336,11 +334,11 @@ class ConflictHigherPriority(TestScenario):
                 self,
                 "Attempt to activate conflicting flight 1",
                 self.tested_uss,
-                self.flight_1_activated_vol_A.request,
-                self.flight_1_id,
+                self.flight1_activated.request,
+                self.flight1_id,
             )
             flight_1_oi_ref = validator.expect_shared(
-                self.flight_1_planned_vol_A.request, skip_if_not_found=True
+                self.flight1_planned.request, skip_if_not_found=True
             )
 
         return flight_1_oi_ref
@@ -349,9 +347,9 @@ class ConflictHigherPriority(TestScenario):
         self, flight_1_oi_ref: Optional[OperationalIntentReference]
     ) -> Tuple[OperationalIntentReference, OperationalIntentReference]:
         _ = delete_flight_intent(
-            self, "Delete flight 2", self.control_uss, self.flight_2_id
+            self, "Delete flight 2", self.control_uss, self.flight2_id
         )
-        self.flight_2_id = None
+        self.flight2_id = None
 
         with OpIntentValidator(
             self,
@@ -365,12 +363,10 @@ class ConflictHigherPriority(TestScenario):
                 self,
                 "Activate flight 1",
                 self.tested_uss,
-                self.flight_1_activated_vol_A.request,
-                self.flight_1_id,
+                self.flight1_activated.request,
+                self.flight1_id,
             )
-            flight_1_oi_ref = validator.expect_shared(
-                self.flight_1_activated_vol_A.request
-            )
+            flight_1_oi_ref = validator.expect_shared(self.flight1_activated.request)
 
         with OpIntentValidator(
             self,
@@ -379,15 +375,13 @@ class ConflictHigherPriority(TestScenario):
             "Validate flight 2 sharing",
             self._intents_extent,
         ) as validator:
-            _, self.flight_2_id = plan_flight_intent(
+            _, self.flight2_id = plan_flight_intent(
                 self,
                 "Plan flight 2",
                 self.control_uss,
-                self.flight_2_planned_vol_A.request,
+                self.flight2_planned.request,
             )
-            flight_2_oi_ref = validator.expect_shared(
-                self.flight_2_planned_vol_A.request
-            )
+            flight_2_oi_ref = validator.expect_shared(self.flight2_planned.request)
 
         with OpIntentValidator(
             self,
@@ -401,12 +395,10 @@ class ConflictHigherPriority(TestScenario):
                 self,
                 "Activate flight 2",
                 self.control_uss,
-                self.flight_2_activated_vol_A.request,
-                self.flight_2_id,
+                self.flight2_activated.request,
+                self.flight2_id,
             )
-            flight_2_oi_ref = validator.expect_shared(
-                self.flight_2_activated_vol_A.request
-            )
+            flight_2_oi_ref = validator.expect_shared(self.flight2_activated.request)
 
         with OpIntentValidator(
             self,
@@ -420,18 +412,18 @@ class ConflictHigherPriority(TestScenario):
                 self,
                 "Modify activated flight 1 in conflict with activated flight 2",
                 self.tested_uss,
-                self.flight_1_activated_vol_A_extended.request,
-                self.flight_1_id,
+                self.flight1m_activated.request,
+                self.flight1_id,
                 preexisting_conflict=True,
             )
 
             if resp.result == InjectFlightResponseResult.ReadyToFly:
                 flight_1_oi_ref = validator.expect_shared(
-                    self.flight_1_activated_vol_A_extended.request
+                    self.flight1m_activated.request
                 )
             else:
                 flight_1_oi_ref = validator.expect_shared(
-                    self.flight_1_activated_vol_A.request
+                    self.flight1_activated.request
                 )
 
         return flight_1_oi_ref, flight_2_oi_ref
@@ -453,10 +445,10 @@ class ConflictHigherPriority(TestScenario):
                 self,
                 "Modify activated flight 2 to not conflict with activated flight 1",
                 self.control_uss,
-                self.flight_2_activated_vol_B.request,
-                self.flight_2_id,
+                self.flight2m_activated.request,
+                self.flight2_id,
             )
-            validator.expect_shared(self.flight_2_activated_vol_B.request)
+            validator.expect_shared(self.flight2m_activated.request)
 
         with OpIntentValidator(
             self,
@@ -470,11 +462,11 @@ class ConflictHigherPriority(TestScenario):
                 self,
                 "Attempt to modify activated flight 1 in conflict",
                 self.tested_uss,
-                self.flight_1_activated_vol_B.request,
-                self.flight_1_id,
+                self.flight1c_activated.request,
+                self.flight1_id,
             )
             validator.expect_shared(
-                self.flight_1_activated_vol_A_extended.request,
+                self.flight1m_activated.request,
                 skip_if_not_found=True,
             )
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss.md
@@ -21,7 +21,7 @@ FlightIntentsResource that provides the following flight intents:
     <th>Must not conflict with</th>
   </tr>
   <tr>
-    <td><code>flight_1_planned_vol_A</code></td>
+    <td><code>flight1_planned</code></td>
     <td rowspan="2">Flight 1</td>
     <td rowspan="5">Any</td>
     <td>Accepted</td>
@@ -29,7 +29,7 @@ FlightIntentsResource that provides the following flight intents:
     <td rowspan="2">Flight 2m</td>
   </tr>
   <tr>
-    <td><code>flight_2_planned_vol_A</code></td>
+    <td><code>flight2_planned</code></td>
     <td rowspan="2">Flight 2</td>
     <td rowspan="3">Higher than Flight 1*</td>
     <td>Accepted</td>

--- a/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss.py
@@ -38,9 +38,9 @@ from monitoring.uss_qualifier.suites.suite import ExecutionContext
 
 class DownUSS(TestScenario):
     flight_1_id: Optional[str] = None
-    flight_1_planned_vol_A: FlightIntent
+    flight1_planned: FlightIntent
 
-    flight_2_planned_vol_A: FlightIntent
+    flight2_planned: FlightIntent
 
     uss_qualifier_sub: str
 
@@ -71,9 +71,9 @@ class DownUSS(TestScenario):
         ).bounding_volume.to_f3548v21()
 
         try:
-            (self.flight_1_planned_vol_A, self.flight_2_planned_vol_A,) = (
-                _flight_intents["flight_1_planned_vol_A"],
-                _flight_intents["flight_2_planned_vol_A"],
+            (self.flight1_planned, self.flight2_planned,) = (
+                _flight_intents["flight1_planned"],
+                _flight_intents["flight2_planned"],
             )
 
             now = arrow.utcnow().datetime
@@ -90,27 +90,27 @@ class DownUSS(TestScenario):
                     ), f"at least one volume of activated intent {intent_name} must be active now (now is {now})"
 
             assert (
-                self.flight_1_planned_vol_A.request.operational_intent.state
+                self.flight1_planned.request.operational_intent.state
                 == OperationalIntentState.Accepted
-            ), "flight_1_planned_vol_A must have state Accepted"
+            ), "flight1_planned must have state Accepted"
             assert (
-                self.flight_2_planned_vol_A.request.operational_intent.state
+                self.flight2_planned.request.operational_intent.state
                 == OperationalIntentState.Accepted
-            ), "flight_2_planned_vol_A must have state Accepted"
+            ), "flight2_planned must have state Accepted"
 
             # TODO: check that flight data is the same across the different versions of the flight
 
             assert (
-                self.flight_2_planned_vol_A.request.operational_intent.priority
-                > self.flight_1_planned_vol_A.request.operational_intent.priority
+                self.flight2_planned.request.operational_intent.priority
+                > self.flight1_planned.request.operational_intent.priority
             ), "flight_2 must have higher priority than flight_1"
             assert Volume4DCollection.from_interuss_scd_api(
-                self.flight_1_planned_vol_A.request.operational_intent.volumes
+                self.flight1_planned.request.operational_intent.volumes
             ).intersects_vol4s(
                 Volume4DCollection.from_interuss_scd_api(
-                    self.flight_2_planned_vol_A.request.operational_intent.volumes
+                    self.flight2_planned.request.operational_intent.volumes
                 )
-            ), "flight_1_planned_vol_A and flight_2_planned_vol_A must intersect"
+            ), "flight1_planned and flight2_planned must intersect"
 
         except KeyError as e:
             raise ValueError(
@@ -174,7 +174,7 @@ class DownUSS(TestScenario):
         self.begin_test_step("Virtual USS plans high-priority flight 2")
         oi_ref, _, query = self.dss.put_op_intent(
             Volume4DCollection.from_interuss_scd_api(
-                self.flight_2_planned_vol_A.request.operational_intent.volumes
+                self.flight2_planned.request.operational_intent.volumes
             ).to_f3548v21(),
             [],  # we assume there is no other operational intent in that area
             OperationalIntentState.Accepted,
@@ -231,11 +231,11 @@ class DownUSS(TestScenario):
                 expected_results,
                 failed_checks,
                 self.tested_uss,
-                self.flight_1_planned_vol_A.request,
+                self.flight1_planned.request,
             )
 
             if resp.result == InjectFlightResponseResult.Planned:
-                validator.expect_shared(self.flight_1_planned_vol_A.request)
+                validator.expect_shared(self.flight1_planned.request)
             elif (
                 resp.result == InjectFlightResponseResult.Rejected
                 or resp.result == InjectFlightResponseResult.ConflictWithFlight

--- a/monitoring/uss_qualifier/test_data/che/flight_intents/conflicting_flights.yaml
+++ b/monitoring/uss_qualifier/test_data/che/flight_intents/conflicting_flights.yaml
@@ -1,6 +1,6 @@
 $content_schema: monitoring/uss_qualifier/resources/flight_planning/flight_intent/FlightIntentCollection.json
 intents:
-  flight_1_planned_vol_A:
+  flight1_planned:
     full:
       basic_information:
         usage_state: Planned
@@ -53,9 +53,9 @@ intents:
         uas_id: ''
         uas_type_certificate: ''
 
-  flight_1_activated_vol_A:
+  flight1_activated:
     delta:
-      source: flight_1_planned_vol_A
+      source: flight1_planned
       mutation:
         basic_information:
           usage_state: InUse
@@ -63,9 +63,9 @@ intents:
             - altitude_lower:
                 value: 605.02
 
-  flight_1_planned_vol_A_extended:
+  flight1m_planned:
     delta:
-      source: flight_1_planned_vol_A
+      source: flight1_planned
       mutation:
         basic_information:
           area:
@@ -73,9 +73,9 @@ intents:
                 altitude_lower:
                   value: 575.03
 
-  flight_1_planned_vol_B:
+  flight1c_planned:
     delta:
-      source: flight_1_planned_vol_A
+      source: flight1_planned
       mutation:
         basic_information:
           area:
@@ -84,9 +84,9 @@ intents:
               altitude_upper:
                 value: 705
 
-  flight_1_activated_vol_A_extended:
+  flight1m_activated:
     delta:
-      source: flight_1_planned_vol_A_extended
+      source: flight1m_planned
       mutation:
         basic_information:
           usage_state: InUse
@@ -94,9 +94,9 @@ intents:
             - altitude_lower:
                 value: 575.05
 
-  flight_1_activated_vol_B:
+  flight1c_activated:
     delta:
-      source: flight_1_planned_vol_B
+      source: flight1c_planned
       mutation:
         basic_information:
           usage_state: InUse
@@ -104,7 +104,7 @@ intents:
             - altitude_lower:
                 value: 650.06
 
-  flight_2_planned_vol_A:
+  flight2_planned:
     full:
       basic_information:
         usage_state: Planned
@@ -157,9 +157,9 @@ intents:
         uas_id: ''
         uas_type_certificate: ''
 
-  flight_2_activated_vol_A:
+  flight2_activated:
     delta:
-      source: flight_2_planned_vol_A
+      source: flight2_planned
       mutation:
         basic_information:
           usage_state: InUse
@@ -167,9 +167,9 @@ intents:
             - altitude_lower:
                 value: 605.08
 
-  flight_2_activated_vol_B:
+  flight2m_activated:
     delta:
-      source: flight_2_activated_vol_A
+      source: flight2_activated
       mutation:
         basic_information:
           area:
@@ -178,9 +178,9 @@ intents:
               altitude_upper:
                 value: 705
 
-  flight_2_equal_prio_planned_vol_B:
+  equal_prio_flight2_planned:
     delta:
-      source: flight_2_activated_vol_B
+      source: flight2m_activated
       mutation:
         basic_information:
           usage_state: Planned
@@ -190,9 +190,9 @@ intents:
         astm_f3548_21:
           priority: 0
 
-  flight_2_equal_prio_activated_vol_B:
+  equal_prio_flight2_activated:
     delta:
-      source: flight_2_equal_prio_planned_vol_B
+      source: equal_prio_flight2_planned
       mutation:
         basic_information:
           usage_state: InUse
@@ -200,9 +200,9 @@ intents:
             - altitude_lower:
                 value: 650.11
 
-  flight_2_equal_prio_nonconforming_vol_A:
+  equal_prio_flight2_nonconforming:
     delta:
-      source: flight_2_equal_prio_activated_vol_B
+      source: equal_prio_flight2_activated
       mutation:
         basic_information:
           uas_state: OffNominal


### PR DESCRIPTION
It would be far easier to reason and debug the two nominal planning scenarios if the flight intent IDs matched the newer diagrams and documentation (instead of retaining the older flight intent IDs).  This PR updates the flight intent IDs for those two scenarios to match the diagrams and documentation.