### PR TITLE
[uss_qualifier] Identify duplicate record_query calls

### DIFF
--- a/monitoring/monitorlib/errors.py
+++ b/monitoring/monitorlib/errors.py
@@ -4,3 +4,11 @@ import traceback
 def stacktrace_string(e: Exception) -> str:
     """Return a multi-line string containing a stacktrace for the specified exception."""
     return "".join(traceback.format_exception(e))
+
+
+def current_stack_string(exclude_levels: int = 1) -> str:
+    """Return a multi-line string containing a trace of the current execution state."""
+    stack = traceback.extract_stack()
+    if exclude_levels > 0:
+        stack = stack[0:-exclude_levels]
+    return "".join(traceback.format_list(stack))

--- a/monitoring/uss_qualifier/scenarios/scenario.py
+++ b/monitoring/uss_qualifier/scenarios/scenario.py
@@ -9,6 +9,7 @@ from loguru import logger
 
 from monitoring import uss_qualifier as uss_qualifier_module
 from monitoring.monitorlib import fetch, inspection
+from monitoring.monitorlib.errors import current_stack_string
 from monitoring.monitorlib.inspection import fullname
 from monitoring.uss_qualifier import scenarios as scenarios_module
 from monitoring.uss_qualifier.common_data_definitions import Severity
@@ -363,6 +364,12 @@ class GenericTestScenario(ABC):
         self._expect_phase({ScenarioPhase.RunningTestStep, ScenarioPhase.CleaningUp})
         if "queries" not in self._step_report:
             self._step_report.queries = []
+        for existing_query in self._step_report.queries:
+            if query.request.timestamp == existing_query.request.timestamp:
+                logger.error(
+                    f"The same query ({query.query_type} to {query.participant_id} at {query.request.timestamp}) was recorded multiple times.  This is likely a bug in uss_qualifier at:\n{current_stack_string(2)}"
+                )
+                return
         self._step_report.queries.append(query)
         participant = (
             "UNKNOWN"


### PR DESCRIPTION
Currently, the only mechanism we have to ensure that a query isn't recorded in a test report more than once is correctness of all calling code.  This PR introduces a loud warning message on the console if and when a query is recorded multiple times, but it stops short of aborting test execution.  This should allow us to easily detect if this happens in the future.  I don't believe it happens currently, though I have not performed an exhaustive search.