### PR TITLE
[mock_uss/tracer] Finish tracer KML generation for op intents

### DIFF
--- a/monitoring/mock_uss/tracer/log_types.py
+++ b/monitoring/mock_uss/tracer/log_types.py
@@ -21,6 +21,9 @@ class TracerLogEntry(ImplicitDict):
     object_type: str
     """The type of log entry that this is (automatically populated according to concrete log entry class name."""
 
+    recorded_at: StringBasedDateTime
+    """The time at which this log entry was created."""
+
     def __init__(self, *args, **kwargs):
         kwargs = kwargs.copy()
         kwargs["object_type"] = type(self).__name__
@@ -276,5 +279,3 @@ class TracerShutdown(TracerLogEntry):
     @staticmethod
     def prefix_code() -> str:
         return "tracer_stop"
-
-    timestamp: StringBasedDateTime

--- a/monitoring/mock_uss/tracer/routes/__init__.py
+++ b/monitoring/mock_uss/tracer/routes/__init__.py
@@ -1,10 +1,12 @@
 import os
 from typing import Tuple
 
+import arrow
 import flask
 from loguru import logger
 from termcolor import colored
 
+from implicitdict import StringBasedDateTime
 from monitoring.mock_uss import webapp
 from monitoring.mock_uss.tracer import context
 from monitoring.mock_uss.tracer.log_types import BadRoute
@@ -27,7 +29,9 @@ from monitoring.mock_uss.tracer.routes import observation_areas
 def tracer_catch_all(u_path) -> Tuple[str, int]:
     logger.debug(f"Handling tracer_catch_all from {os.getpid()}")
     req = fetch.describe_flask_request(flask.request)
-    log_name = context.tracer_logger.log_new(BadRoute(request=req))
+    log_name = context.tracer_logger.log_new(
+        BadRoute(request=req, recorded_at=StringBasedDateTime(arrow.utcnow()))
+    )
 
     claims = req.token
     owner = claims.get("sub", "<No owner in token>")

--- a/monitoring/mock_uss/tracer/routes/observation_areas.py
+++ b/monitoring/mock_uss/tracer/routes/observation_areas.py
@@ -3,6 +3,7 @@ import uuid
 from datetime import datetime
 from typing import Tuple, List, Union
 
+import arrow
 import flask
 import s2sphere
 from loguru import logger
