### PR TITLE
[mock_uss] Have gevent monkey-patch early in mock_uss

### DIFF
--- a/monitoring/mock_uss/__init__.py
+++ b/monitoring/mock_uss/__init__.py
@@ -1,6 +1,10 @@
 import inspect
 import os
 from typing import Any, Optional, Callable
+
+# Because mock_uss uses gevent, we need to monkey-patch before anything else is loaded
+# https://www.gevent.org/intro.html#monkey-patching
+from gevent import monkey; monkey.patch_all()
 from loguru import logger
 
 from monitoring.mock_uss.server import MockUSS


### PR DESCRIPTION
Since we started using gevent, we have had warnings on mock_uss startup like the below:

> /usr/local/lib/python3.11/site-packages/gunicorn/workers/ggevent.py:38: MonkeyPatchWarning: Monkey-patching ssl after ssl has already been imported may lead to errors, including RecursionError on Python 3.6. It may also silently lead to incorrect behaviour on Python 3.7. Please monkey-patch earlier. See https://github.com/gevent/gevent/issues/1016. Modules that had direct imports (NOT patched): ['urllib3.util (/usr/local/lib/python3.11/site-packages/urllib3/util/__init__.py)', 'urllib3.util.ssl_ (/usr/local/lib/python3.11/site-packages/urllib3/util/ssl_.py)', 'aiohttp.connector (/usr/local/lib/python3.11/site-packages/aiohttp/connector.py)', 'aiohttp.client_reqrep (/usr/local/lib/python3.11/site-packages/aiohttp/client_reqrep.py)', 'aiohttp.client_exceptions (/usr/local/lib/python3.11/site-packages/aiohttp/client_exceptions.py)']. 
>   monkey.patch_all()

I hadn't paid much attention to them, but it turns out that `requests` with TLS is likely unusable without applying the [suggested fix](https://www.gevent.org/intro.html#monkey-patching) producing an error similar to the below when a TLS request is made:

```
  File "/app/monitoring/monitorlib/auth.py", line 195, in issue_token
    response = self._oauth_session.post(url)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/requests/sessions.py", line 637, in post
    return self.request("POST", url, data=data, json=json, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/google/auth/transport/requests.py", line 204, in request
    self.credentials.before_request(
  File "/usr/local/lib/python3.11/site-packages/google/auth/credentials.py", line 122, in before_request
    self.refresh(request)
  File "/usr/local/lib/python3.11/site-packages/google/oauth2/service_account.py", line 321, in refresh
    access_token, expiry, _ = _client.jwt_grant(
                              ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/google/oauth2/_client.py", line 145, in jwt_grant
    response_data = _token_endpoint_request(request, token_uri, body)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/google/oauth2/_client.py", line 105, in _token_endpoint_request
    response = request(
               ^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/google/auth/transport/requests.py", line 118, in __call__
    response = self.session.request(
               ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/requests/sessions.py", line 589, in request
    resp = self.send(prep, **send_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/requests/sessions.py", line 703, in send
    r = adapter.send(request, **kwargs)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/requests/adapters.py", line 486, in send
    resp = conn.urlopen(
           ^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/urllib3/connectionpool.py", line 790, in urlopen
    response = self._make_request(
               ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/urllib3/connectionpool.py", line 467, in _make_request
    self._validate_conn(conn)
  File "/usr/local/lib/python3.11/site-packages/urllib3/connectionpool.py", line 1096, in _validate_conn
    conn.connect()
  File "/usr/local/lib/python3.11/site-packages/urllib3/connection.py", line 642, in connect
    sock_and_verified = _ssl_wrap_socket_and_match_hostname(
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/urllib3/connection.py", line 735, in _ssl_wrap_socket_and_match_hostname
    context = create_urllib3_context(
              ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/urllib3/util/ssl_.py", line 290, in create_urllib3_context
    context.minimum_version = TLSVersion.TLSv1_2
    ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/ssl.py", line 608, in minimum_version
    super(SSLContext, SSLContext).minimum_version.__set__(self, value)
  File "/usr/local/lib/python3.11/ssl.py", line 608, in minimum_version
    super(SSLContext, SSLContext).minimum_version.__set__(self, value)
  File "/usr/local/lib/python3.11/ssl.py", line 608, in minimum_version
    super(SSLContext, SSLContext).minimum_version.__set__(self, value)
  [Previous line repeated 466 more times]
  File "/usr/local/lib/python3.11/ssl.py", line 606, in minimum_version
    if value == TLSVersion.SSLv3:
                ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/enum.py", line 196, in __get__
    return ownerclass._member_map_[self.name]
           ^^^^^^^^^^^^^^^^^^^^^^^
RecursionError: maximum recursion depth exceeded while calling a Python object
```

This PR applies the suggested fix.  Monkey-patching is generally not good, but I think we must do this in order to use gevent with mock_uss.