### PR TITLE
[uss_qualifier/test_data/che/conflicting_flights/flight1m_planned] Fix area override

### DIFF
--- a/monitoring/uss_qualifier/configurations/dev/library/resources.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/library/resources.yaml
@@ -134,7 +134,7 @@ che_conflicting_flights:
     file:
       path: file://./test_data/che/flight_intents/conflicting_flights.yaml
       # Note that this hash_sha512 field can be safely deleted if the content changes
-      hash_sha512: 26ee66a5065e555512f8b1e354334678dfe1614c6fbba4898a1541e6306341620e96de8b48e4095c7b03ab6fd58d0aeeee9e69cf367e1b7346e0c5f287460792
+      hash_sha512: 3bd3f48e2902b2a4daa42b4dca411a562b0e2e85b42383e9918f074e9ef2bafa81f0300159d4360c9d2e95aff3ac6db6baa9d767b97e85d16a2fc78feabb7da4
 
 che_invalid_flight_intents:
   $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json

--- a/monitoring/uss_qualifier/test_data/che/flight_intents/conflicting_flights.yaml
+++ b/monitoring/uss_qualifier/test_data/che/flight_intents/conflicting_flights.yaml
@@ -69,9 +69,8 @@ intents:
       mutation:
         basic_information:
           area:
-            - outline_polygon:
-                altitude_lower:
-                  value: 575.03
+            - altitude_lower:
+                value: 575.03
 
   flight1c_planned:
     delta:


### PR DESCRIPTION
I believe that this led to `flight1m_planned` to be wrong, i.e. the `altitude_lower` would not be overridden. Somehow it does not look like it had an impact on the CI though.