### PR TITLE
[uss_qualifier] Remove output_path from configuration

### DIFF
--- a/github_pages/static/index.md
+++ b/github_pages/static/index.md
@@ -21,8 +21,8 @@ These reports were generated during continuous integration for the most recent P
 
 ### [ASTM F3548-21 test configuration](https://github.com/interuss/monitoring/blob/main/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml)
 
-* [Sequence view](./artifacts/uss_qualifier/reports/f3548/sequence)
-* [Tested requirements](./artifacts/uss_qualifier/reports/f3548/gate3)
+* [Sequence view](./artifacts/uss_qualifier/reports/f3548_self_contained/sequence)
+* [Tested requirements](./artifacts/uss_qualifier/reports/f3548_self_contained/gate3)
 
 ### [ASTM F3411-22a test configuration](https://github.com/interuss/monitoring/blob/main/monitoring/uss_qualifier/configurations/dev/netrid_v22a.yaml)
 

--- a/monitoring/uss_qualifier/configurations/configuration.py
+++ b/monitoring/uss_qualifier/configurations/configuration.py
@@ -214,9 +214,6 @@ class RawReportConfiguration(ImplicitDict):
 
 
 class ArtifactsConfiguration(ImplicitDict):
-    output_path: str
-    """Path to folder where artifacts should be written.  Note that this value may be overridden at runtime without affecting the test baseline."""
-
     raw_report: Optional[RawReportConfiguration] = None
     """Configuration for raw report generation"""
 

--- a/monitoring/uss_qualifier/make_artifacts.sh
+++ b/monitoring/uss_qualifier/make_artifacts.sh
@@ -3,10 +3,11 @@
 set -eo pipefail
 
 if [[ $# -lt 2 ]]; then
-  echo "Usage: $0 <CONFIG_NAME(s)> <REPORT_NAME(s)>"
+  echo "Usage: $0 <CONFIG_NAME(s)> <REPORT_NAME(s)> [<OUTPUT_PATH>]"
   echo "Generates artifacts according to the specified configuration(s) using the specified report(s)"
   echo "<CONFIG_NAME>: Location of the configuration file (or multiple locations separated by commas)."
-  echo "<REPORT_NAME>: Location of the report file (or multiple locations separated by commas)."
+  echo "<REPORT_NAME>: Location of the report file (or multiple locations separated by commas).  Relative paths are relative to this folder.  Use file:// prefix to explicitly specify file-based location."
+  echo "<OUTPUT_PATH>: Location to which artifacts should be written (defaults to output/<SIMPLE_CONFIG_NAME>)"
   exit 1
 fi
 
@@ -29,8 +30,15 @@ CONFIG_NAME="${1}"
 
 REPORT_NAME="${2}"
 
-echo "Generating artifacts from configuration(s): ${CONFIG_NAME}"
 echo "Reading report(s) from: ${REPORT_NAME}"
+echo "Generating artifacts from configuration(s): ${CONFIG_NAME}"
+
+MAKE_ARTIFACTS_OPTIONS="--config $CONFIG_NAME --report $REPORT_NAME"
+
+if [ "$#" -gt 2 ]; then
+  OUTPUT_PATH="${3}"
+  MAKE_ARTIFACTS_OPTIONS="$MAKE_ARTIFACTS_OPTIONS --output-path $OUTPUT_PATH"
+fi
 
 OUTPUT_DIR="monitoring/uss_qualifier/output"
 mkdir -p "$OUTPUT_DIR"
@@ -48,4 +56,4 @@ docker run --name uss_qualifier \
   -v "$(pwd)/$CACHE_DIR:/app/$CACHE_DIR" \
   -w /app/monitoring/uss_qualifier \
   interuss/monitoring \
-  python make_artifacts.py --config "$CONFIG_NAME" --report "$REPORT_NAME"
+  python make_artifacts.py $MAKE_ARTIFACTS_OPTIONS

--- a/monitoring/uss_qualifier/reports/artifacts.py
+++ b/monitoring/uss_qualifier/reports/artifacts.py
@@ -17,12 +17,22 @@ from monitoring.uss_qualifier.reports.tested_requirements.generate import (
 )
 
 
+def default_output_path(config_name: str) -> str:
+    if config_name.lower().endswith(".yaml") or config_name.lower().endswith(".json"):
+        simple_config_name = os.path.splitext(config_name)[0]
+    else:
+        simple_config_name = config_name
+    simple_config_name = simple_config_name.split(".")[-1]
+    simple_config_name = os.path.split(simple_config_name)[-1]
+    return os.path.join("output", simple_config_name)
+
+
 def generate_artifacts(
     report: TestRunReport,
     artifacts: ArtifactsConfiguration,
-    output_path_override: Optional[str] = None,
+    output_path: str,
 ):
-    output_path = output_path_override or artifacts.output_path
+    logger.debug(f"Writing artifacts to {os.path.abspath(output_path)}")
     os.makedirs(output_path, exist_ok=True)
 
     def _should_redact(cfg) -> bool:

--- a/schemas/monitoring/uss_qualifier/configurations/configuration/ArtifactsConfiguration.json
+++ b/schemas/monitoring/uss_qualifier/configurations/configuration/ArtifactsConfiguration.json
@@ -7,10 +7,6 @@
       "description": "Path to content that replaces the $ref",
       "type": "string"
     },
-    "output_path": {
-      "description": "Path to folder where artifacts should be written.  Note that this value may be overridden at runtime without affecting the test baseline.",
-      "type": "string"
-    },
     "raw_report": {
       "description": "Configuration for raw report generation",
       "oneOf": [
@@ -65,8 +61,5 @@
       ]
     }
   },
-  "required": [
-    "output_path"
-  ],
   "type": "object"
 }


### PR DESCRIPTION
Currently, we have surprising behavior in that the output path for artifacts is included in the test configuration, but it can be overridden without affecting the test baseline.  This is justified because the local output path is a purely local configuration that doesn't at all affect the substance of the test.  However, because it doesn't affect the substance of the test, it shouldn't be in the configuration for the test (rather, it is an execution modifier).  So, this PR removes output_path from the test configuration and instead accepts it solely as a command line argument (pre-existing capability).  It also adds a default output path that is suitable in many circumstances (including all CI execution).

Existing configurations will still work as additional arguments are ignored (output_path would become an additional requirement), but its behavior may change (writing artifacts to a different location) if output_path in the configuration were previously used to determine the artifact location.  Additional logging messages are added to hopefully make this behavior change apparent at runtime if it was missed at test design time.