### PR TITLE
[monitorlib] Refactor KML routines

### DIFF
--- a/monitoring/monitorlib/kml/__init__.py
+++ b/monitoring/monitorlib/kml/__init__.py
@@ -1,0 +1,1 @@
+KML_NAMESPACE = {"kml": "http://www.opengis.net/kml/2.2"}

--- a/monitoring/monitorlib/kml/f3548v21.py
+++ b/monitoring/monitorlib/kml/f3548v21.py
@@ -1,0 +1,92 @@
+from typing import List
+
+from pykml.factory import KML_ElementMaker as kml
+
+from monitoring.monitorlib.geotemporal import Volume4D
+from monitoring.monitorlib.kml.generation import (
+    GREEN,
+    TRANSLUCENT_GRAY,
+    TRANSLUCENT_GREEN,
+    YELLOW,
+    RED,
+    make_placemark_from_volume,
+)
+from monitoring.monitorlib.scd import priority_of
+from uas_standards.astm.f3548.v21.api import (
+    OperationalIntent,
+    QueryOperationalIntentReferenceParameters,
+    QueryOperationalIntentReferenceResponse,
+)
+
+
+def full_op_intent(op_intent: OperationalIntent) -> kml.Folder:
+    """Render operational intent information into Placemarks in a KML folder."""
+    ref = op_intent.reference
+    details = op_intent.details
+    name = f"{ref.manager}'s P{priority_of(details)} {ref.state.value} {ref.id}[{ref.version}] @ {ref.ovn}"
+    folder = kml.Folder(kml.name(name))
+    if "volumes" in details:
+        for i, v4_f3548 in enumerate(details.volumes):
+            v4 = Volume4D.from_f3548v21(v4_f3548)
+            folder.append(
+                make_placemark_from_volume(
+                    v4,
+                    name=f"Nominal volume {i}",
+                    style_url=f"#F3548v21{ref.state.value}",
+                )
+            )
+    if "off_nominal_volumes" in details:
+        for i, v4_f3548 in enumerate(details.off_nominal_volumes):
+            v4 = Volume4D.from_f3548v21(v4_f3548)
+            folder.append(
+                make_placemark_from_volume(
+                    v4,
+                    name=f"Off-nominal volume {i}",
+                    style_url=f"#F3548v21{ref.state.value}",
+                )
+            )
+    return folder
+
+
+def op_intent_refs_query(
+    req: QueryOperationalIntentReferenceParameters,
+    resp: QueryOperationalIntentReferenceResponse,
+) -> kml.Placemark:
+    """Render the area of interest and response from an operational intent references query into a KML Placemark."""
+    v4 = Volume4D.from_f3548v21(req.area_of_interest)
+    items = "".join(
+        f"<li>{oi.manager}'s {oi.state.value} {oi.id}[{oi.version}]</li>"
+        for oi in resp.operational_intent_references
+    )
+    description = (
+        f"<ul>{items}</ul>" if items else "(no operational intent references found)"
+    )
+    return make_placemark_from_volume(
+        v4, name="area_of_interest", style_url="#QueryArea", description=description
+    )
+
+
+def f3548v21_styles() -> List[kml.Style]:
+    """Provides KML styles according to F3548-21 operational intent states."""
+    return [
+        kml.Style(
+            kml.LineStyle(kml.color(GREEN), kml.width(3)),
+            kml.PolyStyle(kml.color(TRANSLUCENT_GRAY)),
+            id="F3548v21Accepted",
+        ),
+        kml.Style(
+            kml.LineStyle(kml.color(GREEN), kml.width(3)),
+            kml.PolyStyle(kml.color(TRANSLUCENT_GREEN)),
+            id="F3548v21Activated",
+        ),
+        kml.Style(
+            kml.LineStyle(kml.color(YELLOW), kml.width(5)),
+            kml.PolyStyle(kml.color(TRANSLUCENT_GREEN)),
+            id="F3548v21Nonconforming",
+        ),
+        kml.Style(
+            kml.LineStyle(kml.color(RED), kml.width(5)),
+            kml.PolyStyle(kml.color(TRANSLUCENT_GREEN)),
+            id="F3548v21Contingent",
+        ),
+    ]

