### PR TITLE
[deps] update flask to latest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,15 +9,13 @@ arrow==1.1.0
 bc-jsonpath-ng==1.5.9  # uss_qualifier
 cryptography==41.0.6
 faker===8.1.0  # uss_qualifier
-flask==1.1.2
+flask==2.3.3
 geojson===2.5.0  # uss_qualifier
 gevent==22.10.2  # mock_uss / gunicorn worker
 google-auth==1.6.3
 graphviz==0.20.1  # uss_qualifier
 gunicorn==20.1.0
 implicitdict==2.3.0
-itsdangerous==2.0.1 # Version 2.1.0 is not compatible with flask 1.1.2.
-Jinja2==3.0.3 # See https://github.com/interuss/dss/issues/745
 jsonschema==4.17.3  # uss_qualifier
 jwcrypto==1.4
 kubernetes==23.3.0  # deployment_manager
@@ -42,4 +40,3 @@ shapely==1.7.1
 structlog==21.5.0  # deployment_manager
 termcolor==1.1.0
 uas_standards==3.0.0
-Werkzeug==2.0.3 # See https://github.com/interuss/dss/issues/753


### PR DESCRIPTION
This should fix #329 and was obtained through a few iterative updates (it was not immediately obvious to me that the transitive dependencies with a pinned version could simply be removed)

Note that this removes the explicit version pinning of `Werkzeug`, `Jinja2` and `itsdangerous`.

If we need to pin transitive dependencies (which is a generally good idea) I'd suggest looking into something such as [pip-tools](https://github.com/jazzband/pip-tools) (or rolling our own crude version pinning with eg `pip freeze`).

However, there is no urgency with this, as long as dependency management does not start taking too much time.