### PR TITLE
Sleep loudly

### DIFF
--- a/monitoring/deployment_manager/actions/test/hello_world.py
+++ b/monitoring/deployment_manager/actions/test/hello_world.py
@@ -1,10 +1,9 @@
-import time
-
 from monitoring.deployment_manager import deploylib
 import monitoring.deployment_manager.deploylib.namespaces
 import monitoring.deployment_manager.deploylib.systems
 from monitoring.deployment_manager.infrastructure import deployment_action, Context
 from monitoring.deployment_manager.systems.test import hello_world
+from monitoring.monitorlib.delay import sleep
 
 
 @deployment_action("test/hello_world/deploy")
@@ -52,7 +51,7 @@ def destroy(context: Context) -> None:
             namespace.metadata.name, context.spec.cluster.name
         )
     )
-    time.sleep(15)
+    sleep(15, "destruction of hello_world system may take a few seconds")
 
     deploylib.systems.delete_resources(
         existing_resources, namespace, context.clients, context.log

--- a/monitoring/mock_uss/ridsp/behavior.py
+++ b/monitoring/mock_uss/ridsp/behavior.py
@@ -1,6 +1,6 @@
-from time import sleep
 from typing import Optional
 
+from monitoring.monitorlib.delay import sleep
 from monitoring.monitorlib.rid_automated_testing.injection_api import TestFlight
 from implicitdict import ImplicitDict
 from uas_standards.astm.f3411.v19.api import RIDFlight
@@ -56,6 +56,9 @@ def adjust_reported_flight(
                 p.position.alt *= FEET_PER_METER
 
     if behavior.delay_flight_report_s > 0:
-        sleep(behavior.delay_flight_report_s)
+        sleep(
+            behavior.delay_flight_report_s,
+            "specified Service Provider behavior is to delay before reporting flight",
+        )
 
     return adjusted

--- a/monitoring/monitorlib/delay.py
+++ b/monitoring/monitorlib/delay.py
@@ -1,0 +1,27 @@
+from datetime import timedelta
+import time
+from typing import Union
+
+from loguru import logger
+
+
+MAX_SILENT_DELAY_S = 0.4
+"""Number of seconds to delay above which a reasoning message should be displayed."""
+
+
+def sleep(duration: Union[float, timedelta], reason: str) -> None:
+    """Sleep for the specified amount of time, logging the fact that the delay is occurring (when appropriate).
+
+    Args:
+        duration: Amount of time to sleep for; interpreted as seconds if float.
+        reason: Reason the delay is happening (to be printed to console/log if appropriate).
+    """
+    if isinstance(duration, timedelta):
+        duration = duration.total_seconds()
+    if duration <= 0:
+        # No need to delay
+        return
+
+    if duration > MAX_SILENT_DELAY_S:
+        logger.debug(f"Delaying {duration:.1f} seconds because {reason}")
+    time.sleep(duration)

--- a/monitoring/prober/rid/v1/test_isa_expiry.py
+++ b/monitoring/prober/rid/v1/test_isa_expiry.py
@@ -3,6 +3,7 @@
 import datetime
 import time
 
+from monitoring.monitorlib.delay import sleep
 from monitoring.monitorlib.infrastructure import default_scope
 from monitoring.monitorlib import rid_v1
 from monitoring.prober.infrastructure import register_resource_type
@@ -64,7 +65,7 @@ def test_valid_immediately(ids, session_ridv1):
 
 def test_sleep_5_seconds():
     # But if we wait 5 seconds it will expire...
-    time.sleep(5)
+    sleep(5, "if we wait 5 seconds, the ISA of interest will expire")
 
 
 @default_scope(Scope.Read)

--- a/monitoring/prober/rid/v1/test_isa_expiry.py
+++ b/monitoring/prober/rid/v1/test_isa_expiry.py
@@ -1,7 +1,6 @@
 """Test ISAs aren't returned after they expire."""
 
 import datetime
-import time
 
 from monitoring.monitorlib.delay import sleep
 from monitoring.monitorlib.infrastructure import default_scope

--- a/monitoring/prober/rid/v2/test_isa_expiry.py
+++ b/monitoring/prober/rid/v2/test_isa_expiry.py
@@ -68,7 +68,7 @@ def test_valid_immediately(ids, session_ridv2):
 
 def test_sleep_5_seconds():
     # But if we wait 5 seconds it will expire...
-    time.sleep(5)
+    sleep(5, "if we wait 5 seconds, the ISA of interest will expire")
 
 
 @default_scope(Scope.DisplayProvider)

--- a/monitoring/prober/rid/v2/test_isa_expiry.py
+++ b/monitoring/prober/rid/v2/test_isa_expiry.py
@@ -1,8 +1,8 @@
 """Test ISAs aren't returned after they expire."""
 
 import datetime
-import time
 
+from monitoring.monitorlib.delay import sleep
 from uas_standards.astm.f3411.v22a.api import OPERATIONS, OperationID
 from uas_standards.astm.f3411.v22a.constants import Scope
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/isa_expiry.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/isa_expiry.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 import arrow
 
+from monitoring.monitorlib.delay import sleep
 from monitoring.prober.infrastructure import register_resource_type
 from monitoring.uss_qualifier.common_data_definitions import Severity
 from monitoring.uss_qualifier.resources.astm.f3411.dss import DSSInstanceResource
@@ -83,7 +84,7 @@ class ISAExpiry(GenericTestScenario):
             )
 
         # Wait for it to expire
-        time.sleep(5)
+        sleep(5, "we need to wait for the short-lived ISA to expire")
 
         # Search for ISAs: we should not find the expired one
         with self.check(

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss_interoperability.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss_interoperability.py
@@ -1,6 +1,5 @@
 import ipaddress
 import socket
-import time
 import uuid
 from dataclasses import dataclass
 import datetime
@@ -10,6 +9,7 @@ from urllib.parse import urlparse
 
 import s2sphere
 
+from monitoring.monitorlib.delay import sleep
 from monitoring.monitorlib.fetch.rid import ISA
 from monitoring.uss_qualifier.common_data_definitions import Severity
 from monitoring.uss_qualifier.resources.astm.f3411.dss import (
@@ -499,8 +499,10 @@ class DSSInteroperability(GenericTestScenario):
         """Expired ISA automatically removed, ISA modifications
         accessible from all non-primary DSSs"""
 
-        # sleep X seconds for ISA_1 to expire
-        time.sleep(SHORT_WAIT_SEC)
+        sleep(
+            SHORT_WAIT_SEC,
+            "ISA_1 needs to expire so we can check it is automatically removed",
+        )
 
         isa_1 = self._context["isa_1"]
 
@@ -590,7 +592,10 @@ class DSSInteroperability(GenericTestScenario):
     def step12(self):
         """Expired Subscriptions don’t trigger subscription notification requests"""
 
-        time.sleep(SHORT_WAIT_SEC)
+        sleep(
+            SHORT_WAIT_SEC,
+            "ISA needs to expire so we can check it doesn't trigger notifications",
+        )
 
         isa_3 = self._new_isa("isa_3")
         all_sub_2_ids = self._get_entities_by_prefix("sub_2_").keys()

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/virtual_observer.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/virtual_observer.py
@@ -1,4 +1,3 @@
-import time
 from datetime import timedelta, datetime
 from typing import Optional, Callable, List
 from loguru import logger
@@ -6,6 +5,7 @@ from loguru import logger
 import arrow
 from s2sphere import LatLngRect
 
+from monitoring.monitorlib.delay import sleep
 from monitoring.uss_qualifier.scenarios.astm.netrid.injected_flight_collection import (
     InjectedFlightCollection,
 )
@@ -114,7 +114,6 @@ class VirtualObserver(object):
                 break
             delay = t_next - arrow.utcnow()
             if delay.total_seconds() > 0:
-                logger.debug(
-                    f"Waiting {delay.total_seconds()} seconds before polling RID system again..."
+                sleep(
+                    delay, "RID sytem doesn't need to be polled again until this time"
                 )
-                time.sleep(delay.total_seconds())

--- a/monitoring/uss_qualifier/scenarios/dev/noop.py
+++ b/monitoring/uss_qualifier/scenarios/dev/noop.py
@@ -1,6 +1,6 @@
-import time
 from datetime import datetime
 
+from monitoring.monitorlib.delay import sleep
 from monitoring.uss_qualifier.resources.dev import NoOpResource
 from monitoring.uss_qualifier.scenarios.scenario import TestScenario
 from monitoring.uss_qualifier.suites.suite import ExecutionContext
@@ -21,7 +21,7 @@ class NoOp(TestScenario):
             f"Starting at {datetime.utcnow().isoformat()}Z, sleeping for {self.sleep_secs}s...",
         )
 
-        time.sleep(self.sleep_secs)
+        sleep(self.sleep_secs, "the no-op scenario sleeps for the specified time")
 
         self.record_note("End time", f"Ending at {datetime.utcnow().isoformat()}Z.")
 


### PR DESCRIPTION
Our CI is an extremely valuable tool, but it already takes 15-20 minutes to run and we will want to add more checks to it as we develop more tools.  Therefore, it will be valuable to pay attention to the time we are spending to verify functionality.  We currently have a number of places where we sleep, usually to wait for something to happen.  This PR ensures those places are visible and well-justified by replacing all instances of `time.sleep` with a custom `sleep` function that requires specification of a reason.  In the future, we could also use this function to evaluate how much of the total CI time is spent merely sleeping.