### PR TITLE
[uss_qualifier] Add pooled DSS prober configuration

### DIFF
--- a/monitoring/uss_qualifier/configurations/interuss/library/environment.yaml
+++ b/monitoring/uss_qualifier/configurations/interuss/library/environment.yaml
@@ -1,0 +1,133 @@
+# The resources in this file describe the system/environment under test and should not change the test being run.
+# This file defines the environment use to verify releases on a deployment of two DSSs pooled in two different clouds.
+
+# ===== Auth =====
+
+utm_auth:
+  $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
+  resource_type: resources.communications.AuthAdapterResource
+  specification:
+    environment_variable_containing_auth_spec: AUTH_SPEC
+    scopes_authorized:
+      # InterUSS RIDv1 automated testing API
+      - rid.inject_test_data
+      - dss.read.identification_service_areas
+      # ASTM F3411-22a USS emulation roles
+      - rid.service_provider
+      - rid.display_provider
+      # ASTM F3411-19 USS emulation roles
+      - dss.write.identification_service_areas
+      - dss.read.identification_service_areas
+      # InterUSS flight_planning v1 automated testing API
+      - interuss.flight_planning.direct_automated_test
+      - interuss.flight_planning.plan
+      # Legacy InterUSS scd injection v1 automated testing API
+      - utm.inject_test_data
+      # ASTM F3548-21 USS emulation roles
+      - utm.strategic_coordination
+      - utm.conformance_monitoring_sa
+      - utm.availability_arbitration
+      # InterUSS versioning automated testing
+      - interuss.versioning.read_system_versions
+
+second_utm_auth:
+  $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
+  resource_type: resources.communications.AuthAdapterResource
+  specification:
+    environment_variable_containing_auth_spec: AUTH_SPEC_2
+    scopes_authorized:
+      - utm.strategic_coordination
+
+utm_client_identity:
+  $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
+  resource_type: resources.communications.ClientIdentityResource
+  dependencies:
+    auth_adapter: utm_auth
+  specification:
+    whoami_audience: localhost
+    whoami_scope: rid.display_provider
+
+# ===== NetRID =====
+
+netrid_dss_instances_v19:
+  $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
+  resource_type: resources.astm.f3411.DSSInstancesResource
+  dependencies:
+    auth_adapter: utm_auth
+  specification:
+    dss_instances:
+      - participant_id: uss1
+        rid_version: F3411-19
+        base_url: https://dss.ci.google-interuss.uspace.dev
+        has_private_address: false
+      - participant_id: uss2
+        rid_version: F3411-19
+        base_url: https://dss.ci.aws-interuss.uspace.dev
+        has_private_address: false
+
+netrid_dss_instances_v22a:
+  $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
+  resource_type: resources.astm.f3411.DSSInstancesResource
+  dependencies:
+    auth_adapter: utm_auth
+  specification:
+    dss_instances:
+      - participant_id: uss1
+        rid_version: F3411-22a
+        base_url: https://dss.ci.google-interuss.uspace.dev/rid/v2
+        has_private_address: false
+      - participant_id: uss2
+        rid_version: F3411-22a
+        base_url: https://dss.ci.aws-interuss.uspace.dev/rid/v2
+        has_private_address: false
+
+# ===== F3548 =====
+
+scd_dss:
+  $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
+  resource_type: resources.astm.f3548.v21.DSSInstanceResource
+  dependencies:
+    auth_adapter: utm_auth
+  specification:
+    participant_id: uss1
+    base_url: https://dss.ci.google-interuss.uspace.dev
+    has_private_address: false
+
+scd_dss_instances:
+  $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
+  resource_type: resources.astm.f3548.v21.DSSInstancesResource
+  dependencies:
+    auth_adapter: utm_auth
+  specification:
+    dss_instances:
+      - participant_id: uss1
+        base_url: https://dss.ci.google-interuss.uspace.dev
+        has_private_address: false
+      - participant_id: uss2
+        base_url: https://dss.ci.aws-interuss.uspace.dev
+        has_private_address: false
+
+dss_crdb_cluster:
+  $content_schema: monitoring/uss_qualifier/resources/interuss/crdb/crdb/CockroachDBClusterResource.json
+  resource_type: resources.interuss.crdb.crdb.CockroachDBClusterResource
+  specification:
+    nodes:
+      - participant_id: uss1
+        host: 0.db.ci.google-interuss.uspace.dev
+        port: 26257
+      - participant_id: uss1
+        host: 1.db.ci.google-interuss.uspace.dev
+        port: 26257
+      - participant_id: uss1
+        host: 2.db.ci.google-interuss.uspace.dev
+        port: 26257
+      - participant_id: uss2
+        host: 0.db.ci.aws-interuss.uspace.dev
+        port: 26257
+      - participant_id: uss2
+        host: 1.db.ci.aws-interuss.uspace.dev
+        port: 26257
+      - participant_id: uss2
+        host: 2.db.ci.aws-interuss.uspace.dev
+        port: 26257
+

