### PR TITLE
[mock_uss] Add instructions for mock_uss deployment via GKE

### DIFF
--- a/monitoring/mock_uss/deployment/gcp/kubernetes-deployment.md
+++ b/monitoring/mock_uss/deployment/gcp/kubernetes-deployment.md
@@ -1,0 +1,84 @@
+# mock_uss deployment via Google Kubernetes Engine
+
+## Purpose
+
+This document describes how to deploy an instance of mock_uss using Google Kubernetes Engine.  These instructions could also be adapted to deploy via a different Kubernetes host.
+
+## Deployment steps
+
+### Prerequisites
+
+These instructions assume:
+* A GKE Kubernetes cluster is already created
+* Interoperability ecosystem credentials for mock_uss are already obtained
+
+### Connect to cluster
+
+E.g.,:
+
+```shell
+gcloud container clusters get-credentials my-cluster-name --zone my-zone --project my-project
+```
+
+### Upload secret containing authentication information
+
+*If authentication in the interoperability ecosystem does not require the use of a file (e.g., JSON key), this section can be skipped.*
+
+Get the base64 content of the file content:
+
+```shell
+cat my-credentials.json | base64
+```
+
+Create secret definition YAML:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mockuss-creds
+data:
+  my-credentials.json: '**paste base64 data here**'
+```
+
+Apply secret to cluster:
+
+```shell
+kubectl apply -f auth-secret.yaml
+```
+
+(Optional) Confirm that secret exists in the cluster:
+
+```shell
+kubectl describe secret mockuss-creds
+```
+
+### Reserve and link IP address
+
+Create a new global IP address for use with future ingress:
+
+```shell
+gcloud compute addresses create mockuss-address --global --ip-version IPV4
+```
+
+Show the IP address:
+
+```shell
+gcloud compute addresses list
+```
+
+Update DNS records to resolve the domain for this mock_uss instance to this IP address.
+
+### Run mock_uss
+
+Copy mockuss.example.yaml to mockuss.yaml and update values as appropriate for the deployment.
+
+Deploy job/container, service, and ingress:
+
+```shell
+kubectl apply -f mockuss.yaml
+```
+
+GKE ingresses with managed certificates can take tens of minutes to provision; track progress in the Ingresses tab of the Services GKE menu item.
+
+Confirm deployment by visiting https://your-domain.example.com/status in a browser, which should display the version.

--- a/monitoring/mock_uss/deployment/gcp/mockuss.example.yaml
+++ b/monitoring/mock_uss/deployment/gcp/mockuss.example.yaml
@@ -1,0 +1,87 @@
+apiVersion: v1
+kind: Pod
+metadata:
+    name: mockuss-pod
+    labels:
+        app: mockuss
+spec:
+    containers:
+        -   name: mockuss-server
+            image: interuss/monitoring:v0.3.0
+            ports:
+                -   containerPort: 8074
+            volumeMounts:
+                -   name: auth-volume
+                    mountPath: /auth
+                    readOnly: true
+            env:
+                -   name: MOCK_USS_DSS_URL
+                    value: https://dss.example.com <-- UPDATE
+                -   name: MOCK_USS_PUBLIC_KEY
+                    value: https://auth.example.com/jwks.json <-- UPDATE
+                -   name: MOCK_USS_TOKEN_AUDIENCE
+                    value: mockuss.example.com <-- UPDATE
+                -   name: MOCK_USS_BASE_URL
+                    value: https://mockuss.example.com <-- UPDATE
+                -   name: MOCK_USS_SERVICES
+                    value: scdsc,versioning,interaction_logging,flight_planning
+                -   name: MOCK_USS_INTERACTIONS_LOG_DIR
+                    value: /output/interaction_logs
+                -   name: MOCK_USS_PORT
+                    value: "8074"
+                -   name: MOCK_USS_AUTH_SPEC
+                    value: ServiceAccount(https://auth.example.com/oauth/token,/auth/mock_uss-creds.json) <-- UPDATE
+            command: ["/bin/sh", "-c"]
+            args:
+                - mkdir -p /output/interaction_logs && mock_uss/start.sh
+            readinessProbe:
+                httpGet:
+                    path: /status
+                    port: 8074
+    volumes:
+        -   name: auth-volume
+            secret:
+                secretName: mockuss-creds
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+    name: mockuss-service
+spec:
+    selector:
+        app: mockuss
+    ports:
+        - name: http
+          protocol: TCP
+          port: 8074
+          targetPort: 8074
+    type: NodePort
+
+---
+# https://cloud.google.com/kubernetes-engine/docs/how-to/managed-certs
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+    name: managed-cert
+spec:
+    domains:
+        - mockuss.example.com <-- UPDATE
+
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+    name: mockuss-ingress
+    annotations:
+        kubernetes.io/ingress.global-static-ip-name: mockuss-address
+        networking.gke.io/managed-certificates: managed-cert
+        ingressClassName: "gce"
+    labels:
+        app: mockuss
+spec:
+    defaultBackend:
+        service:
+            name: mockuss-service
+            port:
+                number: 8074


### PR DESCRIPTION
Since mock_uss is needed for some automated tests, test environments may need to deploy an instance outside a simple local test environment.  These instructions show one tested deployment approach using Google Kubernetes Engine.