### PR TITLE
[uss_qualifier] Fix test suite local resource override logic

### DIFF
--- a/monitoring/uss_qualifier/suites/definitions.py
+++ b/monitoring/uss_qualifier/suites/definitions.py
@@ -155,18 +155,6 @@ class TestSuiteDefinition(ImplicitDict):
     participant_verifiable_capabilities: Optional[List[ParticipantCapabilityDefinition]]
     """Definitions of capabilities verified by this test suite for individual participants."""
 
-    def __init__(self, *args, **kwargs):
-        super(TestSuiteDefinition, self).__init__(*args, **kwargs)
-        inherits_resources = "resources" in self and self.resources
-        local_resources = "local_resources" in self and self.local_resources
-        if inherits_resources and local_resources:
-            for k in self.resources:
-                if k in self.local_resources:
-                    self.local_resources.pop(k)
-                    logger.debug(
-                        f"Ignoring local resource `{k}` in favor of definition provided in `resources`"
-                    )
-
     @staticmethod
     def load_from_declaration(
         declaration: TestSuiteDeclaration,

--- a/monitoring/uss_qualifier/suites/suite.py
+++ b/monitoring/uss_qualifier/suites/suite.py
@@ -243,7 +243,12 @@ class TestSuite(object):
         if "local_resources" in self.definition and self.definition.local_resources:
             local_resources = create_resources(self.definition.local_resources)
             for local_resource_id, resource in local_resources.items():
-                self.local_resources[local_resource_id] = resource
+                if local_resource_id not in self.local_resources:
+                    self.local_resources[local_resource_id] = resource
+                else:
+                    logger.debug(
+                        f"Overriding local resource {local_resource_id} in test suite {declaration.suite_type} with externally-provided resource"
+                    )
 
         for resource_id, resource_type in self.definition.resources.items():
             is_optional = resource_type.endswith("?")


### PR DESCRIPTION
This PR should fix #515.  The f3548_self_contained configuration was verified to correctly retrieve the system version for the default (local resource) system_identity, and the uspace configuration was verified to correctly retrieve the system version for the overridden (external resource) system_identity.  This behavior is visible in the GetSystemVersions test scenario in the F3548-21 test suite of the sequence view artifacts for these two configurations.