### PR TITLE
[uss_qualifier] Cockroach node tests: specify db user

### DIFF
--- a/monitoring/uss_qualifier/resources/interuss/crdb/crdb.py
+++ b/monitoring/uss_qualifier/resources/interuss/crdb/crdb.py
@@ -84,6 +84,7 @@ class CockroachDBNode(object):
         return crdb.connect(
             host=self.host,
             port=self.port,
+            user="dummy",
             **kwargs,
         )
 


### PR DESCRIPTION
To test the security of cockroach db nodes, the test scenario uses the default user name picked by the python library. When running the test suite on Mac, the docker container tries by default to pick uid 501 which crashes the execution on the client side.

This PR fixes this problem by specifying a user name.

Example of failed check:
```
New failed check:
  details: 'Error message: connection is bad: local user with ID 501 does not exist'
  documentation_url: https://github.com/interuss/monitoring/blob/c1a198d79e104417e1456c5eb7da82cdfe964027/monitoring/uss_qualifier/scenarios/astm/utm/dss/crdb_access.md#node-is-reachable-check
  name: Node is reachable
  participants:
  - uss1
  requirements: []
  severity: High
  summary: Node is not reachable
  timestamp: '2024-03-21T15:19:21.665883Z'
```