### PR TITLE
[uss_qualifier] Centralize traceback.format_exception call

### DIFF
--- a/monitoring/mock_uss/database.py
+++ b/monitoring/mock_uss/database.py
@@ -1,8 +1,8 @@
 import json
-import traceback
 from typing import List, Dict, Optional
 
 from implicitdict import ImplicitDict, StringBasedDateTime, StringBasedTimeDelta
+from monitoring.monitorlib.errors import stacktrace_string
 
 from monitoring.monitorlib.multiprocessing import SynchronizedValue
 
@@ -25,7 +25,7 @@ class TaskError(ImplicitDict):
             trigger=trigger,
             type=type(e).__name__,
             message=str(e),
-            stacktrace="".join(traceback.format_exception(e)),
+            stacktrace=stacktrace_string(e),
         )
 
 

--- a/monitoring/monitorlib/errors.py
+++ b/monitoring/monitorlib/errors.py
@@ -1,0 +1,6 @@
+import traceback
+
+
+def stacktrace_string(e: Exception) -> str:
+    """Return a multi-line string containing a stacktrace for the specified exception."""
+    return "".join(traceback.format_exception(e))

--- a/monitoring/monitorlib/fetch/__init__.py
+++ b/monitoring/monitorlib/fetch/__init__.py
@@ -1,7 +1,6 @@
 import datetime
 import json
 import os
-import traceback
 import uuid
 import jwt
 from typing import Dict, Optional, List, Union
@@ -9,7 +8,6 @@ from typing import Dict, Optional, List, Union
 from enum import Enum
 from urllib.parse import urlparse
 
-import aiohttp
 import flask
 from loguru import logger
 import requests
@@ -19,6 +17,7 @@ from yaml.representer import Representer
 
 from implicitdict import ImplicitDict, StringBasedDateTime
 from monitoring.monitorlib import infrastructure
+from monitoring.monitorlib.errors import stacktrace_string
 from monitoring.monitorlib.rid import RIDVersion
 
 TIMEOUTS = (5, 5)  # Timeouts of `connect` and `read` in seconds
@@ -318,7 +317,7 @@ class QueryError(RuntimeError):
 
     @property
     def stacktrace(self) -> str:
-        return "".join(traceback.format_exception(self))
+        return stacktrace_string(self)
 
 
 yaml.add_representer(Query, Representer.represent_dict)

