### PR TITLE
[uss_qualifier] Do not upgrade Low severity failures to Critical

### DIFF
--- a/monitoring/uss_qualifier/scenarios/scenario.py
+++ b/monitoring/uss_qualifier/scenarios/scenario.py
@@ -110,6 +110,7 @@ class PendingCheck(object):
         if (
             self._stop_fast
             and severity != Severity.Critical
+            and severity != Severity.Low
             and self._phase != ScenarioPhase.CleaningUp
         ):
             note = f"Severity {severity} upgraded to Critical because `stop_fast` flag set true in configuration"


### PR DESCRIPTION
This fixes #408 if what I wrote in https://github.com/interuss/monitoring/issues/408#issuecomment-1857588431 is acceptable.