### PR TITLE
[uss_qualifier] Fix bug in version detection and quiet unnecessary warning message

### DIFF
--- a/monitoring/uss_qualifier/reports/sequence_view/kml.py
+++ b/monitoring/uss_qualifier/reports/sequence_view/kml.py
@@ -134,7 +134,7 @@ def make_scenario_kml(scenario: TestedScenario) -> str:
                         continue
                 if (
                     render_info.response_type is not type(None)
-                    and render_info.request_type
+                    and render_info.response_type
                 ):
                     try:
                         kwargs["resp"] = ImplicitDict.parse(

--- a/monitoring/uss_qualifier/reports/tested_requirements.py
+++ b/monitoring/uss_qualifier/reports/tested_requirements.py
@@ -363,9 +363,13 @@ def _find_participant_system_version(
             if version is not None:
                 return version
     elif test_scenario:
-        if report.test_scenario.scenario_type in (
-            "scenarios.versioning.get_system_versions.GetSystemVersions",
-            "scenarios.versioning.GetSystemVersions",
+        if (
+            report.test_scenario.scenario_type
+            in (
+                "scenarios.versioning.get_system_versions.GetSystemVersions",
+                "scenarios.versioning.GetSystemVersions",
+            )
+            and "notes" in report.test_scenario
         ):
             if participant_id in report.test_scenario.notes:
                 system_identity, version = report.test_scenario.notes[


### PR DESCRIPTION
This PR fixes two issues blocking usage of uss_qualifier in a particular application:

1. When the scenario to query system versions is run but there are no participants, report generation crashes.  This issue is fixed by checking whether the `notes` field is present before trying to access it.
2. KML generation was broken for a renderer that wanted just the response of the query.  This issue is fixed by correcting an incorrect field name reference.