### PR TITLE
[uss_qualifier] RID CRDBAccess scenario: Fix resources mapping

### DIFF
--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_19/dss_probing.yaml
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_19/dss_probing.yaml
@@ -61,7 +61,8 @@ actions:
         isa: isa
   - test_scenario:
       scenario_type: scenarios.astm.netrid.v19.dss.CRDBAccess
-      crdb_cluster: dss_crdb_cluster
+      resources:
+        crdb_cluster: dss_crdb_cluster
       on_failure: Continue
   - test_scenario:
       scenario_type: scenarios.astm.netrid.v19.dss.HeavyTrafficConcurrent

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a/dss_probing.yaml
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a/dss_probing.yaml
@@ -61,7 +61,8 @@ actions:
         isa: isa
   - test_scenario:
       scenario_type: scenarios.astm.netrid.v22a.dss.CRDBAccess
-      crdb_cluster: dss_crdb_cluster
+      resources:
+        crdb_cluster: dss_crdb_cluster
       on_failure: Continue
   - test_scenario:
       scenario_type: scenarios.astm.netrid.v22a.dss.HeavyTrafficConcurrent


### PR DESCRIPTION
Resource mapping of `suites.astm.netrid.f3411_19.dss_probing` and `suites.astm.netrid.f3411_22a.dss_probing` is not properly mapped leading to undesirable skipped actions.