### PR TITLE
[uss_qualifier] Specify F3548  and versioning scopes explicitly

### DIFF
--- a/monitoring/monitorlib/inspection.py
+++ b/monitoring/monitorlib/inspection.py
@@ -1,4 +1,5 @@
 import importlib
+import inspect
 import pkgutil
 from typing import Type
 
@@ -40,3 +41,7 @@ def fullname(class_type: Type) -> str:
         return module + "." + class_type.__qualname__
     else:
         return str(class_type)
+
+
+def calling_function_name(levels: int = 0) -> str:
+    return inspect.stack()[levels + 1].function

--- a/monitoring/uss_qualifier/action_generators/astm/f3548/for_each_dss.py
+++ b/monitoring/uss_qualifier/action_generators/astm/f3548/for_each_dss.py
@@ -75,9 +75,7 @@ class ForEachDSS(ActionGenerator[ForEachDSSSpecification]):
         self._actions = []
         for dss_instance in dss_instances:
             modified_resources = {k: v for k, v in resources.items()}
-            modified_resources[
-                specification.dss_instance_id
-            ] = DSSInstanceResource.from_dss_instance(dss_instance)
+            modified_resources[specification.dss_instance_id] = dss_instance
 
             self._actions.append(
                 TestSuiteAction(specification.action_to_repeat, modified_resources)

--- a/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml
@@ -40,6 +40,9 @@ v1:
               # InterUSS flight_planning v1 automated testing API
               - interuss.flight_planning.direct_automated_test
               - interuss.flight_planning.plan
+              # ASTM F3548-21 USS emulation roles
+              - utm.strategic_coordination
+              - utm.availability_arbitration
 
         # Means by which uss_qualifier can discover which subscription ('sub' claim of its tokes) it is described by
         utm_client_identity:
@@ -58,13 +61,14 @@ v1:
           dependencies:
             client_identity: utm_client_identity
 
-        # A second auth adapter, for checks that require a second set of credentials for accessing the ecosystem.
+        # A second auth adapter, for DSS tests that require a second set of credentials for accessing the ecosystem.
         # Note that the 'sub' claim of the tokens obtained through this adepter MUST be different from the first auth adapter.
         second_utm_auth:
           resource_type: resources.communications.AuthAdapterResource
           specification:
             environment_variable_containing_auth_spec: AUTH_SPEC_2
-            scopes_authorized: []
+            scopes_authorized:
+              - utm.strategic_coordination
 
         # Set of USSs capable of being tested as flight planners
         flight_planners:

--- a/monitoring/uss_qualifier/configurations/dev/library/environment_containers.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/library/environment_containers.yaml
@@ -23,21 +23,20 @@ utm_auth:
       - interuss.flight_planning.plan
       # Legacy InterUSS scd injection v1 automated testing API
       - utm.inject_test_data
-      # ASTM F3548-21 USS emulation roles (not yet programatically constrained)
-#      - utm.strategic_coordination
-#      - utm.constraint_management
-#      - utm.constraint_processing
-#      - utm.conformance_monitoring_sa
-#      - utm.availability_arbitration
-      # InterUSS versioning automated testing API (not yet programatically constrained)
-#      - interuss.versioning.read_system_versions
+      # ASTM F3548-21 USS emulation roles
+      - utm.strategic_coordination
+      - utm.conformance_monitoring_sa
+      - utm.availability_arbitration
+      # InterUSS versioning automated testing
+      - interuss.versioning.read_system_versions
 
 second_utm_auth:
   $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
   resource_type: resources.communications.AuthAdapterResource
   specification:
     environment_variable_containing_auth_spec: AUTH_SPEC_2
-    scopes_authorized: []
+    scopes_authorized:
+      - utm.strategic_coordination
 
 utm_client_identity:
   $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json

--- a/monitoring/uss_qualifier/configurations/dev/library/environment_localhost.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/library/environment_localhost.yaml
@@ -23,21 +23,20 @@ utm_auth:
       - interuss.flight_planning.plan
       # Legacy InterUSS scd injection v1 automated testing API
       - utm.inject_test_data
-      # ASTM F3548-21 USS emulation roles (not yet programatically constrained)
-#      - utm.strategic_coordination
-#      - utm.constraint_management
-#      - utm.constraint_processing
-#      - utm.conformance_monitoring_sa
-#      - utm.availability_arbitration
-      # InterUSS versioning automated testing API (not yet programatically constrained)
-#      - interuss.versioning.read_system_versions
+      # ASTM F3548-21 USS emulation roles
+      - utm.strategic_coordination
+      - utm.conformance_monitoring_sa
+      - utm.availability_arbitration
+      # InterUSS versioning automated testing
+      - interuss.versioning.read_system_versions
 
 second_utm_auth:
   $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
   resource_type: resources.communications.AuthAdapterResource
   specification:
     environment_variable_containing_auth_spec: AUTH_SPEC_2
-    scopes_authorized: []
+    scopes_authorized:
+      - utm.strategic_coordination
 
 utm_client_identity:
   $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json

--- a/monitoring/uss_qualifier/configurations/dev/uspace.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/uspace.yaml
@@ -44,7 +44,7 @@ v1:
           mock_uss_instances: mock_uss_instances_scdsc
           locality: locality_che
 
-          version_providers: scd_version_providers
+          version_providers: scd_version_providers?
 
           conflicting_flights: che_conflicting_flights
           priority_preemption_flights: che_conflicting_flights
@@ -73,7 +73,7 @@ v1:
             test_suite:
               suite_type: suites.uspace.required_services
               resources:
-                version_providers: version_providers
+                version_providers: version_providers?
 
                 conflicting_flights: conflicting_flights
                 priority_preemption_flights: priority_preemption_flights

--- a/monitoring/uss_qualifier/resources/communications/auth_adapter.py
+++ b/monitoring/uss_qualifier/resources/communications/auth_adapter.py
@@ -71,6 +71,6 @@ class AuthAdapterResource(Resource[AuthAdapterSpecification]):
                 if isinstance(scope, Enum):
                     scope = scope.value
                 raise MissingResourceError(
-                    f"AuthAdapterResource provided to {consumer_name} is not declared (in its resource specification) as authorized to obtain scope `{scope}` which is required by {consumer_name} to {reason}.  Update `scopes_authorized` to include `{scope}` to resolve this message.  {len(self.scopes)} scopes already declared as authorized for AuthAdapterResource: {', '.join(self.scopes)}",
+                    f"AuthAdapterResource provided to {consumer_name} is not declared (in its resource specification) as authorized to obtain scope `{scope}` which is required by {consumer_name} to {reason}.  Update `scopes_authorized` to include `{scope}` to resolve this message.  {len(self.scopes)} scopes declared as authorized for AuthAdapterResource: {', '.join(self.scopes)}",
                     "<unknown>",
                 )

--- a/monitoring/uss_qualifier/resources/versioning/client.py
+++ b/monitoring/uss_qualifier/resources/versioning/client.py
@@ -1,12 +1,14 @@
 from typing import Optional, List
 
 from implicitdict import ImplicitDict
+from uas_standards.interuss.automated_testing.versioning.constants import Scope
 
 from monitoring.monitorlib.clients.versioning.client import VersioningClient
 from monitoring.monitorlib.clients.versioning.client_interuss import (
     InterUSSVersioningClient,
 )
 from monitoring.monitorlib.infrastructure import UTMClientSession
+from monitoring.monitorlib.inspection import fullname
 from monitoring.uss_qualifier.reports.report import ParticipantID
 from monitoring.uss_qualifier.resources.communications import AuthAdapterResource
 from monitoring.uss_qualifier.resources.resource import Resource
@@ -37,6 +39,12 @@ class VersionProvidersResource(Resource[VersionProvidersSpecification]):
         specification: VersionProvidersSpecification,
         auth_adapter: AuthAdapterResource,
     ):
