### PR TITLE
[uss_qualifier] add schema paths for op intent ref. entities to schema validation

### DIFF
--- a/monitoring/monitorlib/schema_validation.py
+++ b/monitoring/monitorlib/schema_validation.py
@@ -59,6 +59,17 @@ class F3548_21(str, Enum):
     QuerySubscriptionsResponse = "components.schemas.QuerySubscriptionsResponse"
     DeleteSubscriptionResponse = "components.schemas.DeleteSubscriptionResponse"
 
+    ChangeOperationalIntentReferenceResponse = (
+        "components.schemas.ChangeOperationalIntentReferenceResponse"
+    )
+    GetOperationalIntentReferenceResponse = (
+        "components.schemas.GetOperationalIntentReferenceResponse"
+    )
+    QueryOperationalIntentReferenceResponse = (
+        "components.schemas.QueryOperationalIntentReferenceResponse"
+    )
+    AirspaceConflictResponse = "components.schemas.AirspaceConflictResponse"
+
 
 _openapi_content_cache: Dict[str, dict] = {}
 


### PR DESCRIPTION
Required by some open/draft PRs being worked on in parallel