--- a/monitoring/monitorlib/kml/flight_planning.py
+++ b/monitoring/monitorlib/kml/flight_planning.py
@@ -1,0 +1,65 @@
+from typing import List
+
+from pykml.factory import KML_ElementMaker as kml
+
+from monitoring.monitorlib.geotemporal import Volume4D
+from monitoring.monitorlib.kml.generation import (
+    GREEN,
+    TRANSLUCENT_GRAY,
+    TRANSLUCENT_GREEN,
+    YELLOW,
+    RED,
+    make_placemark_from_volume,
+)
+from uas_standards.interuss.automated_testing.flight_planning.v1.api import (
+    UpsertFlightPlanRequest,
+    UpsertFlightPlanResponse,
+)
+
+
+def upsert_flight_plan(
+    req: UpsertFlightPlanRequest, resp: UpsertFlightPlanResponse
+) -> kml.Folder:
+    """Render a flight planning action into a KML folder."""
+    basic_info = req.flight_plan.basic_information
+    folder = kml.Folder(
+        kml.name(
+            f"Activity {resp.planning_result.value}, flight {resp.flight_plan_status.value}"
+        )
+    )
+    for i, v4_flight_planning in enumerate(basic_info.area):
+        v4 = Volume4D.from_flight_planning_api(v4_flight_planning)
+        folder.append(
+            make_placemark_from_volume(
+                v4,
+                name=f"Volume {i}",
+                style_url=f"#{basic_info.usage_state.value}_{basic_info.uas_state.value}",
+            )
+        )
+    return folder
+
+
+def flight_planning_styles() -> List[kml.Style]:
+    """Provides KML styles with names in the form {FlightPlanState}_{AirspaceUsageState}."""
+    return [
+        kml.Style(
+            kml.LineStyle(kml.color(GREEN), kml.width(3)),
+            kml.PolyStyle(kml.color(TRANSLUCENT_GRAY)),
+            id="Planned_Nominal",
+        ),
+        kml.Style(
+            kml.LineStyle(kml.color(GREEN), kml.width(3)),
+            kml.PolyStyle(kml.color(TRANSLUCENT_GREEN)),
+            id="InUse_Nominal",
+        ),
+        kml.Style(
+            kml.LineStyle(kml.color(YELLOW), kml.width(5)),
+            kml.PolyStyle(kml.color(TRANSLUCENT_GREEN)),
+            id="InUse_OffNominal",
+        ),
+        kml.Style(
+            kml.LineStyle(kml.color(RED), kml.width(5)),
+            kml.PolyStyle(kml.color(TRANSLUCENT_GREEN)),
+            id="InUse_Contingent",
+        ),
+    ]

--- a/monitoring/monitorlib/kml/generation.py
+++ b/monitoring/monitorlib/kml/generation.py
@@ -1,9 +1,7 @@
 import math
-import re
 from typing import List, Optional, Union
 
 import s2sphere
