### PR TITLE
[uss_qualifier] Check for presence of `includes_advisories` before accessing field

### DIFF
--- a/monitoring/monitorlib/clients/flight_planning/client_v1.py
+++ b/monitoring/monitorlib/clients/flight_planning/client_v1.py
@@ -16,6 +16,7 @@ from monitoring.monitorlib.clients.flight_planning.flight_info import (
 )
 from monitoring.monitorlib.clients.flight_planning.planning import (
     PlanningActivityResponse,
+    AdvisoryInclusion,
 )
 from monitoring.monitorlib.clients.flight_planning.planning import (
     PlanningActivityResult,
@@ -93,7 +94,9 @@ class V1FlightPlannerClient(FlightPlannerClient):
             queries=[query],
             activity_result=resp.planning_result,
             flight_plan_status=resp.flight_plan_status,
-            includes_advisories=resp.includes_advisories,
+            includes_advisories=resp.includes_advisories
+            if "includes_advisories" in resp
+            else AdvisoryInclusion.Unknown,
         )
 
         return response

--- a/monitoring/uss_qualifier/resources/flight_planning/flight_planner.py
+++ b/monitoring/uss_qualifier/resources/flight_planning/flight_planner.py
@@ -211,7 +211,14 @@ class FlightPlanner:
             operational_intent_id="<not provided>",
         )
 
-        return response, resp.queries[0], flight_id, resp.includes_advisories
+        return (
+            response,
+            resp.queries[0],
+            flight_id,
+            resp.includes_advisories
+            if "includes_advisories" in resp
+            else AdvisoryInclusion.Unknown,
+        )
 
     def cleanup_flight(
         self, flight_id: str


### PR DESCRIPTION
Fixes #438.

One question is whether to specify None, specify Unknown, or omit the argument when constructing the result when the client's response did not include a value.  I believe all three options are essentially interchangeable for the purpose of processing the result, so I chose the option that made the resulting value more concrete.