### PR TITLE
[uss_qualifier] DSS0100,2 - Enable check of makeDSSReport and upgrade dss to v0.13.0

### DIFF
--- a/build/dev/docker-compose.yaml
+++ b/build/dev/docker-compose.yaml
@@ -20,7 +20,7 @@ services:
       - dss_internal_network
 
   rid_bootstrapper:
-    image: interuss/dss:v0.12.0
+    image: interuss/dss:v0.13.0
     volumes:
       - dss_component_coordination:/var/dss_component_coordination
       - $PWD/startup:/startup:ro
@@ -31,7 +31,7 @@ services:
       - dss_internal_network
 
   scd_bootstrapper:
-    image: interuss/dss:v0.12.0
+    image: interuss/dss:v0.13.0
     volumes:
       - dss_component_coordination:/var/dss_component_coordination
       - $PWD/startup:/startup:ro
@@ -43,7 +43,7 @@ services:
 
   dss:
     hostname: dss.uss1.localutm
-    image: interuss/dss:v0.12.0
+    image: interuss/dss:v0.13.0
     volumes:
       - $PWD/../test-certs:/var/test-certs:ro
       - dss_component_coordination:/var/dss_component_coordination

--- a/monitoring/uss_qualifier/resources/astm/f3548/v21/dss.py
+++ b/monitoring/uss_qualifier/resources/astm/f3548/v21/dss.py
@@ -422,24 +422,14 @@ class DSSInstance(object):
             json=req,
         )
 
-        # TODO: this is a temporary hack: the endpoint is currently not implemented in the DSS, as such we expect the
-        #  DSS to respond with a 400 and a specific error message. This must be updated once this endpoint is actually
-        #  implemented in the DSS.
-        # if query.status_code != 201:
-        #     raise QueryError(
-        #         f"Received code {query.status_code} when attempting to make DSS report{f'; error message: `{query.error_message}`' if query.error_message is not None else ''}",
-        #         query,
-        #     )
-        # else:
-        #     result = query.parse_json_result(ErrorReport)
-        #     return result.report_id, query
-        if query.status_code != 400 or "Not yet implemented" not in query.error_message:
+        if query.status_code != 201:
             raise QueryError(
                 f"Received code {query.status_code} when attempting to make DSS report{f'; error message: `{query.error_message}`' if query.error_message is not None else ''}",
                 query,
             )
         else:
-            return "dummy_report_id", query
+            result = query.parse_json_result(ErrorReport)
+            return result.report_id, query
 
     def query_subscriptions(
         self,

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/report.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/report.py
@@ -47,12 +47,13 @@ class Report(TestScenario):
                 op.path.format(entityid="dummy_op_intent_id"),
                 QueryType.F3548v21DSSGetOperationalIntentReference,
                 "dummy_dss",
-                True
+                True,
             )
             if not query.response.code:
-              return scd_lib.make_exchange_record(
-                  query, "this is a dummy record created by the USS qualifier. This failure is expected."
-              )
+                return scd_lib.make_exchange_record(
+                    query,
+                    "this is a dummy record created by the USS qualifier. This failure is expected.",
+                )
 
             # we are not supposed to reach this state
             raise RuntimeError(

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/report.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/report.py
@@ -40,23 +40,23 @@ class Report(TestScenario):
 
     def _dss_report_case(self):
         def gen_record() -> ExchangeRecord:
-            try:
-                op = OPERATIONS[OperationID.GetOperationalIntentReference]
-                query_and_describe(
-                    infrastructure.UTMClientSession("https://dummy.interuss.org"),
-                    op.verb,
-                    op.path.format(entityid="dummy_op_intent_id"),
-                    QueryType.F3548v21DSSGetOperationalIntentReference,
-                    "dummy_dss",
-                )
-            except QueryError as qe:
-                return scd_lib.make_exchange_record(
-                    qe.cause, "this is a dummy record created by the USS qualifier"
-                )
+            op = OPERATIONS[OperationID.GetOperationalIntentReference]
+            query = query_and_describe(
+                infrastructure.UTMClientSession("https://dummy.interuss.org"),
+                op.verb,
+                op.path.format(entityid="dummy_op_intent_id"),
+                QueryType.F3548v21DSSGetOperationalIntentReference,
+                "dummy_dss",
+                True
+            )
+            if not query.response.code:
+              return scd_lib.make_exchange_record(
+                  query, "this is a dummy record created by the USS qualifier. This failure is expected."
+              )
 
             # we are not supposed to reach this state
-            raise ScenarioCannotContinueError(
-                "illegal state: getOperationalIntentReference to a dummy DSS did not raise a QueryError"
+            raise RuntimeError(
+                "illegal state: getOperationalIntentReference to a dummy DSS shall not have succeeded"
             )
 
         self.begin_test_step("Make valid DSS report")

--- a/monitoring/uss_qualifier/suites/astm/utm/dss_probing.yaml
+++ b/monitoring/uss_qualifier/suites/astm/utm/dss_probing.yaml
@@ -77,6 +77,7 @@ actions:
       scenario_type: scenarios.astm.utm.dss.CRDBAccess
       resources:
         crdb_cluster: dss_crdb_cluster
+    on_failure: Continue
   - test_scenario:
       scenario_type: scenarios.astm.utm.dss.Report
       resources:


### PR DESCRIPTION
This PR enables the check verifying DSS0100,2 and switch the DSS to v0.13.0 since it serves the valid new endpoint.
Note that the first commit demonstrate the failing test on v0.12.0 and the second commit upgrades the DSS version, which successfully pass the test.