-from pykml import parser
 from pykml.factory import KML_ElementMaker as kml
 
 from monitoring.monitorlib.geo import (
@@ -12,13 +10,10 @@ from monitoring.monitorlib.geo import (
     DistanceUnits,
     egm96_geoid_offset,
     Radius,
-    EARTH_CIRCUMFERENCE_M,
-    LatLngPoint,
+    METERS_PER_FOOT,
 )
 from monitoring.monitorlib.geotemporal import Volume4D
 
-KML_NAMESPACE = {"kml": "http://www.opengis.net/kml/2.2"}
-METERS_PER_FOOT = 0.3048
 
 # Hexadecimal colors
 GREEN = "ff00c000"
@@ -28,114 +23,6 @@ CYAN = "ffc0c000"
 TRANSLUCENT_GRAY = "80808080"
 TRANSLUCENT_GREEN = "8000ff00"
 TRANSLUCENT_LIGHT_CYAN = "80ffffaa"
-
-
-def get_kml_root(kml_obj, from_string=False):
-    if from_string:
-        content = parser.fromstring(kml_obj)
-        return content
-    content = parser.parse(kml_obj)
-    return content.getroot()
-
-
-def get_folders(root):
-    return root.Document.Folder.Folder
-
-
-def get_polygon_speed(polygon_name):
-    """Returns speed unit within a polygon."""
-    result = re.search(r"\(([0-9.]+)\)", polygon_name)
-    return float(result.group(1)) if result else None
-
-
-def get_folder_details(folder_elem):
-    speed_polygons = {}
-    alt_polygons = {}
-    operator_location = {}
-    coordinates = ""
-    for placemark in folder_elem.xpath(".//kml:Placemark", namespaces=KML_NAMESPACE):
-        placemark_name = str(placemark.name)
-        polygons = placemark.xpath(".//kml:Polygon", namespaces=KML_NAMESPACE)
-
-        if placemark_name == "operator_location":
-            operator_point = folder_elem.xpath(
-                ".//kml:Placemark/kml:Point/kml:coordinates", namespaces=KML_NAMESPACE
-            )[0]
-            if operator_point:
-                operator_point = str(operator_point).split(",")
-                operator_location = {"lng": operator_point[0], "lat": operator_point[1]}
-        if polygons:
-            if placemark_name.startswith("alt:"):
-                polygon_coords = get_coordinates_from_kml(
-                    polygons[0].outerBoundaryIs.LinearRing.coordinates
-                )
-                alt_polygons.update({placemark_name: polygon_coords})
-            if placemark_name.startswith("speed:"):
-                if not get_polygon_speed(placemark_name):
-                    raise ValueError(
-                        'Could not determine Polygon speed from Placemark "{}"'.format(
-                            placemark_name
-                        )
-                    )
-                polygon_coords = get_coordinates_from_kml(
-                    polygons[0].outerBoundaryIs.LinearRing.coordinates
-                )
-                speed_polygons.update({placemark_name: polygon_coords})
-
-        coords = placemark.xpath(
-            ".//kml:LineString/kml:coordinates", namespaces=KML_NAMESPACE
-        )
-        if coords:
-            coordinates = coords
-            coordinates = get_coordinates_from_kml(coordinates)
-    return {
-        str(folder_elem.name): {
-            "description": get_folder_description(folder_elem),
-            "speed_polygons": speed_polygons,
-            "alt_polygons": alt_polygons,
-            "input_coordinates": coordinates,
-            "operator_location": operator_location,
-        }
-    }
-
-
-def get_coordinates_from_kml(coordinates):
-    """Returns list of tuples of coordinates.
-    Args:
-        coordinates: coordinates element from KML.
-    """
-    if coordinates:
-        return [
-            tuple(float(x.strip()) for x in c.split(","))
-            for c in str(coordinates[0]).split(" ")
-            if c.strip()
-        ]
-
-
-def get_folder_description(folder_elem):
-    """Returns folder description from KML.
-    Args:
-        folder_elem: Folder element from KML.
-    """
-    description = folder_elem.description
-    lines = [line for line in str(description).split("\n") if ":" in line]
-    values = {}
-    for line in lines:
-        cols = [col.strip() for col in line.split(":")]
-        if len(cols) == 2:
-            values[cols[0]] = cols[1]
-    return values
-
-
-def get_kml_content(kml_file, from_string=False):
-    root = get_kml_root(kml_file, from_string)
-    folders = get_folders(root)
-    kml_content = {}
-    for folder in folders:
-        folder_details = get_folder_details(folder)
-        if folder_details:
-            kml_content.update(folder_details)
-    return kml_content
 
 
 def _altitude_mode_of(altitude: Altitude) -> str:
@@ -297,32 +184,6 @@ def make_placemark_from_volume(
     return placemark
 
 
-def flight_planning_styles() -> List[kml.Style]:
-    """Provides KML styles with names in the form {FlightPlanState}_{AirspaceUsageState}."""
-    return [
-        kml.Style(
-            kml.LineStyle(kml.color(GREEN), kml.width(3)),
-            kml.PolyStyle(kml.color(TRANSLUCENT_GRAY)),
-            id="Planned_Nominal",
-        ),
-        kml.Style(
-            kml.LineStyle(kml.color(GREEN), kml.width(3)),
-            kml.PolyStyle(kml.color(TRANSLUCENT_GREEN)),
-            id="InUse_Nominal",
-        ),
-        kml.Style(
-            kml.LineStyle(kml.color(YELLOW), kml.width(5)),
-            kml.PolyStyle(kml.color(TRANSLUCENT_GREEN)),
-            id="InUse_OffNominal",
-        ),
-        kml.Style(
-            kml.LineStyle(kml.color(RED), kml.width(5)),
-            kml.PolyStyle(kml.color(TRANSLUCENT_GREEN)),
-            id="InUse_Contingent",
-        ),
-    ]
-
-
 def query_styles() -> List[kml.Style]:
     """Provides KML styles for query areas."""
     return [
@@ -330,31 +191,5 @@ def query_styles() -> List[kml.Style]:
             kml.LineStyle(kml.color(CYAN), kml.width(3)),
             kml.PolyStyle(kml.color(TRANSLUCENT_LIGHT_CYAN)),
             id="QueryArea",
-        ),
-    ]
-
-
-def f3548v21_styles() -> List[kml.Style]:
-    """Provides KML styles according to F3548-21 operational intent states."""
-    return [
-        kml.Style(
-            kml.LineStyle(kml.color(GREEN), kml.width(3)),
-            kml.PolyStyle(kml.color(TRANSLUCENT_GRAY)),
-            id="F3548v21Accepted",
-        ),
-        kml.Style(
-            kml.LineStyle(kml.color(GREEN), kml.width(3)),
-            kml.PolyStyle(kml.color(TRANSLUCENT_GREEN)),
-            id="F3548v21Activated",
-        ),
-        kml.Style(
-            kml.LineStyle(kml.color(YELLOW), kml.width(5)),
-            kml.PolyStyle(kml.color(TRANSLUCENT_GREEN)),
-            id="F3548v21Nonconforming",
-        ),
-        kml.Style(
-            kml.LineStyle(kml.color(RED), kml.width(5)),
-            kml.PolyStyle(kml.color(TRANSLUCENT_GREEN)),
-            id="F3548v21Contingent",
         ),
     ]

--- a/monitoring/monitorlib/kml/parsing.py
+++ b/monitoring/monitorlib/kml/parsing.py
@@ -1,0 +1,111 @@
+import re
+
+from pykml import parser
+
+
+def get_kml_root(kml_obj, from_string=False):
+    if from_string:
+        content = parser.fromstring(kml_obj)
+        return content
+    content = parser.parse(kml_obj)
+    return content.getroot()
+
+
+def get_folders(root):
+    return root.Document.Folder.Folder
+
+
+def get_polygon_speed(polygon_name):
+    """Returns speed unit within a polygon."""
+    result = re.search(r"\(([0-9.]+)\)", polygon_name)
+    return float(result.group(1)) if result else None
+
+
+def get_folder_details(folder_elem):
+    speed_polygons = {}
+    alt_polygons = {}
+    operator_location = {}
+    coordinates = ""
+    for placemark in folder_elem.xpath(".//kml:Placemark", namespaces=KML_NAMESPACE):
+        placemark_name = str(placemark.name)
+        polygons = placemark.xpath(".//kml:Polygon", namespaces=KML_NAMESPACE)
+
+        if placemark_name == "operator_location":
+            operator_point = folder_elem.xpath(
+                ".//kml:Placemark/kml:Point/kml:coordinates", namespaces=KML_NAMESPACE
+            )[0]
+            if operator_point:
+                operator_point = str(operator_point).split(",")
+                operator_location = {"lng": operator_point[0], "lat": operator_point[1]}
+        if polygons:
+            if placemark_name.startswith("alt:"):
+                polygon_coords = get_coordinates_from_kml(
+                    polygons[0].outerBoundaryIs.LinearRing.coordinates
+                )
+                alt_polygons.update({placemark_name: polygon_coords})
+            if placemark_name.startswith("speed:"):
+                if not get_polygon_speed(placemark_name):
+                    raise ValueError(
+                        'Could not determine Polygon speed from Placemark "{}"'.format(
+                            placemark_name
+                        )
+                    )
+                polygon_coords = get_coordinates_from_kml(
+                    polygons[0].outerBoundaryIs.LinearRing.coordinates
+                )
+                speed_polygons.update({placemark_name: polygon_coords})
+
+        coords = placemark.xpath(
+            ".//kml:LineString/kml:coordinates", namespaces=KML_NAMESPACE
+        )
+        if coords:
+            coordinates = coords
+            coordinates = get_coordinates_from_kml(coordinates)
+    return {
+        str(folder_elem.name): {
+            "description": get_folder_description(folder_elem),
+            "speed_polygons": speed_polygons,
+            "alt_polygons": alt_polygons,
+            "input_coordinates": coordinates,
+            "operator_location": operator_location,
+        }
+    }
+
+
+def get_coordinates_from_kml(coordinates):
+    """Returns list of tuples of coordinates.
+    Args:
+        coordinates: coordinates element from KML.
+    """
+    if coordinates:
+        return [
+            tuple(float(x.strip()) for x in c.split(","))
+            for c in str(coordinates[0]).split(" ")
+            if c.strip()
+        ]
+
+
+def get_folder_description(folder_elem):
+    """Returns folder description from KML.
+    Args:
+        folder_elem: Folder element from KML.
+    """
+    description = folder_elem.description
+    lines = [line for line in str(description).split("\n") if ":" in line]
+    values = {}
+    for line in lines:
+        cols = [col.strip() for col in line.split(":")]
+        if len(cols) == 2:
+            values[cols[0]] = cols[1]
+    return values
+
+
+def get_kml_content(kml_file, from_string=False):
+    root = get_kml_root(kml_file, from_string)
+    folders = get_folders(root)
+    kml_content = {}
+    for folder in folders:
+        folder_details = get_folder_details(folder)
+        if folder_details:
+            kml_content.update(folder_details)
+    return kml_content

--- a/monitoring/monitorlib/kml/parsing.py
+++ b/monitoring/monitorlib/kml/parsing.py
@@ -2,6 +2,8 @@ import re
 
 from pykml import parser
 
+from monitoring.monitorlib.kml import KML_NAMESPACE
+
 
 def get_kml_root(kml_obj, from_string=False):
     if from_string:

--- a/monitoring/uss_qualifier/resources/netrid/simulation/kml_flights.py
+++ b/monitoring/uss_qualifier/resources/netrid/simulation/kml_flights.py
@@ -11,7 +11,7 @@ from shapely.geometry import LineString, Point, Polygon
 
 from implicitdict import StringBasedDateTime
 from monitoring.monitorlib.geo import flatten, unflatten
-from monitoring.monitorlib import kml
+from monitoring.monitorlib.kml.parsing import get_polygon_speed, get_kml_content
 from monitoring.uss_qualifier.resources.netrid.flight_data import (
     FullFlightRecord,
     FlightRecordCollection,
@@ -298,7 +298,7 @@ def get_interpolated_value(point, polygons, all_possible_values, round_value=Fal
 
 
 def get_speeds_from_speed_polygons(speed_polygons):
-    return [kml.get_polygon_speed(n) for n in list(speed_polygons)]
+    return [get_polygon_speed(n) for n in list(speed_polygons)]
 
 
 def get_flight_state_coordinates(flight_details):
@@ -363,7 +363,7 @@ def get_flight_state_coordinates(flight_details):
 def get_flight_records(
     kml_content, reference_time, random_seed
 ) -> FlightRecordCollection:
-    kml_content = kml.get_kml_content(kml_content.encode("utf-8"), True)
+    kml_content = get_kml_content(kml_content.encode("utf-8"), True)
     flight_records = []
     for flight_name, flight_details in kml_content.items():
         flight_description = flight_details["description"]

--- a/monitoring/uss_qualifier/test_data/make_flight_intent_kml.py
+++ b/monitoring/uss_qualifier/test_data/make_flight_intent_kml.py
@@ -12,7 +12,8 @@ from pykml.util import format_xml_with_cdata
 import yaml
 
 from implicitdict import ImplicitDict
-from monitoring.monitorlib.kml import make_placemark_from_volume, flight_planning_styles
+from monitoring.monitorlib.kml.flight_planning import flight_planning_styles
+from monitoring.monitorlib.kml.generation import make_placemark_from_volume
 from monitoring.monitorlib.temporal import Time, TimeDuringTest
 from monitoring.uss_qualifier.fileio import load_dict_with_references, resolve_filename
 from monitoring.uss_qualifier.resources.flight_planning.flight_intent import (


### PR DESCRIPTION
Previously, there was only a single kml.py in monitorlib to handle KML operations.  This PR refactors that single file into multiple files to prepare for the addition of new content in a more sustainable manner.

Some KML generation logic previously only found in sequence view generation is moved to general KML routines for future reuse.

KML generation in sequence view is slightly changed.  First, more errors are caught and handled in a generic fashion (so catching problems with the area_of_interest field no longer needs to be specifically performed), and second, the console warning about not being able to generate a particular element is removed.  This is because there are (and will continue to be) places where generation intentionally cannot be accomplished (specifically: when there is bad data in the data validation scenario) and this is not a concerning situation.  The current warning incorrectly suggests to the console viewer that something is wrong.  Instead, anyone viewing the KML will still see the error if it occurs in the places they are interested in.