### PR TITLE
[uss_qualifier/scenarios/utm/down_uss] Set severity of op intent deletion failure in cleanup to high

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss.md
@@ -39,14 +39,14 @@ DSSInstanceResource that provides access to a DSS instance where:
 ### Resolve USS ID of virtual USS test step
 Make a dummy request to the DSS in order to resolve the USS ID of the virtual USS.
 
-#### Successful dummy query check
+#### 🛑 Successful dummy query check
 
 ### [Restore virtual USS availability test step](../set_uss_available.md)
 
 ### Clear operational intents created by virtual USS test step
 Delete any leftover operational intent references created at DSS by virtual USS.
 
-#### Successful operational intents cleanup check
+#### 🛑 Successful operational intents cleanup check
 If the search for operational intent references or their deletion fail, this check fails per **[astm.f3548.v21.DSS0005,2](../../../../requirements/astm/f3548/v21.md)** or **[astm.f3548.v21.DSS0005,1](../../../../requirements/astm/f3548/v21.md)**, respectively.
 
 ## Plan Flight 1 in conflict with accepted operational intent managed by down USS test case
@@ -56,7 +56,7 @@ This test case aims at testing requirement **[astm.f3548.v21.SCD0005](../../../.
 The USS qualifier, acting as a virtual USS, creates an operational intent at the DSS with a non-working base URL.
 The objective is to make the later request by the tested USS to retrieve operational intent details to fail.
 
-#### Operational intent successfully created check
+#### 🛑 Operational intent successfully created check
 If the creation of the operational intent reference at the DSS fails, this check fails per **[astm.f3548.v21.DSS0005,1](../../../../requirements/astm/f3548/v21.md)**.
 
 ### [Declare virtual USS as down at DSS test step](../set_uss_down.md)
@@ -73,7 +73,7 @@ As such, the tested USS may either:
 - Successfully plan Flight 1 over the conflicting operational intent, or
 - Decide to be more conservative and reject the planning of Flight 1.
 
-#### Successful planning check
+#### 🛑 Successful planning check
 All flight intent data provided is correct and the USS should have either successfully planned Flight 1 per **[astm.f3548.v21.SCD0005](../../../../requirements/astm/f3548/v21.md)**,
 or rejected properly the planning if it decided to be more conservative with such conflicts.
 If the USS indicates that the injection attempt failed, this check will fail.
@@ -81,13 +81,13 @@ If the USS indicates that the injection attempt failed, this check will fail.
 Do take note that if the USS rejects the planning, this check will not fail, but the following *Rejected planning check*
 will. Refer to this check for more information.
 
-#### Rejected planning check
+#### ℹ️ Rejected planning check
 All flight intent data provided is correct and the USS should have either successfully planned Flight 1 or rejected
 properly the planning if it decided to be more conservative with such conflicts.
 If the USS rejects the planning, this check will fail with a low severity per **[astm.f3548.v21.SCD0005](../../../../requirements/astm/f3548/v21.md)**.
 This won't actually fail the test but will serve as a warning.
 
-#### Failure check
+#### 🛑 Failure check
 All flight intent data provided was complete and correct. It should have been processed successfully, allowing the USS
 to reject or accept Flight 1. If the USS indicates that the injection attempt failed, this check will fail per
 **[interuss.automated_testing.flight_planning.ExpectedBehavior](../../../../requirements/interuss/automated_testing/flight_planning.md)**.
@@ -99,13 +99,13 @@ If the planning was accepted, Flight 1 should have been shared.
 If the planning was rejected, Flight 1 should not have been shared, thus should not exist.
 
 ## Cleanup
-### Availability of virtual USS restored check
+### 🛑 Availability of virtual USS restored check
 **[astm.f3548.v21.DSS0100,1](../../../../requirements/astm/f3548/v21.md)**
 
-### Successful flight deletion check
+### 🛑 Successful flight deletion check
 Delete flights injected at USS through the flight planning interface.
 **[interuss.automated_testing.flight_planning.DeleteFlightSuccess](../../../../requirements/interuss/automated_testing/flight_planning.md)**
 
-### Successful operational intents cleanup check
+### 🛑 Successful operational intents cleanup check
 Delete operational intents created at DSS by virtual USS.
 If the search for operational intent references or their deletion fail, this check fails per **[astm.f3548.v21.DSS0005,2](../../../../requirements/astm/f3548/v21.md)** or **[astm.f3548.v21.DSS0005,1](../../../../requirements/astm/f3548/v21.md)**, respectively.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss.py
@@ -139,7 +139,6 @@ class DownUSS(TestScenario):
             if dummy_query.status_code != 200:
                 check.record_failed(
                     summary="Failed to query DSS",
-                    severity=Severity.High,
                     details=f"DSS responded code {dummy_query.status_code}; error message: {dummy_query.error_message}",
                     query_timestamps=[dummy_query.request.timestamp],
                 )
@@ -207,8 +206,7 @@ class DownUSS(TestScenario):
             if oi_ref is None:
                 check.record_failed(
                     f"Operational intent not successfully {msg_action_past}",
-                    Severity.High,
-                    f"DSS responded code {query.status_code}; error message: {query.error_message}",
+                    details=f"DSS responded code {query.status_code}; error message: {query.error_message}",
                     query_timestamps=[query.request.timestamp],
                 )
         self.end_test_step()
@@ -267,7 +265,6 @@ class DownUSS(TestScenario):
                     )
                     check.record_failed(
                         summary="Warning (not a failure): planning got rejected, USS may have been more conservative",
-                        severity=Severity.Low,
                         details=check_details,
                     )
                 validator.expect_not_shared()
@@ -283,7 +280,6 @@ class DownUSS(TestScenario):
             if find_query.status_code != 200:
                 check.record_failed(
                     summary=f"Failed to query operational intent references from DSS in {self._intents_extent} for cleanup",
-                    severity=Severity.High,
                     details=f"DSS responded code {find_query.status_code}; error message: {find_query.error_message}",
                     query_timestamps=[find_query.request.timestamp],
                 )
@@ -298,7 +294,6 @@ class DownUSS(TestScenario):
                     if del_oi is None:
                         check.record_failed(
                             summary=f"Failed to delete op intent {oi_ref.id} from DSS",
-                            severity=Severity.High,
                             details=f"DSS responded code {del_query.status_code}; error message: {del_query.error_message}",
                             query_timestamps=[del_query.request.timestamp],
                         )
@@ -317,7 +312,6 @@ class DownUSS(TestScenario):
             if availability_version is None:
                 check.record_failed(
                     summary=f"Availability of USS {self.uss_qualifier_sub} could not be set to available",
-                    severity=Severity.High,
                     details=f"DSS responded code {avail_query.status_code}; error message: {avail_query.error_message}",
                     query_timestamps=[avail_query.request.timestamp],
                 )

--- a/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss.py
@@ -298,7 +298,7 @@ class DownUSS(TestScenario):
                     if del_oi is None:
                         check.record_failed(
                             summary=f"Failed to delete op intent {oi_ref.id} from DSS",
-                            severity=Severity.Medium,
+                            severity=Severity.High,
                             details=f"DSS responded code {del_query.status_code}; error message: {del_query.error_message}",
                             query_timestamps=[del_query.request.timestamp],
                         )


### PR DESCRIPTION
This addresses partially #447 so that a failure in the deletion interrupts the test execution.

Additionally, this transitions the down_uss scenario to using the icons for setting the severity of the checks.