### PR TITLE
[uss_qualifier/scenarios/flight_planning] Enable skipping check if USS indicates NotSupported

### DIFF
--- a/monitoring/uss_qualifier/scenarios/scenario.py
+++ b/monitoring/uss_qualifier/scenarios/scenario.py
@@ -170,6 +170,9 @@ class PendingCheck(object):
         )
         self._step_report.passed_checks.append(passed_check)
 
+    def skip(self) -> None:
+        self._outcome_recorded = True
+
 
 def get_scenario_type_by_name(scenario_type_name: TestScenarioTypeName) -> Type:
     inspection.import_submodules(scenarios_module)


### PR DESCRIPTION
This will be useful as I'm adding test step fragments that declare flights non-conforming and contingent, which both require CMSA role. If the USS is not CMSA, it will return that this is not supported, and in that case we will want to skip the check, without failing or passing it.