+        auth_adapter.assert_scopes_available(
+            {
+                Scope.ReadSystemVersions: "read and record the version of each system under test",
+            },
+            fullname(type(self)),
+        )
         self.version_providers = []
         for instance in specification.instances:
             if "interuss" in instance and instance.interuss:

--- a/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/get_op_data_validation.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/get_op_data_validation.py
@@ -60,6 +60,7 @@ from monitoring.uss_qualifier.scenarios.flight_planning.test_steps import (
 )
 from monitoring.uss_qualifier.suites.suite import ExecutionContext
 from uas_standards.astm.f3548.v21.api import OperationID
+from uas_standards.astm.f3548.v21.constants import Scope
 
 
 class GetOpResponseDataValidationByUSS(TestScenario):
@@ -82,7 +83,11 @@ class GetOpResponseDataValidationByUSS(TestScenario):
         self.tested_uss_client = tested_uss.client
         self.mock_uss = mock_uss.mock_uss
         self.mock_uss_client = mock_uss.mock_uss.flight_planner
-        self.dss = dss.dss
+        self.dss = dss.get_instance(
+            {
+                Scope.StrategicCoordination: "search for operational intent references to verify outcomes of planning activities"
+            }
+        )
 
         if not flight_intents:
             msg = f"No FlightIntentsResource was provided as input to this test, it is assumed that the jurisdiction does not allow any same priority conflicts, execution of the scenario was stopped without failure"

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss_interoperability.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss_interoperability.py
@@ -5,6 +5,7 @@ from urllib.parse import urlparse
 
 from monitoring.uss_qualifier.suites.suite import ExecutionContext
 from uas_standards.astm.f3548.v21.api import Volume4D, Volume3D, Polygon, LatLngPoint
