### PR TITLE
[uss_qualifier/flight_planning/submit_flight_intent] Factor out test step boundaries and specific failed checks

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/utm/flight_intent_validation/flight_intent_validation.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/flight_intent_validation/flight_intent_validation.py
@@ -168,15 +168,17 @@ class FlightIntentValidation(TestScenario):
             "Validate flight intent too far ahead of time not planned",
             self._intents_extent,
         ) as validator:
+            self.begin_test_step("Attempt to plan flight intent too far ahead of time")
             submit_flight_intent(
                 self,
-                "Attempt to plan flight intent too far ahead of time",
                 "Incorrectly planned",
                 {InjectFlightResponseResult.Rejected},
                 {InjectFlightResponseResult.Failed: "Failure"},
                 self.tested_uss,
                 self.invalid_too_far_away.request,
             )
+            self.end_test_step()
+
             validator.expect_not_shared()
 
     def _validate_ended_cancellation(self):
@@ -222,9 +224,9 @@ class FlightIntentValidation(TestScenario):
             "Validate conflicting flight not planned",
             self._intents_extent,
         ) as validator:
+            self.begin_test_step("Attempt to plan flight conflicting by a tiny overlap")
             submit_flight_intent(
                 self,
-                "Attempt to plan flight conflicting by a tiny overlap",
                 "Incorrectly planned",
                 {
                     InjectFlightResponseResult.ConflictWithFlight,
@@ -234,6 +236,8 @@ class FlightIntentValidation(TestScenario):
                 self.tested_uss,
                 self.valid_conflict_tiny_overlap.request,
             )
+            self.end_test_step()
+
             validator.expect_not_shared()
 
     def cleanup(self):

--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.py
@@ -402,9 +402,9 @@ class ConflictEqualPriorityNotPermitted(TestScenario):
             self._intents_extent,
             flight_2_oi_ref,
         ) as validator:
+            self.begin_test_step("Declare Flight 2 non-conforming")
             resp_flight_2, _ = submit_flight_intent(
                 self,
-                "Declare Flight 2 non-conforming",
                 "Successful transition to non-conforming state",
                 {
                     InjectFlightResponseResult.ReadyToFly,
@@ -415,6 +415,8 @@ class ConflictEqualPriorityNotPermitted(TestScenario):
                 self.flight2_nonconforming.request,
                 self.flight2_id,
             )
+            self.end_test_step()
+
             if resp_flight_2.result == InjectFlightResponseResult.NotSupported:
                 msg = f"{self.control_uss.config.participant_id} does not support the transition to a Nonconforming state; execution of the scenario was stopped without failure"
                 self.record_note("Control USS does not support CMSA role", msg)
@@ -430,9 +432,11 @@ class ConflictEqualPriorityNotPermitted(TestScenario):
             self._intents_extent,
             flight_1_oi_ref,
         ) as validator:
+            self.begin_test_step(
+                "Attempt to modify activated Flight 1 in conflict with nonconforming Flight 2"
+            )
             resp_flight_1, _ = submit_flight_intent(
                 self,
-                "Attempt to modify activated Flight 1 in conflict with nonconforming Flight 2",
                 "Successful modification or rejection",
                 {
                     InjectFlightResponseResult.ReadyToFly,
@@ -443,6 +447,7 @@ class ConflictEqualPriorityNotPermitted(TestScenario):
                 self.flight1m_activated.request,
                 self.flight1_id,
             )
+            self.end_test_step()
 
             if resp_flight_1.result == InjectFlightResponseResult.ReadyToFly:
                 validator.expect_shared(self.flight1m_activated.request)

--- a/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.py
@@ -102,9 +102,9 @@ class DownUSSEqualPriorityNotPermitted(DownUSS):
             "Validate high-priority Flight 2 not shared",
             self._intents_extent,
         ) as validator:
+            self.begin_test_step("Tested USS attempts to plan high-priority Flight 2")
             submit_flight_intent(
                 self,
-                "Tested USS attempts to plan high-priority Flight 2",
                 "Incorrectly planned",
                 {
                     InjectFlightResponseResult.Rejected,
@@ -116,6 +116,8 @@ class DownUSSEqualPriorityNotPermitted(DownUSS):
                 self.tested_uss,
                 self.flight2_planned.request,
             )
+            self.end_test_step()
+
             validator.expect_not_shared()
 
         # Restore virtual USS availability at DSS test step
@@ -150,9 +152,9 @@ class DownUSSEqualPriorityNotPermitted(DownUSS):
             "Validate high-priority Flight 2 not shared",
             self._intents_extent,
         ) as validator:
