### PR TITLE
[uss_qualifier] Set default value of optional args in OpIntentValidator methods

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/utm/test_steps.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/test_steps.py
@@ -273,7 +273,7 @@ class OpIntentValidator(object):
         self,
         flight_intent: Union[InjectFlightRequest, FlightInfo],
         validation_failure_type: OpIntentValidationFailureType,
-        invalid_fields: Optional[List],
+        invalid_fields: Optional[List] = None,
         skip_if_not_found: bool = False,
     ) -> Optional[OperationalIntentReference]:
         """Validate that operational intent information was shared with dss,
@@ -500,7 +500,7 @@ class OpIntentValidator(object):
         self,
         validation_failures: Set[OpIntentValidationFailure],
         expected_validation_type: OpIntentValidationFailureType,
-        expected_invalid_fields: Optional[List[str]],
+        expected_invalid_fields: Optional[List[str]] = None,
     ) -> OpIntentValidationFailure:
         """
         Checks if expected validation type is in validation failures


### PR DESCRIPTION
Two methods in OpIntentValidator with Optional arguments do not have a default value. Setting their default value to None.