### PR TITLE
[uss_qualifier/scenarios/flight_planning] Add test step fragments to declare flight non-conforming or contingent

### DIFF
--- a/monitoring/uss_qualifier/scenarios/flight_planning/declare_flight_contingent.md
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/declare_flight_contingent.md
@@ -1,0 +1,15 @@
+# Declare flight contingent test step fragment
+
+This page describes the content of a common test step where a valid user flight intent should be successfully declared contingent by a flight planner.  See `declare_flight_contingent` in [test_steps.py](test_steps.py).
+
+## 🛑 Successfully declare flight contingent check
+
+All flight intent data provided is correct and valid, therefore it should have been declared contingent by the USS per **[interuss.automated_testing.flight_planning.ExpectedBehavior](../../requirements/interuss/automated_testing/flight_planning.md)**.
+If the USS indicates that the operation is not supported, *this check will be skipped*.
+If the USS indicates anything other than a `Completed` result with an `OffNominal` flight plan status, this check will fail.
+
+## 🛑 Failure check
+
+All flight intent data provided was complete and correct. It should have been processed successfully, allowing the USS
+to process the flight. If the USS indicates that the attempt failed, this check will fail per
+**[interuss.automated_testing.flight_planning.ExpectedBehavior](../../requirements/interuss/automated_testing/flight_planning.md)**.

--- a/monitoring/uss_qualifier/scenarios/flight_planning/declare_flight_nonconforming.md
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/declare_flight_nonconforming.md
@@ -1,0 +1,15 @@
+# Declare flight non-conforming test step fragment
+
+This page describes the content of a common test step where a valid user flight intent should be successfully declared non-conforming by a flight planner.  See `declare_flight_nonconforming` in [test_steps.py](test_steps.py).
+
+## 🛑 Successfully declare flight non-conforming check
+
+All flight intent data provided is correct and valid, therefore it should have been declared non-conforming by the USS per **[interuss.automated_testing.flight_planning.ExpectedBehavior](../../requirements/interuss/automated_testing/flight_planning.md)**.
+If the USS indicates that the operation is not supported, *this check will be skipped*.
+If the USS indicates anything other than a `Completed` result with an `OffNominal` flight plan status, this check will fail.
+
+## 🛑 Failure check
+
+All flight intent data provided was complete and correct. It should have been processed successfully, allowing the USS
+to process the flight. If the USS indicates that the attempt failed, this check will fail per
+**[interuss.automated_testing.flight_planning.ExpectedBehavior](../../requirements/interuss/automated_testing/flight_planning.md)**.

--- a/monitoring/uss_qualifier/scenarios/flight_planning/prioritization_test_steps.py
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/prioritization_test_steps.py
@@ -1,6 +1,10 @@
 from typing import Optional, Tuple
 
 from uas_standards.astm.f3548.v21.api import OperationalIntentState
