### PR TITLE
[uss_qualifier] Improve severity treatment in sequence view artifact

### DIFF
--- a/monitoring/monitorlib/fetch/__init__.py
+++ b/monitoring/monitorlib/fetch/__init__.py
@@ -254,6 +254,9 @@ class QueryType(str, Enum):
         "interuss.automated_testing.flight_planning.v1.DeleteFlightPlan"
     )
 
+    def __str__(self):
+        return self.value
+
     @staticmethod
     def flight_details(rid_version: RIDVersion):
         if rid_version == RIDVersion.f3411_19:

--- a/monitoring/uss_qualifier/reports/sequence_view.py
+++ b/monitoring/uss_qualifier/reports/sequence_view.py
@@ -26,6 +26,7 @@ from monitoring.uss_qualifier.reports.report import (
     TestScenarioReport,
     PassedCheck,
     FailedCheck,
+    Severity,
     SkippedActionReport,
     ErrorReport,
 )
@@ -150,6 +151,7 @@ class Epoch(ImplicitDict):
 @dataclass
 class TestedParticipant(object):
     has_failures: bool = False
+    has_infos: bool = False
     has_successes: bool = False
     has_queries: bool = False
 
@@ -337,7 +339,10 @@ def _compute_tested_scenario(
                 )
                 for pid in participants:
                     p = scenario_participants.get(pid, TestedParticipant())
-                    p.has_failures = True
+                    if failed_check.severity == Severity.Low:
+                        p.has_infos = True
+                    else:
+                        p.has_failures = True
                     scenario_participants[pid] = p
             if "notes" in report and report.notes:
                 for key, note in report.notes.items():
@@ -618,6 +623,7 @@ def _generate_scenario_pages(
                     UNATTRIBUTED_PARTICIPANT=UNATTRIBUTED_PARTICIPANT,
                     len=len,
                     str=str,
+                    Severity=Severity,
                 )
             )
     else:
@@ -654,5 +660,6 @@ def generate_sequence_view(
                 ActionNodeType=ActionNodeType,
                 UNATTRIBUTED_PARTICIPANT=UNATTRIBUTED_PARTICIPANT,
                 len=len,
+                Severity=Severity,
             )
         )

--- a/monitoring/uss_qualifier/reports/templates/sequence_view/overview.html
+++ b/monitoring/uss_qualifier/reports/templates/sequence_view/overview.html
@@ -3,71 +3,7 @@
 <html lang="en">
 <head>
   <title>TR-{{ test_run.test_run_id[0:7] }} sequence view</title>
-  <style>
-    body {
-      margin: 0;
-      color: #24292f;
-      background-color: #ffffff;
-      font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
-      font-size: 16px;
-      line-height: 1.5;
-      word-wrap: break-word;
-    }
-    table {
-      border-spacing: 0;
-      border-collapse: collapse;
-      width: max-content;
-      max-width: 100%;
-      overflow: auto;
-    }
-    tr {
-      border-top: 1px solid hsla(210,18%,87%,1);
-    }
-    table tr:nth-child(2n) {
-      background-color: #f6f8fa;
-    }
-    td {
-      padding: 6px 6px;
-      vertical-align: top;
-      border: 1px solid #d0d7de;
-    }
-    th {
-      padding: 6px 6px;
-      text-align: left;
-      background-color: rgb(230, 230, 230);
-      border: 1px solid #d0d7de;
-      height: 40px;
-    }
-    a {
-      background-color: transparent;
-      color: #0969da;
-      text-decoration: none;
-    }
-    h2 {
-      margin-block-end: 0.1em;
-    }
-    p {
-      margin-top: 0.1em;
-      margin-bottom: 0.1em;
-    }
-    .sticky_cell_value {
-      position: sticky;
-      top: 40px;
-      z-index: 0;
-    }
-    .pass_result {
-      background-color: rgb(192, 255, 192);
-    }
-    .fail_result {
-      background-color: rgb(255, 192, 192);
-    }
-    .not_tested {
-      background-color: rgb(192, 192, 192);
-    }
-    .skipped_explanation {
-      font-style: italic;
-    }
-  </style>
+  {% include "sequence_view/style.html" %}
   {{ explorer_header() }}
 </head>
 <body>
@@ -200,6 +136,8 @@
           {% if row.scenario_node and participant_id in row.scenario_node.scenario.participants %}
             {% if row.scenario_node.scenario.participants[participant_id].has_failures %}
               <td class="fail_result">&#x274C;</td>
