### PR TITLE
[uss_qualifier] Fix test step URLs

### DIFF
--- a/monitoring/uss_qualifier/scenarios/documentation/parsing.py
+++ b/monitoring/uss_qualifier/scenarios/documentation/parsing.py
@@ -127,7 +127,6 @@ def _parse_test_step(
         linked_step_fragment = _get_linked_test_step_fragment(
             values[0].children[0].dest, doc_filename
         )
-        url = linked_step_fragment.url
         checks = linked_step_fragment.checks.copy()
 
     c = 1
@@ -145,7 +144,6 @@ def _parse_test_step(
                 linked_step_fragment = _get_linked_test_step_fragment(
                     values[c].children[0].dest, doc_filename
                 )
-                url = linked_step_fragment.url
                 checks.extend(linked_step_fragment.checks.copy())
                 c += dc
             else:


### PR DESCRIPTION
"Test step fragments" used to be "linked test steps" as they were intended to capture all information about a particular reusable test step.  Because of this, the URL for the test step was changed to be the linked page whenever the test step linked out to one of these "linked test steps".  However, now test steps are only ever defined in test scenario pages, even if they link out to a fragment directly from the test step title.  So, the URL for the test step should be the test step heading in the test scenario documentation, not any linked fragment.  This PR makes that fix.