### PR TITLE
[uss_qualifier] DSS0210,2 check op-intent references are synchronized

### DIFF
--- a/monitoring/monitorlib/schema_validation.py
+++ b/monitoring/monitorlib/schema_validation.py
@@ -59,6 +59,16 @@ class F3548_21(str, Enum):
     QuerySubscriptionsResponse = "components.schemas.QuerySubscriptionsResponse"
     DeleteSubscriptionResponse = "components.schemas.DeleteSubscriptionResponse"
 
+    ChangeOperationalIntentReferenceResponse = (
+        "components.schemas.ChangeOperationalIntentReferenceResponse"
+    )
+    GetOperationalIntentReferenceResponse = (
+        "components.schemas.GetOperationalIntentReferenceResponse"
+    )
+    QueryOperationalIntentReferenceResponse = (
+        "components.schemas.QueryOperationalIntentReferenceResponse"
+    )
+
 
 _openapi_content_cache: Dict[str, dict] = {}
 

--- a/monitoring/prober/infrastructure.py
+++ b/monitoring/prober/infrastructure.py
@@ -100,7 +100,7 @@ ResourceType = int
 resource_type_code_descriptions: Dict[ResourceType, str] = {}
 
 
-# Next code: 381
+# Next code: 382
 def register_resource_type(code: int, description: str) -> ResourceType:
     """Register that the specified code refers to the described resource.
 

--- a/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml
@@ -24,6 +24,7 @@ v1:
           dss_instances: dss_instances
           mock_uss: mock_uss
           second_utm_auth: second_utm_auth
+          utm_client_identity: utm_client_identity
           planning_area: planning_area
           problematically_big_area: problematically_big_area
 

--- a/monitoring/uss_qualifier/configurations/dev/message_signing.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/message_signing.yaml
@@ -60,6 +60,7 @@ v1:
           dss_instances: scd_dss_instances
           id_generator: id_generator
           second_utm_auth: second_utm_auth
+          utm_client_identity: utm_client_identity
           planning_area: che_planning_area
           problematically_big_area: che_problematically_big_area
     execution:

--- a/monitoring/uss_qualifier/resources/astm/f3548/v21/planning_area.py
+++ b/monitoring/uss_qualifier/resources/astm/f3548/v21/planning_area.py
@@ -11,7 +11,7 @@ from uas_standards.astm.f3548.v21.api import (
     ImplicitSubscriptionParameters,
 )
 
-from monitoring.monitorlib.geo import make_latlng_rect, Volume3D
+from monitoring.monitorlib.geo import LatLngPoint, make_latlng_rect, Volume3D, Polygon
 from monitoring.monitorlib.geotemporal import Volume4D
 from monitoring.monitorlib.temporal import Time
 from monitoring.uss_qualifier.resources.astm.f3548.v21.subscription_params import (

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/clean_workspace.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/clean_workspace.md
@@ -4,8 +4,8 @@ This page describes the content of a common test step that ensures a clean works
 
 ## 🛑 Operational intent references can be queried by ID check
 
-If an existing operational intent reference cannot directly be queried by its ID, the DSS implementation is in violation of
-**[astm.f3548.v21.DSS0005,1](../../../../requirements/astm/f3548/v21.md)**.
+If an existing operational intent reference cannot directly be queried by its ID, or if for a non-existing one the DSS replies with a status code different than 404,
+the DSS implementation is in violation of **[astm.f3548.v21.DSS0005,1](../../../../requirements/astm/f3548/v21.md)**.
 
 ## 🛑 Operational intent references can be searched for check
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/oir/crud/read.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/oir/crud/read.md
@@ -12,6 +12,13 @@ The response to a successful get operational intent reference query is expected 
 
 If it does not, the DSS is failing to implement **[astm.f3548.v21.DSS0005,1](../../../../../../../requirements/astm/f3548/v21.md)**.
 
+## 🛑 Get operational intent reference response content is correct check
+
+A successful operational intent reference creation query is expected to return a body, the content of which reflects an operational intent reference that was created earlier.
+If the content of the response does not correspond to what was requested, the DSS is failing to implement **[astm.f3548.v21.DSS0005,1](../../../../../../../requirements/astm/f3548/v21.md)**.
+
+This check will usually be performing a series of sub-checks from the [validate](../validate) fragments.
+
 ## 🛑 Successful operational intent reference search query check
 
 If the DSS fails to let us search in the area for which the OIR was created, it is failing to meet **[astm.f3548.v21.DSS0005,1](../../../../../../../requirements/astm/f3548/v21.md)**.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/remove_op_intent.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/remove_op_intent.md
@@ -1,7 +1,0 @@
-# Remove operational intent test step fragment
-
-This test step fragment attempts to remove from the DSS a specific operational intent reference managed by a user whose credentials are provided to uss_qualifier.
-
-## 🛑 Operational intent reference removed check
-
-If the operational intent reference could not be removed, the DSS instance used does not meet **[astm.f3548.v21.DSS0005,1](../../../../requirements/astm/f3548/v21.md)**

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/__init__.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/__init__.py
@@ -1,1 +1,2 @@
 from .subscription_synchronization import SubscriptionSynchronization
+from .op_intent_ref_synchronization import OIRSynchronization

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md
@@ -1,0 +1,136 @@
+# ASTM SCD DSS: Operational Intent Reference Synchronization test scenario
+
+## Overview
+
+Verifies that all CRUD operations on operational intent references performed on a given DSS instance
+are properly propagated to every other DSS instance participating in the deployment.
+
+## Resources
+
+### dss
+
+[`DSSInstanceResource`](../../../../../resources/astm/f3548/v21/dss.py) the DSS instance through which entities are created, modified and deleted.
+
+### other_instances
+
+[`DSSInstancesResource`](../../../../../resources/astm/f3548/v21/dss.py) pointing to the DSS instances used to confirm that entities are properly propagated.
+
+### id_generator
+
+[`IDGeneratorResource`](../../../../../resources/interuss/id_generator.py) providing the Subscription ID for this scenario.
+
+### planning_area
+
+[`PlanningAreaResource`](../../../../../resources/astm/f3548/v21/planning_area.py) describes the 3D volume in which subscriptions will be created.
+
+### client_identity
+
+[`ClientIdentityResource`](../../../../../resources/communications/client_identity.py) to be used for this scenario.
+
+## Setup test case
+
+### [Ensure clean workspace test step](../clean_workspace.md)
+
+This step ensures that no subscription with the known test ID exists in the DSS.
+
+## OIR synchronization test case
+
+This test case creates an operational intent reference on the main DSS, and verifies that it is properly synchronized to the other DSS instances.
+
+It then goes on to mutate and delete it, each time confirming that all other DSSes return the expected results.
+
+### Create OIR validation test step
+
+#### [Create OIR](../fragments/oir/crud/create.md)
+
+Verify that an operational intent reference can be created on the primary DSS.
+
+#### [OIR Content is correct](../fragments/oir/validate/correctness.md)
+
+Verify that the operational intent reference returned by the DSS under test is properly formatted and contains the expected content.
+
+### Query newly created OIR test step
+
+Query the created operational intent at every DSS provided in `dss_instances`.
+
+#### [OIR is synchronized](../fragments/oir/sync.md)
+
+Confirm that the operational intent reference that was just created is properly synchronized across all DSS instances.
+
+#### [Get OIR](../fragments/oir/crud/read.md)
+
+Confirms that each DSS provides access to the created operational intent reference,
+
+#### [OIR Content is correct](../fragments/oir/validate/correctness.md)
+
+Verify that the operational intent reference returned by every DSS is correctly formatted and corresponds to what was created earlier.
+
+#### [OIR Versions are correct](../fragments/oir/validate/non_mutated.md)
+
+Verify that the operational intent reference's version fields are as expected.
+
+### Mutate OIR test step
+
+This test step mutates the previously created operational intent reference to verify that the DSS reacts properly: notably, it checks that the operational intent reference version is updated,
+including for changes that are not directly visible, such as changing the operational intent reference's footprint.
+
+#### [Update OIR](../fragments/oir/crud/update.md)
+
+Confirm that the operational intent reference can be mutated.
+
+#### [Validate OIR](../fragments/oir/validate/correctness.md)
+
+Verify that the operational intent reference returned by the DSS is properly formatted and contains the correct content.
+
+#### [OIR Versions are correct](../fragments/oir/validate/mutated.md)
+
+Verify that the operational intent reference's version fields have been updated.
+
+### Query updated OIR test step
+
+Query the updated operational intent reference at every DSS provided in `dss_instances`.
+
+#### [OIR is synchronized](../fragments/oir/sync.md)
+
+Confirm that the operational intent reference that was just mutated is properly synchronized across all DSS instances.
+
+#### [Get OIR](../fragments/oir/crud/read.md)
+
+Confirms that the operational intent reference that was just mutated can be retrieved from any DSS.
+
+#### [Validate OIR](../fragments/oir/validate/correctness.md)
+
+Verify that the operational intent reference returned by every DSS is correctly formatted and corresponds to what was mutated earlier.
+
+#### [OIR Versions are correct](../fragments/oir/validate/non_mutated.md)
+
+Verify that the operational intent reference's version fields are as expected.
+
+### Delete OIR test step
+
+Attempt to delete the operational intent reference in various ways and ensure that the DSS reacts properly.
+
+This also checks that the operational intent reference data returned by a successful deletion is correct.
+
+#### [Delete OIR](../fragments/oir/crud/delete.md)
+
+Confirms that an operational intent reference can be deleted.
+
+#### [Validate OIR](../fragments/oir/validate/correctness.md)
+
+Verify that the operational intent reference returned by the DSS via the deletion is properly formatted and contains the correct content.
+
+#### [OIR Versions are correct](../fragments/oir/validate/non_mutated.md)
+
+Verify that the operational intent reference's version fields are as expected.
+
+### Query deleted OIR test step
+
+Attempt to query and search for the deleted operational intent reference in various ways
+
+#### 🛑 Secondary DSS should not return the deleted operational intent reference check
+
+If a DSS returns an operational intent reference that was previously successfully deleted from the primary DSS,
+either one of the primary DSS or the DSS that returned the operational intent reference is in violation of **[astm.f3548.v21.DSS0210,2a](../../../../../requirements/astm/f3548/v21.md)**.
+
+## [Cleanup](../clean_workspace.md)

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.py
@@ -1,0 +1,483 @@
+from datetime import datetime, timedelta
+from typing import List, Optional
+
+import loguru
+from implicitdict import StringBasedDateTime
+from uas_standards.astm.f3548.v21 import api
+from uas_standards.astm.f3548.v21.api import (
+    OperationalIntentReference,
+    PutOperationalIntentReferenceParameters,
+    EntityID,
+    OperationalIntentState,
+)
+from uas_standards.astm.f3548.v21.constants import Scope
+
+from monitoring.monitorlib.fetch import QueryError
+from monitoring.monitorlib.geotemporal import Volume4D
+from monitoring.prober.infrastructure import register_resource_type
+from monitoring.uss_qualifier.resources.astm.f3548.v21 import PlanningAreaResource
+from monitoring.uss_qualifier.resources.astm.f3548.v21.dss import (
+    DSSInstanceResource,
+    DSSInstancesResource,
+    DSSInstance,
+)
+from monitoring.uss_qualifier.resources.communications import ClientIdentityResource
+from monitoring.uss_qualifier.resources.interuss.id_generator import IDGeneratorResource
+from monitoring.uss_qualifier.scenarios.astm.utm.dss import test_step_fragments
+from monitoring.uss_qualifier.scenarios.astm.utm.dss.validators.oir_validator import (
+    OIRValidator,
+    TIME_TOLERANCE_SEC,
+)
+from monitoring.uss_qualifier.scenarios.scenario import (
+    TestScenario,
+)
+from monitoring.uss_qualifier.suites.suite import ExecutionContext
+
+
+class OIRSynchronization(TestScenario):
+    """
+    A scenario that checks if multiple DSS instances properly synchronize
+    operational intent references.
+
+    Not in the scope of the first version of this:
+     - access rights (making sure only the manager of the OIR can mutate it)
+     - control of the area synchronization (by doing area searches against the secondaries)
+     - mutation of an entity on a secondary DSS when it was created on the primary
+     - deletion of an entity on a secondary DSS when it was created on the primary
+    """
+
+    SUB_TYPE = register_resource_type(381, "Operational Intent Reference")
+
+    _dss: DSSInstance
+
+    _dss_read_instances: List[DSSInstance]
+
+    # Base identifier for the OIR that will be created
+    _oir_id: EntityID
+
+    # Base parameters used for OIR creation
+    _oir_params: PutOperationalIntentReferenceParameters
+
+    # Keep track of the current OIR state
+    _current_oir: Optional[OperationalIntentReference]
+
+    _expected_manager: str
+
+    def __init__(
+        self,
+        dss: DSSInstanceResource,
+        other_instances: DSSInstancesResource,
+        id_generator: IDGeneratorResource,
+        client_identity: ClientIdentityResource,
+        planning_area: PlanningAreaResource,
+    ):
+        """
+        Args:
+            dss: dss to test
+            other_instances: dss instances to be checked for proper synchronization
+            id_generator: will let us generate specific identifiers
+            client_identity: tells us the identity we should expect as an entity's manager
+            planning_area: An Area to use for the tests. It should be an area for which the DSS is responsible,
+                 but has no other requirements.
+
+        """
+        super().__init__()
+        scopes_primary = {
+            Scope.StrategicCoordination: "create and delete operational intent references"
+        }
+        scopes_read = {Scope.StrategicCoordination: "read operational intents"}
+
+        self._dss = dss.get_instance(scopes_primary)
+        self._primary_pid = self._dss.participant_id
+
+        self._dss_read_instances = [
+            sec_dss.get_instance(scopes_read)
+            for sec_dss in other_instances.dss_instances
+        ]
+
+        self._oir_id = id_generator.id_factory.make_id(self.SUB_TYPE)
+        self._expected_manager = client_identity.subscriber()
+        self._planning_area = planning_area.specification
+
+        # Build a ready-to-use 4D volume with no specified time for searching
+        # the currently active OIRs
+        self._planning_area_volume4d = Volume4D(
+            volume=self._planning_area.volume,
+        )
+
+        self._oir_params = self._planning_area.get_new_operational_intent_ref_params(
+            key=[],
+            state=OperationalIntentState.Accepted,
+            uss_base_url=self._planning_area.base_url,
+            time_start=datetime.now() - timedelta(seconds=10),
+            time_end=datetime.now() + timedelta(minutes=20),
+            subscription_id=None,
+            implicit_sub_base_url=None,
+            implicit_sub_for_constraints=None,
+        )
+
+    def run(self, context: ExecutionContext):
+
+        # Check that we actually have at least one other DSS to test against:
+        if not self._dss_read_instances:
+            loguru.logger.warning(
+                "Skipping EntitySynchronization test: no other DSS instances to test against"
+            )
+            return
+
+        self.begin_test_scenario(context)
+        self._setup_case()
+        self.begin_test_case("OIR synchronization")
+
+        self.begin_test_step("Create OIR validation")
+        self._create_oir_with_params(self._oir_params)
+        self.end_test_step()
+
+        self.begin_test_step("Query newly created OIR")
+        self._query_secondaries_and_compare(self._oir_params)
+        self.end_test_step()
+
+        self.begin_test_step("Mutate OIR")
+        self._test_mutate_oir_shift_time()
+        self.end_test_step()
+
+        self.begin_test_step("Query updated OIR")
+        self._query_secondaries_and_compare(self._oir_params)
+        self.end_test_step()
+
+        self.begin_test_step("Delete OIR")
+        self._test_delete_sub()
+        self.end_test_step()
+
+        self.begin_test_step("Query deleted OIR")
+        self._test_get_deleted_oir()
+        self.end_test_step()
+
+        self.end_test_case()
+        self.end_test_scenario()
+
+    def _setup_case(self):
+        self.begin_test_case("Setup")
+        # Multiple runs of the scenario seem to rely on the same instance of it:
+        # thus we need to reset the state of the scenario before running it.
+        self._current_oir = None
+        self.begin_test_step("Ensure clean workspace")
+        self._ensure_clean_workspace_step()
+        self.end_test_step()
+        self.end_test_case()
+
+    def _ensure_clean_workspace_step(self):
+
+        # Delete any active OIR we might own
+        test_step_fragments.cleanup_active_oirs(
+            self,
+            self._dss,
+            self._planning_area_volume4d.to_f3548v21(),
+            self._expected_manager,
+        )
+
+        # Make sure the OIR ID we are going to use is available
+        test_step_fragments.cleanup_op_intent(self, self._dss, self._oir_id)
+        # Start by dropping any active subs we might own and that could interfere
+        test_step_fragments.cleanup_active_subs(
+            self, self._dss, self._planning_area_volume4d.to_f3548v21()
+        )
+
+    def _create_oir_with_params(
+        self, creation_params: PutOperationalIntentReferenceParameters
+    ):
+
+        with self.check(
+            "Create operational intent reference query succeeds", [self._primary_pid]
+        ) as check:
+            try:
+                oir, subs, q = self._dss.put_op_intent(
+                    extents=creation_params.extents,
+                    key=creation_params.key,
+                    state=creation_params.state,
+                    base_url=creation_params.uss_base_url,
+                    oi_id=self._oir_id,
+                    ovn=None,
+                )
+                self.record_query(q)
+            except QueryError as qe:
+                self.record_queries(qe.queries)
+                check.record_failed(
+                    summary="Create operational intent reference failed",
+                    details=qe.msg,
+                    query_timestamps=qe.query_timestamps,
+                )
+                return
+
+        with self.check(
+            "Create operational intent reference response content is correct",
+            [self._primary_pid],
+        ) as check:
+            OIRValidator(
+                main_check=check,
+                scenario=self,
+                expected_manager=self._expected_manager,
+                participant_id=[self._primary_pid],
+                oir_params=creation_params,
+            ).validate_created_oir(self._oir_id, new_oir=q)
+
+        self._current_oir = oir
+
+    def _query_secondaries_and_compare(
+        self, expected_oir_params: PutOperationalIntentReferenceParameters
+    ):
+        for secondary_dss in self._dss_read_instances:
+            self._validate_oir_from_secondary(
+                secondary_dss=secondary_dss,
+                expected_oir_params=expected_oir_params,
+                involved_participants=list(
+                    {self._primary_pid, secondary_dss.participant_id}
+                ),
+            )
+
+    def _validate_oir_from_secondary(
+        self,
+        secondary_dss: DSSInstance,
+        expected_oir_params: PutOperationalIntentReferenceParameters,
+        involved_participants: List[str],
+    ):
+        with self.check(
+            "Operational intent reference can be found at every DSS",
+            involved_participants,
+        ) as check:
+            try:
+                oir, q = secondary_dss.get_op_intent_reference(self._oir_id)
+                self.record_query(q)
+            except QueryError as e:
+                self.record_queries(e.queries)
+                check.record_failed(
+                    summary="GET for operational intent reference failed",
+                    details=f"Query for operational intent reference failed: {e.msg}",
+                    query_timestamps=e.query_timestamps,
+                )
+
+        with self.check(
+            "Propagated operational intent reference contains the correct manager",
+            involved_participants,
+        ) as check:
+            if oir.manager != self._expected_manager:
+                check.record_failed(
+                    summary="Propagated OIR has an incorrect manager",
+                    details=f"Expected: {self._expected_manager}, Received: {oir.manager}",
+                    query_timestamps=[q.request.timestamp],
+                )
+
+        with self.check(
+            "Propagated operational intent reference contains the correct USS base URL",
+            involved_participants,
+        ) as check:
+            if oir.uss_base_url != expected_oir_params.uss_base_url:
+                check.record_failed(
+                    "Propagated OIR has an incorrect USS base URL",
+                    details=f"Expected: {expected_oir_params.base_url}, Received: {oir.uss_base_url}",
+                    query_timestamps=[q.request.timestamp],
+                )
+
+        with self.check(
+            "Propagated operational intent reference contains the correct state",
+            involved_participants,
+        ) as check:
+            if oir.state != expected_oir_params.state:
+                check.record_failed(
+                    summary="Propagated OIR has an incorrect state",
+                    details=f"Expected: {expected_oir_params.state}, Received: {oir.state}",
+                    query_timestamps=[q.request.timestamp],
+                )
+
+        with self.check(
+            "Propagated operational intent reference contains the correct start time",
+            involved_participants,
+        ) as check:
+            expected_start = expected_oir_params.extents[0].time_start
+            if (
+                abs(
+                    oir.time_start.value.datetime - expected_start.value.datetime
+                ).total_seconds()
+                > TIME_TOLERANCE_SEC
+            ):
+                check.record_failed(
+                    "Propagated OIR has an incorrect start time",
+                    details=f"Expected: {expected_start}, Received: {oir.time_start}",
+                    query_timestamps=[q.request.timestamp],
+                )
+
+        with self.check(
+            "Propagated operational intent reference contains the correct end time",
+            involved_participants,
+        ) as check:
+            expected_end = expected_oir_params.extents[-1].time_end
+            if (
+                abs(
+                    oir.time_end.value.datetime - expected_end.value.datetime
+                ).total_seconds()
+                > TIME_TOLERANCE_SEC
+            ):
+                check.record_failed(
+                    "Propagated OIR has an incorrect end time",
+                    details=f"Expected: {expected_end}, Received: {oir.time_end}",
+                    query_timestamps=[q.request.timestamp],
+                )
+
+        with self.check(
+            "Get operational intent reference response content is correct",
+            [secondary_dss.participant_id],
+        ) as check:
+            # Do a full validation of the OIR as a sanity check
+            OIRValidator(
+                main_check=check,
+                scenario=self,
+                expected_manager=self._expected_manager,
+                participant_id=[secondary_dss.participant_id],
+                oir_params=expected_oir_params,
+            ).validate_fetched_oir(
+                expected_oir_id=self._oir_id,
+                fetched_oir=q,
+                expected_version=self._current_oir.version,
+                expected_ovn=self._current_oir.ovn,
+            )
+
+    def _test_mutate_oir_shift_time(self):
+        """Mutate the OIR by adding 10 seconds to its start and end times.
+        This is achieved by updating the first and last element of the extents.
+        """
+        op = self._oir_params
+
+        new_extents = self._shift_extents(op.extents, timedelta(seconds=10))
+
+        new_params = PutOperationalIntentReferenceParameters(
+            extents=new_extents,
+            key=op.key + [self._current_oir.ovn],
+            state=op.state,
+            uss_base_url=op.uss_base_url,
+            subscription_id=op.subscription_id if "subscription_id" in op else None,
+            new_subscription=op.new_subscription if "new_subscription" in op else None,
+        )
+
+        with self.check(
+            "Mutate operational intent reference query succeeds", [self._primary_pid]
+        ) as check:
+            try:
+                oir, subs, q = self._dss.put_op_intent(
+                    extents=new_extents,
+                    key=new_params.key,
+                    state=new_params.state,
+                    base_url=new_params.uss_base_url,
+                    oi_id=self._oir_id,
+                    ovn=self._current_oir.ovn,
+                )
+                self.record_query(q)
+            except QueryError as qe:
+                self.record_queries(qe.queries)
+                check.record_failed(
+                    summary="Operational intent reference mutation failed",
+                    details=qe.msg,
+                    query_timestamps=qe.query_timestamps,
+                )
+                return
+
+        with self.check(
+            "Mutate operational intent reference response content is correct",
+            [self._primary_pid],
+        ) as check:
+            OIRValidator(
+                main_check=check,
+                scenario=self,
+                expected_manager=self._expected_manager,
+                participant_id=[self._primary_pid],
+                oir_params=new_params,
+            ).validate_mutated_oir(
+                expected_oir_id=self._oir_id,
+                mutated_oir=q,
+                previous_ovn=self._current_oir.ovn,
+                previous_version=self._current_oir.version,
+            )
+
+        self._oir_params = new_params
+        self._current_oir = oir
+
+    def _test_delete_sub(self):
+        with self.check(
+            "Delete operational intent reference query succeeds", [self._primary_pid]
+        ) as check:
+            try:
+                oir, subs, q = self._dss.delete_op_intent(
+                    self._oir_id, self._current_oir.ovn
+                )
+                self.record_query(q)
+            except QueryError as qe:
+                self.record_queries(qe.queries)
+                check.record_failed(
+                    summary="Operational intent reference deletion on primary DSS failed",
+                    details=qe.msg,
+                    query_timestamps=qe.query_timestamps,
+                )
+                return
+
+        with self.check(
+            "Delete operational intent reference response content is correct",
+            [self._primary_pid],
+        ) as check:
+            OIRValidator(
+                main_check=check,
+                scenario=self,
+                expected_manager=self._expected_manager,
+                participant_id=[self._primary_pid],
+                oir_params=self._oir_params,
+            ).validate_deleted_oir(
+                expected_oir_id=self._oir_id,
+                deleted_oir=q,
+                expected_ovn=self._current_oir.ovn,
+                expected_version=self._current_oir.version,
+            )
+
+        self._current_oir = None
+
+    def _test_get_deleted_oir(self):
+        for secondary_dss in self._dss_read_instances:
+            self._confirm_secondary_has_no_oir(secondary_dss)
+
+    def _confirm_secondary_has_no_oir(self, secondary_dss: DSSInstance):
+        with self.check(
+            "Secondary DSS should not return the deleted operational intent reference",
+            [secondary_dss.participant_id],
+        ) as check:
+            try:
+                oir, q = secondary_dss.get_op_intent_reference(self._oir_id)
+                self.record_query(q)
+                status = q.status_code
+                q_ts = [q.request.timestamp]
+            except QueryError as qe:
+                status = qe.cause_status_code
+                q_ts = qe.query_timestamps[-1]
+            if status != 404:
+                check.record_failed(
+                    "Secondary DSS still has the deleted operational intent reference",
+                    details=f"Expected 404, received {status}",
+                    query_timestamps=q_ts,
+                )
+
+    def _shift_extents(
+        self, extents: List[api.Volume4D], delta: timedelta
+    ) -> List[api.Volume4D]:
+        return [
+            api.Volume4D(
+                volume=ext.volume,
+                time_start=api.Time(
+                    value=StringBasedDateTime(ext.time_start.value.datetime + delta)
+                ),
+                time_end=api.Time(
+                    value=StringBasedDateTime(ext.time_end.value.datetime + delta)
+                ),
+            )
+            for ext in extents
+        ]
+
+    def cleanup(self):
+        self.begin_cleanup()
+        self._ensure_clean_workspace_step()
+        self.end_cleanup()

--- a/monitoring/uss_qualifier/scenarios/astm/utm/prep_planners.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/prep_planners.md
@@ -80,7 +80,7 @@ In addition to foreign flight planners, uss_qualifier may have left operational 
 
 ### Remove uss_qualifier op intents test step
 
-#### [Remove op intents](./dss/remove_op_intent.md)
+#### [Remove op intents](./dss/clean_workspace.md)
 
 The operational intent references managed by uss_qualifier discovered in the previous test case are removed.
 

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a.yaml
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a.yaml
@@ -31,6 +31,7 @@ actions:
               utm_client_identity: utm_client_identity
               id_generator: id_generator
               isa: service_area
+              client_identity: utm_client_identity
               problematically_big_area: problematically_big_area
           on_failure: Continue
         dss_instances_source: dss_instances

--- a/monitoring/uss_qualifier/suites/astm/utm/dss_probing.md
+++ b/monitoring/uss_qualifier/suites/astm/utm/dss_probing.md
@@ -4,14 +4,15 @@
 
 ## [Actions](../../README.md#actions)
 
-1. Scenario: [ASTM SCD DSS: Interfaces authentication](../../../scenarios/astm/utm/dss/authentication/authentication_validation.md) ([`scenarios.astm.utm.dss.authentication.AuthenticationValidation`](../../../scenarios/astm/utm/dss/authentication/authentication_validation.py))
-2. Scenario: [ASTM SCD DSS: Subscription Simple](../../../scenarios/astm/utm/dss/subscription_simple.md) ([`scenarios.astm.utm.dss.SubscriptionSimple`](../../../scenarios/astm/utm/dss/subscription_simple.py))
-3. Scenario: [ASTM SCD DSS: Subscription Validation](../../../scenarios/astm/utm/dss/subscription_validation.md) ([`scenarios.astm.utm.dss.SubscriptionValidation`](../../../scenarios/astm/utm/dss/subscription_validation.py))
-4. Scenario: [ASTM F3548-21 UTM DSS Operational Intent Reference Access Control](../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md) ([`scenarios.astm.utm.dss.OpIntentReferenceAccessControl`](../../../scenarios/astm/utm/dss/op_intent_ref_access_control.py))
-5. Scenario: [ASTM F3548-21 UTM DSS interoperability](../../../scenarios/astm/utm/dss/dss_interoperability.md) ([`scenarios.astm.utm.dss.DSSInteroperability`](../../../scenarios/astm/utm/dss/dss_interoperability.py))
-6. Scenario: [ASTM SCD DSS: Subscription Synchronization](../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md) ([`scenarios.astm.utm.dss.synchronization.SubscriptionSynchronization`](../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.py))
-7. Scenario: [ASTM UTM DSS: Direct CRDB access](../../../scenarios/astm/utm/dss/crdb_access.md) ([`scenarios.astm.utm.dss.CRDBAccess`](../../../scenarios/astm/utm/dss/crdb_access.py))
-8. Scenario: [ASTM SCD DSS: Report](../../../scenarios/astm/utm/dss/report.md) ([`scenarios.astm.utm.dss.Report`](../../../scenarios/astm/utm/dss/report.py))
+1. Scenario: [ASTM SCD DSS: Operational Intent Reference Synchronization](../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md) ([`scenarios.astm.utm.dss.synchronization.OIRSynchronization`](../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.py))
+2. Scenario: [ASTM SCD DSS: Interfaces authentication](../../../scenarios/astm/utm/dss/authentication/authentication_validation.md) ([`scenarios.astm.utm.dss.authentication.AuthenticationValidation`](../../../scenarios/astm/utm/dss/authentication/authentication_validation.py))
+3. Scenario: [ASTM SCD DSS: Subscription Simple](../../../scenarios/astm/utm/dss/subscription_simple.md) ([`scenarios.astm.utm.dss.SubscriptionSimple`](../../../scenarios/astm/utm/dss/subscription_simple.py))
+4. Scenario: [ASTM SCD DSS: Subscription Validation](../../../scenarios/astm/utm/dss/subscription_validation.md) ([`scenarios.astm.utm.dss.SubscriptionValidation`](../../../scenarios/astm/utm/dss/subscription_validation.py))
+5. Scenario: [ASTM F3548-21 UTM DSS Operational Intent Reference Access Control](../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md) ([`scenarios.astm.utm.dss.OpIntentReferenceAccessControl`](../../../scenarios/astm/utm/dss/op_intent_ref_access_control.py))
+6. Scenario: [ASTM F3548-21 UTM DSS interoperability](../../../scenarios/astm/utm/dss/dss_interoperability.md) ([`scenarios.astm.utm.dss.DSSInteroperability`](../../../scenarios/astm/utm/dss/dss_interoperability.py))
+7. Scenario: [ASTM SCD DSS: Subscription Synchronization](../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md) ([`scenarios.astm.utm.dss.synchronization.SubscriptionSynchronization`](../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.py))
+8. Scenario: [ASTM UTM DSS: Direct CRDB access](../../../scenarios/astm/utm/dss/crdb_access.md) ([`scenarios.astm.utm.dss.CRDBAccess`](../../../scenarios/astm/utm/dss/crdb_access.py))
+9. Scenario: [ASTM SCD DSS: Report](../../../scenarios/astm/utm/dss/report.md) ([`scenarios.astm.utm.dss.Report`](../../../scenarios/astm/utm/dss/report.py))
 
 ## [Checked requirements](../../README.md#checked-requirements)
 
@@ -23,20 +24,20 @@
     <th><a href="../../README.md#checked-in">Checked in</a></th>
   </tr>
   <tr>
-    <td rowspan="21" style="vertical-align:top;"><a href="../../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
+    <td rowspan="26" style="vertical-align:top;"><a href="../../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,1</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,2</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,5</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0015</a></td>
@@ -107,6 +108,31 @@
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,1i</a></td>
     <td>Implemented</td>
     <td><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2a</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2b</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2c</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2d</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2f</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,7</a></td>

--- a/monitoring/uss_qualifier/suites/astm/utm/dss_probing.yaml
+++ b/monitoring/uss_qualifier/suites/astm/utm/dss_probing.yaml
@@ -1,6 +1,7 @@
 name: DSS testing for ASTM NetRID F3548-21
 resources:
   dss: resources.astm.f3548.v21.DSSInstanceResource
+  utm_client_identity: resources.communications.ClientIdentityResource
   second_utm_auth: resources.communications.AuthAdapterResource?
   all_dss_instances: resources.astm.f3548.v21.DSSInstancesResource?
   dss_crdb_cluster: resources.interuss.crdb.CockroachDBClusterResource?
@@ -9,6 +10,14 @@ resources:
   planning_area: resources.astm.f3548.v21.PlanningAreaResource
   problematically_big_area: resources.VerticesResource
 actions:
+  - test_scenario:
+      scenario_type: scenarios.astm.utm.dss.synchronization.OIRSynchronization
+      resources:
+        dss: dss
+        other_instances: all_dss_instances
+        id_generator: id_generator
+        planning_area: planning_area
+        client_identity: utm_client_identity
   - test_scenario:
       scenario_type: scenarios.astm.utm.dss.authentication.AuthenticationValidation
       resources:

--- a/monitoring/uss_qualifier/suites/astm/utm/f3548_21.md
+++ b/monitoring/uss_qualifier/suites/astm/utm/f3548_21.md
@@ -35,20 +35,20 @@
     <th><a href="../../README.md#checked-in">Checked in</a></th>
   </tr>
   <tr>
-    <td rowspan="47" style="vertical-align:top;"><a href="../../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
+    <td rowspan="52" style="vertical-align:top;"><a href="../../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,1</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a></td>
+    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,2</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/subscription_notifications/receive_notifications_for_awareness/receive_notifications_for_awareness.md">Awareness of relevant operational intents</a><br><a href="../../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/subscription_notifications/receive_notifications_for_awareness/receive_notifications_for_awareness.md">Awareness of relevant operational intents</a><br><a href="../../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,5</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a></td>
+    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0015</a></td>
@@ -124,6 +124,31 @@
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,1i</a></td>
     <td>Implemented</td>
     <td><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2a</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2b</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2c</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2d</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2f</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,7</a></td>

--- a/monitoring/uss_qualifier/suites/astm/utm/f3548_21.yaml
+++ b/monitoring/uss_qualifier/suites/astm/utm/f3548_21.yaml
@@ -13,6 +13,7 @@ resources:
   nominal_planning_selector: resources.flight_planning.FlightPlannerCombinationSelectorResource?
   priority_planning_selector: resources.flight_planning.FlightPlannerCombinationSelectorResource?
   second_utm_auth: resources.communications.AuthAdapterResource?
+  utm_client_identity: resources.communications.ClientIdentityResource
   mock_uss: resources.interuss.mock_uss.client.MockUSSResource?
   id_generator: resources.interuss.IDGeneratorResource
   planning_area: resources.astm.f3548.v21.PlanningAreaResource
@@ -47,6 +48,7 @@ actions:
       dss_instances: dss_instances
       dss_crdb_cluster: dss_crdb_cluster?
       second_utm_auth: second_utm_auth?
+      utm_client_identity: utm_client_identity
       flight_intents: non_conflicting_flights
       id_generator: id_generator
       planning_area: planning_area
@@ -58,6 +60,7 @@ actions:
           resources:
             dss: dss
             second_utm_auth: second_utm_auth?
+            utm_client_identity: utm_client_identity
             all_dss_instances: dss_instances
             dss_crdb_cluster: dss_crdb_cluster?
             flight_intents: flight_intents

--- a/monitoring/uss_qualifier/suites/faa/uft/message_signing.md
+++ b/monitoring/uss_qualifier/suites/faa/uft/message_signing.md
@@ -18,20 +18,20 @@
     <th><a href="../../README.md#checked-in">Checked in</a></th>
   </tr>
   <tr>
-    <td rowspan="47" style="vertical-align:top;"><a href="../../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
+    <td rowspan="52" style="vertical-align:top;"><a href="../../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,1</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a></td>
+    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,2</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/subscription_notifications/receive_notifications_for_awareness/receive_notifications_for_awareness.md">Awareness of relevant operational intents</a><br><a href="../../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/subscription_notifications/receive_notifications_for_awareness/receive_notifications_for_awareness.md">Awareness of relevant operational intents</a><br><a href="../../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,5</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a></td>
+    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0015</a></td>
@@ -107,6 +107,31 @@
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,1i</a></td>
     <td>Implemented</td>
     <td><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2a</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2b</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2c</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2d</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2f</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,7</a></td>

--- a/monitoring/uss_qualifier/suites/faa/uft/message_signing.yaml
+++ b/monitoring/uss_qualifier/suites/faa/uft/message_signing.yaml
@@ -12,6 +12,7 @@ resources:
   invalid_flight_intents: resources.flight_planning.FlightIntentsResource
   id_generator: resources.interuss.IDGeneratorResource
   second_utm_auth: resources.communications.AuthAdapterResource?
+  utm_client_identity: resources.communications.ClientIdentityResource
   planning_area: resources.astm.f3548.v21.PlanningAreaResource
   problematically_big_area: resources.VerticesResource
 actions:
@@ -36,6 +37,7 @@ actions:
       dss_crdb_cluster: dss_crdb_cluster?
       id_generator: id_generator
       second_utm_auth: second_utm_auth
+      utm_client_identity: utm_client_identity
       planning_area: planning_area
       problematically_big_area: problematically_big_area
   on_failure: Continue

--- a/monitoring/uss_qualifier/suites/interuss/dss/all_tests.md
+++ b/monitoring/uss_qualifier/suites/interuss/dss/all_tests.md
@@ -408,20 +408,20 @@
     <td><a href="../../../scenarios/astm/netrid/v22a/dss/heavy_traffic_concurrent.md">ASTM NetRID DSS: Concurrent Requests</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/isa_expiry.md">ASTM NetRID DSS: ISA Expiry</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/isa_subscription_interactions.md">ASTM NetRID DSS: ISA Subscription Interactions</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/isa_validation.md">ASTM NetRID DSS: Submitted ISA Validations</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a></td>
   </tr>
   <tr>
-    <td rowspan="21" style="vertical-align:top;"><a href="../../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
+    <td rowspan="26" style="vertical-align:top;"><a href="../../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,1</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,2</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,5</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0015</a></td>
@@ -492,6 +492,31 @@
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,1i</a></td>
     <td>Implemented</td>
     <td><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2a</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2b</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2c</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2d</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2f</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,7</a></td>

--- a/monitoring/uss_qualifier/suites/interuss/dss/all_tests.yaml
+++ b/monitoring/uss_qualifier/suites/interuss/dss/all_tests.yaml
@@ -21,6 +21,7 @@ actions:
         dss_instances: f3548v21_dss_instances
         dss_crdb_cluster: dss_crdb_cluster?
         second_utm_auth: second_utm_auth?
+        utm_client_identity: utm_client_identity
         flight_intents: flight_intents
         id_generator: id_generator
         planning_area: planning_area
@@ -32,6 +33,7 @@ actions:
             resources:
               dss: dss
               second_utm_auth: second_utm_auth?
+              utm_client_identity: utm_client_identity
               all_dss_instances: dss_instances
               dss_crdb_cluster: dss_crdb_cluster?
               flight_intents: flight_intents

--- a/monitoring/uss_qualifier/suites/uspace/flight_auth.md
+++ b/monitoring/uss_qualifier/suites/uspace/flight_auth.md
@@ -19,20 +19,20 @@
     <th><a href="../README.md#checked-in">Checked in</a></th>
   </tr>
   <tr>
-    <td rowspan="47" style="vertical-align:top;"><a href="../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
+    <td rowspan="52" style="vertical-align:top;"><a href="../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0005,1</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a></td>
+    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0005,2</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../scenarios/astm/utm/subscription_notifications/receive_notifications_for_awareness/receive_notifications_for_awareness.md">Awareness of relevant operational intents</a><br><a href="../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../scenarios/astm/utm/subscription_notifications/receive_notifications_for_awareness/receive_notifications_for_awareness.md">Awareness of relevant operational intents</a><br><a href="../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0005,5</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a></td>
+    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0015</a></td>
@@ -108,6 +108,31 @@
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,1i</a></td>
     <td>Implemented</td>
     <td><a href="../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,2a</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,2b</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,2c</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,2d</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,2f</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,7</a></td>

--- a/monitoring/uss_qualifier/suites/uspace/flight_auth.yaml
+++ b/monitoring/uss_qualifier/suites/uspace/flight_auth.yaml
@@ -14,6 +14,7 @@ resources:
   dss_crdb_cluster: resources.interuss.crdb.CockroachDBClusterResource?
   id_generator: resources.interuss.IDGeneratorResource
   second_utm_auth: resources.communications.AuthAdapterResource?
+  utm_client_identity: resources.communications.ClientIdentityResource
   planning_area: resources.astm.f3548.v21.PlanningAreaResource
   problematically_big_area: resources.VerticesResource
   system_identity: resources.versioning.SystemIdentityResource?
@@ -34,6 +35,7 @@ actions:
       dss_crdb_cluster: dss_crdb_cluster?
       id_generator: id_generator
       second_utm_auth: second_utm_auth
+      utm_client_identity: utm_client_identity
       planning_area: planning_area
       problematically_big_area: problematically_big_area
       system_identity: system_identity?

--- a/monitoring/uss_qualifier/suites/uspace/required_services.md
+++ b/monitoring/uss_qualifier/suites/uspace/required_services.md
@@ -454,20 +454,20 @@
     <td><a href="../../scenarios/astm/netrid/v22a/dss/heavy_traffic_concurrent.md">ASTM NetRID DSS: Concurrent Requests</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_expiry.md">ASTM NetRID DSS: ISA Expiry</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_subscription_interactions.md">ASTM NetRID DSS: ISA Subscription Interactions</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_validation.md">ASTM NetRID DSS: Submitted ISA Validations</a><br><a href="../../scenarios/astm/netrid/v22a/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a><br><a href="../../scenarios/astm/netrid/v22a/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a><br><a href="../../scenarios/astm/netrid/v22a/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a></td>
   </tr>
   <tr>
-    <td rowspan="47" style="vertical-align:top;"><a href="../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
+    <td rowspan="52" style="vertical-align:top;"><a href="../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0005,1</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a></td>
+    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0005,2</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../scenarios/astm/utm/subscription_notifications/receive_notifications_for_awareness/receive_notifications_for_awareness.md">Awareness of relevant operational intents</a><br><a href="../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../scenarios/astm/utm/subscription_notifications/receive_notifications_for_awareness/receive_notifications_for_awareness.md">Awareness of relevant operational intents</a><br><a href="../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0005,5</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a></td>
+    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0015</a></td>
@@ -543,6 +543,31 @@
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,1i</a></td>
     <td>Implemented</td>
     <td><a href="../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,2a</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,2b</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,2c</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,2d</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,2f</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,7</a></td>

--- a/monitoring/uss_qualifier/suites/uspace/required_services.yaml
+++ b/monitoring/uss_qualifier/suites/uspace/required_services.yaml
@@ -54,6 +54,7 @@ actions:
       dss_crdb_cluster: dss_crdb_cluster?
       id_generator: id_generator
       second_utm_auth: second_utm_auth?
+      utm_client_identity: utm_client_identity
       planning_area: planning_area
       problematically_big_area: problematically_big_area
       system_identity: system_identity


### PR DESCRIPTION
First round of checks regarding op-intent reference synchronization.

(This currently excludes DSS0210,2e which will come in a later PR, as well as constraint references, which will have their dedicated scenario)
