### PR TITLE
[mock_uss/tracer] Strongly-type tracer log entries

### DIFF
--- a/monitoring/mock_uss/server.py
+++ b/monitoring/mock_uss/server.py
@@ -238,7 +238,11 @@ class MockUSS(flask.Flask):
                     with db as tx:
                         periodic_task = tx.periodic_tasks[task_to_execute]
                         periodic_task.executing = False
-                        if periodic_task.period.timedelta.total_seconds() == 0:
+                        if (
+                            "period" in periodic_task
+                            and periodic_task.period
+                            and periodic_task.period.timedelta.total_seconds() == 0
+                        ):
                             periodic_task.last_execution_time = StringBasedDateTime(
                                 arrow.utcnow().datetime
                             )

--- a/monitoring/mock_uss/tracer/README.md
+++ b/monitoring/mock_uss/tracer/README.md
@@ -5,7 +5,7 @@ This diagnostic capability monitors UTM traffic in a specified area.  This
 includes, when requested, remote ID Identification Service Areas, strategic
 deconfliction Operational Intents, and Constraints.  This tool records data in a
 way not allowed in a standards-compliant production system, so should not be run
-on a production system.
+in a production environment.
 
 ## Polling
 Polling periodically queries the DSS regarding the objects of interest and notes
@@ -39,10 +39,4 @@ Visit /tracer/logs to see a list of log entries recorded by tracer while the
 current session has been running.
 
 ## Invocation
