### PR TITLE
[uss_qualifier] Remove lingering participants= in record_failed

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/aggregate_checks.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/aggregate_checks.py
@@ -188,7 +188,6 @@ class AggregateChecks(GenericTestScenario):
                         summary=f"found {len(cleartext_queries)} cleartext http queries",
                         details=f"unique cleartext urls: {urls}",
                         severity=Severity.Medium,
-                        participants=[participant_id],
                         query_timestamps=timestamps,
                     )
         else:
@@ -233,14 +232,12 @@ class AggregateChecks(GenericTestScenario):
                     check.record_failed(
                         summary=f"95th percentile of durations for DP display_data details queries is higher than threshold",
                         severity=Severity.Medium,
-                        participants=[participant],
                         details=f"threshold: {self._rid_version.dp_details_resp_percentile95_s}s, 95th percentile: {p95}s",
                     )
                 if p99 > self._rid_version.dp_details_resp_percentile99_s:
                     check.record_failed(
                         summary=f"99th percentile of durations for DP display_data details queries is higher than threshold",
                         severity=Severity.Medium,
-                        participants=[participant],
                         details=f"threshold: {self._rid_version.dp_details_resp_percentile99_s}s, 99th percentile: {p99}s",
                     )
 
@@ -279,7 +276,6 @@ class AggregateChecks(GenericTestScenario):
                     check.record_failed(
                         summary=f"95th percentile of /flights?view requests is {p95} s",
                         severity=Severity.Medium,
-                        participants=[participant],
                         details=f"expected less than {self._rid_version.sp_data_resp_percentile95_s} s, was {p95}",
                     )
             with self.check("99th percentile response time", [participant]) as check:
@@ -287,7 +283,6 @@ class AggregateChecks(GenericTestScenario):
                     check.record_failed(
                         summary=f"99th percentile of /flights?view requests is {p99} s",
                         severity=Severity.Medium,
-                        participants=[participant],
                         details=f"expected less than {self._rid_version.sp_data_resp_percentile99_s} s, was {p99}",
                     )
 
@@ -339,14 +334,12 @@ class AggregateChecks(GenericTestScenario):
                     check.record_failed(
                         summary=f"95th percentile of durations for initial DP display_data queries is higher than threshold",
                         severity=Severity.Medium,
-                        participants=[participant],
                         details=f"threshold: {self._rid_version.dp_init_resp_percentile95_s}, 95th percentile: {init_95th}",
                     )
                 if init_99th > self._rid_version.dp_init_resp_percentile99_s:
                     check.record_failed(
                         summary=f"99th percentile of durations for initial DP display_data queries is higher than threshold",
                         severity=Severity.Medium,
-                        participants=[participant],
                         details=f"threshold: {self._rid_version.dp_init_resp_percentile99_s}, 99th percentile: {init_99th}",
                     )
 
