### PR TITLE
[uss_qualifier] Add suffix for notes with duplicated keys

### DIFF
--- a/monitoring/uss_qualifier/scenarios/scenario.py
+++ b/monitoring/uss_qualifier/scenarios/scenario.py
@@ -280,6 +280,14 @@ class GenericTestScenario(ABC):
         )
         if "notes" not in self._scenario_report:
             self._scenario_report.notes = {}
+
+        if key in self._scenario_report.notes:
+            # prevent notes from being overriden by adding a suffix if key is a duplicate
+            suffix = 1
+            while f"{key}_{suffix}" in self._scenario_report.notes:
+                suffix += 1
+            key += f"_{suffix}"
+
         self._scenario_report.notes[key] = Note(
             message=message,
             timestamp=StringBasedDateTime(arrow.utcnow().datetime),


### PR DESCRIPTION
When recording a note, the default behavior is to override any note that potentially has the same key.
This PR changes that by detecting such cases and automatically adding a suffix to the key in order to not lose notes that way.