### PR TITLE
[uss_qualifier] Remove begin and end test step from reusable functions in test_steps

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss.py
@@ -144,9 +144,9 @@ class DownUSS(TestScenario):
         )
         self.end_test_step()
 
-        set_uss_available(
-            self, "Restore virtual USS availability", self.dss, self.uss_qualifier_sub
-        )
+        self.begin_test_step("Restore virtual USS availability")
+        set_uss_available(self, self.dss, self.uss_qualifier_sub)
+        self.end_test_step()
 
         self.begin_test_step("Clear operational intents created by virtual USS")
         self._clear_op_intents()
@@ -216,9 +216,9 @@ class DownUSS(TestScenario):
         )
 
         # Declare virtual USS as down at DSS test step
-        set_uss_down(
-            self, "Declare virtual USS as down at DSS", self.dss, self.uss_qualifier_sub
-        )
+        self.begin_test_step("Declare virtual USS as down at DSS")
+        set_uss_down(self, self.dss, self.uss_qualifier_sub)
+        self.end_test_step()
 
         # Tested USS attempts to plan Flight 1 test step
         with OpIntentValidator(

--- a/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.py
@@ -90,9 +90,9 @@ class DownUSSEqualPriorityNotPermitted(DownUSS):
         )
 
         # Declare virtual USS as down at DSS test step
-        set_uss_down(
-            self, "Declare virtual USS as down at DSS", self.dss, self.uss_qualifier_sub
-        )
+        self.begin_test_step("Declare virtual USS as down at DSS")
+        set_uss_down(self, self.dss, self.uss_qualifier_sub)
+        self.end_test_step()
 
         # Tested USS attempts to plan high-priority flight 2 test step
         with OpIntentValidator(
@@ -121,12 +121,9 @@ class DownUSSEqualPriorityNotPermitted(DownUSS):
             validator.expect_not_shared()
 
         # Restore virtual USS availability at DSS test step
-        set_uss_available(
-            self,
-            "Restore virtual USS availability at DSS",
-            self.dss,
-            self.uss_qualifier_sub,
-        )
+        self.begin_test_step("Restore virtual USS availability at DSS")
+        set_uss_available(self, self.dss, self.uss_qualifier_sub)
+        self.end_test_step()
 
         return oi_ref
 
@@ -140,9 +137,9 @@ class DownUSSEqualPriorityNotPermitted(DownUSS):
         )
 
         # Declare virtual USS as down at DSS test step
-        set_uss_down(
-            self, "Declare virtual USS as down at DSS", self.dss, self.uss_qualifier_sub
-        )
+        self.begin_test_step("Declare virtual USS as down at DSS")
+        set_uss_down(self, self.dss, self.uss_qualifier_sub)
+        self.end_test_step()
 
         # Tested USS attempts to plan high-priority flight 2 test step
         with OpIntentValidator(
@@ -171,12 +168,9 @@ class DownUSSEqualPriorityNotPermitted(DownUSS):
             validator.expect_not_shared()
 
         # Restore virtual USS availability at DSS test step
-        set_uss_available(
-            self,
-            "Restore virtual USS availability at DSS",
-            self.dss,
-            self.uss_qualifier_sub,
-        )
+        self.begin_test_step("Restore virtual USS availability at DSS")
+        set_uss_available(self, self.dss, self.uss_qualifier_sub)
+        self.end_test_step()
 
         return oi_ref
 
@@ -188,9 +182,9 @@ class DownUSSEqualPriorityNotPermitted(DownUSS):
         )
 
         # Declare virtual USS as down at DSS test step
-        set_uss_down(
-            self, "Declare virtual USS as down at DSS", self.dss, self.uss_qualifier_sub
-        )
+        self.begin_test_step("Declare virtual USS as down at DSS")
+        set_uss_down(self, self.dss, self.uss_qualifier_sub)
+        self.end_test_step()
 
         # Tested USS attempts to plan high-priority flight 2 test step
         with OpIntentValidator(

--- a/monitoring/uss_qualifier/scenarios/astm/utm/test_steps.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/test_steps.py
@@ -580,18 +580,16 @@ class OpIntentValidationFailure(ImplicitDict):
 
 def set_uss_available(
     scenario: TestScenarioType,
-    test_step: str,
     dss: DSSInstance,
     uss_sub: str,
 ) -> str:
     """Set the USS availability to 'Available'.
 
-    This function implements the test step described in set_uss_available.md.
+    This function implements the test step fragment described in set_uss_available.md.
 
     Returns:
         The new version of the USS availability.
     """
-    scenario.begin_test_step(test_step)
     availability_version, avail_query = dss.set_uss_availability(
         uss_sub,
         True,
@@ -606,24 +604,21 @@ def set_uss_available(
                 details=f"DSS responded code {avail_query.status_code}; error message: {avail_query.error_message}",
                 query_timestamps=[avail_query.request.timestamp],
             )
-    scenario.end_test_step()
     return availability_version
 
 
 def set_uss_down(
     scenario: TestScenarioType,
-    test_step: str,
     dss: DSSInstance,
     uss_sub: str,
 ) -> str:
     """Set the USS availability to 'Down'.
 
-    This function implements the test step described in set_uss_down.md.
+    This function implements the test step fragment described in set_uss_down.md.
 
     Returns:
         The new version of the USS availability.
     """
-    scenario.begin_test_step(test_step)
     availability_version, avail_query = dss.set_uss_availability(
         uss_sub,
         False,
@@ -638,5 +633,4 @@ def set_uss_down(
                 details=f"DSS responded code {avail_query.status_code}; error message: {avail_query.error_message}",
                 query_timestamps=[avail_query.request.timestamp],
             )
-    scenario.end_test_step()
     return availability_version


### PR DESCRIPTION
As part of #380, this PR extracts `begin_test_step` and `end_test_step` from the reusable functions in ASTM UTM's test_steps.py (but not OpIntentValidator; that will be a larger project)