### PR TITLE
[make] add a 'restart-all' make target for ease of development iteration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,3 +110,9 @@ monitoring-tests: check-monitoring
 # This reproduces the entire continuous integration workflow (.github/workflows/ci.yml)
 .PHONY: presubmit
 presubmit: hygiene-tests monitoring-tests
+
+# For local development when restarts are frequently required (such as when testing changes on the DSS)
+.PHONY: restart-all
+restart-all: stop-uss-mocks down-locally start-locally start-uss-mocks
+
+


### PR DESCRIPTION
Adds a simple but frequently used combination of make targets to the root `Makefile`: 

`restart-all` makes sure everything is shut down, then starts it again.

This is useful especially when iterating on the DSS or other services that the qualifier depends on to run.