### PR TITLE
[uss_qualifier] Update f3548_self_contained tested requirements

### DIFF
--- a/github_pages/static/index.md
+++ b/github_pages/static/index.md
@@ -22,7 +22,8 @@ These reports were generated during continuous integration for the most recent P
 ### [ASTM F3548-21 test configuration](https://github.com/interuss/monitoring/blob/main/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml)
 
 * [Sequence view](./artifacts/uss_qualifier/reports/f3548/sequence)
-* [Tested requirements](./artifacts/uss_qualifier/reports/f3548/requirements)
+* [Tested requirements, Gate 1](./artifacts/uss_qualifier/reports/f3548/gate1)
+* [Tested requirements, Gate 3](./artifacts/uss_qualifier/reports/f3548/gate3)
 
 ### [ASTM F3411-22a test configuration](https://github.com/interuss/monitoring/blob/main/monitoring/uss_qualifier/configurations/dev/netrid_v22a.yaml)
 

--- a/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml
@@ -184,18 +184,115 @@ v1:
     # Write out full report content
     raw_report: {}
 
-    # Write out a human-readable report of the F3548-21 requirements tested
+    # Write out a human-readable reports of the F3548-21 requirements tested
     tested_requirements:
-      - report_name: requirements
+      - report_name: gate1
         requirement_collections:
-          scd:
-            requirement_collections:
-              - requirement_sets:
-                  - astm.f3548.v21.scd
-                  - astm.f3548.v21.dss_provider
+          scd_no_dss:
+            requirements:
+              - astm.f3548.v21.GEN0300
+              - astm.f3548.v21.GEN0310
+              - astm.f3548.v21.OPIN0015
+              - astm.f3548.v21.OPIN0020
+              - astm.f3548.v21.OPIN0025
+              - astm.f3548.v21.OPIN0030
+              - astm.f3548.v21.OPIN0035
+              - astm.f3548.v21.OPIN0040
+              - astm.f3548.v21.USS0005
+              - astm.f3548.v21.SCD0035
+              - astm.f3548.v21.SCD0040
+              - astm.f3548.v21.SCD0045
+              - astm.f3548.v21.SCD0050
+              - astm.f3548.v21.SCD0075
+              - astm.f3548.v21.SCD0080
+              - astm.f3548.v21.SCD0085
+              - astm.f3548.v21.GEN0500
+              - astm.f3548.v21.USS0105
         participant_requirements:
-          uss1: scd
-          uss2: scd
+          uss1: scd_no_dss
+          uss2: scd_no_dss
+      - report_name: gate3
+        requirement_collections:
+          scd_and_dss:
+            requirements:
+              - astm.f3548.v21.GEN0100
+              - astm.f3548.v21.GEN0105
+              - astm.f3548.v21.GEN0300
+              - astm.f3548.v21.GEN0305
+              - astm.f3548.v21.GEN0310
+              - astm.f3548.v21.OPIN0005
+              - astm.f3548.v21.OPIN0010
+              - astm.f3548.v21.OPIN0015
+              - astm.f3548.v21.OPIN0020
+              - astm.f3548.v21.OPIN0025
+              - astm.f3548.v21.OPIN0030
+              - astm.f3548.v21.OPIN0035
+              - astm.f3548.v21.OPIN0040
+              - astm.f3548.v21.USS0005
+              - astm.f3548.v21.SCD0035
+              - astm.f3548.v21.SCD0040
+              - astm.f3548.v21.SCD0045
+              - astm.f3548.v21.SCD0050
+              - astm.f3548.v21.SCD0075
+              - astm.f3548.v21.SCD0080
+              - astm.f3548.v21.SCD0085
+              - astm.f3548.v21.GEN0500
+              - astm.f3548.v21.USS0105
+              - astm.f3548.v21.DSS0005,1
+              - astm.f3548.v21.DSS0005,2
+              - astm.f3548.v21.DSS0005,5
+              - astm.f3548.v21.DSS0015
+              - astm.f3548.v21.DSS0020
+              - astm.f3548.v21.DSS0100
+              - astm.f3548.v21.DSS0200
+              - astm.f3548.v21.DSS0205
+              - astm.f3548.v21.DSS0210
+              - astm.f3548.v21.DSS0210,A2-7-2,1a
+              - astm.f3548.v21.DSS0210,A2-7-2,1b
+              - astm.f3548.v21.DSS0210,A2-7-2,1c
+              - astm.f3548.v21.DSS0210,A2-7-2,1d
+              - astm.f3548.v21.DSS0210,A2-7-2,2a
+              - astm.f3548.v21.DSS0210,A2-7-2,2b
+              - astm.f3548.v21.DSS0210,A2-7-2,3a
+              - astm.f3548.v21.DSS0210,A2-7-2,3b
+              - astm.f3548.v21.DSS0210,A2-7-2,4a
+              - astm.f3548.v21.DSS0210,A2-7-2,4b
+              - astm.f3548.v21.DSS0210,A2-7-2,4c
+              - astm.f3548.v21.DSS0210,A2-7-2,4d
+              - astm.f3548.v21.DSS0210,A2-7-2,5a
+              - astm.f3548.v21.DSS0210,A2-7-2,5b
+              - astm.f3548.v21.DSS0210,A2-7-2,5c
+              - astm.f3548.v21.DSS0210,A2-7-2,7
+              - astm.f3548.v21.DSS0215
+              - astm.f3548.v21.DSS0300
+          scd_no_dss:
+            requirements:
+              - astm.f3548.v21.GEN0100
+              - astm.f3548.v21.GEN0105
+              - astm.f3548.v21.GEN0300
+              - astm.f3548.v21.GEN0305
+              - astm.f3548.v21.GEN0310
+              - astm.f3548.v21.OPIN0005
+              - astm.f3548.v21.OPIN0010
+              - astm.f3548.v21.OPIN0015
+              - astm.f3548.v21.OPIN0020
+              - astm.f3548.v21.OPIN0025
+              - astm.f3548.v21.OPIN0030
+              - astm.f3548.v21.OPIN0035
+              - astm.f3548.v21.OPIN0040
+              - astm.f3548.v21.USS0005
+              - astm.f3548.v21.SCD0035
+              - astm.f3548.v21.SCD0040
+              - astm.f3548.v21.SCD0045
+              - astm.f3548.v21.SCD0050
+              - astm.f3548.v21.SCD0075
+              - astm.f3548.v21.SCD0080
+              - astm.f3548.v21.SCD0085
+              - astm.f3548.v21.GEN0500
+              - astm.f3548.v21.USS0105
+        participant_requirements:
+          uss1: scd_and_dss
+          uss2: scd_no_dss
 
     # Write out a human-readable report showing the sequence of events of the test
     sequence_view: {}


### PR DESCRIPTION
This PR updates the f3548_self_contained CI configuration to generate two tested requirements reports reflecting a simple SCD-only (no CMSA, no constraints, no availability arbitration) activity in multiple phases.  This change will allow us to better target and measure MVP success in #274 and #434.