### PR TITLE
[qualifier] DSS0210,1 – add initial inter-DSS subscription synchronization scenario

### DIFF
--- a/monitoring/prober/infrastructure.py
+++ b/monitoring/prober/infrastructure.py
@@ -100,7 +100,7 @@ ResourceType = int
 resource_type_code_descriptions: Dict[ResourceType, str] = {}
 
 
-# Next code: 379
+# Next code: 380
 def register_resource_type(code: int, description: str) -> ResourceType:
     """Register that the specified code refers to the described resource.
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/__init__.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/__init__.py
@@ -1,2 +1,3 @@
 from .subscription_validation import SubscriptionValidation
 from .subscription_simple import SubscriptionSimple
+from .subscription_synchronization import SubscriptionSynchronization

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/subscription_crud.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/subscription_crud.md
@@ -1,0 +1,67 @@
+# CRUD subscription test step fragment
+
+This test step fragment validates that subscriptions can be created, updated, read and modified.
+
+## 🛑 Create subscription query succeeds check
+
+As per **[astm.f3548.v21.DSS0005,5](../../../../../requirements/astm/f3548/v21.md)**, the DSS API must allow callers to create a subscription with either one or both of the
+start and end time missing, provided all the required parameters are valid.
+
+## 🛑 Create subscription response is correct check
+
+A successful subscription creation query is expected to return a well-defined body, the content of which reflects the created subscription.
+If the format and content of the response are not conforming, the DSS is failing to implement **[astm.f3548.v21.DSS0005,5](../../../../../requirements/astm/f3548/v21.md)**.
+
+## ⚠️ Create subscription response format conforms to spec check
+
+The response to a successful subscription creation query is expected to conform to the format defined by the OpenAPI specification under the `A3.1` Annex of ASTM F3548−21.
+
+If it does not, the DSS is failing to implement **[astm.f3548.v21.DSS0005,5](../../../../../requirements/astm/f3548/v21.md)**.
+
+## 🛑 Response to subscription creation contains a subscription check
+
+As per **[astm.f3548.v21.DSS0005,5](../../../../../requirements/astm/f3548/v21.md)**, upon creation of a subscription,
+the newly created subscription must be part of its response.
+
+## 🛑 Get Subscription by ID check
+
+If a subscription cannot be queried using its ID, the DSS is failing to meet **[astm.f3548.v21.DSS0005,5](../../../../../requirements/astm/f3548/v21.md)**.
+
+## ⚠️ Get subscription response format conforms to spec check
+
+The response to a successful get subscription query is expected to conform to the format defined by the OpenAPI specification under the `A3.1` Annex of ASTM F3548−21.
+
+If it does not, the DSS is failing to implement **[astm.f3548.v21.DSS0005,5](../../../../../requirements/astm/f3548/v21.md)**.
+
+## 🛑 Successful subscription search query check
+
+If the DSS fails to let us search in the area for which the subscription was created, it is failing to meet **[astm.f3548.v21.DSS0005,5](../../../../../requirements/astm/f3548/v21.md)**.
+
+## 🛑 Created Subscription is in search results check
+
+If the existing subscription is not returned in a search that covers the area it was created for, the DSS is not properly implementing **[astm.f3548.v21.DSS0005,5](../../../../../requirements/astm/f3548/v21.md)**.
+
+## 🛑 Subscription can be mutated check
+
+If a subscription cannot be modified with a valid set of parameters, the DSS is failing to meet **[astm.f3548.v21.DSS0005,5](../../../../../requirements/astm/f3548/v21.md)**.
+
+## 🛑 Response to subscription mutation contains a subscription check
+
+As per **[astm.f3548.v21.DSS0005,5](../../../../../requirements/astm/f3548/v21.md)**, upon mutation of a subscription,
+the newly created subscription must be part of its response.
+
+## ⚠️ Mutate subscription response format conforms to spec check
+
+The response to a successful subscription mutation query is expected to conform to the format defined by the OpenAPI specification under the `A3.1` Annex of ASTM F3548−21.
+
+If it does not, the DSS is failing to implement **[astm.f3548.v21.DSS0005,5](../../../../../requirements/astm/f3548/v21.md)**.
+
+## 🛑 Subscription can be deleted check
+
+An attempt to delete a subscription when the correct version is provided should succeed, otherwise the DSS is in violation of **[astm.f3548.v21.DSS0005,5](../../../../../requirements/astm/f3548/v21.md)**.
+
+## ⚠️ Delete subscription response format conforms to spec check
+
+The response to a successful subscription deletion query is expected to conform to the format defined by the OpenAPI specification under the `A3.1` Annex of ASTM F3548−21.
+
+If it does not, the DSS is failing to implement **[astm.f3548.v21.DSS0005,5](../../../../../requirements/astm/f3548/v21.md)**.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/subscription_sync.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/subscription_sync.md
@@ -1,0 +1,43 @@
+# Synchronize subscription test step fragment
+
+This test step fragment validates that subscriptions are properly synchronized across a set of DSS instances.
+
+## 🛑 Subscription can be found at every DSS check
+
+If the previously created or mutated subscription cannot be found at a DSS, either one of the instances at which the subscription was created or the one that was queried,
+may be failing to implement **[astm.f3548.v21.DSS0210,1a](../../../../../requirements/astm/f3548/v21.md)**.
+
+## 🛑 Propagated subscription contains the correct USS base URL check
+
+If the subscription returned by a DSS to which the subscription was synchronized to does not contain the correct USS base URL,
+either one of the instances at which the subscription was created or the one that was queried, may be failing to implement **[astm.f3548.v21.DSS0210,1c](../../../../../requirements/astm/f3548/v21.md)**.
+
+## 🛑 Propagated subscription contains the correct start time check
+
+If the subscription returned by a DSS to which the subscription was synchronized to does not contain the correct start time,
+either one of the instances at which the subscription was created or the one that was queried, may be failing to implement **[astm.f3548.v21.DSS0210,1e](../../../../../requirements/astm/f3548/v21.md)**.
+
+## 🛑 Propagated subscription contains the correct end time check
+
+If the subscription returned by a DSS to which the subscription was synchronized to does not contain the correct end time,
+either one of the instances at which the subscription was created or the one that was queried, may be failing to implement **[astm.f3548.v21.DSS0210,1e](../../../../../requirements/astm/f3548/v21.md)**.
+
+## 🛑 Propagated subscription contains the correct version check
+
+If the subscription returned by a DSS to which the subscription was synchronized to does not contain the correct version,
+either one of the instances at which the subscription was created or the one that was queried, may be failing to implement **[astm.f3548.v21.DSS0210,1f](../../../../../requirements/astm/f3548/v21.md)**.
+
+## 🛑 Propagated subscription contains the correct notification flags check
+
+If the subscription returned by a DSS to which the subscription was synchronized to does not contain the correct notification flags,
+either one of the instances at which the subscription was created or the one that was queried, may be failing to implement **[astm.f3548.v21.DSS0210,1g](../../../../../requirements/astm/f3548/v21.md)**.
+
+## 🛑 Propagated subscription contains the correct implicit flag check
+
+If the subscription returned by a DSS to which the subscription was synchronized to does not contain the correct implicit flag,
+either one of the instances at which the subscription was created or the one that was queried, may be failing to implement **[astm.f3548.v21.DSS0210,1h](../../../../../requirements/astm/f3548/v21.md)**.
+
+## 🛑 Propagated subscription contains expected notification count check
+
+If the subscription returned by a DSS to which the subscription was synchronized to does not contain the expected notification count,
+either one of the instances at which the subscription was created or the one that was queried, may be failing to implement **[astm.f3548.v21.DSS0210,1i](../../../../../requirements/astm/f3548/v21.md)**.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_synchronization.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_synchronization.md
@@ -1,0 +1,131 @@
+# ASTM SCD DSS: Subscription Synchronization test scenario
+
+## Overview
+
+Verifies that all subscription CRUD operations performed on a single DSS instance are properly propagated to every other DSS
+
+## Resources
+
+### dss
+
+[`DSSInstanceResource`](../../../../resources/astm/f3548/v21/dss.py) the DSS instance through which entities are created, modified and deleted.
+
+### other_instances
+
+[`DSSInstancesResource`](../../../../resources/astm/f3548/v21/dss.py) pointing to the DSS instances used to confirm that entities are properly propagated.
+
+### id_generator
+
+[`IDGeneratorResource`](../../../../resources/interuss/id_generator.py) providing the Subscription ID for this scenario.
+
+### planning_area
+
+[`PlanningAreaResource`](../../../../resources/astm/f3548/v21/planning_area.py) describes the 3D volume in which subscriptions will be created.
+
+## Setup test case
+
+### [Ensure clean workspace test step](clean_workspace.md)
+
+This step ensures that no subscription with the known test ID exists in the DSS.
+
+## Subscription Synchronization test case
+
+This test case create a subscription on the main DSS, and verifies that it is properly synchronized to the other DSS instances.
+
+It then goes on to mutate and delete it, each time confirming that all other DSSes return the expected results.
+
+### Create subscription validation test step
+
+This test step creates multiple subscriptions with different combinations of the optional end and start time parameters.
+
+All subscriptions are left on the DSS when this step ends, as they are expected to be present for the subsequent step.
+
+#### [Create subscription](fragments/subscription_crud.md)
+
+Verify that a subscription can be created on the primary DSS.
+
+#### [Validate subscription](./validate_subscription.md)
+
+Verify that the subscription returned by the DSS under test is properly formatted and contains the expected content.
+
+### Query newly created subscription test step
+
+Query the created subscription at every DSS provided in `dss_instances`.
+
+#### 🛑 Subscription returned by a secondary DSS is valid and correct check
+
+When queried for a subscription that was created via another DSS, a DSS instance is expected to provide a valid subscription.
+
+If it does not, it might be in violation of **[astm.f3548.v21.DSS0005,5](../../../../requirements/astm/f3548/v21.md)**.
+
+#### [Subscription is synchronized](./fragments/subscription_sync.md)
+
+Confirm that the subscription that was just created is properly synchronized across all DSS instances.
+
+#### [Get subscription](fragments/subscription_crud.md)
+
+Confirms that each DSS provides access to the created subscription,
+
+#### [Validate subscription](./validate_subscription.md)
+
+Verify that the subscription returned by every DSS is correctly formatted and corresponds to what was created earlier.
+
+### Mutate subscription test step
+
+This test step mutates the previously created subscription to verify that the DSS reacts properly: notably, it checks that the subscription version is updated,
+including for changes that are not directly visible, such as changing the subscription's footprint.
+
+#### [Update subscription](fragments/subscription_crud.md)
+
+Confirm that the subscription can be mutated.
+
+#### [Validate subscription](./validate_subscription.md)
+
+Verify that the subscription returned by the DSS is properly formatted and contains the correct content.
+
+### Query updated subscription test step
+
+Query the updated subscription at every DSS provided in `dss_instances`.
+
+#### 🛑 Subscription returned by a secondary DSS is valid and correct check
+
+When queried for a subscription that was mutated via another DSS, a DSS instance is expected to provide a valid subscription.
+
+If it does not, it might be in violation of **[astm.f3548.v21.DSS0005,5](../../../../requirements/astm/f3548/v21.md)**.
+
+#### [Subscription is synchronized](./fragments/subscription_sync.md)
+
+Confirm that the subscription that was just mutated is properly synchronized across all DSS instances.
+
+#### [Get subscription](fragments/subscription_crud.md)
+
+Confirms that the subscription that was just mutated can be retrieved from any DSS.
+
+#### [Validate subscription](./validate_subscription.md)
+
+Verify that the subscription returned by every DSS is correctly formatted and corresponds to what was mutated earlier.
+
+### Delete subscription test step
+
+Attempt to delete the subscription in various ways and ensure that the DSS reacts properly.
+
+This also checks that the subscription data returned by a successful deletion is correct.
+
+#### [Delete subscription](fragments/subscription_crud.md)
+
+Confirms that a subscription can be deleted.
+
+#### [Validate subscription](./validate_subscription.md)
+
+Verify that the subscription returned by the DSS via the deletion is properly formatted and contains the correct content.
+
+### Query deleted subscription test step
+
+Attempt to query and search for the deleted subscription in various ways
+
+#### 🛑 Secondary DSS should not return the deleted subscription check
+
+If a DSS returns a subscription that was previously successfully deleted from the primary DSS,
+either one of the primary DSS or the DSS that returned the subscription is in violation of **[astm.f3548.v21.DSS0210,1a](../../../../requirements/astm/f3548/v21.md)**.
+
+## [Cleanup](./clean_workspace.md)

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_synchronization.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_synchronization.py
@@ -1,0 +1,506 @@
+from datetime import datetime, timedelta
+from typing import List, Optional
+
+import loguru
+from uas_standards.astm.f3548.v21.api import Subscription, SubscriptionID
+from uas_standards.astm.f3548.v21.constants import Scope
+
+from monitoring.monitorlib.geotemporal import Volume4D
+from monitoring.monitorlib.mutate.scd import MutatedSubscription
+from monitoring.prober.infrastructure import register_resource_type
+from monitoring.uss_qualifier.resources.astm.f3548.v21 import PlanningAreaResource
+from monitoring.uss_qualifier.resources.astm.f3548.v21.dss import (
+    DSSInstanceResource,
+    DSSInstancesResource,
+    DSSInstance,
+)
+from monitoring.uss_qualifier.resources.astm.f3548.v21.planning_area import (
+    SubscriptionParams,
+)
+from monitoring.uss_qualifier.resources.interuss.id_generator import IDGeneratorResource
+from monitoring.uss_qualifier.scenarios.astm.utm.dss import test_step_fragments
+from monitoring.uss_qualifier.scenarios.astm.utm.dss.subscription_validator import (
+    SubscriptionValidator,
+)
+from monitoring.uss_qualifier.scenarios.scenario import (
+    TestScenario,
+)
+from monitoring.uss_qualifier.suites.suite import ExecutionContext
+
+
+class SubscriptionSynchronization(TestScenario):
+    """
+    A scenario that checks if multiple DSS instances properly synchronize
+    created, updated or deleted entities between them.
+
+    Not in the scope of the first version of this:
+     - access rights (making sure only the manager of the subscription can mutate it)
+     - control of the area synchronization (by doing area searches against the secondaries)
+     - mutation of a subscription on a secondary DSS when it was created on the primary
+     - deletion of a subscription on a secondary DSS when it was created on the primary
+    """
+
+    SUB_TYPE = register_resource_type(379, "Subscription")
+
+    _dss: DSSInstance
+
+    _dss_read_instances: List[DSSInstance]
+
+    # Base identifier for the subscriptions that will be created
+    _sub_id: SubscriptionID
+
+    # Base parameters used for subscription creation
+    _sub_params: SubscriptionParams
+
+    # Keep track of the current subscription state
+    _current_subscription = Optional[Subscription]
+
+    def __init__(
+        self,
+        dss: DSSInstanceResource,
+        other_instances: DSSInstancesResource,
+        id_generator: IDGeneratorResource,
+        planning_area: PlanningAreaResource,
+    ):
+        """
+        Args:
+            dss: dss to test
+            id_generator: will let us generate specific identifiers
+            planning_area: An Area to use for the tests. It should be an area for which the DSS is responsible,
+                 but has no other requirements.
+            problematically_big_area: An area that is too big to be searched for on the DSS
+        """
+        super().__init__()
+        scopes_primary = {
+            Scope.StrategicCoordination: "create and delete subscriptions"
+        }
+        scopes_read = {Scope.StrategicCoordination: "read subscriptions"}
+
+        self._dss = dss.get_instance(scopes_primary)
+        self._primary_pid = self._dss.participant_id
+
+        self._dss_read_instances = [
+            sec_dss.get_instance(scopes_read)
+            for sec_dss in other_instances.dss_instances
+        ]
+
+        self._sub_id = id_generator.id_factory.make_id(self.SUB_TYPE)
+        self._planning_area = planning_area.specification
+
+        # Build a ready-to-use 4D volume with no specified time for searching
+        # the currently active subscriptions
+        self._planning_area_volume4d = Volume4D(
+            volume=self._planning_area.volume,
+        )
+
+        self._sub_params = self._planning_area.get_new_subscription_params(
+            subscription_id=self._sub_id,
+            # Set this slightly in the past: we will update the subscriptions
+            # to a later value that still needs to be roughly 'now' without getting into the future
+            start_time=datetime.now().astimezone() - timedelta(seconds=10),
+            duration=timedelta(minutes=20),
+            # This is a planning area without constraint processing
+            notify_for_op_intents=True,
+            notify_for_constraints=False,
+        )
+
+    def run(self, context: ExecutionContext):
+
+        # Check that we actually have at least one other DSS to test against:
+        if not self._dss_read_instances:
+            loguru.logger.warning(
+                "Skipping EntitySynchronization test: no other DSS instances to test against"
+            )
+            return
+
+        self.begin_test_scenario(context)
+        self._setup_case()
+        self.begin_test_case("Subscription Synchronization")
+
+        self.begin_test_step("Create subscription validation")
+        self._create_sub_with_params(self._sub_params)
+        self.end_test_step()
+
+        self.begin_test_step("Query newly created subscription")
+        self._query_secondaries_and_compare(self._sub_params)
+        self.end_test_step()
+
+        self.begin_test_step("Mutate subscription")
+        self._test_mutate_subscriptions_shift_time()
+        self.end_test_step()
+
+        self.begin_test_step("Query updated subscription")
+        self._query_secondaries_and_compare(self._sub_params)
+        self.end_test_step()
+
+        self.begin_test_step("Delete subscription")
+        self._test_delete_sub()
+        self.end_test_step()
+
+        self.begin_test_step("Query deleted subscription")
+        self._test_get_deleted_sub()
+        self.end_test_step()
+
+        self.end_test_case()
+        self.end_test_scenario()
+
+    def _setup_case(self):
+        self.begin_test_case("Setup")
+        # Multiple runs of the scenario seem to rely on the same instance of it:
+        # thus we need to reset the state of the scenario before running it.
+        self._current_subscription = None
+        self._ensure_clean_workspace_step()
+        self.end_test_case()
+
+    def _ensure_clean_workspace_step(self):
+        self.begin_test_step("Ensure clean workspace")
+        # Start by dropping any active sub
+        self._ensure_no_active_subs_exist()
+        # Check for subscriptions that will collide with our IDs and drop them
+        self._ensure_test_sub_ids_do_not_exist()
+        self.end_test_step()
+
+    def _ensure_test_sub_ids_do_not_exist(self):
+        test_step_fragments.cleanup_sub(self, self._dss, self._sub_id)
+
+    def _ensure_no_active_subs_exist(self):
+        test_step_fragments.cleanup_active_subs(
+            self,
+            self._dss,
+            self._planning_area_volume4d,
+        )
+
+    def _create_sub_with_params(self, creation_params: SubscriptionParams):
+
+        # TODO migrate to the try/except pattern for queries
+        newly_created = self._dss.upsert_subscription(
+            **creation_params,
+        )
+        self.record_query(newly_created)
+
+        with self.check(
+            "Create subscription query succeeds", [self._primary_pid]
+        ) as check:
+            if not newly_created.success:
+                loguru.logger.debug(f"Failed query: {newly_created.response.json}")
+                check.record_failed(
+                    "Subscription creation failed",
+                    details=f"Subscription creation failed with status code {newly_created.status_code}",
+                    query_timestamps=[newly_created.request.timestamp],
+                )
+
+        with self.check(
+            "Create subscription response is correct", [self._primary_pid]
+        ) as check:
+            SubscriptionValidator(
+                check,
+                self,
+                [self._primary_pid],
+                creation_params,
+            ).validate_created_subscription(creation_params.sub_id, newly_created)
+
+        # Store the subscription
+        self._current_subscription = newly_created.subscription
+
+    def _query_secondaries_and_compare(self, expected_sub_params: SubscriptionParams):
+        for secondary_dss in self._dss_read_instances:
+            self._validate_sub_from_secondary(
+                secondary_dss=secondary_dss,
+                expected_sub_params=expected_sub_params,
+                involved_participants=list(
+                    {self._primary_pid, secondary_dss.participant_id}
+                ),
+            )
+
+    def _validate_sub_from_secondary(
+        self,
+        secondary_dss: DSSInstance,
+        expected_sub_params: SubscriptionParams,
+        involved_participants: List[str],
+    ):
+        with self.check(
+            "Subscription can be found at every DSS",
+            involved_participants,
+        ) as check:
+            fetched_sub = secondary_dss.get_subscription(expected_sub_params.sub_id)
+            self.record_query(fetched_sub)
+            if fetched_sub.status_code != 200:
+                check.record_failed(
+                    "Get query for existing subscription failed",
+                    details=f"Get query for a subscription expected to exist failed with status code {fetched_sub.status_code}",
+                    query_timestamps=[fetched_sub.request.timestamp],
+                )
+
+        sub = fetched_sub.subscription
+        with self.check(
+            "Propagated subscription contains the correct USS base URL",
+            involved_participants,
+        ) as check:
+            base_url = (
+                sub.uss_base_url if sub.has_field_with_value("uss_base_url") else None
+            )
+            if base_url != expected_sub_params.base_url:
+                check.record_failed(
+                    "Propagated subscription has an incorrect USS base URL",
+                    details=f"Expected: {expected_sub_params.base_url}, Received: {base_url}",
+                    query_timestamps=[fetched_sub.request.timestamp],
+                )
+
+        with self.check(
+            "Propagated subscription contains the correct start time",
+            involved_participants,
+        ) as check:
+            start_time = (
+                sub.time_start.value.datetime
+                if sub.has_field_with_value("time_start")
+                else None
+            )
+            if start_time != expected_sub_params.start_time:
+                check.record_failed(
+                    "Propagated subscription has an incorrect start time",
+                    details=f"Expected: {expected_sub_params.start_time}, Received: {start_time}",
+                    query_timestamps=[fetched_sub.request.timestamp],
+                )
+
+        with self.check(
+            "Propagated subscription contains the correct end time",
+            involved_participants,
+        ) as check:
+            end_time = (
+                sub.time_end.value.datetime
+                if sub.has_field_with_value("time_end")
+                else None
+            )
+            if end_time != expected_sub_params.end_time:
+                check.record_failed(
+                    "Propagated subscription has an incorrect end time",
+                    details=f"Expected: {expected_sub_params.end_time}, Received: {end_time}",
+                    query_timestamps=[fetched_sub.request.timestamp],
+                )
+
+        with self.check(
+            "Propagated subscription contains the correct version",
+            involved_participants,
+        ) as check:
+            version = sub.version if sub.has_field_with_value("version") else None
+            if version != self._current_subscription.version:
+                check.record_failed(
+                    "Propagated subscription has an incorrect version",
+                    details=f"Expected: {self._current_subscription.version}, Received: {version}",
+                    query_timestamps=[fetched_sub.request.timestamp],
+                )
+
+        with self.check(
+            "Propagated subscription contains the correct notification flags",
+            involved_participants,
+        ) as check:
+            notify_for_op_intents = (
+                sub.notify_for_operational_intents
+                if sub.has_field_with_value("notify_for_operational_intents")
+                else None
+            )
+            notify_for_constraints = (
+                sub.notify_for_constraints
+                if sub.has_field_with_value("notify_for_constraints")
+                else None
+            )
+            if notify_for_op_intents != expected_sub_params.notify_for_op_intents:
+                check.record_failed(
+                    "Propagated subscription has unexpected notify_for_op_intents flag",
+                    details=f"Expected: {expected_sub_params.notify_for_op_intents}, Received: {notify_for_op_intents}",
+                    query_timestamps=[fetched_sub.request.timestamp],
+                )
+            if notify_for_constraints != expected_sub_params.notify_for_constraints:
+                check.record_failed(
+                    "Propagated subscription has unexpected notify_for_constraints flag",
+                    details=f"Expected: {expected_sub_params.notify_for_constraints}, Received: {notify_for_constraints}",
+                    query_timestamps=[fetched_sub.request.timestamp],
+                )
+
+        with self.check(
+            "Propagated subscription contains the correct implicit flag",
+            involved_participants,
+        ) as check:
+            is_implicit = (
+                sub.implicit_subscription
+                if sub.has_field_with_value("implicit_subscription")
+                else None
+            )
+            # We created the subscription directly: it should not have the implicit flag
+            if is_implicit:
+                check.record_failed(
+                    "Propagated subscription has an incorrect implicit flag",
+                    details=f"Expected: {expected_sub_params.implicit_subscription}, Received: {is_implicit}",
+                    query_timestamps=[fetched_sub.request.timestamp],
+                )
+
+        with self.check(
+            "Propagated subscription contains expected notification count",
+            involved_participants,
+        ) as check:
+            notif_index = (
+                sub.notification_index
+                if sub.has_field_with_value("notification_index")
+                else None
+            )
+            # Technically a notification may already have caused the index to be incremented, so we can't
+            # strictly expect the retrieved one to be the same then at time of creation.
+            # However, it should at least be the same.
+            if (
+                notif_index is None
+                or notif_index < self._current_subscription.notification_index
+            ):
+                check.record_failed(
+                    "Propagated subscription has an unexpected notification index",
+                    details=f"Expected: 0 or more, Received: {notif_index}",
+                    query_timestamps=[fetched_sub.request.timestamp],
+                )
+
+        with self.check(
+            "Subscription returned by a secondary DSS is valid and correct",
+            [secondary_dss.participant_id],
+        ) as check:
+            # Do a full validation of the subscription as a sanity check
+            SubscriptionValidator(
+                check,
+                self,
+                [secondary_dss.participant_id],
+                expected_sub_params,
+            ).validate_fetched_subscription(
+                expected_sub_id=expected_sub_params.sub_id,
+                fetched_sub=fetched_sub,
+                expected_version=self._current_subscription.version,
+                is_implicit=False,
+            )
+
+    def _compare_upsert_resp_with_params(
+        self,
+        sub_id: str,
+        creation_resp_under_test: MutatedSubscription,
+        creation_params: SubscriptionParams,
+        was_mutated: bool,
+    ):
+        """
+        Verify that the response of the server is conforming to the spec and the parameters we used in the request.
+        """
+        check_name = (
+            "Response to subscription mutation contains a subscription"
+            if was_mutated
+            else "Response to subscription creation contains a subscription"
+        )
+        with self.check(
+            check_name,
+            [self._primary_pid],
+        ) as check:
+            if not creation_resp_under_test.subscription:
+                check.record_failed(
+                    "Response to subscription creation did not contain a subscription",
+                    details="A subscription is expected to be returned in the response to a subscription creation request."
+                    f"Parameters used: {creation_params}",
+                    query_timestamps=[creation_resp_under_test.request.timestamp],
+                )
+
+        with self.check(
+            "Mutate subscription response format conforms to spec", [self._primary_pid]
+        ) as check:
+            SubscriptionValidator(
+                check,
+                self,
+                [self._primary_pid],
+                creation_params,
+            ).validate_mutated_subscription(
+                expected_sub_id=sub_id,
+                mutated_sub=creation_resp_under_test,
+                previous_version=self._current_subscription.version,
+                is_implicit=False,
+            )
+
+    def _test_mutate_subscriptions_shift_time(self):
+        """Mutate the subscription by adding 10 seconds to its start and end times"""
+
+        op = self._sub_params
+        sub = self._current_subscription
+        new_params = SubscriptionParams(
+            sub_id=self._sub_id,
+            area_vertices=op.area_vertices,
+            min_alt_m=op.min_alt_m,
+            max_alt_m=op.max_alt_m,
+            start_time=sub.time_start.value.datetime + timedelta(seconds=10),
+            end_time=sub.time_end.value.datetime + timedelta(seconds=10),
+            base_url=op.base_url,
+            notify_for_op_intents=op.notify_for_op_intents,
+            notify_for_constraints=op.notify_for_constraints,
+        )
+        mutated_sub_response = self._dss.upsert_subscription(
+            version=sub.version,
+            **new_params,
+        )
+        self.record_query(mutated_sub_response)
+        with self.check("Subscription can be mutated", [self._primary_pid]) as check:
+            if mutated_sub_response.status_code != 200:
+                check.record_failed(
+                    "Subscription mutation failed",
+                    details=f"Subscription mutation failed with status code {mutated_sub_response.status_code}",
+                    query_timestamps=[mutated_sub_response.request.timestamp],
+                )
+
+        # Check that what we get back is valid and corresponds to what we want to create
+        self._compare_upsert_resp_with_params(
+            self._sub_id, mutated_sub_response, new_params, was_mutated=True
+        )
+        # Store the subscription
+        self._current_subscription = mutated_sub_response.subscription
+        # Update the parameters we used for that subscription
+        self._sub_params = new_params
+
+    def _test_delete_sub(self):
+        deleted_sub = self._dss.delete_subscription(
+            sub_id=self._sub_id, sub_version=self._current_subscription.version
+        )
+        self.record_query(deleted_sub)
+        with self.check("Subscription can be deleted", [self._primary_pid]) as check:
+            if deleted_sub.status_code != 200:
+                check.record_failed(
+                    "Subscription deletion failed",
+                    details=f"Subscription deletion failed with status code {deleted_sub.status_code}",
+                    query_timestamps=[deleted_sub.request.timestamp],
+                )
+
+        with self.check(
+            "Delete subscription response format conforms to spec", [self._primary_pid]
+        ) as check:
+            SubscriptionValidator(
+                check,
+                self,
+                [self._primary_pid],
+                self._sub_params,
+            ).validate_deleted_subscription(
+                expected_sub_id=self._sub_id,
+                deleted_subscription=deleted_sub,
+                expected_version=self._current_subscription.version,
+                is_implicit=False,
+            )
+
+        self._current_subscription = None
+
+    def _test_get_deleted_sub(self):
+        for secondary_dss in self._dss_read_instances:
+            self._confirm_secondary_has_no_sub(secondary_dss)
+
+    def _confirm_secondary_has_no_sub(self, secondary_dss: DSSInstance):
+        fetched_sub = secondary_dss.get_subscription(self._sub_id)
+        with self.check(
+            "Secondary DSS should not return the deleted subscription",
+            [secondary_dss.participant_id],
+        ) as check:
+            if fetched_sub.status_code != 404:
+                check.record_failed(
+                    "Get query for deleted subscription did not return 404",
+                    details=f"Get query for a deleted subscription returned status code {fetched_sub.status_code}",
+                    query_timestamps=[fetched_sub.request.timestamp],
+                )
+
+    def cleanup(self):
+        self.begin_cleanup()
+        self._ensure_test_sub_ids_do_not_exist()
+        self.end_cleanup()

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/validate_subscription.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/validate_subscription.md
@@ -1,6 +1,6 @@
 # Validate subscription test step fragment
 
-This test step fragment attempts to validate a subscription returned by the DSS after its creation or mutation.
+This test step fragment attempts to validate a single subscription returned by the DSS after its creation or mutation.
 
 The code for these checks lives in the [subscription_validator.py](./subscription_validator.py) class.
 

--- a/monitoring/uss_qualifier/suites/astm/utm/dss_probing.md
+++ b/monitoring/uss_qualifier/suites/astm/utm/dss_probing.md
@@ -8,6 +8,7 @@
 2. Scenario: [ASTM SCD DSS: Subscription Validation](../../../scenarios/astm/utm/dss/subscription_validation.md) ([`scenarios.astm.utm.dss.SubscriptionValidation`](../../../scenarios/astm/utm/dss/subscription_validation.py))
 3. Scenario: [ASTM F3548-21 UTM DSS Operational Intent Reference Access Control](../../../scenarios/astm/utm/op_intent_ref_access_control.md) ([`scenarios.astm.utm.OpIntentReferenceAccessControl`](../../../scenarios/astm/utm/op_intent_ref_access_control.py))
 4. Scenario: [ASTM F3548-21 UTM DSS interoperability](../../../scenarios/astm/utm/dss_interoperability.md) ([`scenarios.astm.utm.DSSInteroperability`](../../../scenarios/astm/utm/dss_interoperability.py))
+5. Scenario: [ASTM SCD DSS: Subscription Synchronization](../../../scenarios/astm/utm/dss/subscription_synchronization.md) ([`scenarios.astm.utm.dss.SubscriptionSynchronization`](../../../scenarios/astm/utm/dss/subscription_synchronization.py))
 
 ## [Checked requirements](../../README.md#checked-requirements)
 
@@ -19,25 +20,60 @@
     <th><a href="../../README.md#checked-in">Checked in</a></th>
   </tr>
   <tr>
-    <td rowspan="6" style="vertical-align:top;"><a href="../../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
+    <td rowspan="13" style="vertical-align:top;"><a href="../../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,1</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a></td>
+    <td><a href="../../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,2</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a></td>
+    <td><a href="../../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,5</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a></td>
+    <td><a href="../../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0015</a></td>
     <td>Implemented</td>
     <td><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,1a</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,1c</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,1e</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,1f</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,1g</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,1h</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,1i</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0300</a></td>

--- a/monitoring/uss_qualifier/suites/astm/utm/dss_probing.yaml
+++ b/monitoring/uss_qualifier/suites/astm/utm/dss_probing.yaml
@@ -34,3 +34,10 @@ actions:
         primary_dss_instance: dss
         all_dss_instances: all_dss_instances
         planning_area: planning_area
+  - test_scenario:
+      scenario_type: scenarios.astm.utm.dss.SubscriptionSynchronization
+      resources:
+        dss: dss
+        other_instances: all_dss_instances
+        id_generator: id_generator
+        planning_area: planning_area

--- a/monitoring/uss_qualifier/suites/astm/utm/f3548_21.md
+++ b/monitoring/uss_qualifier/suites/astm/utm/f3548_21.md
@@ -32,20 +32,20 @@
     <th><a href="../../README.md#checked-in">Checked in</a></th>
   </tr>
   <tr>
-    <td rowspan="30" style="vertical-align:top;"><a href="../../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
+    <td rowspan="37" style="vertical-align:top;"><a href="../../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,1</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a></td>
+    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,2</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,5</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a></td>
+    <td><a href="../../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0015</a></td>
@@ -56,6 +56,41 @@
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0100,1</a></td>
     <td>Implemented</td>
     <td><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,1a</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,1c</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,1e</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,1f</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,1g</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,1h</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,1i</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0300</a></td>

--- a/monitoring/uss_qualifier/suites/faa/uft/message_signing.md
+++ b/monitoring/uss_qualifier/suites/faa/uft/message_signing.md
@@ -18,20 +18,20 @@
     <th><a href="../../README.md#checked-in">Checked in</a></th>
   </tr>
   <tr>
-    <td rowspan="30" style="vertical-align:top;"><a href="../../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
+    <td rowspan="37" style="vertical-align:top;"><a href="../../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,1</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a></td>
+    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,2</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,5</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a></td>
+    <td><a href="../../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0015</a></td>
@@ -42,6 +42,41 @@
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0100,1</a></td>
     <td>Implemented</td>
     <td><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,1a</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,1c</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,1e</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,1f</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,1g</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,1h</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,1i</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0300</a></td>

--- a/monitoring/uss_qualifier/suites/interuss/dss/all_tests.md
+++ b/monitoring/uss_qualifier/suites/interuss/dss/all_tests.md
@@ -408,25 +408,60 @@
     <td><a href="../../../scenarios/astm/netrid/v22a/dss/heavy_traffic_concurrent.md">ASTM NetRID DSS: Concurrent Requests</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/isa_expiry.md">ASTM NetRID DSS: ISA Expiry</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/isa_subscription_interactions.md">ASTM NetRID DSS: ISA Subscription Interactions</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/isa_validation.md">ASTM NetRID DSS: Submitted ISA Validations</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a></td>
   </tr>
   <tr>
-    <td rowspan="6" style="vertical-align:top;"><a href="../../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
+    <td rowspan="13" style="vertical-align:top;"><a href="../../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,1</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a></td>
+    <td><a href="../../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,2</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a></td>
+    <td><a href="../../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,5</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a></td>
+    <td><a href="../../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0015</a></td>
     <td>Implemented</td>
     <td><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,1a</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,1c</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,1e</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,1f</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,1g</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,1h</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,1i</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0300</a></td>

--- a/monitoring/uss_qualifier/suites/uspace/flight_auth.md
+++ b/monitoring/uss_qualifier/suites/uspace/flight_auth.md
@@ -19,20 +19,20 @@
     <th><a href="../README.md#checked-in">Checked in</a></th>
   </tr>
   <tr>
-    <td rowspan="30" style="vertical-align:top;"><a href="../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
+    <td rowspan="37" style="vertical-align:top;"><a href="../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0005,1</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a></td>
+    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0005,2</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0005,5</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a></td>
+    <td><a href="../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0015</a></td>
@@ -43,6 +43,41 @@
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0100,1</a></td>
     <td>Implemented</td>
     <td><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,1a</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,1c</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,1e</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,1f</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,1g</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,1h</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,1i</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0300</a></td>

--- a/monitoring/uss_qualifier/suites/uspace/required_services.md
+++ b/monitoring/uss_qualifier/suites/uspace/required_services.md
@@ -454,20 +454,20 @@
     <td><a href="../../scenarios/astm/netrid/v22a/dss/heavy_traffic_concurrent.md">ASTM NetRID DSS: Concurrent Requests</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_expiry.md">ASTM NetRID DSS: ISA Expiry</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_subscription_interactions.md">ASTM NetRID DSS: ISA Subscription Interactions</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_validation.md">ASTM NetRID DSS: Submitted ISA Validations</a><br><a href="../../scenarios/astm/netrid/v22a/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a><br><a href="../../scenarios/astm/netrid/v22a/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a><br><a href="../../scenarios/astm/netrid/v22a/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a></td>
   </tr>
   <tr>
-    <td rowspan="30" style="vertical-align:top;"><a href="../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
+    <td rowspan="37" style="vertical-align:top;"><a href="../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0005,1</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a></td>
+    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0005,2</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0005,5</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a></td>
+    <td><a href="../../scenarios/astm/utm/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0015</a></td>
@@ -478,6 +478,41 @@
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0100,1</a></td>
     <td>Implemented</td>
     <td><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,1a</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,1c</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,1e</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,1f</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,1g</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,1h</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,1i</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/utm/dss/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0300</a></td>


### PR DESCRIPTION
First pass at verifying DSS0210: currently this only focuses on subscriptions (DSS0210,1).

It willing ignores the following:
 -  manager/access-rights of the subscription
 -  area of the subscription

These will be added in later PRs.

This PR also includes a new `crud_subscription.md` documentation fragment to avoid duplication. Existing scenarios that could profit from it will be migrated after this PR lands.

(Built on top of #490, as long as that PR is open make sure to only look at the last commit of this PR) 