### PR TITLE
[uss_qualifier] improve documentation for op intent reference ACL validation

### DIFF
--- a/monitoring/uss_qualifier/requirements/astm/f3548/v21.md
+++ b/monitoring/uss_qualifier/requirements/astm/f3548/v21.md
@@ -148,6 +148,11 @@ For information on these requirements, refer to [the ASTM standard F3548-21](htt
 ## Discovery and Synchronization Service
 
 * <tt>DSS0005</tt>
+  * <tt>DSS0005,1</tt>
+  * <tt>DSS0005,2</tt>
+  * <tt>DSS0005,3</tt>
+  * <tt>DSS0005,4</tt>
+  * <tt>DSS0005,5</tt>
 * <tt>DSS0010</tt>
 * <tt>DSS0015</tt>
 * <tt>DSS0020</tt>

--- a/monitoring/uss_qualifier/scenarios/astm/utm/__init__.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/__init__.py
@@ -12,4 +12,4 @@ from .off_nominal_planning.down_uss import DownUSS
 from .off_nominal_planning.down_uss_equal_priority_not_permitted import (
     DownUSSEqualPriorityNotPermitted,
 )
-from .op_intent_access_control import OpIntentAccessControl
+from .op_intent_ref_access_control import OpIntentReferenceAccessControl

--- a/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss.md
@@ -58,7 +58,7 @@ The USS qualifier, acting as a virtual USS, creates an operational intent at the
 The objective is to make the later request by the tested USS to retrieve operational intent details to fail.
 
 #### Operational intent successfully created check
-If the creation of the operational intent reference at the DSS fails, this check fails per **[astm.f3548.v21.DSS0005](../../../../requirements/astm/f3548/v21.md)**.
+If the creation of the operational intent reference at the DSS fails, this check fails per **[astm.f3548.v21.DSS0005,1](../../../../requirements/astm/f3548/v21.md)**.
 
 ### [Declare virtual USS as down at DSS test step](../set_uss_down.md)
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md
@@ -58,14 +58,14 @@ The USS qualifier, acting as a virtual USS, creates an operational intent at the
 The objective is to make the later request by the tested USS to retrieve operational intent details to fail.
 
 #### Operational intent successfully created check
-If the creation of the operational intent reference at the DSS fails, this check fails per **[astm.f3548.v21.DSS0005](../../../../requirements/astm/f3548/v21.md)**.
+If the creation of the operational intent reference at the DSS fails, this check fails per **[astm.f3548.v21.DSS0005,1](../../../../requirements/astm/f3548/v21.md)**.
 
 ### Virtual USS activates conflicting operational intent test step
 The USS qualifier, acting as a virtual USS, activates the operational intent previously created at the DSS with a non-working base URL.
 The objective is to make the later request by the tested USS to retrieve operational intent details to fail.
 
 #### Operational intent successfully activated check
-If the activation of the operational intent reference at the DSS fails, this check fails per **[astm.f3548.v21.DSS0005](../../../../requirements/astm/f3548/v21.md)**.
+If the activation of the operational intent reference at the DSS fails, this check fails per **[astm.f3548.v21.DSS0005,1](../../../../requirements/astm/f3548/v21.md)**.
 
 ### [Declare virtual USS as down at DSS test step](../set_uss_down.md)
 
@@ -102,7 +102,7 @@ The USS qualifier, acting as a virtual USS, transitions to Nonconforming the ope
 The objective is to make the later request by the tested USS to retrieve operational intent details to fail.
 
 #### Operational intent successfully transitioned to Nonconforming check
-If the transition of the operational intent reference at the DSS fails, this check fails per **[astm.f3548.v21.DSS0005](../../../../requirements/astm/f3548/v21.md)**.
+If the transition of the operational intent reference at the DSS fails, this check fails per **[astm.f3548.v21.DSS0005,1](../../../../requirements/astm/f3548/v21.md)**.
 
 ### [Declare virtual USS as down at DSS test step](../set_uss_down.md)
 
@@ -139,7 +139,7 @@ The USS qualifier, acting as a virtual USS, transitions to Contingent the operat
 The objective is to make the later request by the tested USS to retrieve operational intent details to fail.
 
 #### Operational intent successfully transitioned to Contingent check
-If the transition of the operational intent reference at the DSS fails, this check fails per **[astm.f3548.v21.DSS0005](../../../../requirements/astm/f3548/v21.md)**.
+If the transition of the operational intent reference at the DSS fails, this check fails per **[astm.f3548.v21.DSS0005,1](../../../../requirements/astm/f3548/v21.md)**.
 
 ### [Declare virtual USS as down at DSS test step](../set_uss_down.md)
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/op_intent_ref_access_control.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/op_intent_ref_access_control.md
@@ -1,8 +1,8 @@
-# ASTM F3548-21 UTM DSS Operational Intent Access Control test scenario
+# ASTM F3548-21 UTM DSS Operational Intent Reference Access Control test scenario
 
 ## Overview
 
-This scenario ensures that a DSS will only let the owner of an operational intent modify it.
+This scenario ensures that a DSS will only let the owner of an operational intent reference modify it.
 
 ## Resources
 
@@ -11,7 +11,7 @@ This scenario ensures that a DSS will only let the owner of an operational inten
 A `resources.flight_planning.FlightIntentsResource` containing the flight intents to be used in this scenario:
 
 This scenario expects to find at least two separate flight intents in this resource, as it will use their extent
-to create two operational intents.
+to create two operational intents references.
 
 ### dss
 
@@ -48,79 +48,79 @@ this will be verified at runtime, and this scenario will fail if the second set 
 
 ### id_generator
 
-A `resources.interuss.IDGeneratorResource` that will be used to generate the IDs of the operational intents created in this scenario.
+A `resources.interuss.IDGeneratorResource` that will be used to generate the IDs of the operational intent references created in this scenario.
 
 ## Setup test case
 
 Makes sure that the DSS is in a clean and expected state before running the test, and that the passed resources work as required.
 
-The setup will create two separate operational intents: one for each set of the available credentials.
+The setup will create two separate operational intent references: one for each set of the available credentials.
 
 ### Ensure clean workspace test step
 
-#### 🛑 Operational intents can be queried directly by their ID check
+#### 🛑 Operational intent references can be queried directly by their ID check
 
-If an existing operational intent cannot directly be queried by its ID, the DSS implementation is in violation of
-**[astm.f3548.v21.DSS0005](../../../requirements/astm/f3548/v21.md)**.
+If an existing operational intent reference cannot directly be queried by its ID, the DSS implementation is in violation of
+**[astm.f3548.v21.DSS0005,1](../../../requirements/astm/f3548/v21.md)**.
 
-#### 🛑 Operational intents can be searched using valid credentials check
+#### 🛑 Operational intent references can be searched using valid credentials check
 
 A client with valid credentials should be allowed to search for operational intents in a given area.
-Otherwise, the DSS is not in compliance with **[astm.f3548.v21.DSS0005](../../../requirements/astm/f3548/v21.md)**.
+Otherwise, the DSS is not in compliance with **[astm.f3548.v21.DSS0005,2](../../../requirements/astm/f3548/v21.md)**.
 
-#### 🛑 Operational intents can be deleted by their owner check
+#### 🛑 Operational intent references can be deleted by their owner check
 
 If an existing operational intent cannot be deleted when providing the proper ID and OVN, the DSS implementation is in violation of
-**[astm.f3548.v21.DSS0005](../../../requirements/astm/f3548/v21.md)**.
+**[astm.f3548.v21.DSS0005,1](../../../requirements/astm/f3548/v21.md)**.
 
-### Create operational intents with different credentials test step
+### Create operational intent references with different credentials test step
 
-This test step ensures that an operation intent created with the main credentials is available for the main test case.
+This test step ensures that an operation intent reference created with the main credentials is available for the main test case.
 
-To verify that the second credentials are valid, it will also create an operational intent with those credentials.
+To verify that the second credentials are valid, it will also create an operational intent reference with those credentials.
 
 #### 🛑 Can create an operational intent with valid credentials check
 
 If the DSS does not allow the creation of operation intents when the required parameters and credentials are provided,
-it is in violation of **[astm.f3548.v21.DSS0005](../../../requirements/astm/f3548/v21.md)**.
+it is in violation of **[astm.f3548.v21.DSS0005,1](../../../requirements/astm/f3548/v21.md)**.
 
 #### 🛑 Passed sets of credentials are different check
 
 This scenario requires two sets of credentials that have a different 'sub' claim in order to validate that the
 DSS properly controls access to operational intents.
 
-## Attempt unauthorized flight intent modification test case
+## Attempt unauthorized operational intent reference modification test case
 
-This test case ensures that the DSS does not allow a caller to modify or delete operational intent that they did not create.
+This test case ensures that the DSS does not allow a caller to modify or delete operational intent references that they did not create.
 
-### Attempt unauthorized flight intent modification test step
+### Attempt unauthorized operational intent reference modification test step
 
-This test step will attempt to modify the operational intent that was created using the configured `dss` resource,
+This test step will attempt to modify the operational intent references that was created using the configured `dss` resource,
 using the credentials provided in the `second_utm_auth` resource, and expect all such attempts to fail.
 
-#### 🛑 Operational intents can be queried directly by their ID check
+#### 🛑 Operational intent references can be queried directly by their ID check
 
 If an existing operational intent cannot directly be queried by its ID, the DSS implementation is in violation of
-**[astm.f3548.v21.DSS0005](../../../requirements/astm/f3548/v21.md)**.
+**[astm.f3548.v21.DSS0005,1](../../../requirements/astm/f3548/v21.md)**.
 
 #### 🛑 Non-owning credentials cannot modify operational intent check
 
-If an operational intent can be modified by a client which did not create it, the DSS implementation is
+If an operational intent reference can be modified by a client which did not create it, the DSS implementation is
 in violation of **[astm.f3548.v21.OPIN0035](../../../requirements/astm/f3548/v21.md)**.
 
 #### 🛑 Non-owning credentials cannot delete operational intent check
 
-If an operational intent can be deleted by a client which did not create it, the DSS implementation is
+If an operational intent reference can be deleted by a client which did not create it, the DSS implementation is
 in violation of **[astm.f3548.v21.OPIN0035](../../../requirements/astm/f3548/v21.md)**.
 
 ## Cleanup
 
-### 🛑 Operational intents can be queried directly by their ID check
+### 🛑 Operational intent references can be queried directly by their ID check
 
 If an existing operational intent cannot directly be queried by its ID, the DSS implementation is in violation of
-**[astm.f3548.v21.DSS0005](../../../requirements/astm/f3548/v21.md)**.
+**[astm.f3548.v21.DSS0005,1](../../../requirements/astm/f3548/v21.md)**.
 
-### 🛑 Operational intents can be deleted by their owner check
+### 🛑 Operational intent references can be deleted by their owner check
 
 If an existing operational intent cannot be deleted when providing the proper ID and OVN, the DSS implementation is in violation of
-**[astm.f3548.v21.DSS0005](../../../requirements/astm/f3548/v21.md)**.
+**[astm.f3548.v21.DSS0005,1](../../../requirements/astm/f3548/v21.md)**.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/op_intent_ref_access_control.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/op_intent_ref_access_control.py
@@ -24,13 +24,13 @@ from monitoring.uss_qualifier.scenarios.scenario import TestScenario
 from monitoring.uss_qualifier.suites.suite import ExecutionContext
 
 
-class OpIntentAccessControl(TestScenario):
+class OpIntentReferenceAccessControl(TestScenario):
     """
     Tests that the DSS only allows a client to edit their own flight intents, but not those of another USS.
     """
 
-    OP_INTENT_1 = register_resource_type(375, "Operational Intent")
-    OP_INTENT_2 = register_resource_type(376, "Operational Intent")
+    OP_INTENT_1 = register_resource_type(375, "Operational Intent Reference")
+    OP_INTENT_2 = register_resource_type(376, "Operational Intent Reference")
 
     # The DSS under test
     _dss: DSSInstance
@@ -105,15 +105,21 @@ class OpIntentAccessControl(TestScenario):
         self._ensure_clean_workspace()
         self.end_test_step()
 
-        self.begin_test_step("Create operational intents with different credentials")
+        self.begin_test_step(
+            "Create operational intent references with different credentials"
+        )
         self._create_op_intents()
         self._ensure_credentials_are_different()
         self.end_test_step()
 
         self.end_test_case()
 
-        self.begin_test_case("Attempt unauthorized flight intent modification")
-        self.begin_test_step("Attempt unauthorized flight intent modification")
+        self.begin_test_case(
+            "Attempt unauthorized operational intent reference modification"
+        )
+        self.begin_test_step(
+            "Attempt unauthorized operational intent reference modification"
+        )
 
         self._check_mutation_on_non_owned_intent_fails()
 
@@ -126,7 +132,8 @@ class OpIntentAccessControl(TestScenario):
         (oi_ref, q) = self._dss.get_op_intent_reference(self._oid_1)
         self.record_query(q)
         with self.check(
-            "Operational intents can be queried directly by their ID", self._pid
+            "Operational intent references can be queried directly by their ID",
+            self._pid,
         ) as check:
             # If the Op Intent does not exist, it's fine to run into a 404.
             if q.response.status_code not in [200, 404]:
@@ -140,7 +147,8 @@ class OpIntentAccessControl(TestScenario):
             self.record_query(dq)
             if dq.response.status_code != 200:
                 with self.check(
-                    "Operational intents can be deleted by their owner", self._pid
+                    "Operational intent references can be deleted by their owner",
+                    self._pid,
                 ) as check:
                     check.record_failed(
                         f"Could not delete operational intent using main credentials",
@@ -151,7 +159,8 @@ class OpIntentAccessControl(TestScenario):
         (oi_ref, q) = self._dss_separate_creds.get_op_intent_reference(self._oid_2)
         self.record_query(q)
         with self.check(
-            "Operational intents can be queried directly by their ID", self._pid
+            "Operational intent references can be queried directly by their ID",
+            self._pid,
         ) as check:
             if q.response.status_code not in [200, 404]:
                 check.record_failed(
@@ -165,7 +174,7 @@ class OpIntentAccessControl(TestScenario):
             )
             self.record_query(dq)
             with self.check(
-                "Operational intents can be deleted by their owner", self._pid
+                "Operational intent references can be deleted by their owner", self._pid
             ) as check:
                 if dq.response.status_code != 200:
                     check.record_failed(
@@ -182,11 +191,12 @@ class OpIntentAccessControl(TestScenario):
         self.record_query(q)
         loguru.logger.info(f"Search query: {q.response}")
         with self.check(
-            "Operational intents can be searched using valid credentials", self._pid
+            "Operational intent references can be searched using valid credentials",
+            self._pid,
         ) as check:
             if q.response.status_code != 200:
                 check.record_failed(
-                    f"Could not search operational intents using main credentials",
+                    f"Could not search operational intent references using main credentials",
                     details=f"DSS responded with {q.response.status_code} to attempt to search OIs",
                     query_timestamps=[q.request.timestamp],
                 )
@@ -197,7 +207,8 @@ class OpIntentAccessControl(TestScenario):
                 (_, _, dq) = self._dss.delete_op_intent(op_intent.id, op_intent.ovn)
                 self.record_query(dq)
                 with self.check(
-                    "Operational intents can be deleted by their owner", self._pid
+                    "Operational intent references can be deleted by their owner",
+                    self._pid,
                 ) as check:
                     if dq.response.status_code != 200:
                         check.record_failed(
@@ -211,11 +222,12 @@ class OpIntentAccessControl(TestScenario):
         )
         self.record_query(q)
         with self.check(
-            "Operational intents can be searched using valid credentials", self._pid
+            "Operational intent references can be searched using valid credentials",
+            self._pid,
         ) as check:
             if q.response.status_code != 200:
                 check.record_failed(
-                    f"Could not search operational intents using second credentials",
+                    f"Could not search operational intent references using second credentials",
                     details=f"DSS responded with {q.response.status_code} to attempt to search OIs",
                     query_timestamps=[q.request.timestamp],
                 )
@@ -231,7 +243,8 @@ class OpIntentAccessControl(TestScenario):
                 )
                 self.record_query(dq)
                 with self.check(
-                    "Operational intents can be deleted by their owner", self._pid
+                    "Operational intent references can be deleted by their owner",
+                    self._pid,
                 ) as check:
                     if dq.response.status_code != 200:
                         check.record_failed(
@@ -362,7 +375,8 @@ class OpIntentAccessControl(TestScenario):
         self.record_query(qcheck)
 
         with self.check(
-            "Operational intents can be queried directly by their ID", self._pid
+            "Operational intent references can be queried directly by their ID",
+            self._pid,
         ) as check:
             if qcheck.response.status_code != 200:
                 check.record_failed(

--- a/monitoring/uss_qualifier/suites/astm/utm/dss_probing.md
+++ b/monitoring/uss_qualifier/suites/astm/utm/dss_probing.md
@@ -4,7 +4,7 @@
 
 ## [Actions](../../README.md#actions)
 
-1. Scenario: [ASTM F3548-21 UTM DSS Operational Intent Access Control](../../../scenarios/astm/utm/op_intent_access_control.md) ([`scenarios.astm.utm.OpIntentAccessControl`](../../../scenarios/astm/utm/op_intent_access_control.py))
+1. Scenario: [ASTM F3548-21 UTM DSS Operational Intent Reference Access Control](../../../scenarios/astm/utm/op_intent_ref_access_control.md) ([`scenarios.astm.utm.OpIntentReferenceAccessControl`](../../../scenarios/astm/utm/op_intent_ref_access_control.py))
 2. Scenario: [ASTM F3548-21 UTM DSS interoperability](../../../scenarios/astm/utm/dss_interoperability.md) ([`scenarios.astm.utm.DSSInteroperability`](../../../scenarios/astm/utm/dss_interoperability.py))
 
 ## [Checked requirements](../../README.md#checked-requirements)
@@ -17,10 +17,15 @@
     <th><a href="../../README.md#checked-in">Checked in</a></th>
   </tr>
   <tr>
-    <td rowspan="3" style="vertical-align:top;"><a href="../../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
-    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005</a></td>
+    <td rowspan="4" style="vertical-align:top;"><a href="../../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,1</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/op_intent_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Access Control</a></td>
+    <td><a href="../../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,2</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0300</a></td>
@@ -30,6 +35,6 @@
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">OPIN0035</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/op_intent_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Access Control</a></td>
+    <td><a href="../../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a></td>
   </tr>
 </table>

--- a/monitoring/uss_qualifier/suites/astm/utm/dss_probing.yaml
+++ b/monitoring/uss_qualifier/suites/astm/utm/dss_probing.yaml
@@ -7,7 +7,7 @@ resources:
   id_generator: resources.interuss.IDGeneratorResource
 actions:
   - test_scenario:
-      scenario_type: scenarios.astm.utm.OpIntentAccessControl
+      scenario_type: scenarios.astm.utm.OpIntentReferenceAccessControl
       resources:
         dss: dss
         second_utm_auth: second_utm_auth

--- a/monitoring/uss_qualifier/suites/astm/utm/f3548_21.md
+++ b/monitoring/uss_qualifier/suites/astm/utm/f3548_21.md
@@ -31,10 +31,20 @@
     <th><a href="../../README.md#checked-in">Checked in</a></th>
   </tr>
   <tr>
-    <td rowspan="26" style="vertical-align:top;"><a href="../../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
+    <td rowspan="28" style="vertical-align:top;"><a href="../../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/op_intent_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Access Control</a><br><a href="../../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,1</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,2</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0100</a></td>
@@ -84,7 +94,7 @@
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">OPIN0035</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/op_intent_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Access Control</a></td>
+    <td><a href="../../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">OPIN0040</a></td>

--- a/monitoring/uss_qualifier/suites/faa/uft/message_signing.md
+++ b/monitoring/uss_qualifier/suites/faa/uft/message_signing.md
@@ -18,10 +18,20 @@
     <th><a href="../../README.md#checked-in">Checked in</a></th>
   </tr>
   <tr>
-    <td rowspan="26" style="vertical-align:top;"><a href="../../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
+    <td rowspan="28" style="vertical-align:top;"><a href="../../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/op_intent_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Access Control</a><br><a href="../../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,1</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,2</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0100</a></td>
@@ -71,7 +81,7 @@
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">OPIN0035</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/op_intent_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Access Control</a></td>
+    <td><a href="../../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">OPIN0040</a></td>

--- a/monitoring/uss_qualifier/suites/uspace/flight_auth.md
+++ b/monitoring/uss_qualifier/suites/uspace/flight_auth.md
@@ -19,10 +19,20 @@
     <th><a href="../README.md#checked-in">Checked in</a></th>
   </tr>
   <tr>
-    <td rowspan="26" style="vertical-align:top;"><a href="../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
+    <td rowspan="28" style="vertical-align:top;"><a href="../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0005</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/op_intent_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Access Control</a><br><a href="../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3548/v21.md">DSS0005,1</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3548/v21.md">DSS0005,2</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0100</a></td>
@@ -72,7 +82,7 @@
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">OPIN0035</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/op_intent_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Access Control</a></td>
+    <td><a href="../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">OPIN0040</a></td>

--- a/monitoring/uss_qualifier/suites/uspace/required_services.md
+++ b/monitoring/uss_qualifier/suites/uspace/required_services.md
@@ -449,10 +449,20 @@
     <td><a href="../../scenarios/astm/netrid/v22a/dss/heavy_traffic_concurrent.md">ASTM NetRID DSS: Concurrent Requests</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_expiry.md">ASTM NetRID DSS: ISA Expiry</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_subscription_interactions.md">ASTM NetRID DSS: ISA Subscription Interactions</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_validation.md">ASTM NetRID DSS: Submitted ISA Validations</a><br><a href="../../scenarios/astm/netrid/v22a/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a><br><a href="../../scenarios/astm/netrid/v22a/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a><br><a href="../../scenarios/astm/netrid/v22a/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a></td>
   </tr>
   <tr>
-    <td rowspan="26" style="vertical-align:top;"><a href="../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
+    <td rowspan="28" style="vertical-align:top;"><a href="../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0005</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/op_intent_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Access Control</a><br><a href="../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3548/v21.md">DSS0005,1</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3548/v21.md">DSS0005,2</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0100</a></td>
@@ -502,7 +512,7 @@
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">OPIN0035</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/op_intent_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Access Control</a></td>
+    <td><a href="../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">OPIN0040</a></td>


### PR DESCRIPTION
This PR:

* Splits the `DSS0005` requirement into each of the 5 sub-items that it contains
  * Note that `DSS0005` can still be referenced directly, as certain checks seem very coarse grained and it is not possible to attribute them to one of the sub-items – I guess this should be improved but is not in the scope of this PR)
* Makes the documentation more precise by properly calling what we are creating on the DSS an "Operational Intent Reference" and not an "Operational Intent"