+from uas_standards.astm.f3548.v21.constants import Scope
 
 from monitoring.uss_qualifier.resources.astm.f3548.v21.dss import (
     DSSInstancesResource,
@@ -32,11 +33,14 @@ class DSSInteroperability(TestScenario):
         all_dss_instances: DSSInstancesResource,
     ):
         super().__init__()
-        self._dss_primary = primary_dss_instance.dss
+        scopes = {
+            Scope.StrategicCoordination: "search for operational intent references to verify DSS is reachable"
+        }
+        self._dss_primary = primary_dss_instance.get_instance(scopes)
         self._dss_others = [
-            dss
+            dss.get_instance(scopes)
             for dss in all_dss_instances.dss_instances
-            if not dss.is_same_as(primary_dss_instance.dss)
+            if not dss.is_same_as(primary_dss_instance)
         ]
 
     def run(self, context: ExecutionContext):

--- a/monitoring/uss_qualifier/scenarios/astm/utm/flight_intent_validation/flight_intent_validation.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/flight_intent_validation/flight_intent_validation.py
@@ -3,7 +3,7 @@ import arrow
 from monitoring.monitorlib.geotemporal import Volume4DCollection
 from monitoring.uss_qualifier.suites.suite import ExecutionContext
 from uas_standards.astm.f3548.v21.api import OperationalIntentState
-from uas_standards.astm.f3548.v21.constants import OiMaxPlanHorizonDays
+from uas_standards.astm.f3548.v21.constants import OiMaxPlanHorizonDays, Scope
 
 from monitoring.uss_qualifier.resources.astm.f3548.v21 import DSSInstanceResource
 from monitoring.uss_qualifier.resources.astm.f3548.v21.dss import DSSInstance
@@ -54,7 +54,11 @@ class FlightIntentValidation(TestScenario):
     ):
         super().__init__()
         self.tested_uss = tested_uss.flight_planner
