### PR TITLE
[uss_qualifier/reports] Add aggregate participants to tested requirements

### DIFF
--- a/monitoring/uss_qualifier/configurations/configuration.py
+++ b/monitoring/uss_qualifier/configurations/configuration.py
@@ -160,10 +160,21 @@ class TestedRequirementsConfiguration(ImplicitDict):
     ]
     """Definition of requirement collections specific to production of this artifact."""
 
+    aggregate_participants: Optional[Dict[ParticipantID, List[ParticipantID]]]
+    """If specified, a list of 'aggregate participants', each of which is composed of multiple test participants.
+
+    If specified, these aggregate participants are the preferred subject for `participant_requirements`.
+    """
+
     participant_requirements: Optional[
-        Dict[ParticipantID, TestedRequirementsCollectionIdentifier]
+        Dict[ParticipantID, Optional[TestedRequirementsCollectionIdentifier]]
     ]
-    """If a requirement collection is specified for a participant, only the requirements in the specified collection will be listed on that participant's report."""
+    """If a requirement collection is specified for a participant, only the requirements in the specified collection will be listed on that participant's report.
+
+    If a requirement collection is specified as None/null for a participant, all potentially-testable requirements will be included.
+
+    If a participant is not listed, no report will be generated for them.
+    """
 
 
 class SequenceViewConfiguration(ImplicitDict):

--- a/monitoring/uss_qualifier/configurations/dev/dss_probing.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/dss_probing.yaml
@@ -51,7 +51,7 @@ v1:
                   - astm.f3411.v19.dss_provider
                   - astm.f3548.v21.dss_provider
         participant_requirements:
-          uss1: all_astm_dss_requirements
+          uss1: null
           uss2: all_astm_dss_requirements
   validation:
     criteria:

--- a/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml
@@ -130,10 +130,10 @@ v1:
             auth_adapter: utm_auth
           specification:
             instances:
-              - participant_id: uss1
+              - participant_id: uss1_core
                 interuss:
                   base_url: http://scdsc.uss1.localutm/versioning
-              - participant_id: uss2
+              - participant_id: uss2_core
                 interuss:
                   base_url: http://scdsc.uss2.localutm/versioning
 
@@ -144,10 +144,10 @@ v1:
             auth_adapter: utm_auth
           specification:
             instances:
-              - participant_id: uss1
+              - participant_id: uss1_core
                 interuss:
                   base_url: http://scdsc.uss1.localutm/versioning
-              - participant_id: uss2
+              - participant_id: uss2_core
                 interuss:
                   base_url: http://scdsc.uss2.localutm/versioning
 
@@ -159,10 +159,10 @@ v1:
           specification:
             flight_planners:
               # uss1 is the mock_uss directly exposing flight planning functionality
-              - participant_id: uss1
+              - participant_id: uss1_core
                 v1_base_url: http://scdsc.uss1.localutm/flight_planning/v1
               # uss2 is another mock_uss directly exposing flight planning functionality
-              - participant_id: uss2
+              - participant_id: uss2_core
                 v1_base_url: http://scdsc.uss2.localutm/flight_planning/v1
 
         # Details of conflicting flights (used in nominal planning scenario)
@@ -214,7 +214,7 @@ v1:
             auth_adapter: utm_auth
           specification:
             # A USS that hosts a DSS instance is also a participant in the test, even if they don't fulfill any other roles
-            participant_id: uss1
+            participant_id: uss1_dss
             base_url: http://dss.uss1.localutm
 
         dss_instances:
@@ -223,13 +223,13 @@ v1:
                 auth_adapter: utm_auth
             specification:
               dss_instances:
-                - participant_id: uss1
+                - participant_id: uss1_dss
                   user_participant_ids:
                     # Participants using a DSS instance they do not provide should be listed as users of that DSS (so that they can take credit for USS requirements enforced by the DSS)
                     - mock_uss  # mock_uss uses this DSS instance; it does not provide its own instance
                   base_url: http://dss.uss1.localutm
                   has_private_address: true
-                - participant_id: uss2
+                - participant_id: uss2_dss
                   base_url: http://dss.uss2.localutm
                   has_private_address: true
 
@@ -273,6 +273,13 @@ v1:
     # Write out a human-readable reports of the F3548-21 requirements tested
     tested_requirements:
       - report_name: gate1
+        aggregate_participants:
+          uss1:
+            - uss1_core
+            - uss1_dss
+          uss2:
+            - uss2_core
+            - uss2_dss
         requirement_collections:
           scd_no_dss:
             requirements:
@@ -298,6 +305,13 @@ v1:
           uss1: scd_no_dss
           uss2: scd_no_dss
       - report_name: gate3
+        aggregate_participants:
+          uss1:
+            - uss1_core
+            - uss1_dss
+          uss2:
+            - uss2_core
+            - uss2_dss
         requirement_collections:
           scd_and_dss:
             requirements:

--- a/monitoring/uss_qualifier/reports/tested_requirements/breakdown.py
+++ b/monitoring/uss_qualifier/reports/tested_requirements/breakdown.py
@@ -1,4 +1,4 @@
-from typing import Union, Set, Optional
+from typing import Union, Set, Optional, Iterable
 
 from implicitdict import ImplicitDict
 
