### PR TITLE
[prober] update prober to support next DSS version

### DIFF
--- a/monitoring/prober/scd/test_operations_simple.py
+++ b/monitoring/prober/scd/test_operations_simple.py
@@ -458,7 +458,8 @@ def test_mutate_op1_bad_key(ids, scd_api, scd_session, scd_session2):
     )
     assert resp.status_code == 409, resp.content
     missing_ops, _, _ = _parse_conflicts(resp.json())
-    assert ids(OP1_TYPE) in missing_ops
+    # We're mutating OP1, so OP2 should be missing
+    # (OVN of the OIR being updted is not required)
     assert ids(OP2_TYPE) in missing_ops
 
     req["key"] = [op1_ovn]
@@ -470,15 +471,6 @@ def test_mutate_op1_bad_key(ids, scd_api, scd_session, scd_session2):
     assert ids(OP2_TYPE) in missing_ops
     assert not (op2_ovn in ovns)
     assert not (op1_ovn in ovns)
-
-    req["key"] = [op2_ovn]
-    resp = scd_session.put(
-        "/operational_intent_references/{}/{}".format(ids(OP1_TYPE), op1_ovn), json=req
-    )
-    assert resp.status_code == 409, resp.content
-    missing_ops, _, ovns = _parse_conflicts(resp.json())
-    assert ids(OP1_TYPE) in missing_ops
-    assert not (op2_ovn in ovns)
 
 
 # Successfully mutate Op1


### PR DESCRIPTION
We're [updating the DSS](https://github.com/interuss/dss/pull/1006): the change is about the validation of the `key` field of requests for updating an operational intent reference.

Currently, when an OIR is updated, the DSS will expect the OVN of that OIR to be passed in the `key` field. This contradicts the [specification](https://github.com/astm-utm/Protocol/blob/cb7cf962d3a0c01b5ab12502f5f54789624977bf/utm.yaml#L745C27-L746C46), so required a DSS update.

This PR updates the prober (which was correctly testing the previous behavior) for it to accept the new behavior.

This should be compatible with the current and upcoming version of the DSS (it was tested against the new one already)