### PR TITLE
[uss_qualifier] Fix optional resources mock_uss and second_utm_auth

### DIFF
--- a/monitoring/uss_qualifier/suites/astm/utm/dss_probing.yaml
+++ b/monitoring/uss_qualifier/suites/astm/utm/dss_probing.yaml
@@ -1,7 +1,7 @@
 name: DSS testing for ASTM NetRID F3548-21
 resources:
   dss: resources.astm.f3548.v21.DSSInstanceResource
-  second_utm_auth: resources.communications.AuthAdapterResource
+  second_utm_auth: resources.communications.AuthAdapterResource?
   all_dss_instances: resources.astm.f3548.v21.DSSInstancesResource?
   flight_intents: resources.flight_planning.FlightIntentsResource
   id_generator: resources.interuss.IDGeneratorResource

--- a/monitoring/uss_qualifier/suites/astm/utm/f3548_21.yaml
+++ b/monitoring/uss_qualifier/suites/astm/utm/f3548_21.yaml
@@ -17,7 +17,7 @@ actions:
     scenario_type: scenarios.astm.utm.PrepareFlightPlanners
     resources:
       flight_planners: flight_planners
-      mock_uss: mock_uss
+      mock_uss: mock_uss?
       dss: dss
       flight_intents: invalid_flight_intents
       flight_intents2: priority_preemption_flights?
@@ -28,7 +28,7 @@ actions:
     generator_type: action_generators.astm.f3548.ForEachDSS
     resources:
       dss_instances: dss_instances
-      second_utm_auth: second_utm_auth
+      second_utm_auth: second_utm_auth?
       flight_intents: non_conflicting_flights
       id_generator: id_generator
     specification:
@@ -37,7 +37,7 @@ actions:
           suite_type: suites.astm.utm.dss_probing
           resources:
             dss: dss
-            second_utm_auth: second_utm_auth
+            second_utm_auth: second_utm_auth?
             all_dss_instances: dss_instances
             flight_intents: flight_intents
             id_generator: id_generator

--- a/monitoring/uss_qualifier/suites/suite.py
+++ b/monitoring/uss_qualifier/suites/suite.py
@@ -223,10 +223,13 @@ class TestSuite(object):
         self.declaration = declaration
         self.definition = TestSuiteDefinition.load_from_declaration(declaration)
         if "resources" in declaration and declaration.resources:
-            self.local_resources = {
-                local_resource_id: resources[parent_resource_id]
-                for local_resource_id, parent_resource_id in declaration.resources.items()
-            }
+            if "suite_type" in declaration and declaration.suite_type:
+                subject = declaration.suite_type
+            else:
+                subject = "<custom definition>"
+            self.local_resources = make_child_resources(
+                resources, declaration.resources, f"Test suite {subject}"
+            )
         else:
             self.local_resources = {}
         if "local_resources" in self.definition and self.definition.local_resources:


### PR DESCRIPTION
#406 attempted to allow mock_uss to be omitted from certain test suites, but it did not ensure that actions within those test suites wouldn't be skipped even when the omitted resource was optional.  This PR fixes that oversight and verifies that omitting mock_uss and second_utm_auth only skips the scenarios that actually need those resources by (temporarily) commenting out the mock_uss and second_utm_auth resources in the f3548_self_contained configuration.