### PR TITLE
[uss_qualifier] properly name the function returning the subject of an identity resource

### DIFF
--- a/monitoring/uss_qualifier/resources/communications/client_identity.py
+++ b/monitoring/uss_qualifier/resources/communications/client_identity.py
@@ -18,10 +18,10 @@ class ClientIdentitySpecification(ImplicitDict):
     """
 
     whoami_audience: str
-    """Audience to request for the access token used to determine subscriber identity."""
+    """Audience to request for the access token used to determine the subject."""
 
     whoami_scope: str
-    """Scope to request for the access token used to determine subscribe identity.  Must be a scope that the client is
+    """Scope to request for the access token used to determine the subject.  Must be a scope that the client is
     authorized to obtain."""
 
 
@@ -40,9 +40,9 @@ class ClientIdentityResource(Resource[ClientIdentitySpecification]):
         # Keep the adapter: we will only use it later at the moment it is required
         self._adapter = auth_adapter.adapter
 
-    def subscriber(self) -> str:
+    def subject(self) -> str:
         """
-        Return the subscriber identity as determined by the adapter:
+        Return the subject corresponding to this ClientIdentityResource as determined by the adapter:
         this will usually only trigger a token request if no token had been requested yet by the auth adapter.
 
         This is a function and not a field, to possibly profit from a token that would have been requested earlier
@@ -63,7 +63,7 @@ class ClientIdentityResource(Resource[ClientIdentitySpecification]):
             # Confirm we have a `sub` field available: if we don't, we bail
             if sub is None:
                 raise ValueError(
-                    f"subscriber is None, meaning `sub` claim was not found in payload of token, "
+                    f"subject is None, meaning `sub` claim was not found in payload of token, "
                     f"using {type(self._adapter).__name__} requesting {self.specification.whoami_scope} scope "
                     f"for {self.specification.whoami_audience} audience: {headers['Authorization'][len('Bearer: '):]}"
                 )

--- a/monitoring/uss_qualifier/resources/interuss/id_generator.py
+++ b/monitoring/uss_qualifier/resources/interuss/id_generator.py
@@ -27,6 +27,6 @@ class IDGeneratorResource(Resource[IDGeneratorSpecification]):
     def id_factory(self) -> IDFactory:
         # Not thread safe, but the consequences here are acceptable
         if self._id_factory is None:
-            self._id_factory = IDFactory(self._client_identity.subscriber())
+            self._id_factory = IDFactory(self._client_identity.subject())
 
         return self._id_factory

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/subscription_simple.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/subscription_simple.py
@@ -608,7 +608,7 @@ class SubscriptionSimple(GenericTestScenario):
         with self.check(
             "Returned subscription owner is correct", [self._dss_wrapper.participant_id]
         ) as check:
-            client_sub = self._client_identity.subscriber()
+            client_sub = self._client_identity.subject()
             if sub_under_test.owner != client_sub:
                 check.record_failed(
                     "Returned subscription owner does not match provided one",

--- a/schemas/monitoring/uss_qualifier/resources/communications/client_identity/ClientIdentitySpecification.json
+++ b/schemas/monitoring/uss_qualifier/resources/communications/client_identity/ClientIdentitySpecification.json
@@ -8,11 +8,11 @@
       "type": "string"
     },
     "whoami_audience": {
-      "description": "Audience to request for the access token used to determine subscriber identity.",
+      "description": "Audience to request for the access token used to determine the subject.",
       "type": "string"
     },
     "whoami_scope": {
-      "description": "Scope to request for the access token used to determine subscribe identity.  Must be a scope that the client is\nauthorized to obtain.",
+      "description": "Scope to request for the access token used to determine the subject.  Must be a scope that the client is\nauthorized to obtain.",
       "type": "string"
     }
   },


### PR DESCRIPTION
This returns the subject (from the `sub` field of a JWT) and not a subscription.