### PR TITLE
[mock_uss/tracer] Add auth and log management to tracer

### DIFF
--- a/monitoring/mock_uss/docker-compose.yaml
+++ b/monitoring/mock_uss/docker-compose.yaml
@@ -221,6 +221,7 @@ services:
       - MOCK_USS_TOKEN_AUDIENCE=tracer.uss4.localutm,localhost,host.docker.internal
       - MOCK_USS_BASE_URL=http://tracer.uss4.localutm
       - MOCK_USS_TRACER_OUTPUT_FOLDER=output/tracer
+      - MOCK_USS_TRACER_UI_USERS=admin@admin=admin;viewer=
       - MOCK_USS_SERVICES=tracer
       - MOCK_USS_PORT=80
     expose:

--- a/monitoring/mock_uss/templates/tracer/base.html
+++ b/monitoring/mock_uss/templates/tracer/base.html
@@ -10,7 +10,7 @@
 </head>
 <body>
   <div>
-    Tracer:
+    Tracer ({{ username }}):
     <a href="{{ url_for('tracer_list_logs') }}">Home (logs)</a>
     <a href="{{ url_for('tracer_observation_areas_ui') }}">Observation Areas</a>
   </div>

--- a/monitoring/mock_uss/templates/tracer/logs.html
+++ b/monitoring/mock_uss/templates/tracer/logs.html
@@ -12,4 +12,32 @@
     </li>
   {% endfor %}
 </ul>
+<p>
+  <a href="{{ url_for('tracer_download_logs') }}">Download logs</a>
+</p>
+<script>
+function clearAllLogs() {
+  let random_chars = (Math.random() + 1).toString(36).slice(2, 7);
+  let response = prompt("Are you sure you want to delete all log files?  Enter " + random_chars + " below to confirm.");
+  if (response == random_chars) {
+    let xhr = new XMLHttpRequest();
+    let url = "{{ url_for('tracer_clear_logs') }}";
+    xhr.open("DELETE", url);
+    xhr.onreadystatechange = function () {
+        if (this.readyState == XMLHttpRequest.DONE) {
+            if (this.status == 200) {
+                location.reload();
+            } else {
+                alert("Error clearing logs (see also network log in debugger):\n" + this.response);
+            }
+        }
+    }
+    xhr.send();
+  }
+  return false;
+}
+</script>
+<p>
+  <a href="#" onclick="clearAllLogs()">Clear logs</a>
+</p>
 {% endblock %}

--- a/monitoring/mock_uss/templates/tracer/logs.html
+++ b/monitoring/mock_uss/templates/tracer/logs.html
@@ -12,6 +12,7 @@
     </li>
   {% endfor %}
 </ul>
+{% if is_admin %}
 <p>
   <a href="{{ url_for('tracer_download_logs') }}">Download logs</a>
 </p>