--- a/monitoring/uss_qualifier/configurations/interuss/pooled_dss_probing.yaml
+++ b/monitoring/uss_qualifier/configurations/interuss/pooled_dss_probing.yaml
@@ -1,0 +1,68 @@
+$content_schema: monitoring/uss_qualifier/configurations/configuration/USSQualifierConfiguration.json
+v1:
+  test_run:
+    resources:
+      resource_declarations:
+        kentland_service_area: { $ref: '../dev/library/resources.yaml#/kentland_service_area' }
+        kentland_planning_area: { $ref: '../dev/library/resources.yaml#/kentland_planning_area' }
+        kentland_problematically_big_area: { $ref: '../dev/library/resources.yaml#/kentland_problematically_big_area' }
+
+        utm_auth: { $ref: './library/environment.yaml#/utm_auth' }
+        second_utm_auth: {$ref: './library/environment.yaml#/second_utm_auth'}
+        utm_client_identity: { $ref: '../dev/library/resources.yaml#/utm_client_identity' }
+        id_generator: { $ref: '../dev/library/resources.yaml#/id_generator' }
+        dss_crdb_cluster: { $ref: './library/environment.yaml#/dss_crdb_cluster' }
+        scd_dss_instances: { $ref: './library/environment.yaml#/scd_dss_instances' }
+        netrid_dss_instances_v22a: { $ref: './library/environment.yaml#/netrid_dss_instances_v22a' }
+        netrid_dss_instances_v19: { $ref: './library/environment.yaml#/netrid_dss_instances_v19' }
+        che_non_conflicting_flights: {$ref: '../dev/library/resources.yaml#/che_non_conflicting_flights'}
+    non_baseline_inputs:
+      - v1.test_run.resources.resource_declarations.utm_auth
+      - v1.test_run.resources.resource_declarations.second_utm_auth
+      - v1.test_run.resources.resource_declarations.dss_crdb_cluster
+      - v1.test_run.resources.resource_declarations.scd_dss_instances
+      - v1.test_run.resources.resource_declarations.netrid_dss_instances_v22a
+      - v1.test_run.resources.resource_declarations.netrid_dss_instances_v19
+    action:
+      test_suite:
+        suite_type: suites.interuss.dss.all_tests
+        resources:
+          f3411v19_dss_instances: netrid_dss_instances_v19
+          f3411v22a_dss_instances: netrid_dss_instances_v22a
+          f3548v21_dss_instances: scd_dss_instances
+          dss_crdb_cluster: dss_crdb_cluster
+          utm_client_identity: utm_client_identity
+          id_generator: id_generator
+          service_area: kentland_service_area
+          planning_area: kentland_planning_area
+          problematically_big_area: kentland_problematically_big_area
+          second_utm_auth: second_utm_auth
+          flight_intents: che_non_conflicting_flights
+    execution:
+      stop_fast: false
+  artifacts:
+    output_path: output/pooled_dss_probing
+    raw_report: { }
+    sequence_view: { }
+    tested_requirements:
+      - report_name: requirements
+        requirement_collections:
+          all_astm_dss_requirements:
+            requirement_collections:
+              - requirement_sets:
+                  - astm.f3411.v22a.dss_provider
+                  - astm.f3411.v19.dss_provider
+                  - astm.f3548.v21.dss_provider
+        participant_requirements:
+          uss1: all_astm_dss_requirements
+          uss2: all_astm_dss_requirements
+  validation:
+    criteria:
+      - $ref: ../dev/library/validation.yaml#/execution_error_none
+      - $ref: ../dev/library/validation.yaml#/failed_check_severity_max_low
+      - applicability:
+          skipped_actions: {}
+        pass_condition:
+          elements:
+            count:
+              equal_to: 0


### PR DESCRIPTION
This PR captures the configuration used to verify a pool of DSS.
This is used to validate `dss:v0.12.0` release.

Successful run requires #583 and #585.