+from uas_standards.interuss.automated_testing.flight_planning.v1.api import (
+    BasicFlightPlanInformationUsageState,
+    BasicFlightPlanInformationUasState,
+)
 
 from uas_standards.interuss.automated_testing.scd.v1.api import (
     InjectFlightRequest,
@@ -29,7 +33,14 @@ def plan_priority_conflict_flight_intent(
 
     Returns: The injection response.
     """
-    expect_flight_intent_state(flight_intent, OperationalIntentState.Accepted, scenario)
+    expect_flight_intent_state(
+        flight_intent,
+        (
+            BasicFlightPlanInformationUsageState.Planned,
+            BasicFlightPlanInformationUasState.Nominal,
+        ),
+        scenario,
+    )
 
     resp, _, _ = submit_flight_intent(
         scenario,
@@ -59,7 +70,14 @@ def modify_planned_priority_conflict_flight_intent(
 
     Returns: The injection response.
     """
-    expect_flight_intent_state(flight_intent, OperationalIntentState.Accepted, scenario)
+    expect_flight_intent_state(
+        flight_intent,
+        (
+            BasicFlightPlanInformationUsageState.Planned,
+            BasicFlightPlanInformationUasState.Nominal,
+        ),
+        scenario,
+    )
 
     resp, _, _ = submit_flight_intent(
         scenario,
@@ -91,7 +109,12 @@ def activate_priority_conflict_flight_intent(
     Returns: The injection response.
     """
     expect_flight_intent_state(
-        flight_intent, OperationalIntentState.Activated, scenario
+        flight_intent,
+        (
+            BasicFlightPlanInformationUsageState.InUse,
+            BasicFlightPlanInformationUasState.Nominal,
+        ),
+        scenario,
     )
 
     resp, _, _ = submit_flight_intent(
@@ -124,7 +147,12 @@ def modify_activated_priority_conflict_flight_intent(
     Returns: The injection response.
     """
     expect_flight_intent_state(
-        flight_intent, OperationalIntentState.Activated, scenario
+        flight_intent,
+        (
+            BasicFlightPlanInformationUsageState.InUse,
+            BasicFlightPlanInformationUasState.Nominal,
+        ),
+        scenario,
     )
 
     resp, _, _ = submit_flight_intent(
@@ -155,7 +183,14 @@ def plan_conflict_flight_intent(
 
     Returns: The injection response.
     """
-    expect_flight_intent_state(flight_intent, OperationalIntentState.Accepted, scenario)
+    expect_flight_intent_state(
+        flight_intent,
+        (
+            BasicFlightPlanInformationUsageState.Planned,
+            BasicFlightPlanInformationUasState.Nominal,
+        ),
+        scenario,
+    )
 
     resp, _, _ = submit_flight_intent(
         scenario,
@@ -185,7 +220,14 @@ def modify_planned_conflict_flight_intent(
 
     Returns: The injection response.
     """
-    expect_flight_intent_state(flight_intent, OperationalIntentState.Accepted, scenario)
+    expect_flight_intent_state(
+        flight_intent,
+        (
+            BasicFlightPlanInformationUsageState.Planned,
+            BasicFlightPlanInformationUasState.Nominal,
+        ),
+        scenario,
+    )
 
     resp, _, _ = submit_flight_intent(
         scenario,
@@ -217,7 +259,12 @@ def activate_conflict_flight_intent(
     Returns: The injection response.
     """
     expect_flight_intent_state(
-        flight_intent, OperationalIntentState.Activated, scenario
+        flight_intent,
+        (
+            BasicFlightPlanInformationUsageState.InUse,
+            BasicFlightPlanInformationUasState.Nominal,
+        ),
+        scenario,
     )
 
     resp, _, _ = submit_flight_intent(
@@ -250,7 +297,12 @@ def modify_activated_conflict_flight_intent(
     Returns: The injection response.
     """
     expect_flight_intent_state(
-        flight_intent, OperationalIntentState.Activated, scenario
+        flight_intent,
+        (
+            BasicFlightPlanInformationUsageState.InUse,
+            BasicFlightPlanInformationUasState.Nominal,
+        ),
+        scenario,
     )
 
     resp, _, _ = submit_flight_intent(
@@ -285,7 +337,14 @@ def plan_permitted_conflict_flight_intent(
       * The injection response.
       * The ID of the injected flight if it is returned, None otherwise.
     """
-    expect_flight_intent_state(flight_intent, OperationalIntentState.Accepted, scenario)
+    expect_flight_intent_state(
+        flight_intent,
+        (
+            BasicFlightPlanInformationUsageState.Planned,
+            BasicFlightPlanInformationUasState.Nominal,
+        ),
+        scenario,
+    )
 
     resp, flight_id, _ = submit_flight_intent(
         scenario,
@@ -314,7 +373,14 @@ def modify_planned_permitted_conflict_flight_intent(
 
     Returns: The injection response.
     """
-    expect_flight_intent_state(flight_intent, OperationalIntentState.Accepted, scenario)
+    expect_flight_intent_state(
+        flight_intent,
+        (
+            BasicFlightPlanInformationUsageState.Planned,
+            BasicFlightPlanInformationUasState.Nominal,
+        ),
+        scenario,
+    )
 
     resp, _, _ = submit_flight_intent(
         scenario,
@@ -345,7 +411,12 @@ def activate_permitted_conflict_flight_intent(
     Returns: The injection response.
     """
     expect_flight_intent_state(
-        flight_intent, OperationalIntentState.Activated, scenario
+        flight_intent,
+        (
+            BasicFlightPlanInformationUsageState.InUse,
+            BasicFlightPlanInformationUasState.Nominal,
+        ),
+        scenario,
     )
 
     resp, _, _ = submit_flight_intent(
@@ -377,7 +448,12 @@ def modify_activated_permitted_conflict_flight_intent(
     Returns: The injection response.
     """
     expect_flight_intent_state(
-        flight_intent, OperationalIntentState.Activated, scenario
+        flight_intent,
+        (
+            BasicFlightPlanInformationUsageState.InUse,
+            BasicFlightPlanInformationUasState.Nominal,
+        ),
+        scenario,
     )
 
     resp, _, _ = submit_flight_intent(

--- a/monitoring/uss_qualifier/scenarios/flight_planning/test_steps.py
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/test_steps.py
@@ -462,6 +462,84 @@ def activate_flight(
     )
 
 
+def declare_flight_nonconforming(
+    scenario: TestScenarioType,
+    flight_planner: FlightPlannerClient,
+    flight_info: FlightInfo,
+    flight_id: str,
+    additional_fields: Optional[dict] = None,
+) -> PlanningActivityResponse:
+    """Declare a flight intent non-conforming. Note that if the USS does not support the CMSA role, it may indicate that
+     the operation is not supported. In this case the check is skipped.
+
+    This function implements the test step fragment described in
+    declare_flight_nonconforming.md.
+
+    Returns the injection response.
+    """
+    expect_flight_intent_state(
+        flight_info,
+        (
+            BasicFlightPlanInformationUsageState.InUse,
+            BasicFlightPlanInformationUasState.OffNominal,
+        ),
+        scenario,
+    )
+
+    return submit_flight(
+        scenario=scenario,
+        success_check="Successfully declare flight non-conforming",
+        expected_results={
+            (PlanningActivityResult.Completed, FlightPlanStatus.OffNominal)
+        },
+        failed_checks={PlanningActivityResult.Failed: "Failure"},
+        flight_planner=flight_planner,
+        flight_info=flight_info,
+        flight_id=flight_id,
+        additional_fields=additional_fields,
+        skip_if_not_supported=True,
+    )[0]
+
+
+def declare_flight_contingent(
+    scenario: TestScenarioType,
+    flight_planner: FlightPlannerClient,
+    flight_info: FlightInfo,
+    flight_id: str,
+    additional_fields: Optional[dict] = None,
+) -> PlanningActivityResponse:
+    """Declare a flight intent contingent. Note that if the USS does not support the CMSA role, it may indicate that
+     the operation is not supported. In this case the check is skipped.
+
+    This function implements the test step fragment described in
+    declare_flight_contingent.md.
+
+    Returns the injection response.
+    """
+    expect_flight_intent_state(
+        flight_info,
+        (
+            BasicFlightPlanInformationUsageState.InUse,
+            BasicFlightPlanInformationUasState.Contingent,
+        ),
+        scenario,
+    )
+
+    return submit_flight(
+        scenario=scenario,
+        success_check="Successfully declare flight contingent",
+        expected_results={
+            (PlanningActivityResult.Completed, FlightPlanStatus.OffNominal)
+        },
+        failed_checks={PlanningActivityResult.Failed: "Failure"},
+        flight_planner=flight_planner,
+        flight_info=flight_info,
+        flight_id=flight_id,
+        additional_fields=additional_fields,
+        skip_if_not_supported=True,
+    )[0]
+
+
 def submit_flight(
     scenario: TestScenarioType,
     success_check: str,

--- a/monitoring/uss_qualifier/scenarios/flight_planning/test_steps.py
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/test_steps.py
@@ -471,10 +471,12 @@ def submit_flight(
     flight_info: FlightInfo,
     flight_id: Optional[str] = None,
     additional_fields: Optional[dict] = None,
+    skip_if_not_supported: bool = False,
 ) -> Tuple[PlanningActivityResponse, Optional[str]]:
     """Submit a flight intent with an expected result.
     A check fail is considered by default of high severity and as such will raise an ScenarioCannotContinueError.
     The severity of each failed check may be overridden if needed.
+    If skip_if_not_supported=True and the USS responds that the operation is not supported, the check is skipped without failing.
 
     This function does not directly implement a test step.
 
@@ -492,16 +494,23 @@ def submit_flight(
             resp, query, flight_id = request_flight(
                 flight_planner, flight_info, flight_id, additional_fields
             )
-            result = (resp.activity_result, resp.flight_plan_status)
+            scenario.record_query(query)
         except QueryError as e:
-            for q in e.queries:
-                scenario.record_query(q)
+            scenario.record_queries(e.queries)
             check.record_failed(
                 summary=f"Error from {flight_planner.participant_id} when attempting to submit a flight intent (flight ID: {flight_id})",
                 details=f"{str(e)}\n\nStack trace:\n{e.stacktrace}",
                 query_timestamps=[q.request.timestamp for q in e.queries],
             )
-        scenario.record_query(query)
+
+        if (
+            skip_if_not_supported
+            and resp.activity_result == PlanningActivityResult.NotSupported
+        ):
+            check.skip()
+            return resp, None
+
+        result = (resp.activity_result, resp.flight_plan_status)
         check_details = (
             f'{flight_planner.participant_id} indicated {result} rather than the expected {" or ".join([f"({expected_result[0]}, {expected_result[1]})" for expected_result in expected_results])}'
             + (

--- a/monitoring/uss_qualifier/scenarios/scenario.py
+++ b/monitoring/uss_qualifier/scenarios/scenario.py
@@ -170,6 +170,9 @@ class PendingCheck(object):
         )
         self._step_report.passed_checks.append(passed_check)
 
+    def skip(self) -> None:
+        self._outcome_recorded = True
+
 
 def get_scenario_type_by_name(scenario_type_name: TestScenarioTypeName) -> Type:
     inspection.import_submodules(scenarios_module)


### PR DESCRIPTION
This PR sits on top of #567 and #568, as such please only consider commit 4fe9073c1039a1bf4aa01c64a909a686abce3dee