### PR TITLE
[uss_qualifier] Remove OPIN0005 and OPIN0010 from f3548_self_contained

### DIFF
--- a/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml
@@ -220,8 +220,6 @@ v1:
               - astm.f3548.v21.GEN0300
               - astm.f3548.v21.GEN0305
               - astm.f3548.v21.GEN0310
-              - astm.f3548.v21.OPIN0005
-              - astm.f3548.v21.OPIN0010
               - astm.f3548.v21.OPIN0015
               - astm.f3548.v21.OPIN0020
               - astm.f3548.v21.OPIN0025
@@ -272,8 +270,6 @@ v1:
               - astm.f3548.v21.GEN0300
               - astm.f3548.v21.GEN0305
               - astm.f3548.v21.GEN0310
-              - astm.f3548.v21.OPIN0005
-              - astm.f3548.v21.OPIN0010
               - astm.f3548.v21.OPIN0015
               - astm.f3548.v21.OPIN0020
               - astm.f3548.v21.OPIN0025


### PR DESCRIPTION
Upon further review of requirements for which that InterUSS could provide automated testing in basic SCD usage, OPIN0005 and OPIN0010 were better verified by the USS performing aggregate conformance monitoring themselves.  Therefore, these two requirements are no longer considered necessary automated tests for [basic SCD automated testing](https://github.com/interuss/monitoring/issues/470).  Since f3548_self_contained is currently attempting to reflect those requirements, this PR removes those two requirements from the tested requirements artifact generated.