### PR TITLE
[uss_qualifier] Clean uss_qualifier op intents at prep time

### DIFF
--- a/monitoring/uss_qualifier/resources/astm/f3548/v21/dss.py
+++ b/monitoring/uss_qualifier/resources/astm/f3548/v21/dss.py
@@ -259,12 +259,15 @@ class DSSInstance(object):
         if query.status_code != 200:
             return None, None, query
         else:
-            result = ChangeOperationalIntentReferenceResponse(
-                ImplicitDict.parse(
-                    query.response.json, ChangeOperationalIntentReferenceResponse
+            try:
+                result = ChangeOperationalIntentReferenceResponse(
+                    ImplicitDict.parse(
+                        query.response.json, ChangeOperationalIntentReferenceResponse
+                    )
                 )
-            )
-            return result.operational_intent_reference, result.subscribers, query
+                return result.operational_intent_reference, result.subscribers, query
+            except ValueError as e:
+                return None, None, query
 
     def set_uss_availability(
         self,

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/remove_op_intent.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/remove_op_intent.md
@@ -4,4 +4,4 @@ This test step fragment attempts to remove from the DSS a specific operational i
 
 ## 🛑 Operational intent reference removed check
 
-If the operational intent reference could not be removed, the DSS instance used does not meet **[astm.f3548.v21.DSS0005,1](../../../../../../requirements/astm/f3548/v21.md)**
+If the operational intent reference could not be removed, the DSS instance used does not meet **[astm.f3548.v21.DSS0005,1](../../../../requirements/astm/f3548/v21.md)**

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/remove_op_intent.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/remove_op_intent.md
@@ -1,0 +1,7 @@
+# Remove operational intent test step fragment
+
+This test step fragment attempts to remove from the DSS a specific operational intent reference managed by a user whose credentials are provided to uss_qualifier.
+
+## 🛑 Operational intent reference removed check
+
+If the operational intent reference could not be removed, the DSS instance used does not meet **[astm.f3548.v21.DSS0005,1](../../../../../../requirements/astm/f3548/v21.md)**

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/test_step_fragments.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/test_step_fragments.py
@@ -1,0 +1,28 @@
+from monitoring.uss_qualifier.resources.astm.f3548.v21.dss import DSSInstance
+from monitoring.uss_qualifier.scenarios.scenario import TestScenarioType
+from uas_standards.astm.f3548.v21.api import EntityID
+
+
+def remove_op_intent(
+    scenario: TestScenarioType, dss: DSSInstance, oi_id: EntityID, ovn: str
+) -> None:
+    """Remove the specified operational intent reference from the DSS.
+
+    The specified operational intent reference must be managed by `dss`'s auth adapter subscriber.
+
+    This function implements the test step fragment described in remove_op_intent.md.
+    """
+    removed_ref, subscribers_to_notify, query = dss.delete_op_intent(oi_id, ovn)
+    scenario.record_query(query)
+
+    with scenario.check(
+        "Operational intent reference removed", dss.participant_id
+    ) as check:
+        if removed_ref is None:
+            check.record_failed(
+                summary=f"Could not remove op intent reference {oi_id}",
+                details=f"When attempting to remove op intent reference {oi_id} from the DSS, received {query.status_code}",
+                query_timestamps=[query.request.timestamp],
+            )
+
+    # TODO: Attempt to notify subscribers

--- a/monitoring/uss_qualifier/scenarios/astm/utm/prep_planners.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/prep_planners.md
@@ -34,7 +34,7 @@ FlightIntentsResource containing flight intents that will be used in subsequent 
 
 (Optional) If more than one FlightIntentsResource will be used in subsequent tests, additional intents may be specified with this resource.
 
-## Preparation test case
+## Flight planners preparation test case
 
 ### Check for flight planning readiness test step
 
@@ -70,6 +70,29 @@ If the DSS fails to reply to a query concerning operational intent references in
 an operational intent from its own creator, it is in violation of **[astm.f3548.v21.DSS0005,1](../../../requirements/astm/f3548/v21.md)**
 or **[astm.f3548.v21.DSS0005,2](../../../requirements/astm/f3548/v21.md)**, and this check will fail.
 
+#### 🛑 Area is clear of foreign op intents check
+
+If operational intents from foreign (non-uss_qualifier) users remain in the 4D area(s) following the preceding area clearing, then the current state of the test environment is not suitable to conduct tests so this check will fail.
+
+## uss_qualifier preparation test case
+
+In addition to foreign flight planners, uss_qualifier may have left operational intents in the DSS from an incomplete previous run.  This test case attempts to clean them up if they exist.  If there are no operational intents from uss_qualifier in the flight intent areas, this test case will be skipped.
+
+### Remove uss_qualifier op intents test step
+
+#### [Remove op intents](./dss/remove_op_intent.md)
+
+The operational intent references managed by uss_qualifier discovered in the previous test case are removed.
+
+### Clear area validation test step
+
+uss_qualifier verifies with the DSS that there are no operational intents remaining in the area.
+
+#### 🛑 DSS responses check
+
+If the DSS fails to reply to a query concerning operational intent references in a given area, it is in violation of **[astm.f3548.v21.DSS0005,1](../../../requirements/astm/f3548/v21.md)**
+or **[astm.f3548.v21.DSS0005,2](../../../requirements/astm/f3548/v21.md)**, and this check will fail.
+
 #### 🛑 Area is clear check
 
-If operational intents remain in the 4D area(s) following the preceding area clearing, then the current state of the test environment is not suitable to conduct tests so this check will fail.
+If any operational intents remain in the 4D area(s) following the preceding area clearing, then the current state of the test environment is not suitable to conduct tests so this check will fail.


### PR DESCRIPTION
Currently, uss_qualifier often prepares a clean workspace by having all the flight planners remove flights from test areas.  If a previous test run did not end cleanly, there may also be dangling operational intents managed by uss_qualifier in the test areas, however, and these operational intents will not be removed by any of the USSs (because they do not manage them).  This PR adds a test case to the preparation scenario to remove uss_qualifier's operational intents from the test areas if they exist.  It was tested at development time by artificially adding a uss_qualifier operational intent at the beginning of the scenario.