+            {% elif row.scenario_node.scenario.participants[participant_id].has_infos %}
+              <td class="info_result">&#8505;&#65039;</td>
             {% elif row.scenario_node.scenario.participants[participant_id].has_successes %}
               <td class="pass_result">&#x2705;</td>
             {% elif row.scenario_node.scenario.participants[participant_id].has_queries %}

--- a/monitoring/uss_qualifier/reports/templates/sequence_view/scenario.html
+++ b/monitoring/uss_qualifier/reports/templates/sequence_view/scenario.html
@@ -1,69 +1,11 @@
 <!DOCTYPE html>
 {% from "explorer.html" import explorer_header, explorer_content, explorer_footer %}
+{% from "sequence_view/severity.html" import severity_symbol, severity_class with context %}
 <html lang="en">
 <head>
   <meta charset="UTF-8">
   <title>s{{ test_scenario.scenario_index }} - {{ test_scenario.name }}</title>
-  <style>
-    body {
-      margin: 0;
-      color: #24292f;
-      background-color: #ffffff;
-      font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
-      font-size: 16px;
-      line-height: 1.5;
-      word-wrap: break-word;
-    }
-    table {
-      border-spacing: 0;
-      border-collapse: collapse;
-      width: max-content;
-      max-width: 100%;
-      overflow: auto;
-    }
-    tr {
-      border-top: 1px solid hsla(210,18%,87%,1);
-    }
-    table tr:nth-child(2n) {
-      background-color: #f6f8fa;
-    }
-    td {
-      padding: 6px 6px;
-      vertical-align: top;
-      border: 1px solid #d0d7de;
-    }
-    th {
-      padding: 6px 6px;
-      text-align: left;
-      background-color: rgb(230, 230, 230);
-      border: 1px solid #d0d7de;
-    }
-    a {
-      background-color: transparent;
-      color: #0969da;
-      text-decoration: none;
-    }
-    h2 {
-      margin-block-end: 0.1em;
-    }
-    .sticky_cell_value {
-      position: sticky;
-      top: 0px;
-      z-index: 0;
-    }
-    .pass_result {
-      background-color: rgb(192, 255, 192);
-    }
-    .fail_result {
-      background-color: rgb(255, 192, 192);
-    }
-    .not_tested {
-      background-color: rgb(192, 192, 192);
-    }
-    .failed_check_summary {
-      font-style: italic;
-    }
-  </style>
+  {% include "sequence_view/style.html" %}
   {{ explorer_header() }}
 </head>
 <body>
@@ -131,8 +73,8 @@
                   {% endif %}
                 {% endfor %}
               {% elif event.type == EventType.FailedCheck %}
-                <td>&#x274C;</td>
-                <td class="fail_result">
+                <td>{{ severity_symbol(event.failed_check.severity) }}</td>
+                <td class="{{ severity_class(event.failed_check.severity) }}">
                   {% if event.failed_check.documentation_url %}
                     <a href="{{ event.failed_check.documentation_url }}">{{ event.failed_check.name }}</a>
                   {% else %}
@@ -152,7 +94,9 @@
                 </td>
                 {% for participant_id in all_participants %}
                   {% if (participant_id != UNATTRIBUTED_PARTICIPANT and participant_id in event.failed_check.participants) or (participant_id == UNATTRIBUTED_PARTICIPANT and not event.failed_check.participants) %}
-                    <td class="fail_result">&#x274C;</td>
+                    <td class="{{ severity_class(event.failed_check.severity) }}">
+                      {{ severity_symbol(event.failed_check.severity) }}
+                    </td>
                   {% else %}
                     <td></td>
                   {% endif %}

--- a/monitoring/uss_qualifier/reports/templates/sequence_view/scenario.html
+++ b/monitoring/uss_qualifier/reports/templates/sequence_view/scenario.html
@@ -104,9 +104,9 @@
               {% elif event.type == EventType.Query %}
                 <td>&#x1F310;</td>
                 <td>
-                  {{ event.query.request.method }} {{ event.query.request.url_hostname }}
+                  {% set query_dict = {event.query.request.method + " " + event.query.request.url_hostname + " " + str(event.query.response.status_code): event.query} %}
                   {% set query_id = "e" + str(event.event_index) + "query" %}
-                  {{ explorer_content(query_id, event.query) }}
+                  {{ explorer_content(query_id, query_dict) }}
                   {% set collapsible.queries = collapsible.queries + [query_id] %}
                 </td>
                 {% for participant_id in all_participants %}