@@ -44,20 +44,20 @@ from monitoring.uss_qualifier.suites.definitions import (
 def make_breakdown(
     report: TestRunReport,
     participant_reqs: Optional[Set[RequirementID]],
-    participant_id: ParticipantID,
+    participant_ids: Iterable[ParticipantID],
 ) -> TestedBreakdown:
-    """Break down a report into requirements tested for the specified participant.
+    """Break down a report into requirements tested for the specified participants.
 
     Args:
         report: Report to break down.
-        participant_reqs: Set of requirements to report for this participant.  If None, defaults to everything.
-        participant_id: ID of participant for which the breakdown is being computed.
+        participant_reqs: Set of requirements to report for these participants.  If None, defaults to everything.
+        participant_ids: IDs of participants for which the breakdown is being computed.
 
-    Returns: TestedBreakdown for participant for report.
+    Returns: TestedBreakdown for participants for report.
     """
     participant_breakdown = TestedBreakdown(packages=[])
     _populate_breakdown_with_action_report(
-        participant_breakdown, report.report, participant_id, participant_reqs
+        participant_breakdown, report.report, participant_ids, participant_reqs
     )
     _populate_breakdown_with_action_declaration(
         participant_breakdown, report.configuration.v1.test_run.action, participant_reqs
@@ -95,23 +95,23 @@ def _populate_breakdown_with_req_set(
 def _populate_breakdown_with_action_report(
     breakdown: TestedBreakdown,
     action: TestSuiteActionReport,
-    participant_id: ParticipantID,
+    participant_ids: Iterable[ParticipantID],
     req_set: Optional[Set[RequirementID]],
 ) -> None:
     test_suite, test_scenario, action_generator = action.get_applicable_report()
     if test_scenario:
         return _populate_breakdown_with_scenario_report(
-            breakdown, action.test_scenario, participant_id, req_set
+            breakdown, action.test_scenario, participant_ids, req_set
         )
     elif test_suite:
         for subaction in action.test_suite.actions:
             _populate_breakdown_with_action_report(
-                breakdown, subaction, participant_id, req_set
+                breakdown, subaction, participant_ids, req_set
             )
     elif action_generator:
         for subaction in action.action_generator.actions:
             _populate_breakdown_with_action_report(
-                breakdown, subaction, participant_id, req_set
+                breakdown, subaction, participant_ids, req_set
             )
     else:
         pass  # Skipped action
@@ -120,14 +120,14 @@ def _populate_breakdown_with_action_report(
 def _populate_breakdown_with_scenario_report(
     breakdown: TestedBreakdown,
     scenario_report: TestScenarioReport,
-    participant_id: ParticipantID,
+    participant_ids: Iterable[ParticipantID],
     req_set: Optional[Set[RequirementID]],
 ) -> None:
     scenario_type_name = scenario_report.scenario_type
     for case in scenario_report.cases:
         for step in case.steps:
             for check in step.passed_checks + step.failed_checks:
-                if participant_id not in check.participants:
+                if not any(pid in check.participants for pid in participant_ids):
                     continue
                 for req_id in check.requirements:
                     if req_set is not None and req_id not in req_set:

--- a/schemas/monitoring/uss_qualifier/configurations/configuration/TestedRequirementsConfiguration.json
+++ b/schemas/monitoring/uss_qualifier/configurations/configuration/TestedRequirementsConfiguration.json
@@ -7,9 +7,31 @@
       "description": "Path to content that replaces the $ref",
       "type": "string"
     },
+    "aggregate_participants": {
+      "additionalProperties": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "description": "If specified, a list of 'aggregate participants', each of which is composed of multiple test participants.\n\nIf specified, these aggregate participants are the preferred subject for `participant_requirements`.",
+      "properties": {
+        "$ref": {
+          "description": "Path to content that replaces the $ref",
+          "type": "string"
+        }
+      },
+      "type": [
+        "object",
+        "null"
+      ]
+    },
     "participant_requirements": {
       "additionalProperties": {
-        "type": "string"
+        "type": [
+          "string",
+          "null"
+        ]
       },
       "properties": {
         "$ref": {


### PR DESCRIPTION
Currently, the tested requirements artifact is generated for each named participant.  When attempting to verify compliance with this artifact, that currently means that only one participant ID can be used for a participant, even if they have logically-separate components of their system.  Specifically, to be verified for both core USS requirements and DSS requirements, the same participant ID must be used for both the core and DSS portions of a USS's system.  This makes the sequence view artifact less readable because the core and DSS portions of the system are often distinctly different subsystems, so it would be nice to attribute problems to one subsystem or another.

This PR addresses this challenge by implementing optional "aggregate participants" for the tested requirements artifact.  An aggregate participant is just a virtual participant encompassing multiple participant IDs.  So, for instance, uss1_core and uss1_dss can be separate participant IDs (leading to a clearer sequence view artifact), but then can be combined into a single uss1 aggregate participant for the tested requirements artifact.  This is demonstrated in f3548_self_contained.

If a test designer doesn't want to use aggregate participants, this additional feature is fully backwards-compatible with the current codebase.  The only difference is that now, tested requirements artifacts are only generated for specifically-identified participants (rather than all participants).  This is a separate change from the aggregate participant addition, but is necessary from a UX perspective to make sure the artifacts are not misleading (it would be confusing to have uss1, uss1_core, and uss1_dss have artifacts if the designer was only interested in the aggregated uss1 artifact).

As an added benefit, system version detection is now performed more robustly, indicating a conflict with conflicting versions rather than just selecting the first one.