### PR TITLE
[uss_qualifier] Query participants for test environment system versions in F3548-21

### DIFF
--- a/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml
@@ -14,6 +14,7 @@ v1:
         # Mapping of <resource name in test suite> to <resource name in resource pool>
         resources:
           id_generator: id_generator
+          test_env_version_providers: test_env_version_providers
           flight_planners: flight_planners
           conflicting_flights: conflicting_flights
           invalid_flight_intents: invalid_flight_intents
@@ -42,6 +43,8 @@ v1:
               # InterUSS flight_planning v1 automated testing API
               - interuss.flight_planning.direct_automated_test
               - interuss.flight_planning.plan
+              # InterUSS versioning automated testing API
+              - interuss.versioning.read_system_versions
               # ASTM F3548-21 USS emulation roles
               - utm.strategic_coordination
               - utm.availability_arbitration
@@ -112,6 +115,20 @@ v1:
                 lng: -80
               - lat: 38
                 lng: -80
+
+        # Means by which to obtain the versions of participants' systems under test (in the test environment).
+        test_env_version_providers:
+          resource_type: resources.versioning.VersionProvidersResource
+          dependencies:
+            auth_adapter: utm_auth
+          specification:
+            instances:
+              - participant_id: uss1
+                interuss:
+                  base_url: http://scdsc.uss1.localutm/versioning
+              - participant_id: uss2
+                interuss:
+                  base_url: http://scdsc.uss2.localutm/versioning
 
         # Set of USSs capable of being tested as flight planners
         flight_planners:
@@ -207,8 +224,10 @@ v1:
     # elements within this configuration to exclude from the configuration when computing the baseline signature.
     non_baseline_inputs:
       - v1.test_run.resources.resource_declarations.utm_auth
+      - v1.test_run.resources.resource_declarations.test_env_version_providers
       - v1.test_run.resources.resource_declarations.flight_planners
       - v1.test_run.resources.resource_declarations.dss
+      - v1.test_run.resources.resource_declarations.dss_instances
       - v1.test_run.resources.resource_declarations.mock_uss
 
     # How to execute a test run using this configuration

--- a/monitoring/uss_qualifier/configurations/dev/uspace.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/uspace.yaml
@@ -45,7 +45,7 @@ v1:
           mock_uss_instances: mock_uss_instances_scdsc
           locality: locality_che
 
-          version_providers: scd_version_providers?
+          test_env_version_providers: scd_version_providers?
 
           conflicting_flights: che_conflicting_flights
           priority_preemption_flights: che_conflicting_flights
@@ -75,7 +75,7 @@ v1:
             test_suite:
               suite_type: suites.uspace.required_services
               resources:
-                version_providers: version_providers?
+                test_env_version_providers: test_env_version_providers?
 
                 conflicting_flights: conflicting_flights
                 priority_preemption_flights: priority_preemption_flights

--- a/monitoring/uss_qualifier/suites/astm/utm/f3548_21.md
+++ b/monitoring/uss_qualifier/suites/astm/utm/f3548_21.md
@@ -4,22 +4,23 @@
 
 ## [Actions](../../README.md#actions)
 
-1. Scenario: [ASTM F3548 flight planners preparation](../../../scenarios/astm/utm/prep_planners.md) ([`scenarios.astm.utm.PrepareFlightPlanners`](../../../scenarios/astm/utm/prep_planners.py))
-2. Action generator: [`action_generators.astm.f3548.ForEachDSS`](../../../action_generators/astm/f3548/for_each_dss.py)
+1. Scenario: [Get system versions](../../../scenarios/versioning/get_system_versions.md) ([`scenarios.versioning.GetSystemVersions`](../../../scenarios/versioning/get_system_versions.py))
+2. Scenario: [ASTM F3548 flight planners preparation](../../../scenarios/astm/utm/prep_planners.md) ([`scenarios.astm.utm.PrepareFlightPlanners`](../../../scenarios/astm/utm/prep_planners.py))
+3. Action generator: [`action_generators.astm.f3548.ForEachDSS`](../../../action_generators/astm/f3548/for_each_dss.py)
     1. Suite: [DSS testing for ASTM NetRID F3548-21](dss_probing.md) ([`suites.astm.utm.dss_probing`](dss_probing.yaml))
