### PR TITLE
[uss_qualifier] op-intent refs ACL checks: skip scenario if references can't be cleaned up (fix #418)

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/utm/op_intent_ref_access_control.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/op_intent_ref_access_control.md
@@ -73,6 +73,18 @@ Otherwise, the DSS is not in compliance with **[astm.f3548.v21.DSS0005,2](../../
 If an existing operational intent cannot be deleted when providing the proper ID and OVN, the DSS implementation is in violation of
 **[astm.f3548.v21.DSS0005,1](../../../requirements/astm/f3548/v21.md)**.
 
+#### ⚠️ Any existing operational intent reference has been removed check
+
+If, after cleanup, one or more operational intent reference are still present at the DSS, this scenario cannot proceed.
+
+This scenario is able to remove any operational intent reference that belongs to the configured credentials, but it cannot remove references
+that belong to other credentials.
+
+A regular failure of this check indicates that other scenarios might not properly clean up their resources, or that the _Prepare Flight Planners_
+scenario should be moved in front of the present one.
+
+If this check fails, the rest of the scenario is entirely skipped.
+
 ### Create operational intent references with different credentials test step
 
 This test step ensures that an operation intent reference created with the main credentials is available for the main test case.

--- a/monitoring/uss_qualifier/suites/astm/utm/f3548_21.md
+++ b/monitoring/uss_qualifier/suites/astm/utm/f3548_21.md
@@ -4,9 +4,9 @@
 
 ## [Actions](../../README.md#actions)
 
-1. Action generator: [`action_generators.astm.f3548.ForEachDSS`](../../../action_generators/astm/f3548/for_each_dss.py)
+1. Scenario: [ASTM F3548 flight planners preparation](../../../scenarios/astm/utm/prep_planners.md) ([`scenarios.astm.utm.PrepareFlightPlanners`](../../../scenarios/astm/utm/prep_planners.py))
+2. Action generator: [`action_generators.astm.f3548.ForEachDSS`](../../../action_generators/astm/f3548/for_each_dss.py)
     1. Suite: [DSS testing for ASTM NetRID F3548-21](dss_probing.md) ([`suites.astm.utm.dss_probing`](dss_probing.yaml))
-2. Scenario: [ASTM F3548 flight planners preparation](../../../scenarios/astm/utm/prep_planners.md) ([`scenarios.astm.utm.PrepareFlightPlanners`](../../../scenarios/astm/utm/prep_planners.py))
 3. Action generator: [`action_generators.flight_planning.FlightPlannerCombinations`](../../../action_generators/flight_planning/planner_combinations.py)
     1. Scenario: [Validation of operational intents](../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md) ([`scenarios.astm.utm.FlightIntentValidation`](../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.py))
 4. Action generator: [`action_generators.flight_planning.FlightPlannerCombinations`](../../../action_generators/flight_planning/planner_combinations.py)

--- a/monitoring/uss_qualifier/suites/astm/utm/f3548_21.yaml
+++ b/monitoring/uss_qualifier/suites/astm/utm/f3548_21.yaml
@@ -13,6 +13,17 @@ resources:
   mock_uss: resources.interuss.mock_uss.client.MockUSSResource?
   id_generator: resources.interuss.IDGeneratorResource
 actions:
+- test_scenario:
+    scenario_type: scenarios.astm.utm.PrepareFlightPlanners
+    resources:
+      flight_planners: flight_planners
+      mock_uss: mock_uss
+      dss: dss
+      flight_intents: invalid_flight_intents
+      flight_intents2: priority_preemption_flights?
+      flight_intents3: conflicting_flights?
+      flight_intents4: non_conflicting_flights?
+  on_failure: Abort
 - action_generator:
     generator_type: action_generators.astm.f3548.ForEachDSS
     resources:
@@ -34,17 +45,6 @@ actions:
       dss_instances_source: dss_instances
       dss_instance_id: dss
     on_failure: Continue
-- test_scenario:
-    scenario_type: scenarios.astm.utm.PrepareFlightPlanners
-    resources:
-      flight_planners: flight_planners
-      mock_uss: mock_uss
-      dss: dss
-      flight_intents: invalid_flight_intents
-      flight_intents2: priority_preemption_flights?
-      flight_intents3: conflicting_flights?
-      flight_intents4: non_conflicting_flights?
-  on_failure: Abort
 - action_generator:
     generator_type: action_generators.flight_planning.FlightPlannerCombinations
     resources:


### PR DESCRIPTION
This adds an explicit check to `OpIntentReferenceAccessControl` to verify that the workspace is clean, and skip the scenario steps if it is not.

This also moves the `PrepareFlightPlanners` in front of `ForEachDSS` in the `f3548_21.yaml` test suite configuration, as the stray OIRs reported in #418 seem not to belong to the op intent reference ACL test scenario and there is a higher chance of them getting cleaned up this way.

(This scenario will attempt to cleanup up stray OIRs that seem to belong to the credentials that are being used, but it can't possibly clean up references that are owned by other credentials)

In the event of cleanup failure, the scenario has been updated to simply skip all further checks.