-        self.dss = dss.dss
+        self.dss = dss.get_instance(
+            {
+                Scope.StrategicCoordination: "search for operational intent references to verify outcomes of planning activities"
+            }
+        )
 
         _flight_intents = {
             k: FlightIntent.from_flight_info_template(v)

--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.py
@@ -12,6 +12,7 @@ from monitoring.uss_qualifier.suites.suite import ExecutionContext
 from uas_standards.astm.f3548.v21.api import (
     OperationalIntentReference,
 )
+from uas_standards.astm.f3548.v21.constants import Scope
 from monitoring.monitorlib.geotemporal import Volume4DCollection
 
 from monitoring.uss_qualifier.resources.astm.f3548.v21 import DSSInstanceResource
@@ -81,7 +82,16 @@ class ConflictEqualPriorityNotPermitted(TestScenario):
         super().__init__()
         self.tested_uss = tested_uss.flight_planner
         self.control_uss = control_uss.flight_planner
-        self.dss = dss.dss
+
+        scopes = {
+            Scope.StrategicCoordination: "search for operational intent references to verify outcomes of planning activities and retrieve operational intent details"
+        }
+        if dss.can_use_scope(Scope.ConformanceMonitoringForSituationalAwareness):
+            scopes[
+                Scope.ConformanceMonitoringForSituationalAwareness
+            ] = "query for telemetry for off-nominal operational intents"
+
+        self.dss = dss.get_instance(scopes)
 
         expected_flight_intents = [
             ExpectedFlightIntent(

--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.py
@@ -12,6 +12,7 @@ from monitoring.uss_qualifier.suites.suite import ExecutionContext
 from uas_standards.astm.f3548.v21.api import (
     OperationalIntentReference,
 )
+from uas_standards.astm.f3548.v21.constants import Scope
 
 from monitoring.monitorlib.geotemporal import Volume4DCollection, Volume4D
 from uas_standards.interuss.automated_testing.scd.v1.api import (
@@ -80,7 +81,11 @@ class ConflictHigherPriority(TestScenario):
         super().__init__()
         self.tested_uss = tested_uss.flight_planner
         self.control_uss = control_uss.flight_planner
-        self.dss = dss.dss
+        self.dss = dss.get_instance(
+            {
+                Scope.StrategicCoordination: "search for operational intent references to verify outcomes of planning activities and retrieve operational intent details"
+            }
+        )
 
         expected_flight_intents = [
             ExpectedFlightIntent(

--- a/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss.py
@@ -8,6 +8,7 @@ from uas_standards.astm.f3548.v21.api import (
     OperationalIntentState,
     OperationalIntentReference,
 )
+from uas_standards.astm.f3548.v21.constants import Scope
 from uas_standards.interuss.automated_testing.scd.v1.api import (
     InjectFlightResponseResult,
 )
@@ -55,7 +56,12 @@ class DownUSS(TestScenario):
     ):
         super().__init__()
         self.tested_uss = tested_uss.flight_planner
-        self.dss = dss.dss
+        self.dss = dss.get_instance(
+            {
+                Scope.StrategicCoordination: "search for operational intent references to verify outcomes of planning activities and retrieve operational intent details",
+                Scope.AvailabilityArbitration: "declare virtual USS down in DSS",
+            }
+        )
 
         _flight_intents: Dict[str, FlightIntent] = {
             k: FlightIntent.from_flight_info_template(v)

--- a/monitoring/uss_qualifier/scenarios/astm/utm/op_intent_ref_access_control.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/op_intent_ref_access_control.py
@@ -2,6 +2,7 @@ from typing import List
 
 from uas_standards.astm.f3548.v21 import api as f3548v21
 from uas_standards.astm.f3548.v21.api import OperationalIntentState
+from uas_standards.astm.f3548.v21.constants import Scope
 
 from monitoring.monitorlib.geotemporal import Volume4DCollection
 from monitoring.prober.infrastructure import register_resource_type
@@ -57,19 +58,19 @@ class OpIntentReferenceAccessControl(TestScenario):
         id_generator: IDGeneratorResource,
     ):
         super().__init__()
-        self._dss = dss.dss
-        self._pid = [dss.dss.participant_id]
+        scopes = {
+            Scope.StrategicCoordination: "create and delete operational intent references"
+        }
+        self._dss = dss.get_instance(scopes)
+        self._pid = [self._dss.participant_id]
 
         self._oid_1 = id_generator.id_factory.make_id(self.OP_INTENT_1)
         self._oid_2 = id_generator.id_factory.make_id(self.OP_INTENT_2)
 
         if second_utm_auth is not None:
             # Build a second DSSWrapper identical to the first but with the other auth adapter
-            self._dss_separate_creds = DSSInstance(
-                participant_id=dss.dss.participant_id,
-                base_url=dss.dss.base_url,
-                has_private_address=dss.dss.has_private_address,
-                auth_adapter=second_utm_auth.adapter,
+            self._dss_separate_creds = self._dss.with_different_auth(
+                second_utm_auth, scopes
             )
 
         try:

--- a/monitoring/uss_qualifier/scenarios/astm/utm/prep_planners.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/prep_planners.py
@@ -18,6 +18,7 @@ from monitoring.uss_qualifier.resources.interuss.mock_uss.client import (
 from uas_standards.astm.f3548.v21.api import (
     OperationalIntentReference,
 )
+from uas_standards.astm.f3548.v21.constants import Scope
 
 
 class PrepareFlightPlanners(GenericPrepareFlightPlanners):
@@ -41,7 +42,11 @@ class PrepareFlightPlanners(GenericPrepareFlightPlanners):
             flight_intents3,
             flight_intents4,
         )
-        self.dss = dss.dss
+        self.dss = dss.get_instance(
+            {
+                Scope.StrategicCoordination: "search for operational intent references and remove ones under uss_qualifier management"
+            }
+        )
 
     def run(self, context):
         self.begin_test_scenario(context)

--- a/monitoring/uss_qualifier/scenarios/astm/utm/test_steps.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/test_steps.py
@@ -11,6 +11,7 @@ from uas_standards.astm.f3548.v21.api import (
     OperationalIntentReference,
     GetOperationalIntentDetailsResponse,
 )
+from uas_standards.astm.f3548.v21.constants import Scope
 from monitoring.monitorlib.clients.flight_planning.flight_info import (
     UasState,
     AirspaceUsageState,
@@ -174,7 +175,9 @@ class OpIntentValidator(object):
         if flight_intent.basic_information.uas_state in {
             UasState.OffNominal,
             UasState.Contingent,
-        }:
+        } and self._dss.can_use_scope(
+            Scope.ConformanceMonitoringForSituationalAwareness
+        ):
             self._check_op_intent_telemetry(oi_ref)
 
         self._scenario.end_test_step()

--- a/monitoring/uss_qualifier/suites/uspace/required_services.yaml
+++ b/monitoring/uss_qualifier/suites/uspace/required_services.yaml
@@ -1,6 +1,6 @@
 name: U-space required services
 resources:
-  version_providers: resources.versioning.VersionProvidersResource
+  version_providers: resources.versioning.VersionProvidersResource?
 
   conflicting_flights: resources.flight_planning.FlightIntentsResource
   priority_preemption_flights: resources.flight_planning.FlightIntentsResource


### PR DESCRIPTION
Following #449, this PR explicitly specifies scopes needed and used with regard to F3548-21 and InterUSS versioning.  The F3548 scopes are almost all used through a "DSSInstance"<sup>1</sup>.  The primary change in this PR is to make it so that obtaining a DSSInstance from a DSSInstanceResource requires the user (usually a test scenario) to specify which scopes they need to use, and then the DSSInstance obtained will refuse to perform operations that require any other unrequested/undeclared scopes.  The declaration of scope usage throws a MissingResourceError if the required scopes aren't available, and this allows test scenarios that require scopes that aren't available to merely be skipped (similar to #449).

While the "standard" dev library resources have all scopes granted, f3548_self_contained omits the CMSA scope and therefore skips the checks where that scope is needed.

<sup>1</sup> This really should be named something like InteroperabilityEcosystemClient because it does access a DSS instance, but it also accesses USSs based on the information obtained from that DSS instance.