@@ -357,14 +350,12 @@ class AggregateChecks(GenericTestScenario):
                     check.record_failed(
                         summary=f"95th percentile of durations for subsequent DP display_data queries is higher than threshold",
                         severity=Severity.Medium,
-                        participants=[participant],
                         details=f"threshold: {self._rid_version.dp_data_resp_percentile95_s}, 95th percentile: {subsequent_95th}",
                     )
                 if subsequent_99th > self._rid_version.dp_data_resp_percentile99_s:
                     check.record_failed(
                         summary=f"99th percentile of durations for subsequent DP display_data queries is higher than threshold",
                         severity=Severity.Medium,
-                        participants=[participant],
                         details=f"threshold: {self._rid_version.dp_data_resp_percentile99_s}, 95th percentile: {subsequent_99th}",
                     )
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/isa_expiry.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/isa_expiry.py
@@ -98,7 +98,6 @@ class ISAExpiry(GenericTestScenario):
                 check.record_failed(
                     summary=f"Expired ISA {self._isa_id} found in search results",
                     severity=Severity.Medium,
-                    participants=[self._dss.participant_id],
                     details=f"Searched for area {self._isa_area} with unspecified end and start time.",
                     query_timestamps=[
                         created_isa.dss_query.query.request.timestamp,

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/isa_subscription_interactions.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/isa_subscription_interactions.py
@@ -136,7 +136,6 @@ class ISASubscriptionInteractions(GenericTestScenario):
                 check.record_failed(
                     summary="Subscription response does not include the freshly created ISA",
                     severity=Severity.High,
-                    participants=[self._dss.participant_id],
                     details=f"The subscription created for the area {self._isa_area} is expected to contain the ISA created for this same area. The returned subscription did not mention it.",
                     query_timestamps=[
                         created_isa.dss_query.query.request.timestamp,
@@ -152,7 +151,6 @@ class ISASubscriptionInteractions(GenericTestScenario):
                 check.record_failed(
                     summary="Subscription notification_index is not 0",
                     severity=Severity.High,
-                    participants=[self._dss.participant_id],
                     details=f"The subscription created for the area {self._isa_area} is expected to have a notification_index of 0. The returned subscription has a notification_index of {created_subscription.subscription.notification_index}.",
                     query_timestamps=[created_subscription.query.request.timestamp],
                 )
@@ -188,7 +186,6 @@ class ISASubscriptionInteractions(GenericTestScenario):
                 check.record_failed(
                     summary="ISA mutation response does not contain expected subscription ID",
                     severity=Severity.High,
-                    participants=[self._dss.participant_id],
                     details="Mutating an ISA to which a subscription was made, the DSS failed to return the subscription ID in the response.",
                     query_timestamps=[
                         created_isa.dss_query.query.request.timestamp,
@@ -210,7 +207,6 @@ class ISASubscriptionInteractions(GenericTestScenario):
                     check.record_failed(
                         summary="Subscription notification_index has not been increased",
                         severity=Severity.High,
-                        participants=[self._dss.participant_id],
                         details=f"The subscription created for the area {self._isa_area} is expected to have a notification_index of 1 or more. The returned subscription has a notification_index of {subs_to_mutated_isa[created_subscription.subscription.id].notification_index}.",
                         query_timestamps=[created_subscription.query.request.timestamp],
                     )
@@ -244,7 +240,6 @@ class ISASubscriptionInteractions(GenericTestScenario):
                 check.record_failed(
                     summary="ISA deletion response does not contain expected subscription ID",
                     severity=Severity.High,
-                    participants=[self._dss.participant_id],
                     details="Deleting an ISA to which a subscription was made, the DSS failed to return the subscription ID in the response.",
                     query_timestamps=[
                         created_isa.dss_query.query.request.timestamp,
@@ -285,7 +280,6 @@ class ISASubscriptionInteractions(GenericTestScenario):
                     check.record_failed(
                         summary="Subscription notification_index has not been incremented",
                         severity=Severity.High,
-                        participants=[self._dss.participant_id],
                         details=f"The subscription created for the area {self._isa_area} is expected to have its notification increased after the subscription was deleted."
                         f"The returned subscription has a notification_index of {subs_after_deletion.notification_index}, whilte the previous notification_index for that subscription was {sub_to_mutated_isa.notification_index}",
                         query_timestamps=[created_subscription.query.request.timestamp],
@@ -353,7 +347,6 @@ class ISASubscriptionInteractions(GenericTestScenario):
                 check.record_failed(
                     summary="Subscription response does not include the freshly created ISA",
                     severity=Severity.High,
-                    participants=[self._dss.participant_id],
                     details=f"The subscription created for the area {self._isa_area} is expected to contain the ISA created for this same area. The returned subscription did not mention it.",
                     query_timestamps=[
                         created_isa.dss_query.query.request.timestamp,
@@ -369,7 +362,6 @@ class ISASubscriptionInteractions(GenericTestScenario):
                 check.record_failed(
                     summary="Subscription notification_index is not 0",
                     severity=Severity.High,
-                    participants=[self._dss.participant_id],
                     details=f"The subscription created for the area {self._isa_area} is expected to have a notification_index of 0. The returned subscription has a notification_index of {created_subscription.subscription.notification_index}.",
                     query_timestamps=[created_subscription.query.request.timestamp],
                 )
@@ -405,7 +397,6 @@ class ISASubscriptionInteractions(GenericTestScenario):
                 check.record_failed(
                     summary="ISA mutation response does not contain expected subscription ID",
                     severity=Severity.High,
-                    participants=[self._dss.participant_id],
                     details="Mutating an ISA to which a subscription was made and then subsequently moved to the ISA's boundary,"
                     " the DSS failed to return the subscription ID in the response.",
                     query_timestamps=[
@@ -429,7 +420,6 @@ class ISASubscriptionInteractions(GenericTestScenario):
                     check.record_failed(
                         summary="Subscription notification_index has not been increased",
                         severity=Severity.High,
-                        participants=[self._dss.participant_id],
                         details=f"The subscription created for the area {self._isa_area} is expected to have a notification_index of 1 or more. The returned subscription has a notification_index of {subs_to_mutated_isa[created_subscription.subscription.id].notification_index}.",
                         query_timestamps=[created_subscription.query.request.timestamp],
                     )
@@ -463,7 +453,6 @@ class ISASubscriptionInteractions(GenericTestScenario):
                 check.record_failed(
                     summary="ISA deletion response does not contain expected subscription ID",
                     severity=Severity.High,
-                    participants=[self._dss.participant_id],
                     details="Deleting an ISA to which a subscription was made, the DSS failed to return the subscription ID in the response.",
                     query_timestamps=[
                         created_isa.dss_query.query.request.timestamp,
@@ -504,7 +493,6 @@ class ISASubscriptionInteractions(GenericTestScenario):
                     check.record_failed(
                         summary="Subscription notification_index has not been incremented",
                         severity=Severity.High,
-                        participants=[self._dss.participant_id],
                         details=f"The subscription created for the area {self._isa_area} is expected to have its notification increased after the subscription was deleted."
                         f"The returned subscription has a notification_index of {subs_after_deletion.notification_index}, whilte the previous notification_index for that subscription was {sub_to_mutated_isa.notification_index}",
                         query_timestamps=[created_subscription.query.request.timestamp],

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss_interoperability.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss_interoperability.py
@@ -130,7 +130,6 @@ class DSSInteroperability(GenericTestScenario):
                     check.record_failed(
                         summary=f"DSS host {parsed_url.netloc} is not publicly addressable",
                         severity=Severity.Medium,
-                        participants=[dss.participant_id],
                         details=f"DSS (URL: {dss.base_url}, netloc: {parsed_url.netloc}, resolved IP: {ip_addr}) is not publicly addressable",
                     )
 
@@ -184,7 +183,6 @@ class DSSInteroperability(GenericTestScenario):
                     check.record_failed(
                         summary=f"DSS did not return ISA {isa_1.uuid} from testStep1 when creating Subscription {sub_1.uuid}",
                         severity=Severity.High,
-                        participants=[dss.participant_id],
                         details=f"service_areas IDs: {', '.join([isa.id for isa in created_sub.isas])}",
                         query_timestamps=[created_sub.query.request.timestamp],
                     )
@@ -206,7 +204,6 @@ class DSSInteroperability(GenericTestScenario):
                     summary=f"ISA[{dss.participant_id}].{field_name} not equal ISA[{self._dss_primary.participant_id}].{field_name}",
                     details=f"ISA[{dss.participant_id}].{field_name} is {primary_isa_field_value}; ISA[{self._dss_primary.participant_id}].{field_name} is {other_isa_field_value}",
                     severity=Severity.High,
-                    participants=[dss.participant_id],
                     query_timestamps=[created_sub.query.request.timestamp],
                 )
 
@@ -304,7 +301,6 @@ class DSSInteroperability(GenericTestScenario):
                     summary=f"Subscription[{dss.participant_id}].{field_name} not equal Subscription[{self._dss_primary.participant_id}].{field_name}",
                     details=f"Subscription[{dss.participant_id}].{field_name} is {primary_sub_field_value}; Subscription[{self._dss_primary.participant_id}].{field_name} is {other_sub_field_value}",
                     severity=Severity.High,
-                    participants=[dss.participant_id],
                     query_timestamps=[other_sub.query.request.timestamp],
                 )
 
@@ -417,7 +413,6 @@ class DSSInteroperability(GenericTestScenario):
                     check.record_failed(
                         summary=f"DSS returned too few subscriptions",
                         severity=Severity.High,
-                        participants=[dss.participant_id],
                         details=f"Missing: {', '.join(missing_subs)}",
                         query_timestamps=[subs.query.request.timestamp],
                     )
@@ -496,7 +491,6 @@ class DSSInteroperability(GenericTestScenario):
                     check.record_failed(
                         summary="Found deleted Subscriptions",
                         severity=Severity.High,
-                        participants=[dss.participant_id],
                         details=f"Deleted Subscriptions found: {found_deleted_sub}",
                         query_timestamps=[subs.query.request.timestamp],
                     )
@@ -532,7 +526,6 @@ class DSSInteroperability(GenericTestScenario):
                     check.record_failed(
                         summary=f"DSS returned expired ISA {isa_1.uuid} when creating Subscription {sub_2.uuid}",
                         severity=Severity.High,
-                        participants=[dss.participant_id],
                         details=f"service_areas IDs: {', '.join(isa_ids)}",
                         query_timestamps=[created_sub.query.request.timestamp],
                     )
@@ -563,7 +556,6 @@ class DSSInteroperability(GenericTestScenario):
                 check.record_failed(
                     summary=f"DSS returned too few Subscriptions",
                     severity=Severity.High,
-                    participants=[self._dss_primary.participant_id],
                     details=f"Missing Subscriptions: {', '.join(missing_subs)}",
                     query_timestamps=[mutated_isa.dss_query.query.request.timestamp],
                 )
@@ -591,7 +583,6 @@ class DSSInteroperability(GenericTestScenario):
                 check.record_failed(
                     summary=f"DSS returned too few Subscriptions",
                     severity=Severity.High,
-                    participants=[self._dss_primary.participant_id],
                     details=f"Missing Subscriptions: {', '.join(missing_subs)}",
                     query_timestamps=[del_isa.dss_query.query.request.timestamp],
                 )
@@ -628,7 +619,6 @@ class DSSInteroperability(GenericTestScenario):
                 check.record_failed(
                     summary="Found expired Subscriptions",
                     severity=Severity.High,
-                    participants=[self._dss_primary.participant_id],
                     details=f"Expired Subscriptions found: {', '.join(found_expired_sub)}",
                     query_timestamps=[mutated_isa.dss_query.query.request.timestamp],
                 )
@@ -658,7 +648,6 @@ class DSSInteroperability(GenericTestScenario):
                     check.record_failed(
                         summary="Found expired Subscriptions",
                         severity=Severity.High,
-                        participants=[dss.participant_id],
                         details=f"Expired Subscriptions found: {', '.join(found_expired_sub)}",
                         query_timestamps=[subs.query.request.timestamp],
                     )
@@ -702,7 +691,6 @@ class DSSInteroperability(GenericTestScenario):
                 check.record_failed(
                     summary="Found expired Subscriptions",
                     severity=Severity.High,
-                    participants=[self._dss_primary.participant_id],
                     details=f"Expired Subscriptions found: {', '.join(found_expired_sub)}",
                     query_timestamps=[del_isa.dss_query.query.request.timestamp],
                 )
@@ -734,7 +722,6 @@ class DSSInteroperability(GenericTestScenario):
                     check.record_failed(
                         summary=f"DSS returned expired ISA {isa_3.uuid} when creating Subscription {sub_3.uuid}",
                         severity=Severity.High,
-                        participants=[dss.participant_id],
                         details=f"service_areas IDs: {', '.join(isa_ids)}",
                         query_timestamps=[created_sub.query.request.timestamp],
                     )

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/misbehavior.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/misbehavior.py
@@ -184,14 +184,12 @@ class Misbehavior(GenericTestScenario):
                 if uss_flights_query.success:
                     check.record_failed(
                         "Unauthenticated request for flights to USS was fulfilled",
-                        participants=[participant_id],
                         severity=Severity.Medium,
                         details=f"Queried flights on {flights_url} for USS {participant_id} with no credentials, expected a failure but got a success reply.",
                     )
                 elif uss_flights_query.status_code != 401:
                     check.record_failed(
                         "Unauthenticated request for flights failed with wrong HTTP code",
-                        participants=[participant_id],
                         severity=Severity.Medium,
                         details=f"Queried flights on {flights_url} for USS {participant_id} with no credentials, expected an HTTP 401 but got an HTTP {uss_flights_query.status_code}.",
                     )
@@ -211,14 +209,12 @@ class Misbehavior(GenericTestScenario):
                     if uss_flight_details_query.success:
                         check.record_failed(
                             "Unauthenticated request for flight details to USS was fulfilled",
-                            participants=[participant_id],
                             severity=Severity.Medium,
                             details=f"Queried flight details on {flights_url} for USS {participant_id} for flight {flight.id} with no credentials, expected a failure but got a success reply.",
                         )
                     elif uss_flight_details_query.status_code != 401:
                         check.record_failed(
                             "Unauthenticated request for flight details failed with wrong HTTP code",
-                            participants=[participant_id],
                             severity=Severity.Medium,
                             details=f"Queried flight details on {flights_url} for USS {participant_id} for flight {flight.id} with no credentials, expected an HTTP 401 but got an HTTP {uss_flight_details_query.status_code}.",
                         )

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/display_data_evaluator.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/display_data_evaluator.py
@@ -820,7 +820,6 @@ class RIDObservationEvaluator(object):
                     summary="Could not query ISAs from DSS",
                     severity=Severity.Medium,
                     details=f"Query to {self._dss.participant_id}'s DSS at {sp_observation.dss_isa_query.query.request.url} failed {sp_observation.dss_isa_query.query.status_code}",
-                    participants=[self._dss.participant_id],
                     query_timestamps=[
                         sp_observation.dss_isa_query.query.request.initiated_at.datetime
                     ],
@@ -936,7 +935,6 @@ class RIDObservationEvaluator(object):
                         summary="Flight details query not successful",
                         severity=Severity.Medium,
                         details=f"Flight details query to {details_query.query.request.url} failed {details_query.status_code}",
-                        participants=[mapping.injected_flight.uss_participant_id],
                         query_timestamps=[details_query.query.request.timestamp],
                     )
             errors = schema_validation.validate(

--- a/monitoring/uss_qualifier/scenarios/astm/utm/aggregate_checks.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/aggregate_checks.py
@@ -114,7 +114,6 @@ class AggregateChecks(TestScenario):
                 if p95 > constants.MaxRespondToOIDetailsRequestSeconds:
                     check.record_failed(
                         summary=f"95th percentile of durations for operational intent details requests to USS is higher than threshold",
-                        participants=[participant],
                         details=f"threshold: {constants.MaxRespondToOIDetailsRequestSeconds}s, 95th percentile: {p95}s",
                     )
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss_interoperability.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss_interoperability.py
@@ -69,7 +69,6 @@ class DSSInteroperability(TestScenario):
                 elif ipaddress.ip_address(ip_addr).is_private:
                     check.record_failed(
                         summary=f"DSS host {parsed_url.netloc} is not publicly addressable",
-                        participants=[dss.participant_id],
                         details=f"DSS (URL: {dss.base_url}, netloc: {parsed_url.netloc}, resolved IP: {ip_addr}) is not publicly addressable",
                     )
 


### PR DESCRIPTION
#403 removed the complexity of allowing `record_failed` invocations to override the participants specified when initiating the `check`.  However, the method I used to try and find all the existing `record_failed` invocations that specified `participants=` was not effective as I missed many places.  This has caused a failure in [CI for an open PR](https://github.com/interuss/monitoring/actions/runs/7228920476/job/19699095241?pr=376), making it more difficult to identify the root cause of that failure.  This PR attempts to clean up the remaining locations.

I identified the locations in this PR by searching all files for instances of `participants=` and manually evaluating each instance before removing it.  I attempted to remove an instance of `participants=` specification only if 1) it was part of a `record_failed` invocation and 2) this argument was redundant with/identical to the participants specified when the `check` was initiated.  (side note: we had a lot of redundancy!)  I did not find any instances of `record_failed` where `participants` was overridden with a different or new value from when the `check` was initiated.

I also searched for instances of `requirements=` that may have been missed in a similar way, but I did not find any.

I did not perform a manual search of the 264 instances of `record_failed` we have in the codebase to identify any invocations that might have passed `participants` positionally rather than by keyword, but I intend to keep an eye out when we remove specification of `severity` from these invocations per #404.