-From the repository root:
-
-```shell script
-./monitoring/mock_uss/run_locally_tracer.sh
-```
-
-See that script for parameters that can be adjusted for a deployed system.
+An instance of tracer-enabled mock_uss is brought up as part of the [local deployment](../README.md#local-deployment).  It can also be deployed [with Google Cloud Platform](../deployment/gcp) when configured appropriately.

--- a/monitoring/mock_uss/tracer/log_types.py
+++ b/monitoring/mock_uss/tracer/log_types.py
@@ -1,0 +1,260 @@
+from abc import abstractmethod
+import sys
+from typing import Optional, Type
+
+from implicitdict import ImplicitDict, StringBasedDateTime
+from monitoring.monitorlib.fetch import rid as rid_fetch, RequestDescription, summarize
+from monitoring.monitorlib.fetch import scd as scd_fetch
+from monitoring.monitorlib.fetch.rid import FetchedISAs
+from monitoring.monitorlib.mutate import rid as rid_mutate
+from monitoring.monitorlib.mutate import scd as scd_mutate
+
+
+class TracerLogEntry(ImplicitDict):
+    """A log entry for a tracer event.
+
+    All subclasses must be defined in this module.
+    """
+
+    object_type: str
+    """The type of log entry that this is (automatically populated according to concrete log entry class name."""
+
+    def __init__(self, *args, **kwargs):
+        kwargs = kwargs.copy()
+        kwargs["object_type"] = type(self).__name__
+        super(TracerLogEntry, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def prefix_code() -> str:
+        raise NotImplementedError()
+
+    def human_info(self) -> dict:
+        """Reorganize the information in this log entry into human-consumable form.
+
+        This form will be displayed to tracer viewers when viewing the log in a browser.
+        """
+        return self
+
+    @staticmethod
+    def entry_type(type_name: Optional[str]) -> Optional[Type]:
+        matches = [
+            cls
+            for name, cls in sys.modules[__name__].__dict__.items()
+            if name == type_name
+            and isinstance(cls, type)
+            and issubclass(cls, TracerLogEntry)
+        ]
+        if not matches:
+            return None
+        if len(matches) > 1:
+            raise ValueError(
+                f"Multiple TracerLogEntry classes named `{type_name}` found"
+            )
+        return matches[0]
+
+
+class PollStart(TracerLogEntry):
+    """Log entry for when polling starts."""
+
+    @staticmethod
+    def prefix_code() -> str:
+        return "poll_start"
+
+    config: dict
+    """Configuration used for polling."""
+
+
+class RIDSubscribe(TracerLogEntry):
+    """Log entry for establishing an RID subscription."""
+
+    @staticmethod
+    def prefix_code() -> str:
+        return "rid_subscribe"
+
+    changed_subscription: rid_mutate.ChangedSubscription
+    """Subscription, as created in the DSS."""
+
+
+class RIDISANotification(TracerLogEntry):
+    """Log entry for an incoming RID ISA notification from another USS."""
+
+    @staticmethod
+    def prefix_code() -> str:
+        return "notify_isa"
+
+    observation_area_id: str
+    """ID of observation area with which this notification is associated."""
+
+    request: RequestDescription
+    """Incoming notification request from other USS."""
+
+
+class RIDUnsubscribe(TracerLogEntry):
+    """Log entry for the removal of an RID subscription."""
+
+    @staticmethod
+    def prefix_code() -> str:
+        return "rid_unsubscribe"
+
+    existing_subscription: rid_fetch.FetchedSubscription
+    """Subscription, as read from the DSS just before deletion."""
+
+    deleted_subscription: Optional[rid_mutate.ChangedSubscription]
+    """Subscription returned from DSS upon deletion."""
+
+
+class PollISAs(TracerLogEntry):
+    """Log entry for polling identification service areas from the DSS."""
+
+    @staticmethod
+    def prefix_code() -> str:
+        return "poll_isas"
+
+    poll: FetchedISAs
+    """Result of polling ISAs."""
+
+    def human_info(self) -> dict:
+        return {
+            "summary": summarize.isas(self.poll),
+            "details": self,
+        }
+
+
+class PollFlights(TracerLogEntry):
+    """Log entry for client-requested poll of all RID flights in an area."""
+
+    @staticmethod
+    def prefix_code() -> str:
+        return "clientrequest_pollflights"
+
+    observation_area_id: str
+    """ID of the observation area for which the flight polling was requested."""
+
+    poll: rid_fetch.FetchedFlights
+    """All information relating to the RID flights fetched."""
+
+    def human_info(self) -> dict:
+        return {
+            "summary": summarize.flights(self.poll),
+            "details": self,
+        }
+
+
+class SCDSubscribe(TracerLogEntry):
+    """Log entry for establishing an SCD subscription."""
+
+    @staticmethod
+    def prefix_code() -> str:
+        return "scd_subscribe"
+
+    changed_subscription: scd_mutate.MutatedSubscription
+    """Subscription, as created in the DSS."""
+
+
+class OperationalIntentNotification(TracerLogEntry):
+    """Log entry for an incoming operational intent notification from another USS."""
+
+    @staticmethod
+    def prefix_code() -> str:
+        return "notify_op"
+
+    observation_area_id: str
+    """ID of observation area with which this notification is associated."""
+
+    request: RequestDescription
+    """Incoming notification request from other USS."""
+
+
+class ConstraintNotification(TracerLogEntry):
+    """Log entry for an incoming constraint notification from another USS."""
+
+    @staticmethod
+    def prefix_code() -> str:
+        return "notify_constraint"
+
+    observation_area_id: str
+    """ID of observation area with which this notification is associated."""
+
+    request: RequestDescription
+    """Incoming notification request from other USS."""
+
+
+class SCDUnsubscribe(TracerLogEntry):
+    """Log entry for the removal of an SCD subscription."""
+
+    @staticmethod
+    def prefix_code() -> str:
+        return "scd_unsubscribe"
+
+    existing_subscription: scd_fetch.FetchedSubscription
+    """Subscription, as read from the DSS just before deletion."""
+
+    deleted_subscription: Optional[scd_mutate.MutatedSubscription]
+    """Subscription returned from DSS upon deletion."""
+
+
+class PollOperationalIntents(TracerLogEntry):
+    """Log entry for polling operational intents from DSS and managing USSs."""
+
+    @staticmethod
+    def prefix_code() -> str:
+        return "poll_ops"
+
+    poll: scd_fetch.FetchedEntities
+    """Results from polling operational intents from DSS and managing USSs."""
+
+    def human_info(self) -> dict:
+        return {
+            "summary": summarize.entities(self.poll),
+            "details": self,
+        }
+
+
+class PollConstraints(TracerLogEntry):
+    """Log entry for polling constraints from DSS and managing USSs."""
+
+    @staticmethod
+    def prefix_code() -> str:
+        return "poll_constraints"
+
+    poll: scd_fetch.FetchedEntities
+    """Results from polling constraints from DSS and managing USSs."""
+
+    def human_info(self) -> dict:
+        return {
+            "summary": summarize.entities(self.poll),
+            "details": self,
+        }
+
+
+class BadRoute(TracerLogEntry):
+    """Log entry for access to an undefined (bad) endpoint."""
+
+    @staticmethod
+    def prefix_code() -> str:
+        return "uss_badroute"
+
+    request: RequestDescription
+    """Incoming notification request from other USS."""
+
+
+class ObservationAreaImportError(TracerLogEntry):
+    """Log entry for an error while attempting to import an operation area from subscriptions in the DSS."""
+
+    @staticmethod
+    def prefix_code() -> str:
+        return "import_obs_areas_error"
+
+    rid_subscriptions: Optional[rid_fetch.FetchedSubscriptions]
+    """Result of attempting to fetch RID subscriptions"""
+
+
+class TracerShutdown(TracerLogEntry):
+    """Log entry for when tracer shuts down."""
+
+    @staticmethod
+    def prefix_code() -> str:
+        return "tracer_stop"
+
+    timestamp: StringBasedDateTime

--- a/monitoring/mock_uss/tracer/routes/__init__.py
+++ b/monitoring/mock_uss/tracer/routes/__init__.py
@@ -6,8 +6,9 @@ from loguru import logger
 from termcolor import colored
 
 from monitoring.mock_uss import webapp
+from monitoring.mock_uss.tracer import context
+from monitoring.mock_uss.tracer.log_types import BadRoute
 from monitoring.monitorlib import fetch, versioning
-from .. import context
 
 
 @webapp.route("/tracer/status")
@@ -26,8 +27,7 @@ from monitoring.mock_uss.tracer.routes import observation_areas
 def tracer_catch_all(u_path) -> Tuple[str, int]:
     logger.debug(f"Handling tracer_catch_all from {os.getpid()}")
     req = fetch.describe_flask_request(flask.request)
-    req["endpoint"] = "catch_all"
-    log_name = context.tracer_logger.log_new("uss_badroute", req)
+    log_name = context.tracer_logger.log_new(BadRoute(request=req))
 
     claims = req.token
     owner = claims.get("sub", "<No owner in token>")

--- a/monitoring/mock_uss/tracer/tracerlog.py
+++ b/monitoring/mock_uss/tracer/tracerlog.py
@@ -1,10 +1,10 @@
 import datetime
 import json
 import os
-from typing import Dict
 
 import yaml
 
+from monitoring.mock_uss.tracer.log_types import TracerLogEntry
 from monitoring.monitorlib import infrastructure
 
 
@@ -23,10 +23,10 @@ class Logger(object):
             body = {"t0": t0.isoformat(), "t1": t1.isoformat(), "code": code}
             f.write(yaml.dump(body, explicit_start=True))
 
-    def log_new(self, code: str, content: Dict) -> str:
+    def log_new(self, content: TracerLogEntry) -> str:
         n = len(os.listdir(self.log_path))
         basename = "{:06d}_{}_{}".format(
-            n, datetime.datetime.now().strftime("%H%M%S_%f"), code
+            n, datetime.datetime.now().strftime("%H%M%S_%f"), content.prefix_code()
         )
         logname = "{}.yaml".format(basename)
         fullname = os.path.join(self.log_path, logname)


### PR DESCRIPTION
As both a legacy cleanup and preparation for additional tracer capabilities, this PR strongly-types the log entries that tracer writes to disk.  These new types are defined in log_types.py, and behaviors and properties specific to a particular log type are collected there as well.

A few additional tracer cleanup items are completed as well.