### PR TITLE
[uss_qualifier] Add USS credit for requirements enforced by DSS

### DIFF
--- a/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml
@@ -203,6 +203,9 @@ v1:
             specification:
               dss_instances:
                 - participant_id: uss1
+                  user_participant_ids:
+                    # Participants using a DSS instance they do not provide should be listed as users of that DSS (so that they can take credit for USS requirements enforced by the DSS)
+                    - mock_uss  # mock_uss uses this DSS instance; it does not provide its own instance
                   base_url: http://dss.uss1.localutm
                   has_private_address: true
                 - participant_id: uss2

--- a/monitoring/uss_qualifier/configurations/dev/library/environment_containers.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/library/environment_containers.yaml
@@ -206,6 +206,8 @@ scd_dss_instances:
   specification:
     dss_instances:
       - participant_id: uss1
+        user_participant_ids:
+          - mock_uss
         base_url: http://dss.uss1.localutm
         has_private_address: true
       - participant_id: uss2

--- a/monitoring/uss_qualifier/configurations/dev/library/environment_localhost.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/library/environment_localhost.yaml
@@ -206,6 +206,8 @@ scd_dss_instances:
   specification:
     dss_instances:
       - participant_id: uss1
+        user_participant_ids:
+          - mock_uss
         base_url: http://localhost:8082
         has_private_address: true
       - participant_id: uss2

--- a/monitoring/uss_qualifier/resources/astm/f3548/v21/dss.py
+++ b/monitoring/uss_qualifier/resources/astm/f3548/v21/dss.py
@@ -53,6 +53,9 @@ class DSSInstanceSpecification(ImplicitDict):
     participant_id: str
     """ID of the USS responsible for this DSS instance"""
 
+    user_participant_ids: Optional[List[str]]
+    """IDs of any participants using this DSS instance, apart from the USS responsible for this DSS instance."""
+
     base_url: str
     """Base URL for the DSS instance according to the ASTM F3548-21 API"""
 
@@ -69,6 +72,7 @@ class DSSInstanceSpecification(ImplicitDict):
 
 class DSSInstance(object):
     participant_id: str
+    user_participant_ids: List[str]
     base_url: str
     has_private_address: bool = False
     client: infrastructure.UTMClientSession
@@ -77,12 +81,14 @@ class DSSInstance(object):
     def __init__(
         self,
         participant_id: str,
+        user_participant_ids: List[str],
         base_url: str,
         has_private_address: Optional[bool],
         auth_adapter: infrastructure.AuthAdapter,
         scopes_authorized: List[str],
     ):
         self.participant_id = participant_id
+        self.user_participant_ids = user_participant_ids
         self.base_url = base_url
         if has_private_address is not None:
             self.has_private_address = has_private_address
@@ -109,6 +115,7 @@ class DSSInstance(object):
         )
         return DSSInstance(
             participant_id=self.participant_id,
+            user_participant_ids=self.user_participant_ids,
             base_url=self.base_url,
             has_private_address=self.has_private_address,
             auth_adapter=auth_adapter.adapter,
@@ -464,6 +471,10 @@ class DSSInstanceResource(Resource[DSSInstanceSpecification]):
         )
         return DSSInstance(
             self._specification.participant_id,
+            self._specification.user_participant_ids
+            if "user_participant_ids" in self._specification
+            and self._specification.user_participant_ids
+            else [],
             self._specification.base_url,
             self._specification.get("has_private_address"),
             self._auth_adapter.adapter,

--- a/monitoring/uss_qualifier/scenarios/astm/utm/op_intent_ref_access_control.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/op_intent_ref_access_control.py
@@ -37,6 +37,9 @@ class OpIntentReferenceAccessControl(TestScenario):
     _dss: DSSInstance
     _pid: List[str]
 
+    # Participant IDs of users using this DSS instance
+    _uids: List[str]
+
     # The same DSS, available via a separate auth adapter
     _dss_separate_creds: DSSInstance
 
@@ -64,6 +67,7 @@ class OpIntentReferenceAccessControl(TestScenario):
         }
         self._dss = dss.get_instance(scopes)
         self._pid = [self._dss.participant_id]
+        self._uids = self._dss.user_participant_ids
 
         self._oid_1 = id_generator.id_factory.make_id(self.OP_INTENT_1)
         self._oid_2 = id_generator.id_factory.make_id(self.OP_INTENT_2)
@@ -407,7 +411,7 @@ class OpIntentReferenceAccessControl(TestScenario):
     def _check_mutation_on_non_owned_intent_fails(self):
         with self.check(
             "Non-owning credentials cannot modify operational intent",
-            self._pid,
+            self._pid + self._uids,
         ) as check:
             try:
                 # Attempt to update the state of the intent created with the main credentials using the second credentials
@@ -437,7 +441,7 @@ class OpIntentReferenceAccessControl(TestScenario):
 
         with self.check(
             "Non-owning credentials cannot modify operational intent",
-            self._pid,
+            self._pid + self._uids,
         ) as check:
             try:
                 # Attempt to update the base_url of the intent created with the main credentials using the second credentials
@@ -468,7 +472,7 @@ class OpIntentReferenceAccessControl(TestScenario):
         # Try to delete
         with self.check(
             "Non-owning credentials cannot delete operational intent",
-            self._pid,
+            self._pid + self._uids,
         ) as check:
             try:
                 (_, _, dq) = self._dss_separate_creds.delete_op_intent(
@@ -510,7 +514,7 @@ class OpIntentReferenceAccessControl(TestScenario):
 
         with self.check(
             "Non-owning credentials cannot modify operational intent",
-            self._pid,
+            self._pid + self._uids,
         ) as check:
             if op_1_current != self._current_ref_1:
                 check.record_failed(

--- a/schemas/monitoring/uss_qualifier/resources/astm/f3548/v21/dss/DSSInstanceSpecification.json
+++ b/schemas/monitoring/uss_qualifier/resources/astm/f3548/v21/dss/DSSInstanceSpecification.json
@@ -21,6 +21,16 @@
     "participant_id": {
       "description": "ID of the USS responsible for this DSS instance",
       "type": "string"
+    },
+    "user_participant_ids": {
+      "description": "IDs of any participants using this DSS instance.",
+      "items": {
+        "type": "string"
+      },
+      "type": [
+        "array",
+        "null"
+      ]
     }
   },
   "required": [

--- a/schemas/monitoring/uss_qualifier/resources/astm/f3548/v21/dss/DSSInstanceSpecification.json
+++ b/schemas/monitoring/uss_qualifier/resources/astm/f3548/v21/dss/DSSInstanceSpecification.json
@@ -23,7 +23,7 @@
       "type": "string"
     },
     "user_participant_ids": {
-      "description": "IDs of any participants using this DSS instance.",
+      "description": "IDs of any participants using this DSS instance, apart from the USS responsible for this DSS instance.",
       "items": {
         "type": "string"
       },


### PR DESCRIPTION
Some USS requirements in F3548-21 are enforced by the DSS instance a USS uses.  For instance, the DSS should prevent modification or deletion of operational intent references that a USS doesn't manage, per OPIN0035.  Also, the DSS should prevent creation or modification of an operational intent in a state other than Accepted if the managing USS doesn't have a subscription, [per SCD0080](https://github.com/interuss/monitoring/issues/466#issue-2077443460).

This PR adds information about the users of an F3548 DSS instance so their compliance to DSS-enforced requirements can be recorded, and uses that information in an existing scenario to record OPIN0035 compliance for those users.