### PR TITLE
[uss_qualifier] Remove exception note

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/utm/test_steps.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/test_steps.py
@@ -90,14 +90,6 @@ class OpIntentValidator(object):
                 )
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        if exc_type is not None:
-            self._scenario.record_note(
-                self._flight_planner.participant_id,
-                f"Exception occurred during OpIntentValidator ({exc_type}: {exc_val}).",
-            )
-            raise exc_val
-
     def _find_after_oi(self, oi_id: str) -> Optional[OperationalIntentReference]:
         found = [oi_ref for oi_ref in self._after_oi_refs if oi_ref.id == oi_id]
         return found[0] if len(found) != 0 else None

--- a/monitoring/uss_qualifier/scenarios/astm/utm/test_steps.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/test_steps.py
@@ -90,6 +90,9 @@ class OpIntentValidator(object):
                 )
         return self
 
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
     def _find_after_oi(self, oi_id: str) -> Optional[OperationalIntentReference]:
         found = [oi_ref for oi_ref in self._after_oi_refs if oi_ref.id == oi_id]
         return found[0] if len(found) != 0 else None


### PR DESCRIPTION
Currently, OpIntentValidator will produce a note when exiting its context with an exception, but a common "exception" that is actually unexceptional is a QueryError.  Adding a note about this unexceptional exception is confusing in the report (see, e.g., event 57 in #609) because nothing exceptional has occurred, nor is any part of the testing apparatus broken.  In addition, reraising the exception in `__exit__` [should not be needed](https://docs.python.org/3.11/reference/datamodel.html#object.__exit__).  If a true exception occurs within OpIntentValidator's context, it should simply be propagated out of the context as will happen in the absence of `__exit__`.  Furthermore, OpIntentValidator itself should not log or note this exception because it may (likely is, in the case of QueryError) be handled outside the context.