@@ -149,7 +150,10 @@ def tracer_import_observation_areas() -> Union[Tuple[str, int], flask.Response]:
         )
         if not rid_subscriptions.success:
             context.tracer_logger.log_new(
-                ObservationAreaImportError(rid_subscriptions=rid_subscriptions)
+                ObservationAreaImportError(
+                    rid_subscriptions=rid_subscriptions,
+                    recorded_at=StringBasedDateTime(arrow.utcnow()),
+                )
             )
             return (
                 f"Could not retrieve F3411 subscriptions (code {rid_subscriptions.status_code})",
@@ -227,5 +231,5 @@ def _shutdown():
     logger.info("Observation areas cleanup complete.")
 
     context.tracer_logger.log_new(
-        TracerShutdown(timestamp=StringBasedDateTime(datetime.utcnow()))
+        TracerShutdown(recorded_at=StringBasedDateTime(arrow.utcnow()))
     )

--- a/monitoring/mock_uss/tracer/routes/rid.py
+++ b/monitoring/mock_uss/tracer/routes/rid.py
@@ -1,11 +1,12 @@
 import os
 from typing import Tuple
 
+import arrow
 import flask
 from loguru import logger
 from termcolor import colored
 
-from implicitdict import ImplicitDict
+from implicitdict import ImplicitDict, StringBasedDateTime
 from monitoring.mock_uss import webapp
 from monitoring.mock_uss.tracer import context
 from monitoring.mock_uss.tracer.log_types import RIDISANotification
@@ -51,7 +52,11 @@ def tracer_rid_isa_notification(
     logger.debug(f"Handling tracer_rid_isa_notification from {os.getpid()}")
     req = fetch.describe_flask_request(flask.request)
     log_name = context.tracer_logger.log_new(
-        RIDISANotification(observation_area_id=observation_area_id, request=req)
+        RIDISANotification(
+            observation_area_id=observation_area_id,
+            request=req,
+            recorded_at=StringBasedDateTime(arrow.utcnow()),
+        )
     )
 
     claims = req.token

--- a/monitoring/mock_uss/tracer/routes/scd.py
+++ b/monitoring/mock_uss/tracer/routes/scd.py
@@ -1,10 +1,12 @@
 import os
 from typing import Tuple
 
+import arrow
 import flask
 from loguru import logger
 from termcolor import colored
 
+from implicitdict import StringBasedDateTime
 from monitoring.mock_uss import webapp
 from monitoring.mock_uss.tracer import context
 from monitoring.mock_uss.tracer.log_types import (
@@ -27,7 +29,9 @@ def tracer_scd_v21_operation_notification(observation_area_id: str) -> Tuple[str
     req = fetch.describe_flask_request(flask.request)
     log_name = context.tracer_logger.log_new(
         OperationalIntentNotification(
-            observation_area_id=observation_area_id, request=req
+            observation_area_id=observation_area_id,
+            request=req,
+            recorded_at=StringBasedDateTime(arrow.utcnow()),
         )
     )
 
@@ -91,7 +95,11 @@ def tracer_scd_v21_constraint_notification(observation_area_id: str) -> Tuple[st
     logger.debug(f"Handling tracer_scd_v21_constraint_notification from {os.getpid()}")
     req = fetch.describe_flask_request(flask.request)
     log_name = context.tracer_logger.log_new(
-        ConstraintNotification(observation_area_id=observation_area_id, request=req)
+        ConstraintNotification(
+            observation_area_id=observation_area_id,
+            request=req,
+            recorded_at=StringBasedDateTime(arrow.utcnow()),
+        )
     )
 
     claims = infrastructure.get_token_claims({k: v for k, v in flask.request.headers})

--- a/monitoring/mock_uss/tracer/routes/ui.py
+++ b/monitoring/mock_uss/tracer/routes/ui.py
@@ -171,9 +171,8 @@ def tracer_kmls(kml):
 @ui_auth.login_required
 def tracer_kml_historical():
     kml_name = f"historical_{datetime.datetime.utcnow().isoformat().split('.')[0]}.kml"
-    day = flask.request.args.get("day", None)
     return flask.Response(
-        render_historical_kml(context.tracer_logger.log_path, day),
+        render_historical_kml(context.tracer_logger.log_path),
         mimetype="application/vnd.google-earth.kml+xml",
         headers={"Content-Disposition": f"attachment;filename={kml_name}"},
     )
@@ -242,7 +241,11 @@ def tracer_rid_request_poll(observation_area_id: str):
         enhanced_details=flask.request.form.get("enhanced_details", type=bool),
     )
     log_name = context.tracer_logger.log_new(
-        PollFlights(observation_area_id=observation_area_id, poll=flights_result)
+        PollFlights(
+            observation_area_id=observation_area_id,
+            poll=flights_result,
+            recorded_at=StringBasedDateTime(arrow.utcnow()),
+        )
     )
     return flask.redirect(flask.url_for("tracer_logs", log=log_name))
 

--- a/monitoring/mock_uss/tracer/subscriptions.py
+++ b/monitoring/mock_uss/tracer/subscriptions.py
@@ -1,5 +1,6 @@
 import uuid
 
+import arrow
 from implicitdict import StringBasedDateTime
 import yaml
 from yaml.representer import Representer
@@ -62,7 +63,12 @@ def subscribe_rid(
         rid_version=rid_version,
         utm_client=rid_client,
     )
-    logger.log_new(RIDSubscribe(changed_subscription=create_result))
+    logger.log_new(
+        RIDSubscribe(
+            changed_subscription=create_result,
+            recorded_at=StringBasedDateTime(arrow.utcnow()),
+        )
+    )
     if not create_result.success:
         raise SubscriptionManagementError("Could not create RID Subscription")
     return subscription_id
@@ -93,7 +99,12 @@ def subscribe_scd(
         area.volume.altitude_lower_wgs84_m(0),
         area.volume.altitude_upper_wgs84_m(3048),
     )
-    logfile = logger.log_new(SCDSubscribe(changed_subscription=create_result))
+    logfile = logger.log_new(
+        SCDSubscribe(
+            changed_subscription=create_result,
+            recorded_at=StringBasedDateTime(arrow.utcnow()),
+        )
+    )
     if not create_result.success:
         raise SubscriptionManagementError(
             "Could not create new SCD Subscription -> {}".format(logfile)
@@ -107,7 +118,12 @@ def unsubscribe_rid(
     logger = context.tracer_logger
     existing_result = fetch.rid.subscription(subscription_id, rid_version, rid_client)
     if existing_result.status_code != 404 and not existing_result.success:
-        logfile = logger.log_new(RIDUnsubscribe(existing_subscription=existing_result))
+        logfile = logger.log_new(
+            RIDUnsubscribe(
+                existing_subscription=existing_result,
+                recorded_at=StringBasedDateTime(arrow.utcnow()),
+            )
+        )
         raise SubscriptionManagementError(
             "Could not query existing RID Subscription -> {}".format(logfile)
         )
@@ -121,7 +137,9 @@ def unsubscribe_rid(
         )
         logfile = logger.log_new(
             RIDUnsubscribe(
-                existing_subscription=existing_result, deleted_subscription=del_result
+                existing_subscription=existing_result,
+                deleted_subscription=del_result,
+                recorded_at=StringBasedDateTime(arrow.utcnow()),
             )
         )
         if not del_result.success:
@@ -134,7 +152,12 @@ def unsubscribe_scd(subscription_id: str, scd_client: UTMClientSession) -> None:
     logger = context.tracer_logger
     get_result = fetch.scd.get_subscription(scd_client, subscription_id)
     if not get_result.success:
-        logfile = logger.log_new(SCDUnsubscribe(existing_subscription=get_result))
+        logfile = logger.log_new(
+            SCDUnsubscribe(
+                existing_subscription=get_result,
+                recorded_at=StringBasedDateTime(arrow.utcnow()),
+            )
+        )
         raise SubscriptionManagementError(
             "Could not query existing SCD Subscription -> {}".format(logfile)
         )
@@ -147,7 +170,9 @@ def unsubscribe_scd(subscription_id: str, scd_client: UTMClientSession) -> None:
         )
         logfile = logger.log_new(
             SCDUnsubscribe(
-                existing_subscription=get_result, deleted_subscription=del_result
+                existing_subscription=get_result,
+                deleted_subscription=del_result,
+                recorded_at=StringBasedDateTime(arrow.utcnow()),
             )
         )
         if not del_result.success:

--- a/monitoring/mock_uss/tracer/tracer_poll.py
+++ b/monitoring/mock_uss/tracer/tracer_poll.py
@@ -3,7 +3,8 @@ import json
 import sys
 from typing import Optional, Dict
 
-from implicitdict import ImplicitDict
+import arrow
+from implicitdict import ImplicitDict, StringBasedDateTime
 
 from monitoring.mock_uss.tracer.config import (
     KEY_TRACER_OUTPUT_FOLDER,
@@ -77,7 +78,9 @@ def _log_poll_start(logger):
             KEY_TRACER_KML_FOLDER: webapp.config[KEY_TRACER_KML_FOLDER],
             "code_version": versioning.get_code_version(),
         }
-        logger.log_new(PollStart(config=config))
+        logger.log_new(
+            PollStart(config=config, recorded_at=StringBasedDateTime(arrow.utcnow()))
+        )
 
 
 @webapp.periodic_task(TASK_POLL_OBSERVATION_AREAS)
@@ -130,7 +133,7 @@ def poll_isas(area: ObservationArea, logger: tracerlog.Logger) -> None:
             tx.need_line_break = True
         need_line_break = tx.need_line_break
 
-    log_entry = PollISAs(poll=result)
+    log_entry = PollISAs(poll=result, recorded_at=StringBasedDateTime(arrow.utcnow()))
     if log_new:
         logger.log_new(log_entry)
         if need_line_break:
@@ -173,7 +176,9 @@ def poll_ops(
             tx.need_line_break = True
         need_line_break = tx.need_line_break
 
-    log_entry = PollOperationalIntents(poll=result)
+    log_entry = PollOperationalIntents(
+        poll=result, recorded_at=StringBasedDateTime(arrow.utcnow())
+    )
     if log_new:
         logger.log_new(log_entry)
         if need_line_break:
@@ -212,7 +217,9 @@ def poll_constraints(
             tx.need_line_break = True
         need_line_break = tx.need_line_break
 
-    log_entry = PollConstraints(poll=result)
+    log_entry = PollConstraints(
+        poll=result, recorded_at=StringBasedDateTime(arrow.utcnow())
+    )
     if log_new:
         logger.log_new(log_entry)
         if need_line_break:


### PR DESCRIPTION
Following #612, this PR finishes KML generation for operational intents in tracer.  Primarily, the operational intent polling log message now contributes historical volume information.  The log entry data structures were previously missing actual timestamp information -- it was partially encoded into the file names, but this information was not complete when observation and generation spanned more than one calendar day -- so this PR adds a `recorded_at` field for all log entry data structures.  Due to the fairly absurd time required to load YAML using the native Python pyyaml loader, some performance metrics are added to historical KML generation and the YAML loader is switched to the C version.