### PR TITLE
[spec] split astm f3548 requirment dss0210 further into sub-specs

### DIFF
--- a/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml
@@ -306,7 +306,24 @@ v1:
               - astm.f3548.v21.DSS0100,1
               - astm.f3548.v21.DSS0200
               - astm.f3548.v21.DSS0205
-              - astm.f3548.v21.DSS0210
+              - astm.f3548.v21.DSS0210,1a
+              - astm.f3548.v21.DSS0210,1b
+              - astm.f3548.v21.DSS0210,1c
+              - astm.f3548.v21.DSS0210,1d
+              - astm.f3548.v21.DSS0210,1e
+              - astm.f3548.v21.DSS0210,1f
+              - astm.f3548.v21.DSS0210,1g
+              - astm.f3548.v21.DSS0210,1h
+              - astm.f3548.v21.DSS0210,1i
+              - astm.f3548.v21.DSS0210,2a
+              - astm.f3548.v21.DSS0210,2b
+              - astm.f3548.v21.DSS0210,2c
+              - astm.f3548.v21.DSS0210,2d
+              - astm.f3548.v21.DSS0210,2e
+              - astm.f3548.v21.DSS0210,2f
+              - astm.f3548.v21.DSS0210,3a
+              - astm.f3548.v21.DSS0210,3b
+              - astm.f3548.v21.DSS0210,3c
               - astm.f3548.v21.DSS0210,A2-7-2,1a
               - astm.f3548.v21.DSS0210,A2-7-2,1b
               - astm.f3548.v21.DSS0210,A2-7-2,1c

--- a/monitoring/uss_qualifier/requirements/astm/f3548/v21.md
+++ b/monitoring/uss_qualifier/requirements/astm/f3548/v21.md
@@ -161,7 +161,25 @@ For information on these requirements, refer to [the ASTM standard F3548-21](htt
   * <tt>DSS0100,2</tt>
 * <tt>DSS0200</tt>
 * <tt>DSS0205</tt>
-* <tt>DSS0210</tt>
+* DSS0210
+  * <tt>DSS0210,1a</tt>
+  * <tt>DSS0210,1b</tt>
+  * <tt>DSS0210,1c</tt>
+  * <tt>DSS0210,1d</tt>
+  * <tt>DSS0210,1e</tt>
+  * <tt>DSS0210,1f</tt>
+  * <tt>DSS0210,1g</tt>
+  * <tt>DSS0210,1h</tt>
+  * <tt>DSS0210,1i</tt>
+  * <tt>DSS0210,2a</tt>
+  * <tt>DSS0210,2b</tt>
+  * <tt>DSS0210,2c</tt>
+  * <tt>DSS0210,2d</tt>
+  * <tt>DSS0210,2e</tt>
+  * <tt>DSS0210,2f</tt>
+  * <tt>DSS0210,3a</tt>
+  * <tt>DSS0210,3b</tt>
+  * <tt>DSS0210,3c</tt>
 * <tt>DSS0215</tt>
 * <tt>DSS0300</tt>
 

--- a/monitoring/uss_qualifier/requirements/astm/f3548/v21/dss_provider.md
+++ b/monitoring/uss_qualifier/requirements/astm/f3548/v21/dss_provider.md
@@ -18,12 +18,29 @@ This file describes the set of ASTM F3548-21 requirements with which a USS provi
   * **astm.f3548.v21.DSS0100,2**
 * **astm.f3548.v21.DSS0200**
 * **astm.f3548.v21.DSS0205**
-* **astm.f3548.v21.DSS0210**
 * **astm.f3548.v21.DSS0215**
 * **astm.f3548.v21.DSS0300**
 
 ## Data Synchronization Requirements
 
+* **astm.f3548.v21.DSS0210,1a**
+* **astm.f3548.v21.DSS0210,1b**
+* **astm.f3548.v21.DSS0210,1c**
+* **astm.f3548.v21.DSS0210,1d**
+* **astm.f3548.v21.DSS0210,1e**
+* **astm.f3548.v21.DSS0210,1f**
+* **astm.f3548.v21.DSS0210,1g**
+* **astm.f3548.v21.DSS0210,1h**
+* **astm.f3548.v21.DSS0210,1i**
+* **astm.f3548.v21.DSS0210,2a**
+* **astm.f3548.v21.DSS0210,2b**
+* **astm.f3548.v21.DSS0210,2c**
+* **astm.f3548.v21.DSS0210,2d**
+* **astm.f3548.v21.DSS0210,2e**
+* **astm.f3548.v21.DSS0210,2f**
+* **astm.f3548.v21.DSS0210,3a**
+* **astm.f3548.v21.DSS0210,3b**
+* **astm.f3548.v21.DSS0210,3c**
 * **astm.f3548.v21.DSS0210,A2-7-2,1a**
 * **astm.f3548.v21.DSS0210,A2-7-2,1b**
 * **astm.f3548.v21.DSS0210,A2-7-2,1c**


### PR DESCRIPTION
Separates the `DSS0210` requirement into its sub-components.

This should both help us keep track of progress and give more detailed information to testers when scenarios fail, as `DSS0210` will combine various testing approaches and might be spread across several scenarios.