### PR TITLE
[uss_qualifier] Fix local_debug default value

### DIFF
--- a/monitoring/uss_qualifier/resources/astm/f3411/dss.py
+++ b/monitoring/uss_qualifier/resources/astm/f3411/dss.py
@@ -33,12 +33,14 @@ class DSSInstanceSpecification(ImplicitDict):
 
     def __init__(self, *args, **kwargs):
         super().__init__(**kwargs)
-        if (
-            not self.has_field_with_value("local_debug")
-            and self.has_field_with_value("has_private_address")
-            and self.get("has_private_address")
-        ):
-            self.local_debug = True
+        if not self.has_field_with_value("local_debug"):
+            if (
+                self.has_field_with_value("has_private_address")
+                and self.get("has_private_address")
+            ):
+                self.local_debug = True
+            else:
+                self.local_debug = False
         try:
             urlparse(self.base_url)
         except ValueError:

--- a/monitoring/uss_qualifier/resources/astm/f3411/dss.py
+++ b/monitoring/uss_qualifier/resources/astm/f3411/dss.py
@@ -34,9 +34,8 @@ class DSSInstanceSpecification(ImplicitDict):
     def __init__(self, *args, **kwargs):
         super().__init__(**kwargs)
         if not self.has_field_with_value("local_debug"):
-            if (
-                self.has_field_with_value("has_private_address")
-                and self.get("has_private_address")
+            if self.has_field_with_value("has_private_address") and self.get(
+                "has_private_address"
             ):
                 self.local_debug = True
             else:


### PR DESCRIPTION
When defining non-local (has_private_address=false) instances of the DSS, the default value of local_debug is not honored.

This PR fixes it.