### PR TITLE
[prober] lookup and specify correct subscription version in deletion test

### DIFF
--- a/monitoring/prober/scd/test_operations_simple.py
+++ b/monitoring/prober/scd/test_operations_simple.py
@@ -218,12 +218,18 @@ def test_delete_implicit_sub(ids, scd_api, scd_session, scd_session2):
     assert resp.status_code == 200, resp.content
     operational_intent_reference = resp.json()["operational_intent_reference"]
     implicit_sub_id = operational_intent_reference["subscription_id"]
-    implicit_sub_version = operational_intent_reference["version"]
+
+    # We need to obtain the implicit subscription's version in order to properly attempt to delete it:
+    sub_resp = scd_session.get("/subscriptions/{}".format(implicit_sub_id))
+    assert sub_resp.status_code == 200, sub_resp.content
+    implicit_sub_version = sub_resp.json()["subscription"]["version"]
 
     resp = scd_session.delete(
         "/subscriptions/{}/{}".format(implicit_sub_id, implicit_sub_version)
     )
-    assert resp.status_code == 400, resp.content
+    # Expect 400 or 409 while we fix the logic in the DSS. Both this test and the DSS were handling things improperly:
+    # allow both the expected (409) and the technically correct but not-in-concordance-with-the-spec result (400)
+    assert resp.status_code in [400, 409], resp.content
 
 
 # Try (unsuccessfully) to delete Op1 from non-owning USS


### PR DESCRIPTION
Discovered that this test was not using the correct version for attempting to delete a subscription.

This was working as long as the DSS was not taking the version into account: with the fix being worked on [here](https://github.com/interuss/dss/pull/986) this will no longer work and we will get a different 4XX code.

The current fix will tolerate both the 400 and 409 outcome so that we may gracefully swap the DSS instance that is used without breaking the test.