+            self.begin_test_step("Tested USS attempts to plan high-priority Flight 2")
             submit_flight_intent(
                 self,
-                "Tested USS attempts to plan high-priority Flight 2",
                 "Incorrectly planned",
                 {
                     InjectFlightResponseResult.Rejected,
@@ -164,6 +166,8 @@ class DownUSSEqualPriorityNotPermitted(DownUSS):
                 self.tested_uss,
                 self.flight2_planned.request,
             )
+            self.end_test_step()
+
             validator.expect_not_shared()
 
         # Restore virtual USS availability at DSS test step
@@ -196,9 +200,9 @@ class DownUSSEqualPriorityNotPermitted(DownUSS):
             "Validate high-priority Flight 2 not shared",
             self._intents_extent,
         ) as validator:
+            self.begin_test_step("Tested USS attempts to plan high-priority Flight 2")
             submit_flight_intent(
                 self,
-                "Tested USS attempts to plan high-priority Flight 2",
                 "Incorrectly planned",
                 {
                     InjectFlightResponseResult.Rejected,
@@ -210,4 +214,6 @@ class DownUSSEqualPriorityNotPermitted(DownUSS):
                 self.tested_uss,
                 self.flight2_planned.request,
             )
+            self.end_test_step()
+
             validator.expect_not_shared()

--- a/monitoring/uss_qualifier/scenarios/flight_planning/prioritization_test_steps.py
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/prioritization_test_steps.py
@@ -34,9 +34,9 @@ def plan_priority_conflict_flight_intent(
         flight_intent, OperationalIntentState.Accepted, scenario, test_step
     )
 
-    return submit_flight_intent(
+    scenario.begin_test_step(test_step)
+    resp, _ = submit_flight_intent(
         scenario,
-        test_step,
         "Incorrectly planned",
         {
             InjectFlightResponseResult.ConflictWithFlight,
@@ -45,7 +45,10 @@ def plan_priority_conflict_flight_intent(
         {InjectFlightResponseResult.Failed: "Failure"},
         flight_planner,
         flight_intent,
-    )[0]
+    )
+
+    scenario.end_test_step()
+    return resp
 
 
 def modify_planned_priority_conflict_flight_intent(
@@ -66,9 +69,9 @@ def modify_planned_priority_conflict_flight_intent(
         flight_intent, OperationalIntentState.Accepted, scenario, test_step
     )
 
-    return submit_flight_intent(
+    scenario.begin_test_step(test_step)
+    resp, _ = submit_flight_intent(
         scenario,
-        test_step,
         "Incorrectly modified",
         {
             InjectFlightResponseResult.ConflictWithFlight,
@@ -78,7 +81,10 @@ def modify_planned_priority_conflict_flight_intent(
         flight_planner,
         flight_intent,
         flight_id,
-    )[0]
+    )
+
+    scenario.end_test_step()
+    return resp
 
 
 def activate_priority_conflict_flight_intent(
@@ -99,9 +105,9 @@ def activate_priority_conflict_flight_intent(
         flight_intent, OperationalIntentState.Activated, scenario, test_step
     )
 
-    return submit_flight_intent(
+    scenario.begin_test_step(test_step)
+    resp, _ = submit_flight_intent(
         scenario,
-        test_step,
         "Incorrectly activated",
         {
             InjectFlightResponseResult.ConflictWithFlight,
@@ -111,7 +117,10 @@ def activate_priority_conflict_flight_intent(
         flight_planner,
         flight_intent,
         flight_id,
-    )[0]
+    )
+
+    scenario.end_test_step()
+    return resp
 
 
 def modify_activated_priority_conflict_flight_intent(
@@ -132,9 +141,9 @@ def modify_activated_priority_conflict_flight_intent(
         flight_intent, OperationalIntentState.Activated, scenario, test_step
     )
 
-    return submit_flight_intent(
+    scenario.begin_test_step(test_step)
+    resp, _ = submit_flight_intent(
         scenario,
-        test_step,
         "Incorrectly modified",
         {
             InjectFlightResponseResult.ConflictWithFlight,
@@ -144,7 +153,10 @@ def modify_activated_priority_conflict_flight_intent(
         flight_planner,
         flight_intent,
         flight_id,
-    )[0]
+    )
+
+    scenario.end_test_step()
+    return resp
 
 
 def plan_conflict_flight_intent(
@@ -164,9 +176,9 @@ def plan_conflict_flight_intent(
         flight_intent, OperationalIntentState.Accepted, scenario, test_step
     )
 
-    return submit_flight_intent(
+    scenario.begin_test_step(test_step)
+    resp, _ = submit_flight_intent(
         scenario,
-        test_step,
         "Incorrectly planned",
         {
             InjectFlightResponseResult.ConflictWithFlight,
@@ -175,7 +187,10 @@ def plan_conflict_flight_intent(
         {InjectFlightResponseResult.Failed: "Failure"},
         flight_planner,
         flight_intent,
-    )[0]
+    )
+
+    scenario.end_test_step()
+    return resp
 
 
 def modify_planned_conflict_flight_intent(
@@ -196,9 +211,9 @@ def modify_planned_conflict_flight_intent(
         flight_intent, OperationalIntentState.Accepted, scenario, test_step
     )
 
-    return submit_flight_intent(
+    scenario.begin_test_step(test_step)
+    resp, _ = submit_flight_intent(
         scenario,
-        test_step,
         "Incorrectly modified",
         {
             InjectFlightResponseResult.ConflictWithFlight,
@@ -208,7 +223,10 @@ def modify_planned_conflict_flight_intent(
         flight_planner,
         flight_intent,
         flight_id,
-    )[0]
+    )
+
+    scenario.end_test_step()
+    return resp
 
 
 def activate_conflict_flight_intent(
@@ -229,9 +247,9 @@ def activate_conflict_flight_intent(
         flight_intent, OperationalIntentState.Activated, scenario, test_step
     )
 
-    return submit_flight_intent(
+    scenario.begin_test_step(test_step)
+    resp, _ = submit_flight_intent(
         scenario,
-        test_step,
         "Incorrectly activated",
         {
             InjectFlightResponseResult.ConflictWithFlight,
@@ -241,7 +259,10 @@ def activate_conflict_flight_intent(
         flight_planner,
         flight_intent,
         flight_id,
-    )[0]
+    )
+
+    scenario.end_test_step()
+    return resp
 
 
 def modify_activated_conflict_flight_intent(
@@ -262,9 +283,9 @@ def modify_activated_conflict_flight_intent(
         flight_intent, OperationalIntentState.Activated, scenario, test_step
     )
 
-    return submit_flight_intent(
+    scenario.begin_test_step(test_step)
+    resp, _ = submit_flight_intent(
         scenario,
-        test_step,
         "Incorrectly modified",
         {
             InjectFlightResponseResult.ConflictWithFlight,
@@ -274,7 +295,10 @@ def modify_activated_conflict_flight_intent(
         flight_planner,
         flight_intent,
         flight_id,
-    )[0]
+    )
+
+    scenario.end_test_step()
+    return resp
 
 
 def plan_permitted_conflict_flight_intent(
@@ -296,15 +320,18 @@ def plan_permitted_conflict_flight_intent(
         flight_intent, OperationalIntentState.Accepted, scenario, test_step
     )
 
-    return submit_flight_intent(
+    scenario.begin_test_step(test_step)
+    resp, flight_id = submit_flight_intent(
         scenario,
-        test_step,
         "Successful planning",
         {InjectFlightResponseResult.Planned},
         {InjectFlightResponseResult.Failed: "Failure"},
         flight_planner,
         flight_intent,
     )
+
+    scenario.end_test_step()
+    return resp, flight_id
 
 
 def modify_planned_permitted_conflict_flight_intent(
@@ -325,16 +352,19 @@ def modify_planned_permitted_conflict_flight_intent(
         flight_intent, OperationalIntentState.Accepted, scenario, test_step
     )
 
-    return submit_flight_intent(
+    scenario.begin_test_step(test_step)
+    resp, _ = submit_flight_intent(
         scenario,
-        test_step,
         "Successful modification",
         {InjectFlightResponseResult.Planned},
         {InjectFlightResponseResult.Failed: "Failure"},
         flight_planner,
         flight_intent,
         flight_id,
-    )[0]
+    )
+
+    scenario.end_test_step()
+    return resp
 
 
 def activate_permitted_conflict_flight_intent(
@@ -355,16 +385,19 @@ def activate_permitted_conflict_flight_intent(
         flight_intent, OperationalIntentState.Activated, scenario, test_step
     )
 
-    return submit_flight_intent(
+    scenario.begin_test_step(test_step)
+    resp, _ = submit_flight_intent(
         scenario,
-        test_step,
         "Successful activation",
         {InjectFlightResponseResult.ReadyToFly},
         {InjectFlightResponseResult.Failed: "Failure"},
         flight_planner,
         flight_intent,
         flight_id,
-    )[0]
+    )
+
+    scenario.end_test_step()
+    return resp
 
 
 def modify_activated_permitted_conflict_flight_intent(
@@ -385,13 +418,16 @@ def modify_activated_permitted_conflict_flight_intent(
         flight_intent, OperationalIntentState.Activated, scenario, test_step
     )
 
-    return submit_flight_intent(
+    scenario.begin_test_step(test_step)
+    resp, _ = submit_flight_intent(
         scenario,
-        test_step,
         "Successful modification",
         {InjectFlightResponseResult.ReadyToFly},
         {InjectFlightResponseResult.Failed: "Failure"},
         flight_planner,
         flight_intent,
         flight_id,
-    )[0]
+    )
+
+    scenario.end_test_step()
+    return resp


### PR DESCRIPTION
The objective is to display more appropriate/specific summary and details when failing a check with a low severity.
Additionally fix a tiny bug in `expect_flight_intent_state`.

This PR might be enough to address #398.