### PR TITLE
[uss_qualifier] split scd read fragments that have checks related to search

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/oir/crud/read.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/oir/crud/read.md
@@ -11,17 +11,3 @@ If an operational intent reference cannot be queried using its ID, the DSS is fa
 The response to a successful get operational intent reference query is expected to conform to the format defined by the OpenAPI specification under the `A3.1` Annex of ASTM F3548−21.
 
 If it does not, the DSS is failing to implement **[astm.f3548.v21.DSS0005,1](../../../../../../../requirements/astm/f3548/v21.md)**.
-
-## 🛑 Successful operational intent reference search query check
-
-If the DSS fails to let us search in the area for which the OIR was created, it is failing to meet **[astm.f3548.v21.DSS0005,1](../../../../../../../requirements/astm/f3548/v21.md)**.
-
-## 🛑 Search operational intent reference response format conforms to spec check
-
-The response to a successful operational intent reference search query is expected to conform to the format defined by the OpenAPI specification under the `A3.1` Annex of ASTM F3548−21.
-
-If it does not, the DSS is failing to implement **[astm.f3548.v21.DSS0005,1](../../../../../../../requirements/astm/f3548/v21.md)**.
-
-## 🛑 Created operational intent reference is in search results check
-
-If the existing operational intent reference is not returned in a search that covers the area it was created for, the DSS is not properly implementing **[astm.f3548.v21.DSS0005,2](../../../../../../../requirements/astm/f3548/v21.md)**.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/oir/crud/search.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/oir/crud/search.md
@@ -1,0 +1,17 @@
+# Search operational intent reference test step fragment
+
+This test step fragment validates that operational intent references can be searched for
+
+## 🛑 Successful operational intent reference search query check
+
+If the DSS fails to let us search in the area for which the OIR was created, it is failing to meet **[astm.f3548.v21.DSS0005,1](../../../../../../../requirements/astm/f3548/v21.md)**.
+
+## 🛑 Search operational intent reference response format conforms to spec check
+
+The response to a successful operational intent reference search query is expected to conform to the format defined by the OpenAPI specification under the `A3.1` Annex of ASTM F3548−21.
+
+If it does not, the DSS is failing to implement **[astm.f3548.v21.DSS0005,1](../../../../../../../requirements/astm/f3548/v21.md)**.
+
+## 🛑 Created operational intent reference is in search results check
+
+If the existing operational intent reference is not returned in a search that covers the area it was created for, the DSS is not properly implementing **[astm.f3548.v21.DSS0005,2](../../../../../../../requirements/astm/f3548/v21.md)**.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/sub/crud/read.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/sub/crud/read.md
@@ -11,11 +11,3 @@ If a subscription cannot be queried using its ID, the DSS is failing to meet **[
 The response to a successful get subscription query is expected to conform to the format defined by the OpenAPI specification under the `A3.1` Annex of ASTM F3548−21.
 
 If it does not, the DSS is failing to implement **[astm.f3548.v21.DSS0005,5](../../../../../../../requirements/astm/f3548/v21.md)**.
-
-## 🛑 Successful subscription search query check
-
-If the DSS fails to let us search in the area for which the subscription was created, it is failing to meet **[astm.f3548.v21.DSS0005,5](../../../../../../../requirements/astm/f3548/v21.md)**.
-
-## 🛑 Created Subscription is in search results check
-
-If the existing subscription is not returned in a search that covers the area it was created for, the DSS is not properly implementing **[astm.f3548.v21.DSS0005,5](../../../../../../../requirements/astm/f3548/v21.md)**.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/sub/crud/search.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/sub/crud/search.md
@@ -1,0 +1,11 @@
+# Search subscription test step fragment
+
+This test step fragment validates that subscriptions can be searched for.
+
+## 🛑 Successful subscription search query check
+
+If the DSS fails to let us search in the area for which the subscription was created, it is failing to meet **[astm.f3548.v21.DSS0005,5](../../../../../../../requirements/astm/f3548/v21.md)**.
+
+## 🛑 Created Subscription is in search results check
+
+If the existing subscription is not returned in a search that covers the area it was created for, the DSS is not properly implementing **[astm.f3548.v21.DSS0005,5](../../../../../../../requirements/astm/f3548/v21.md)**.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/subscription_synchronization.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/subscription_synchronization.md
@@ -61,6 +61,10 @@ Confirm that the subscription that was just created is properly synchronized acr
 
 Confirms that each DSS provides access to the created subscription,
 
+#### [Search subscription](../fragments/sub/crud/search.md)
+
+Confirms that each DSS returns the created subscription when searched for.
+
 #### [Validate subscription](../fragments/sub/validate/correctness.md)
 
 Verify that the subscription returned by every DSS is correctly formatted and corresponds to what was created earlier.
@@ -98,6 +102,10 @@ Confirm that the subscription that was just mutated is properly synchronized acr
 
 Confirms that the subscription that was just mutated can be retrieved from any DSS.
 
+#### [Search subscription](../fragments/sub/crud/search.md)
+
+Confirms that the subscription that was just mutated can be searched for from any DSS.
+
 #### [Validate subscription](../fragments/sub/validate/correctness.md)
 
 Verify that the subscription returned by every DSS is correctly formatted and corresponds to what was mutated earlier.
@@ -134,6 +142,10 @@ Confirm that the subscription that was just mutated is properly synchronized acr
 #### [Get subscription](../fragments/sub/crud/read.md)
 
 Confirms that the subscription that was just mutated can be retrieved from any DSS, and that it has the expected content.
+
+#### [Search subscription](../fragments/sub/crud/search.md)
+
+Confirms that the subscription that was just mutated can be searched for from any DSS, and that it has the expected content.
 
 #### [Validate subscription](../fragments/sub/validate/correctness.md)
 


### PR DESCRIPTION
The `oir/crud/read.md` and `oir/sub/read.md` fragments contain checks related to search that are not always run by any scenario importing the fragments, which is something we want to avoid.

This splits the _search_ specific parts of the fragment into a separate file.