--- a/monitoring/uss_qualifier/reports/templates/sequence_view/severity.html
+++ b/monitoring/uss_qualifier/reports/templates/sequence_view/severity.html
@@ -1,0 +1,21 @@
+{% macro severity_symbol(s) %}
+  {% if s == Severity.Low %}
+    &#8505;&#65039;
+  {% elif s == Severity.Medium %}
+    &#9888;&#65039;
+  {% elif s == Severity.High %}
+    &#x1F6D1;
+  {% elif s == Severity.Critical %}
+    &#9762;&#65039;
+  {% else %}
+    ?
+  {% endif %}
+{% endmacro %}
+
+{% macro severity_class(s) %}
+  {% if s == Severity.Low %}
+    info_result
+  {% else %}
+    fail_result
+  {% endif %}
+{% endmacro %}

--- a/monitoring/uss_qualifier/reports/templates/sequence_view/style.html
+++ b/monitoring/uss_qualifier/reports/templates/sequence_view/style.html
@@ -1,0 +1,72 @@
+<style>
+  body {
+    margin: 0;
+    color: #24292f;
+    background-color: #ffffff;
+    font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
+    font-size: 16px;
+    line-height: 1.5;
+    word-wrap: break-word;
+  }
+  table {
+    border-spacing: 0;
+    border-collapse: collapse;
+    width: max-content;
+    max-width: 100%;
+    overflow: auto;
+  }
+  tr {
+    border-top: 1px solid hsla(210,18%,87%,1);
+  }
+  table tr:nth-child(2n) {
+    background-color: #f6f8fa;
+  }
+  td {
+    padding: 6px 6px;
+    vertical-align: top;
+    border: 1px solid #d0d7de;
+  }
+  th {
+    padding: 6px 6px;
+    text-align: left;
+    background-color: rgb(230, 230, 230);
+    border: 1px solid #d0d7de;
+    height: 40px;
+  }
+  a {
+    background-color: transparent;
+    color: #0969da;
+    text-decoration: none;
+  }
+  h2 {
+    margin-block-end: 0.1em;
+  }
+  p {
+    margin-top: 0.1em;
+    margin-bottom: 0.1em;
+  }
+  .sticky_cell_value {
+    position: sticky;
+    top: 0px; // 40px
+    z-index: 0;
+  }
+  .pass_result {
+    background-color: rgb(192, 255, 192);
+  }
+  .fail_result {
+    background-color: rgb(255, 192, 192);
+  }
+  .info_result {
+    background-color: rgb(255, 255, 192);
+  }
+  .not_tested {
+    background-color: rgb(192, 192, 192);
+  }
+  .skipped_explanation {
+    font-style: italic;
+  }
+  .failed_check_summary {
+    font-style: italic;
+  }
+</style>
+

--- a/monitoring/uss_qualifier/scenarios/documentation/parsing.py
+++ b/monitoring/uss_qualifier/scenarios/documentation/parsing.py
@@ -33,6 +33,8 @@ _test_step_cache: Dict[str, TestStepDocumentation] = {}
 
 
 def _length_of_section(values, start_of_section: int) -> int:
+    if start_of_section + 1 >= len(values):
+        return 1
     level = values[start_of_section].level
     c = start_of_section + 1
     while c < len(values):

--- a/monitoring/uss_qualifier/suites/suite.py
+++ b/monitoring/uss_qualifier/suites/suite.py
@@ -37,6 +37,7 @@ from monitoring.uss_qualifier.reports.report import (
     TestSuiteReport,
     TestSuiteActionReport,
     ParticipantCapabilityEvaluationReport,
+    Severity,
     SkippedActionReport,
 )
 from monitoring.uss_qualifier.resources.definitions import ResourceID
@@ -62,9 +63,14 @@ from monitoring.uss_qualifier.suites.definitions import (
 
 def _print_failed_check(failed_check: FailedCheck) -> None:
     yaml_lines = yaml.dump(json.loads(json.dumps(failed_check))).split("\n")
-    logger.warning(
-        "New failed check:\n{}", "\n".join("  " + line for line in yaml_lines)
-    )
+    if failed_check.severity == Severity.Low:
+        logger.info(
+            "Informational finding:\n{}", "\n".join("  " + line for line in yaml_lines)
+        )
+    else:
+        logger.warning(
+            "New failed check:\n{}", "\n".join("  " + line for line in yaml_lines)
+        )
 
 
 class TestSuiteAction(object):


### PR DESCRIPTION
This PR partially addresses #409 via the low-hanging fruit of different console messages and sequence view artifact renderings of low-severity "failed checks".

It also cleans up sequence view artifacts by making the style reusable and fully collapsing query information by default.

A scenario documentation parsing bug is fixed and the default string representation of QueryType is changed to be the fully-qualified value, which should be more clear to user readers.