### PR TITLE
[uss_qualifier/configurations] Remove availability arbitration reqs from gate 3 req set

### DIFF
--- a/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml
@@ -345,9 +345,6 @@ v1:
               - astm.f3548.v21.DSS0210,2d
               - astm.f3548.v21.DSS0210,2e
               - astm.f3548.v21.DSS0210,2f
-              - astm.f3548.v21.DSS0210,3a
-              - astm.f3548.v21.DSS0210,3b
-              - astm.f3548.v21.DSS0210,3c
               - astm.f3548.v21.DSS0210,A2-7-2,1a
               - astm.f3548.v21.DSS0210,A2-7-2,1b
               - astm.f3548.v21.DSS0210,A2-7-2,1c


### PR DESCRIPTION
The f3548_self_contained CI configuration attempts to capture a representative test and requirements for basic SCD deployment, and that basic deployment doesn't include availability arbitration.  As such, the DSS tests for availability arbitration functionality are not within the scope of this configuration, so this PR removes them from the "Gate 3" tested requirements artifact.