@@ -40,4 +41,5 @@ function clearAllLogs() {
 <p>
   <a href="#" onclick="clearAllLogs()">Clear logs</a>
 </p>
+{% endif %}
 {% endblock %}

--- a/monitoring/mock_uss/templates/tracer/observation_area_ui.html
+++ b/monitoring/mock_uss/templates/tracer/observation_area_ui.html
@@ -60,7 +60,7 @@
     Polling: {{ area.f3548.poll }}
   </p>
   <p>
-    Subscription: {{ area.f3548.subscription_id if "subscription_id" in area.f3548 else "N/A" }}
+    Subscription: {{ area.f3548.subscription_id }}
   </p>
   <p>
     Monitor operational intents: {{ area.f3548.monitor_op_intents }}

--- a/monitoring/mock_uss/templates/tracer/observation_area_ui.html
+++ b/monitoring/mock_uss/templates/tracer/observation_area_ui.html
@@ -60,7 +60,7 @@
     Polling: {{ area.f3548.poll }}
   </p>
   <p>
-    Subscription: {{ area.f3548.subscription_id }}
+    Subscription: {{ area.f3548.subscription_id if "subscription_id" in area.f3548 else "N/A" }}
   </p>
   <p>
     Monitor operational intents: {{ area.f3548.monitor_op_intents }}

--- a/monitoring/mock_uss/templates/tracer/observation_areas_ui.html
+++ b/monitoring/mock_uss/templates/tracer/observation_areas_ui.html
@@ -40,8 +40,8 @@ function makeObservationAreaRequest() {
 
     let ridVersion = document.getElementById("rid_version").value;
     if (ridVersion != "None") {
-        let pollRID = document.getElementById("poll_f3411").value;
-        let subscribeRID = document.getElementById("subscribe_f3411").value;
+        let pollRID = document.getElementById("poll_f3411").checked;
+        let subscribeRID = document.getElementById("subscribe_f3411").checked;
         obsArea["f3411"] = {
             "rid_version": ridVersion,
             "poll": pollRID,
@@ -51,10 +51,10 @@ function makeObservationAreaRequest() {
 
     let scdVersion = document.getElementById("scd_version").value;
     if (scdVersion != "None") {
-        let pollF3548 = document.getElementById("poll_f3548").value;
-        let subscribeF3548 = document.getElementById("subscribe_f3548").value;
-        let opIntents = document.getElementById("op_intents").value;
-        let constraints = document.getElementById("constraints").value;
+        let pollF3548 = document.getElementById("poll_f3548").checked;
+        let subscribeF3548 = document.getElementById("subscribe_f3548").checked;
+        let opIntents = document.getElementById("op_intents").checked;
+        let constraints = document.getElementById("constraints").checked;
         obsArea["f3548"] = {
             "poll": pollF3548,
             "subscribe": subscribeF3548,

--- a/monitoring/mock_uss/tracer/observation_area_operations.py
+++ b/monitoring/mock_uss/tracer/observation_area_operations.py
@@ -96,11 +96,14 @@ def delete_observation_area(area: ObservationArea) -> ObservationArea:
                 rid_client=rid_client,
             )
 
-    if area.f3548 is not None:
+    if (
+        area.f3548 is not None
+        and "subscription_id" in area.f3548
+        and area.f3548.subscription_id
+    ):
         scd_client = context.get_client(area.f3548.auth_spec, area.f3548.dss_base_url)
-        if area.f3548.subscription_id:
-            unsubscribe_scd(
-                subscription_id=area.f3548.subscription_id, scd_client=scd_client
-            )
+        unsubscribe_scd(
+            subscription_id=area.f3548.subscription_id, scd_client=scd_client
+        )
 
     return area

--- a/monitoring/mock_uss/tracer/observation_area_operations.py
+++ b/monitoring/mock_uss/tracer/observation_area_operations.py
@@ -96,11 +96,7 @@ def delete_observation_area(area: ObservationArea) -> ObservationArea:
                 rid_client=rid_client,
             )
 
-    if (
-        area.f3548 is not None
-        and "subscription_id" in area.f3548
-        and area.f3548.subscription_id
-    ):
+    if area.f3548 is not None and area.f3548.subscription_id:
         scd_client = context.get_client(area.f3548.auth_spec, area.f3548.dss_base_url)
         unsubscribe_scd(
             subscription_id=area.f3548.subscription_id, scd_client=scd_client

--- a/monitoring/mock_uss/tracer/observation_areas.py
+++ b/monitoring/mock_uss/tracer/observation_areas.py
@@ -47,7 +47,7 @@ class F3548ObservationArea(ImplicitDict):
     poll: bool
     """This area observes by periodically polling for information."""
 
-    subscription_id: Optional[str]
+    subscription_id: Optional[str] = None
     """The F3548 subscription ID established to provide observation via notifications."""
 
 

--- a/monitoring/mock_uss/tracer/routes/observation_areas.py
+++ b/monitoring/mock_uss/tracer/routes/observation_areas.py
@@ -25,6 +25,7 @@ from monitoring.mock_uss.tracer.observation_areas import (
     F3411ObservationArea,
 )
 from monitoring.mock_uss.tracer.tracer_poll import TASK_POLL_OBSERVATION_AREAS
+from monitoring.mock_uss.tracer.ui_auth import ui_auth
 from monitoring.monitorlib import fetch
 import monitoring.monitorlib.fetch.rid
 from monitoring.monitorlib.geo import Volume3D
@@ -32,6 +33,7 @@ from monitoring.monitorlib.geotemporal import Volume4D
 
 
 @webapp.route("/tracer/observation_areas", methods=["GET"])
+@ui_auth.login_required
 def tracer_list_observation_areas() -> Tuple[str, int]:
     with db as tx:
         result = ListObservationAreasResponse(
@@ -41,6 +43,7 @@ def tracer_list_observation_areas() -> Tuple[str, int]:
 
 
 @webapp.route("/tracer/observation_areas/<area_id>", methods=["PUT"])
+@ui_auth.login_required(role="admin")
 def tracer_upsert_observation_area(area_id: str) -> Tuple[str, int]:
     try:
         req_body = flask.request.json
@@ -80,6 +83,7 @@ def tracer_upsert_observation_area(area_id: str) -> Tuple[str, int]:
 
 
 @webapp.route("/tracer/observation_areas/<area_id>", methods=["DELETE"])
+@ui_auth.login_required(role="admin")
 def tracer_delete_observation_area(area_id: str) -> Tuple[str, int]:
     with db as tx:
         if area_id not in tx.observation_areas:
@@ -96,6 +100,7 @@ def tracer_delete_observation_area(area_id: str) -> Tuple[str, int]:
 
 
 @webapp.route("/tracer/observation_areas/import_requests", methods=["POST"])
+@ui_auth.login_required(role="admin")
 def tracer_import_observation_areas() -> Tuple[str, int]:
     try:
         req_body = flask.request.json

--- a/monitoring/mock_uss/tracer/routes/ui.py
+++ b/monitoring/mock_uss/tracer/routes/ui.py
@@ -41,6 +41,7 @@ def tracer_list_logs():
             logs=logs,
             kmls=kmls,
             username=ui_auth.current_user().username,
+            is_admin=ui_auth.current_user().is_admin(),
         )
     )
     response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"

--- a/monitoring/mock_uss/tracer/routes/ui.py
+++ b/monitoring/mock_uss/tracer/routes/ui.py
@@ -11,6 +11,7 @@ from monitoring.mock_uss import webapp
 from monitoring.mock_uss.tracer import context
 from monitoring.mock_uss.tracer.database import db
 from monitoring.mock_uss.tracer.observation_areas import ObservationArea
+from monitoring.mock_uss.tracer.ui_auth import ui_auth
 from monitoring.monitorlib import fetch, geo, infrastructure
 from monitoring.monitorlib.fetch import summarize
 import monitoring.monitorlib.fetch.rid
@@ -18,6 +19,7 @@ import monitoring.monitorlib.fetch.scd
 
 
 @webapp.route("/tracer/logs")
+@ui_auth.login_required
 def tracer_list_logs():
     logger.debug(f"Handling tracer_list_logs from {os.getpid()}")
     logs = [
@@ -59,6 +61,7 @@ def _redact_and_augment_log(obj):
 
 
 @webapp.route("/tracer/logs/<log>")
+@ui_auth.login_required
 def tracer_logs(log):
     logger.debug(f"Handling tracer_logs from {os.getpid()}")
     logfile = os.path.join(context.tracer_logger.log_path, log)
@@ -100,6 +103,7 @@ def tracer_logs(log):
 
 
 @webapp.route("/tracer/kml/now.kml")
+@ui_auth.login_required
 def tracer_kml_now():
     logger.debug(f"Handling tracer_kml_now from {os.getpid()}")
     all_kmls = glob.glob(os.path.join(context.tracer_logger.log_path, "kml", "*.kml"))
@@ -115,6 +119,7 @@ def tracer_kml_now():
 
 
 @webapp.route("/tracer/kml/<kml>")
+@ui_auth.login_required
 def tracer_kmls(kml):
     logger.debug(f"Handling tracer_kmls from {os.getpid()}")
     kmlfile = os.path.join(context.tracer_logger.log_path, "kml", kml)
@@ -137,6 +142,7 @@ def _get_validated_obs_area(observation_area_id: str) -> ObservationArea:
 
 
 @webapp.route("/tracer/observation_areas/<observation_area_id>/ui", methods=["GET"])
+@ui_auth.login_required(role="admin")
 def tracer_observation_area_ui(observation_area_id: str):
     logger.debug(f"Handling tracer_observation_area_ui from {os.getpid()}")
     area = _get_validated_obs_area(observation_area_id)
@@ -169,6 +175,7 @@ def tracer_observation_area_ui(observation_area_id: str):
     "/tracer/observation_areas/<observation_area_id>/rid_poll_requests",
     methods=["POST"],
 )
+@ui_auth.login_required(role="admin")
 def tracer_rid_request_poll(observation_area_id: str):
     logger.debug(f"Handling tracer_rid_request_poll from {os.getpid()}")
     area = _get_validated_obs_area(observation_area_id)
@@ -194,6 +201,7 @@ def tracer_rid_request_poll(observation_area_id: str):
 
 
 @webapp.route("/tracer/observation_areas/ui", methods=["GET"])
+@ui_auth.login_required
 def tracer_observation_areas_ui():
     return flask.render_template(
         "tracer/observation_areas_ui.html",

--- a/monitoring/mock_uss/tracer/tracerlog.py
+++ b/monitoring/mock_uss/tracer/tracerlog.py
@@ -1,5 +1,6 @@
 import copy
 import datetime
+import json
 import os
 from typing import Dict
 
@@ -31,7 +32,7 @@ class Logger(object):
         logname = "{}.yaml".format(basename)
         fullname = os.path.join(self.log_path, logname)
 
-        dump = copy.deepcopy(content)
+        dump = json.loads(json.dumps(content))
         dump["object_type"] = type(content).__name__
         with open(fullname, "w") as f:
             f.write(yaml.dump(dump, indent=2))

--- a/monitoring/mock_uss/tracer/tracerlog.py
+++ b/monitoring/mock_uss/tracer/tracerlog.py
@@ -1,4 +1,3 @@
-import copy
 import datetime
 import json
 import os

--- a/monitoring/mock_uss/tracer/ui_auth.py
+++ b/monitoring/mock_uss/tracer/ui_auth.py
@@ -1,0 +1,62 @@
+from dataclasses import dataclass
+from typing import List, Union
+
+from flask_httpauth import HTTPBasicAuth
+from werkzeug.security import generate_password_hash, check_password_hash
+
+from monitoring.mock_uss import import_environment_variable, webapp
+
+ui_auth = HTTPBasicAuth()
+
+KEY_TRACER_UI_USERS = "MOCK_USS_TRACER_UI_USERS"
+"""Environment variable containing configuration of users allowed to access the UI.
+
+Form: {USER1}[@{ROLE1}[,{ROLE2}[,{ROLE3}]]]={PASSWORD1};{USER2}[@{ROLE1}[,{ROLE2}[,{ROLE3}]]]={PASSWORD2}
+
+Example: admin@admin=admin;user1@viewer=avalidpassword;user2@viewer=anotherpassword
+"""
+
+import_environment_variable(KEY_TRACER_UI_USERS, required=False, default="")
+
+
+@dataclass
+class User(object):
+    username: str
+    password_hash: str
+    roles: List[str]
+
+
+def _get_users() -> List[User]:
+    users = []
+    user_strings = webapp.config.get(KEY_TRACER_UI_USERS).split(";")
+    for user_string in user_strings:
+        if not user_string.strip():
+            continue
+        if "=" not in user_string:
+            raise ValueError(f"Invalid tracer UI user string provided: `{user_string}`")
+        name_and_roles, password = user_string.split("=")
+        if "@" in name_and_roles:
+            name, roles_string = name_and_roles.split("@")
+            roles = [r.strip() for r in roles_string.split(",")]
+        else:
+            name = name_and_roles
+            roles = []
+        password_hash = generate_password_hash(password.strip())
+        users.append(User(username=name, password_hash=password_hash, roles=roles))
+    return users
+
+
+@ui_auth.verify_password
+def verify_password(username: str, password: str) -> Union[bool, User]:
+    user = [u for u in _get_users() if u.username == username]
+    if not user:
+        return False  # No matching user
+    if check_password_hash(user[0].password_hash, password):
+        return user[0]
+    else:
+        return False  # Matching user, but wrong password
+
+
+@ui_auth.get_user_roles
+def get_user_roles(user: User) -> List[str]:
+    return user.roles

--- a/monitoring/mock_uss/tracer/ui_auth.py
+++ b/monitoring/mock_uss/tracer/ui_auth.py
@@ -25,6 +25,9 @@ class User(object):
     password_hash: str
     roles: List[str]
 
+    def is_admin(self) -> bool:
+        return "admin" in self.roles
+
 
 def _get_users() -> List[User]:
     users = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ bc-jsonpath-ng==1.5.9  # uss_qualifier
 cryptography==42.0.4
 faker===8.1.0  # uss_qualifier
 flask==2.3.3
+Flask-HTTPAuth==4.8.0  # mock_uss tracer
 geojson===2.5.0  # uss_qualifier
 gevent==22.10.2  # mock_uss / gunicorn worker
 google-auth==1.6.3


### PR DESCRIPTION
There is an upcoming need to use the tracer functionality of mock_uss in a non-development environment.

Currently, the tracer UI & management endpoints are unprotected with the idea that it will only be used in development environments.  This PR primarily protects all of tracer's unprotected endpoints with HTTP Basic auth.  No session management is implemented as most modern browsers will cache credentials and reuse them on calls to other resources on the server (verified with Chrome).

Also, deployment will likely be [via Kubernetes](https://github.com/interuss/monitoring/blob/main/monitoring/mock_uss/deployment/gcp/kubernetes-deployment.md), so the tasks previously performed via command line directly in a VM need to be performable via the external interface now.  So, downloading of all logs and clearing of logs are added in this PR as well.

Finally, a few bugs discovered during testing are fixed.