-3. Action generator: [`action_generators.flight_planning.FlightPlannerCombinations`](../../../action_generators/flight_planning/planner_combinations.py)
-    1. Scenario: [Validation of operational intents](../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md) ([`scenarios.astm.utm.FlightIntentValidation`](../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.py))
 4. Action generator: [`action_generators.flight_planning.FlightPlannerCombinations`](../../../action_generators/flight_planning/planner_combinations.py)
-    1. Scenario: [Nominal planning: conflict with higher priority](../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md) ([`scenarios.astm.utm.ConflictHigherPriority`](../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.py))
+    1. Scenario: [Validation of operational intents](../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md) ([`scenarios.astm.utm.FlightIntentValidation`](../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.py))
 5. Action generator: [`action_generators.flight_planning.FlightPlannerCombinations`](../../../action_generators/flight_planning/planner_combinations.py)
-    1. Scenario: [Nominal planning: not permitted conflict with equal priority](../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md) ([`scenarios.astm.utm.ConflictEqualPriorityNotPermitted`](../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.py))
+    1. Scenario: [Nominal planning: conflict with higher priority](../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md) ([`scenarios.astm.utm.ConflictHigherPriority`](../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.py))
 6. Action generator: [`action_generators.flight_planning.FlightPlannerCombinations`](../../../action_generators/flight_planning/planner_combinations.py)
-    1. Scenario: [Data Validation of GET operational intents by USS](../../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md) ([`scenarios.astm.utm.data_exchange_validation.GetOpResponseDataValidationByUSS`](../../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.py))
+    1. Scenario: [Nominal planning: not permitted conflict with equal priority](../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md) ([`scenarios.astm.utm.ConflictEqualPriorityNotPermitted`](../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.py))
 7. Action generator: [`action_generators.flight_planning.FlightPlannerCombinations`](../../../action_generators/flight_planning/planner_combinations.py)
-    1. Scenario: [Off-Nominal planning: down USS](../../../scenarios/astm/utm/off_nominal_planning/down_uss.md) ([`scenarios.astm.utm.DownUSS`](../../../scenarios/astm/utm/off_nominal_planning/down_uss.py))
+    1. Scenario: [Data Validation of GET operational intents by USS](../../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md) ([`scenarios.astm.utm.data_exchange_validation.GetOpResponseDataValidationByUSS`](../../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.py))
 8. Action generator: [`action_generators.flight_planning.FlightPlannerCombinations`](../../../action_generators/flight_planning/planner_combinations.py)
+    1. Scenario: [Off-Nominal planning: down USS](../../../scenarios/astm/utm/off_nominal_planning/down_uss.md) ([`scenarios.astm.utm.DownUSS`](../../../scenarios/astm/utm/off_nominal_planning/down_uss.py))
+9. Action generator: [`action_generators.flight_planning.FlightPlannerCombinations`](../../../action_generators/flight_planning/planner_combinations.py)
     1. Scenario: [Off-Nominal planning: down USS with equal priority conflicts not permitted](../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md) ([`scenarios.astm.utm.DownUSSEqualPriorityNotPermitted`](../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.py))
-9. Scenario: [ASTM F3548 UTM aggregate checks](../../../scenarios/astm/utm/aggregate_checks.md) ([`scenarios.astm.utm.AggregateChecks`](../../../scenarios/astm/utm/aggregate_checks.py))
+10. Scenario: [ASTM F3548 UTM aggregate checks](../../../scenarios/astm/utm/aggregate_checks.md) ([`scenarios.astm.utm.AggregateChecks`](../../../scenarios/astm/utm/aggregate_checks.py))
 
 ## [Checked requirements](../../README.md#checked-requirements)
 
@@ -223,5 +224,11 @@
     <td><a href="../../../requirements/interuss/mock_uss/hosted_instance.md">ExposeInterface</a></td>
     <td>Implemented</td>
     <td><a href="../../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a></td>
+  </tr>
+  <tr>
+    <td rowspan="1" style="vertical-align:top;"><a href="../../../requirements/versioning.md">versioning</a></td>
+    <td><a href="../../../requirements/versioning.md">ReportSystemVersion</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/versioning/get_system_versions.md">Get system versions</a></td>
   </tr>
 </table>

--- a/monitoring/uss_qualifier/suites/astm/utm/f3548_21.yaml
+++ b/monitoring/uss_qualifier/suites/astm/utm/f3548_21.yaml
@@ -1,5 +1,6 @@
 name: ASTM F3548-21
 resources:
+  test_env_version_providers: resources.versioning.VersionProvidersResource?
   flight_planners: resources.flight_planning.FlightPlannersResource
   dss: resources.astm.f3548.v21.DSSInstanceResource
   dss_instances: resources.astm.f3548.v21.DSSInstancesResource?
