### PR TITLE
[uss_qualifier] Relax type requirements when performing test checks

### DIFF
--- a/monitoring/uss_qualifier/scenarios/scenario.py
+++ b/monitoring/uss_qualifier/scenarios/scenario.py
@@ -95,14 +95,18 @@ class PendingCheck(object):
         summary: str,
         severity: Severity,
         details: str = "",
-        participants: Optional[List[ParticipantID]] = None,
+        participants: Optional[Union[ParticipantID, List[ParticipantID]]] = None,
         query_timestamps: Optional[List[datetime]] = None,
         additional_data: Optional[dict] = None,
-        requirements: Optional[List[str]] = None,
+        requirements: Optional[Union[str, List[str]]] = None,
     ) -> None:
         self._outcome_recorded = True
+        if isinstance(participants, str):
+            participants = [participants]
         if participants is None:
             participants = self._participants
+        if isinstance(requirements, str):
+            requirements = [requirements]
         if requirements is None:
             requirements = self._documentation.applicable_requirements
 
@@ -388,8 +392,12 @@ class GenericTestScenario(ABC):
         return available_checks[name]
 
     def check(
-        self, name: str, participants: Optional[List[ParticipantID]] = None
+        self,
+        name: str,
+        participants: Optional[Union[ParticipantID, List[ParticipantID]]] = None,
     ) -> PendingCheck:
+        if isinstance(participants, str):
+            participants = [participants]
         self._expect_phase({ScenarioPhase.RunningTestStep, ScenarioPhase.CleaningUp})
         available_checks = {c.name: c for c in self._current_step.checks}
         if name in available_checks:


### PR DESCRIPTION
A common problem in uss_qualifier is developers providing a single ParticipantID rather than a list of ParticipantIDs when initiating a check.  Since a ParticipantID is a string and a string is actually a list (of characters), this problem often goes unnoticed and participants are attributed as "u", "s", "s", and "1".  This is currently a problem both in an active PR and a PR that was merged (was not caught in review).

This PR fixes that problem by allowing either a single ParticipantID or a list of ParticipantIDs to be provided, and treats either correctly.  It also does the same for requirements where the same problem sometimes occurs.