### PR TITLE
[uss_qualifier/scenarios/flight_planning] Enable expect_flight_intent_state to validate FlightInfo format

### DIFF
--- a/monitoring/uss_qualifier/scenarios/flight_planning/prioritization_test_steps.py
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/prioritization_test_steps.py
@@ -1,6 +1,10 @@
 from typing import Optional, Tuple
 
 from uas_standards.astm.f3548.v21.api import OperationalIntentState
+from uas_standards.interuss.automated_testing.flight_planning.v1.api import (
+    BasicFlightPlanInformationUsageState,
+    BasicFlightPlanInformationUasState,
+)
 
 from uas_standards.interuss.automated_testing.scd.v1.api import (
     InjectFlightRequest,
@@ -29,7 +33,14 @@ def plan_priority_conflict_flight_intent(
 
     Returns: The injection response.
     """
-    expect_flight_intent_state(flight_intent, OperationalIntentState.Accepted, scenario)
+    expect_flight_intent_state(
+        flight_intent,
+        (
+            BasicFlightPlanInformationUsageState.Planned,
+            BasicFlightPlanInformationUasState.Nominal,
+        ),
+        scenario,
+    )
 
     resp, _, _ = submit_flight_intent(
         scenario,
@@ -59,7 +70,14 @@ def modify_planned_priority_conflict_flight_intent(
 
     Returns: The injection response.
     """
-    expect_flight_intent_state(flight_intent, OperationalIntentState.Accepted, scenario)
+    expect_flight_intent_state(
+        flight_intent,
+        (
+            BasicFlightPlanInformationUsageState.Planned,
+            BasicFlightPlanInformationUasState.Nominal,
+        ),
+        scenario,
+    )
 
     resp, _, _ = submit_flight_intent(
         scenario,
@@ -91,7 +109,12 @@ def activate_priority_conflict_flight_intent(
     Returns: The injection response.
     """
     expect_flight_intent_state(
-        flight_intent, OperationalIntentState.Activated, scenario
+        flight_intent,
+        (
+            BasicFlightPlanInformationUsageState.InUse,
+            BasicFlightPlanInformationUasState.Nominal,
+        ),
+        scenario,
     )
 
     resp, _, _ = submit_flight_intent(
@@ -124,7 +147,12 @@ def modify_activated_priority_conflict_flight_intent(
     Returns: The injection response.
     """
     expect_flight_intent_state(
-        flight_intent, OperationalIntentState.Activated, scenario
+        flight_intent,
+        (
+            BasicFlightPlanInformationUsageState.InUse,
+            BasicFlightPlanInformationUasState.Nominal,
+        ),
+        scenario,
     )
 
     resp, _, _ = submit_flight_intent(
@@ -155,7 +183,14 @@ def plan_conflict_flight_intent(
 
     Returns: The injection response.
     """
-    expect_flight_intent_state(flight_intent, OperationalIntentState.Accepted, scenario)
+    expect_flight_intent_state(
+        flight_intent,
+        (
+            BasicFlightPlanInformationUsageState.Planned,
+            BasicFlightPlanInformationUasState.Nominal,
+        ),
+        scenario,
+    )
 
     resp, _, _ = submit_flight_intent(
         scenario,
@@ -185,7 +220,14 @@ def modify_planned_conflict_flight_intent(
 
     Returns: The injection response.
     """
-    expect_flight_intent_state(flight_intent, OperationalIntentState.Accepted, scenario)
+    expect_flight_intent_state(
+        flight_intent,
+        (
+            BasicFlightPlanInformationUsageState.Planned,
+            BasicFlightPlanInformationUasState.Nominal,
+        ),
+        scenario,
+    )
 
     resp, _, _ = submit_flight_intent(
         scenario,
@@ -217,7 +259,12 @@ def activate_conflict_flight_intent(
     Returns: The injection response.
     """
     expect_flight_intent_state(
-        flight_intent, OperationalIntentState.Activated, scenario
+        flight_intent,
+        (
+            BasicFlightPlanInformationUsageState.InUse,
+            BasicFlightPlanInformationUasState.Nominal,
+        ),
+        scenario,
     )
 
     resp, _, _ = submit_flight_intent(
@@ -250,7 +297,12 @@ def modify_activated_conflict_flight_intent(
     Returns: The injection response.
     """
     expect_flight_intent_state(
-        flight_intent, OperationalIntentState.Activated, scenario
+        flight_intent,
+        (
+            BasicFlightPlanInformationUsageState.InUse,
+            BasicFlightPlanInformationUasState.Nominal,
+        ),
+        scenario,
     )
 
     resp, _, _ = submit_flight_intent(
@@ -285,7 +337,14 @@ def plan_permitted_conflict_flight_intent(
       * The injection response.
       * The ID of the injected flight if it is returned, None otherwise.
     """
-    expect_flight_intent_state(flight_intent, OperationalIntentState.Accepted, scenario)
+    expect_flight_intent_state(
+        flight_intent,
+        (
+            BasicFlightPlanInformationUsageState.Planned,
+            BasicFlightPlanInformationUasState.Nominal,
+        ),
+        scenario,
+    )
 
     resp, flight_id, _ = submit_flight_intent(
         scenario,
@@ -314,7 +373,14 @@ def modify_planned_permitted_conflict_flight_intent(
 
     Returns: The injection response.
     """
-    expect_flight_intent_state(flight_intent, OperationalIntentState.Accepted, scenario)
+    expect_flight_intent_state(
+        flight_intent,
+        (
+            BasicFlightPlanInformationUsageState.Planned,
+            BasicFlightPlanInformationUasState.Nominal,
+        ),
+        scenario,
+    )
 
     resp, _, _ = submit_flight_intent(
         scenario,
@@ -345,7 +411,12 @@ def activate_permitted_conflict_flight_intent(
     Returns: The injection response.
     """
     expect_flight_intent_state(
-        flight_intent, OperationalIntentState.Activated, scenario
+        flight_intent,
+        (
+            BasicFlightPlanInformationUsageState.InUse,
+            BasicFlightPlanInformationUasState.Nominal,
+        ),
+        scenario,
     )
 
     resp, _, _ = submit_flight_intent(
@@ -377,7 +448,12 @@ def modify_activated_permitted_conflict_flight_intent(
     Returns: The injection response.
     """
     expect_flight_intent_state(
-        flight_intent, OperationalIntentState.Activated, scenario
+        flight_intent,
+        (
+            BasicFlightPlanInformationUsageState.InUse,
+            BasicFlightPlanInformationUasState.Nominal,
+        ),
+        scenario,
     )
 
     resp, _, _ = submit_flight_intent(

--- a/monitoring/uss_qualifier/scenarios/flight_planning/prioritization_test_steps.py
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/prioritization_test_steps.py
@@ -35,10 +35,8 @@ def plan_priority_conflict_flight_intent(
     """
     expect_flight_intent_state(
         flight_intent,
-        (
-            BasicFlightPlanInformationUsageState.Planned,
-            BasicFlightPlanInformationUasState.Nominal,
-        ),
+        BasicFlightPlanInformationUsageState.Planned,
+        BasicFlightPlanInformationUasState.Nominal,
         scenario,
     )
 
@@ -72,10 +70,8 @@ def modify_planned_priority_conflict_flight_intent(
     """
     expect_flight_intent_state(
         flight_intent,
-        (
-            BasicFlightPlanInformationUsageState.Planned,
-            BasicFlightPlanInformationUasState.Nominal,
-        ),
+        BasicFlightPlanInformationUsageState.Planned,
+        BasicFlightPlanInformationUasState.Nominal,
         scenario,
     )
 
@@ -110,10 +106,8 @@ def activate_priority_conflict_flight_intent(
     """
     expect_flight_intent_state(
         flight_intent,
-        (
-            BasicFlightPlanInformationUsageState.InUse,
-            BasicFlightPlanInformationUasState.Nominal,
-        ),
+        BasicFlightPlanInformationUsageState.InUse,
+        BasicFlightPlanInformationUasState.Nominal,
         scenario,
     )
 
@@ -148,10 +142,8 @@ def modify_activated_priority_conflict_flight_intent(
     """
     expect_flight_intent_state(
         flight_intent,
-        (
-            BasicFlightPlanInformationUsageState.InUse,
-            BasicFlightPlanInformationUasState.Nominal,
-        ),
+        BasicFlightPlanInformationUsageState.InUse,
+        BasicFlightPlanInformationUasState.Nominal,
         scenario,
     )
 
@@ -185,10 +177,8 @@ def plan_conflict_flight_intent(
     """
     expect_flight_intent_state(
         flight_intent,
-        (
-            BasicFlightPlanInformationUsageState.Planned,
-            BasicFlightPlanInformationUasState.Nominal,
-        ),
+        BasicFlightPlanInformationUsageState.Planned,
+        BasicFlightPlanInformationUasState.Nominal,
         scenario,
     )
 
@@ -222,10 +212,8 @@ def modify_planned_conflict_flight_intent(
     """
     expect_flight_intent_state(
         flight_intent,
-        (
-            BasicFlightPlanInformationUsageState.Planned,
-            BasicFlightPlanInformationUasState.Nominal,
-        ),
+        BasicFlightPlanInformationUsageState.Planned,
+        BasicFlightPlanInformationUasState.Nominal,
         scenario,
     )
 
@@ -260,10 +248,8 @@ def activate_conflict_flight_intent(
     """
     expect_flight_intent_state(
         flight_intent,
-        (
-            BasicFlightPlanInformationUsageState.InUse,
-            BasicFlightPlanInformationUasState.Nominal,
-        ),
+        BasicFlightPlanInformationUsageState.InUse,
+        BasicFlightPlanInformationUasState.Nominal,
         scenario,
     )
 
@@ -298,10 +284,8 @@ def modify_activated_conflict_flight_intent(
     """
     expect_flight_intent_state(
         flight_intent,
-        (
-            BasicFlightPlanInformationUsageState.InUse,
-            BasicFlightPlanInformationUasState.Nominal,
-        ),
+        BasicFlightPlanInformationUsageState.InUse,
+        BasicFlightPlanInformationUasState.Nominal,
         scenario,
     )
 
@@ -339,10 +323,8 @@ def plan_permitted_conflict_flight_intent(
     """
     expect_flight_intent_state(
         flight_intent,
-        (
-            BasicFlightPlanInformationUsageState.Planned,
-            BasicFlightPlanInformationUasState.Nominal,
-        ),
+        BasicFlightPlanInformationUsageState.Planned,
+        BasicFlightPlanInformationUasState.Nominal,
         scenario,
     )
 
@@ -375,10 +357,8 @@ def modify_planned_permitted_conflict_flight_intent(
     """
     expect_flight_intent_state(
         flight_intent,
-        (
-            BasicFlightPlanInformationUsageState.Planned,
-            BasicFlightPlanInformationUasState.Nominal,
-        ),
+        BasicFlightPlanInformationUsageState.Planned,
+        BasicFlightPlanInformationUasState.Nominal,
         scenario,
     )
 
@@ -412,10 +392,8 @@ def activate_permitted_conflict_flight_intent(
     """
     expect_flight_intent_state(
         flight_intent,
-        (
-            BasicFlightPlanInformationUsageState.InUse,
-            BasicFlightPlanInformationUasState.Nominal,
-        ),
+        BasicFlightPlanInformationUsageState.InUse,
+        BasicFlightPlanInformationUasState.Nominal,
         scenario,
     )
 
@@ -449,10 +427,8 @@ def modify_activated_permitted_conflict_flight_intent(
     """
     expect_flight_intent_state(
         flight_intent,
-        (
-            BasicFlightPlanInformationUsageState.InUse,
-            BasicFlightPlanInformationUasState.Nominal,
-        ),
+        BasicFlightPlanInformationUsageState.InUse,
+        BasicFlightPlanInformationUasState.Nominal,
         scenario,
     )
 

--- a/monitoring/uss_qualifier/scenarios/flight_planning/test_steps.py
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/test_steps.py
@@ -41,24 +41,23 @@ from monitoring.uss_qualifier.scenarios.scenario import TestScenarioType
 
 def expect_flight_intent_state(
     flight_intent: Union[InjectFlightRequest, FlightInfo],
-    expected_state: Tuple[
-        BasicFlightPlanInformationUsageState, BasicFlightPlanInformationUasState
-    ],
+    expected_usage_state: BasicFlightPlanInformationUsageState,
+    expected_uas_state: BasicFlightPlanInformationUasState,
     scenario: TestScenarioType,
 ) -> None:
     """Confirm that provided flight intent test data has the expected state or raise a ValueError."""
     if isinstance(flight_intent, InjectFlightRequest):
         flight_intent = FlightInfo.from_scd_inject_flight_request(flight_intent)
 
-    flight_intent_state = (
-        flight_intent.basic_information.usage_state,
-        flight_intent.basic_information.uas_state,
-    )
-    if flight_intent_state != expected_state:
-        function_name = str(inspect.stack()[1][3])
-        test_step = scenario.current_step_name()
+    function_name = str(inspect.stack()[1][3])
+    test_step = scenario.current_step_name()
+    if flight_intent.basic_information.usage_state != expected_usage_state:
         raise ValueError(
-            f"Error in test data: state for {function_name} during test step '{test_step}' in scenario '{scenario.documentation.name}' is expected to be `{expected_state}`, but got `{flight_intent_state}` instead"
+            f"Error in test data: usage state for {function_name} during test step '{test_step}' in scenario '{scenario.documentation.name}' is expected to be `{expected_usage_state}`, but got `{flight_intent.basic_information.usage_state}` instead"
+        )
+    if flight_intent.basic_information.uas_state != expected_uas_state:
+        raise ValueError(
+            f"Error in test data: UAS state for {function_name} during test step '{test_step}' in scenario '{scenario.documentation.name}' is expected to be `{expected_uas_state}`, but got `{flight_intent.basic_information.uas_state}` instead"
         )
 
 
@@ -79,10 +78,8 @@ def plan_flight_intent(
     """
     expect_flight_intent_state(
         flight_intent,
-        (
-            BasicFlightPlanInformationUsageState.Planned,
-            BasicFlightPlanInformationUasState.Nominal,
-        ),
+        BasicFlightPlanInformationUsageState.Planned,
+        BasicFlightPlanInformationUasState.Nominal,
         scenario,
     )
 
@@ -113,10 +110,8 @@ def activate_flight_intent(
     """
     expect_flight_intent_state(
         flight_intent,
-        (
-            BasicFlightPlanInformationUsageState.InUse,
-            BasicFlightPlanInformationUasState.Nominal,
-        ),
+        BasicFlightPlanInformationUsageState.InUse,
+        BasicFlightPlanInformationUasState.Nominal,
         scenario,
     )
 
@@ -148,10 +143,8 @@ def modify_planned_flight_intent(
     """
     expect_flight_intent_state(
         flight_intent,
-        (
-            BasicFlightPlanInformationUsageState.Planned,
-            BasicFlightPlanInformationUasState.Nominal,
-        ),
+        BasicFlightPlanInformationUsageState.Planned,
+        BasicFlightPlanInformationUasState.Nominal,
         scenario,
     )
 
@@ -185,10 +178,8 @@ def modify_activated_flight_intent(
     """
     expect_flight_intent_state(
         flight_intent,
-        (
-            BasicFlightPlanInformationUsageState.InUse,
-            BasicFlightPlanInformationUasState.Nominal,
-        ),
+        BasicFlightPlanInformationUsageState.InUse,
+        BasicFlightPlanInformationUasState.Nominal,
         scenario,
     )
 


### PR DESCRIPTION
Useful for the test step fragments I'm adding that will use FlightInfo format.