@@ -13,7 +14,19 @@ resources:
   mock_uss: resources.interuss.mock_uss.client.MockUSSResource?
   id_generator: resources.interuss.IDGeneratorResource
   planning_area: resources.astm.f3548.v21.PlanningAreaResource
+  system_identity: resources.versioning.SystemIdentityResource?
+local_resources:
+  system_identity:
+    resource_type: resources.versioning.SystemIdentityResource
+    specification:
+      system_identity: astm.f3548.v21
 actions:
+- test_scenario:
+    scenario_type: scenarios.versioning.GetSystemVersions
+    resources:
+      version_providers: test_env_version_providers?
+      system_identity: system_identity
+    on_failure: Continue
 - test_scenario:
     scenario_type: scenarios.astm.utm.PrepareFlightPlanners
     resources:

--- a/monitoring/uss_qualifier/suites/definitions.py
+++ b/monitoring/uss_qualifier/suites/definitions.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Dict, List, Optional
 
 from implicitdict import ImplicitDict
+from loguru import logger
+
 from monitoring.uss_qualifier.action_generators.definitions import (
     ActionGeneratorDefinition,
 )
@@ -16,7 +17,6 @@ from monitoring.uss_qualifier.reports.capability_definitions import (
 from monitoring.uss_qualifier.resources.definitions import (
     ResourceID,
     ResourceTypeName,
-    ResourceCollection,
     ResourceDeclaration,
 )
 from monitoring.uss_qualifier.scenarios.definitions import (
@@ -147,7 +147,7 @@ class TestSuiteDefinition(ImplicitDict):
     """Enumeration of the resources used by this test suite"""
 
     local_resources: Optional[Dict[ResourceID, ResourceDeclaration]]
-    """Declarations of resources originating in this test suite."""
+    """Declarations of resources originating in this test suite.  If a resource is defined in both `resources` and `local_resources`, the resource in `local_resources` will be ignored (`resources` overrides `local_resources`)."""
 
     actions: List[TestSuiteActionDeclaration]
     """The actions to take when running the test suite.  Components will be executed in order."""
@@ -162,8 +162,9 @@ class TestSuiteDefinition(ImplicitDict):
         if inherits_resources and local_resources:
             for k in self.resources:
                 if k in self.local_resources:
-                    raise ValueError(
-                        f"Resource '{k}' found in both `resources` and `local_resources`; resource IDs must be unique"
+                    self.local_resources.pop(k)
+                    logger.debug(
+                        f"Ignoring local resource `{k}` in favor of definition provided in `resources`"
                     )
 
     @staticmethod

--- a/monitoring/uss_qualifier/suites/faa/uft/message_signing.md
+++ b/monitoring/uss_qualifier/suites/faa/uft/message_signing.md
@@ -211,4 +211,10 @@
     <td>Implemented</td>
     <td><a href="../../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a></td>
   </tr>
+  <tr>
+    <td rowspan="1" style="vertical-align:top;"><a href="../../../requirements/versioning.md">versioning</a></td>
+    <td><a href="../../../requirements/versioning.md">ReportSystemVersion</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/versioning/get_system_versions.md">Get system versions</a></td>
+  </tr>
 </table>

--- a/monitoring/uss_qualifier/suites/uspace/flight_auth.md
+++ b/monitoring/uss_qualifier/suites/uspace/flight_auth.md
@@ -212,4 +212,10 @@
     <td>Implemented</td>
     <td><a href="../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a></td>
   </tr>
+  <tr>
+    <td rowspan="1" style="vertical-align:top;"><a href="../../requirements/versioning.md">versioning</a></td>
+    <td><a href="../../requirements/versioning.md">ReportSystemVersion</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/versioning/get_system_versions.md">Get system versions</a></td>
+  </tr>
 </table>

--- a/monitoring/uss_qualifier/suites/uspace/flight_auth.yaml
+++ b/monitoring/uss_qualifier/suites/uspace/flight_auth.yaml
@@ -1,5 +1,6 @@
 name: U-space flight authorisation
 resources:
+  test_env_version_providers: resources.versioning.VersionProvidersResource?
   conflicting_flights: resources.flight_planning.FlightIntentsResource
   priority_preemption_flights: resources.flight_planning.FlightIntentsResource
   invalid_flight_auth_flights: resources.flight_planning.FlightIntentsResource
@@ -12,10 +13,12 @@ resources:
   id_generator: resources.interuss.IDGeneratorResource
   second_utm_auth: resources.communications.AuthAdapterResource?
   planning_area: resources.astm.f3548.v21.PlanningAreaResource
+  system_identity: resources.versioning.SystemIdentityResource?
 actions:
 - test_suite:
     suite_type: suites.astm.utm.f3548_21
     resources:
+      test_env_version_providers: test_env_version_providers?
       conflicting_flights: conflicting_flights
       priority_preemption_flights: priority_preemption_flights
       invalid_flight_intents: invalid_flight_intents
@@ -27,6 +30,7 @@ actions:
       id_generator: id_generator
       second_utm_auth: second_utm_auth
       planning_area: planning_area
+      system_identity: system_identity?
   on_failure: Continue
 - test_scenario:
     scenario_type: scenarios.flight_planning.PrepareFlightPlanners

--- a/monitoring/uss_qualifier/suites/uspace/required_services.yaml
+++ b/monitoring/uss_qualifier/suites/uspace/required_services.yaml
@@ -31,7 +31,7 @@ actions:
 - test_scenario:
     scenario_type: scenarios.versioning.GetSystemVersions
     resources:
-      test_env_version_providers: test_env_version_providers
+      version_providers: test_env_version_providers
       system_identity: system_identity
     on_failure: Continue
 - test_suite:

--- a/monitoring/uss_qualifier/suites/uspace/required_services.yaml
+++ b/monitoring/uss_qualifier/suites/uspace/required_services.yaml
@@ -1,6 +1,6 @@
 name: U-space required services
 resources:
-  version_providers: resources.versioning.VersionProvidersResource?
+  test_env_version_providers: resources.versioning.VersionProvidersResource?
 
   conflicting_flights: resources.flight_planning.FlightIntentsResource
   priority_preemption_flights: resources.flight_planning.FlightIntentsResource
@@ -31,12 +31,13 @@ actions:
 - test_scenario:
     scenario_type: scenarios.versioning.GetSystemVersions
     resources:
-      version_providers: version_providers
+      test_env_version_providers: test_env_version_providers
       system_identity: system_identity
     on_failure: Continue
 - test_suite:
     suite_type: suites.uspace.flight_auth
     resources:
+      test_env_version_providers: test_env_version_providers?
       conflicting_flights: conflicting_flights
       priority_preemption_flights: priority_preemption_flights
       invalid_flight_intents: invalid_flight_intents
@@ -49,6 +50,7 @@ actions:
       id_generator: id_generator
       second_utm_auth: second_utm_auth?
       planning_area: planning_area
+      system_identity: system_identity
   on_failure: Continue
 - test_suite:
     suite_type: suites.uspace.network_identification

--- a/schemas/monitoring/uss_qualifier/suites/definitions/TestSuiteDefinition.json
+++ b/schemas/monitoring/uss_qualifier/suites/definitions/TestSuiteDefinition.json
@@ -18,7 +18,7 @@
       "additionalProperties": {
         "$ref": "../../resources/definitions/ResourceDeclaration.json"
       },
-      "description": "Declarations of resources originating in this test suite.",
+      "description": "Declarations of resources originating in this test suite.  If a resource is defined in both `resources` and `local_resources`, the resource in `local_resources` will be ignored (`resources` overrides `local_resources`).",
       "properties": {
         "$ref": {
           "description": "Path to content that replaces the $ref",


### PR DESCRIPTION
System version information is important for a number of reasons in automated testing.  First, it serves to identify the system that was actually tested (and therefore what system actually passed the tests, when that occurs).  Second, F3548-21 GEN0305 specifies "An interoperability test instance shall (GEN0305) use the currently deployed version of the implementer’s USS software except when testing an update to the implementer’s USS software."  Therefore, knowing the version of the software under test as well as the "currently deployed" version of the software is needed to satisfy this requirement.

This PR adds a system version retrieval test scenario to the F3548-21 test suite to begin to address GEN0305 (per #467), as well as enabling reporting of the system version tested in tested requirements reports.  A later PR will add querying of the "currently deployed" version of the software to compare against the test-environment version of the software queried here.  A potential third PR may also re-query the test-environment version of the software at the end of the test to check that the deployed version was stable throughout testing.

When the F3548-21 suite is used within the U-space required services suite, the U-space system identifier is used to override the default system identifier as the U-space system must meet F3548-21 requirements so we don't want to provide the possibility of scoping the F3548-21 system with and disjointness from the U-space system.