--- a/monitoring/monitorlib/idempotency.py
+++ b/monitoring/monitorlib/idempotency.py
@@ -110,6 +110,7 @@ def idempotent_request(get_request_id: Optional[Callable[[], Optional[str]]] = N
                     return flask.jsonify(response["json"]), response["code"]
 
             result = fn(*args, **kwargs)
+            to_return = result
 
             response = {
                 "timestamp": arrow.utcnow().isoformat(),
@@ -150,7 +151,7 @@ def idempotent_request(get_request_id: Optional[Callable[[], Optional[str]]] = N
             with _fulfilled_requests as cached_requests:
                 cached_requests[request_id] = response
 
-            return result
+            return to_return
 
         return wrapper
 

--- a/monitoring/uss_qualifier/main.py
+++ b/monitoring/uss_qualifier/main.py
@@ -71,6 +71,7 @@ def execute_test_run(whole_config: USSQualifierConfiguration):
     config = whole_config.v1.test_run
     codebase_version = get_code_version()
     commit_hash = get_commit_hash()
+    logger.info(f"Codebase version {codebase_version}, commit hash {commit_hash}")
 
     logger.info("Instantiating resources")
     resources = create_resources(config.resources.resource_declarations)

--- a/monitoring/uss_qualifier/reports/report.py
+++ b/monitoring/uss_qualifier/reports/report.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 from datetime import datetime
-import traceback
 from typing import List, Optional, Dict, Tuple, Any, Union, Set, Iterator, Callable
 
 from implicitdict import ImplicitDict, StringBasedDateTime
 
 from monitoring.monitorlib import fetch, inspection
+from monitoring.monitorlib.errors import stacktrace_string
 from monitoring.uss_qualifier.action_generators.definitions import GeneratorTypeName
 from monitoring.uss_qualifier.common_data_definitions import Severity
 from monitoring.uss_qualifier.configurations.configuration import (
@@ -202,7 +202,7 @@ class ErrorReport(ImplicitDict):
             type=str(inspection.fullname(e.__class__)),
             message=str(e),
             timestamp=StringBasedDateTime(datetime.utcnow()),
-            stacktrace="".join(traceback.format_exception(e)),
+            stacktrace=stacktrace_string(e),
         )
 
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/misbehavior.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/misbehavior.py
@@ -1,4 +1,3 @@
-import traceback
 from typing import List, Set
 
 import s2sphere
@@ -6,6 +5,7 @@ from requests.exceptions import RequestException
 from s2sphere import LatLngRect
 
 from monitoring.monitorlib import auth
+from monitoring.monitorlib.errors import stacktrace_string
 from monitoring.monitorlib.fetch import rid
 from monitoring.monitorlib.infrastructure import UTMClientSession
 from monitoring.monitorlib.rid import RIDVersion
@@ -246,7 +246,7 @@ class Misbehavior(GenericTestScenario):
                     )
                 check.record_passed()
             except (RequestException, ValueError) as e:
-                stacktrace = "".join(traceback.format_exception(e))
+                stacktrace = stacktrace_string(e)
                 check.record_failed(
                     summary="Error while trying to delete test flight",
                     severity=Severity.Medium,

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/nominal_behavior.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/nominal_behavior.py
@@ -1,9 +1,9 @@
-import traceback
 from typing import List, Optional
 
 from requests.exceptions import RequestException
 from s2sphere import LatLngRect
 
+from monitoring.monitorlib.errors import stacktrace_string
 from monitoring.monitorlib.rid import RIDVersion
 from monitoring.uss_qualifier.common_data_definitions import Severity
 from monitoring.uss_qualifier.resources.astm.f3411.dss import DSSInstancesResource
@@ -136,7 +136,7 @@ class NominalBehavior(GenericTestScenario):
                     )
                 check.record_passed()
             except (RequestException, ValueError) as e:
-                stacktrace = "".join(traceback.format_exception(e))
+                stacktrace = stacktrace_string(e)
                 check.record_failed(
                     summary="Error while trying to delete test flight",
                     severity=Severity.Medium,


### PR DESCRIPTION
As evidenced by #367, we call `traceback.format_exception` in a number of different places in our codebase to construct a stracktrace string.  Prompted by some mysterious observed exceptions, this PR makes a single `stacktrace_string` function that everywhere else in the codebase references, and that function is the only place that calls `format_exception` (this would have made #367 easier had it already existed).

While trying to reproduce the issue, I also discovered misbehavior when returning a tuple from idempotent handlers so this PR fixes that issue as well.

Finally, the codebase information is printed to console to help debug problems like this in the future.

Observed logs, lightly redacted:

```
  2023-12-19 11:16:04.381 | INFO     | __main__:main:185 - ========== Running uss_qualifier for configuration file:///tmp/tmpx47759m2.yaml ==========
  2023-12-19 11:16:04.430 | INFO     | __main__:run_config:123 - Validating configuration...
  2023-12-19 11:16:07.310 | INFO     | __main__:run_config:153 - Executing test run
  2023-12-19 11:16:07.310 | INFO     | __main__:execute_test_run:75 - Instantiating resources
  2023-12-19 11:16:07.400 | INFO     | __main__:execute_test_run:78 - Computing signatures of inputs
  2023-12-19 11:16:07.402 | INFO     | __main__:execute_test_run:93 - Instantiating top-level test suite action
  2023-12-19 11:16:07.436 | WARNING  | monitoring.uss_qualifier.suites.suite:__init__:259 - Skipping action 0 (action_generator action_generators.astm.f3548.ForEachDSS) because Test suite action to run action_generator action_generators.astm.f3548.ForEachDSS could not find required resource ID "dss_instances" used to populate child resource ID "dss_instances"
  2023-12-19 11:16:07.437 | WARNING  | monitoring.uss_qualifier.suites.suite:__init__:259 - Skipping action 1 (test_scenario scenarios.astm.utm.PrepareFlightPlanners) because Test suite action to run test_scenario scenarios.astm.utm.PrepareFlightPlanners could not find required resource ID "mock_uss" used to populate child resource ID "mock_uss"
  2023-12-19 11:16:08.047 | WARNING  | monitoring.uss_qualifier.suites.suite:__init__:259 - Skipping action 3 (action_generator action_generators.flight_planning.FlightPlannerCombinations) because Test suite action to run action_generator action_generators.flight_planning.FlightPlannerCombinations could not find required resource ID "priority_preemption_flights" used to populate child resource ID "priority_preemption_flights"
  2023-12-19 11:16:08.302 | WARNING  | monitoring.uss_qualifier.suites.suite:__init__:259 - Skipping action 5 (action_generator action_generators.flight_planning.FlightPlannerCombinations) because Test suite action to run action_generator action_generators.flight_planning.FlightPlannerCombinations could not find required resource ID "mock_uss" used to populate child resource ID "mock_uss"
  2023-12-19 11:16:08.657 | INFO     | __main__:execute_test_run:96 - Running top-level test suite action
  2023-12-19 11:16:08.657 | INFO     | monitoring.uss_qualifier.suites.suite:_run_test_suite:175 - Beginning test suite ASTM F3548-21...
  2023-12-19 11:16:08.658 | INFO     | monitoring.uss_qualifier.suites.suite:_run_test_scenario:146 - Running "Validation of operational intents" scenario...
  2023-12-19 11:16:08.659 | INFO     | monitoring.uss_qualifier.scenarios.scenario:record_note:289 - Note: Tested USS -> REDACTED
  2023-12-19 11:16:12.854 | DEBUG    | monitoring.uss_qualifier.scenarios.scenario:record_query:371 - Queried PUT https://REDACTED/flight_plans/4646769d-1a3d-4414-9f9c-360e715f87eb -> 403 (2.5s); attributed participant REDACTED and type interuss.automated_testing.flight_planning.v1.UpsertFlightPlan
  2023-12-19 11:16:12.854 | INFO     | monitoring.uss_qualifier.scenarios.scenario:record_note:289 - Note: REDACTED -> Exception occurred during OpIntentValidator (<class 'TypeError'>: format_exception() missing 2 required positional arguments: 'value' and 'tb').
  Traceback (most recent call last):
    File "/app/monitoring/monitoring/uss_qualifier/resources/flight_planning/flight_planner.py", line 171, in request_flight
      resp = self.client.try_plan_flight(
    File "/app/monitoring/monitoring/monitorlib/clients/flight_planning/client_v1.py", line 104, in try_plan_flight
      return self._inject(
    File "/app/monitoring/monitoring/monitorlib/clients/flight_planning/client_v1.py", line 67, in _inject
      raise PlanningActivityError(
  monitoring.monitorlib.clients.flight_planning.client.PlanningActivityError: Attempt to plan flight returned status 403 rather than 200 as expected

  During handling of the above exception, another exception occurred:

  Traceback (most recent call last):
    File "/app/monitoring/monitoring/uss_qualifier/scenarios/flight_planning/test_steps.py", line 253, in submit_flight_intent
      resp, query, flight_id = flight_planner.request_flight(
    File "/app/monitoring/monitoring/uss_qualifier/resources/flight_planning/flight_planner.py", line 175, in request_flight
      raise QueryError(str(e), e.queries)
  monitoring.monitorlib.fetch.QueryError: Attempt to plan flight returned status 403 rather than 200 as expected

  During handling of the above exception, another exception occurred:

  Traceback (most recent call last):
    File "/app/monitoring/monitoring/uss_qualifier/suites/suite.py", line 150, in _run_test_scenario
      scenario.run(context)
    File "/app/monitoring/monitoring/uss_qualifier/scenarios/astm/utm/flight_intent_validation/flight_intent_validation.py", line 150, in run
      self._attempt_invalid()
    File "/app/monitoring/monitoring/uss_qualifier/scenarios/astm/utm/flight_intent_validation/flight_intent_validation.py", line 182, in _attempt_invalid
      validator.expect_not_shared()
    File "/app/monitoring/monitoring/uss_qualifier/scenarios/astm/utm/test_steps.py", line 93, in __exit__
      raise exc_val
    File "/app/monitoring/monitoring/uss_qualifier/scenarios/astm/utm/flight_intent_validation/flight_intent_validation.py", line 172, in _attempt_invalid
      submit_flight_intent(
    File "/app/monitoring/monitoring/uss_qualifier/scenarios/flight_planning/test_steps.py", line 262, in submit_flight_intent
      details=f"{str(e)}\n\nStack trace:\n{e.stacktrace}",
    File "/app/monitoring/monitoring/monitorlib/fetch/__init__.py", line 321, in stacktrace
      return "".join(traceback.format_exception(self))
  TypeError: format_exception() missing 2 required positional arguments: 'value' and 'tb'

  During handling of the above exception, another exception occurred:

  Traceback (most recent call last):
    File "/app/monitoring/monitoring/uss_qualifier/main.py", line 205, in <module>
      sys.exit(main())
    File "/app/monitoring/monitoring/uss_qualifier/main.py", line 188, in main
      exit_code = run_config(
    File "/app/monitoring/monitoring/uss_qualifier/main.py", line 154, in run_config
      report = execute_test_run(whole_config)
    File "/app/monitoring/monitoring/uss_qualifier/main.py", line 97, in execute_test_run
      report = action.run(context)
    File "/app/monitoring/monitoring/uss_qualifier/suites/suite.py", line 131, in run
      report = TestSuiteActionReport(test_suite=self._run_test_suite(context))
    File "/app/monitoring/monitoring/uss_qualifier/suites/suite.py", line 176, in _run_test_suite
      report = self.test_suite.run(context)
    File "/app/monitoring/monitoring/uss_qualifier/suites/suite.py", line 285, in run
      _run_actions(actions(), context, report)
    File "/app/monitoring/monitoring/uss_qualifier/suites/suite.py", line 328, in _run_actions
      action_report = action.run(context)
    File "/app/monitoring/monitoring/uss_qualifier/suites/suite.py", line 134, in run
      action_generator=self._run_action_generator(context)
    File "/app/monitoring/monitoring/uss_qualifier/suites/suite.py", line 187, in _run_action_generator
      _run_actions(self.action_generator.actions(), context, report)
    File "/app/monitoring/monitoring/uss_qualifier/suites/suite.py", line 328, in _run_actions
      action_report = action.run(context)
    File "/app/monitoring/monitoring/uss_qualifier/suites/suite.py", line 128, in run
      test_scenario=self._run_test_scenario(context)
    File "/app/monitoring/monitoring/uss_qualifier/suites/suite.py", line 161, in _run_test_scenario
      scenario.record_execution_error(e)
    File "/app/monitoring/monitoring/uss_qualifier/scenarios/scenario.py", line 501, in record_execution_error
      self._scenario_report.execution_error = ErrorReport.create_from_exception(e)
    File "/app/monitoring/monitoring/uss_qualifier/reports/report.py", line 205, in create_from_exception
      stacktrace="".join(traceback.format_exception(e)),
  TypeError: format_exception() missing 2 required positional arguments: 'value' and 'tb'
```