### PR TITLE
[uss_qualifier, mock_uss] Implement geospatial comprehension querying

### DIFF
--- a/github_pages/static/index.md
+++ b/github_pages/static/index.md
@@ -38,3 +38,7 @@ These reports were generated during continuous integration for the most recent P
 
 * [Sequence view](./artifacts/uss_qualifier/reports/general_flight_auth/sequence)
 * [Tested requirements](./artifacts/uss_qualifier/reports/general_flight_auth/requirements)
+
+### [Geospatial feature comprehension configuration](https://github.com/interuss/monitoring/blob/main/monitoring/uss_qualifier/configurations/dev/geospatial_comprehension.yaml)
+
+* [Sequence view](./artifacts/uss_qualifier/reports/geospatial_comprehension/sequence)

--- a/monitoring/mock_uss/geoawareness/routes.py
+++ b/monitoring/mock_uss/geoawareness/routes.py
@@ -6,8 +6,8 @@ from monitoring.mock_uss import webapp
 from monitoring.monitorlib.geoawareness_automated_testing.api import (
     SCOPE_GEOAWARENESS_TEST,
 )
-from ..auth import requires_scope
-from ...monitorlib import versioning
+from monitoring.mock_uss.auth import requires_scope
+from monitoring.monitorlib import versioning
 
 
 @webapp.route("/geoawareness/status")
@@ -19,3 +19,4 @@ def geoawareness_status():
 
 
 from . import routes_geoawareness
+from . import routes_geospatial_map

--- a/monitoring/mock_uss/geoawareness/routes_geospatial_map.py
+++ b/monitoring/mock_uss/geoawareness/routes_geospatial_map.py
@@ -1,0 +1,71 @@
+import flask
+from implicitdict import ImplicitDict
+from uas_standards.interuss.automated_testing.geospatial_map.v1.api import (
+    OperationID,
+    OPERATIONS,
+    GeospatialMapQueryRequest,
+    GeospatialMapQueryReply,
+    GeospatialMapCheckResult,
+    GeospatialMapCheckResultFeaturesSelectionOutcome,
+)
+from uas_standards.interuss.automated_testing.geospatial_map.v1.constants import Scope
+
+from monitoring.mock_uss import webapp
+from monitoring.mock_uss.auth import requires_scope
+
+
+def geospatial_map_route(op_id: OperationID):
+    op = OPERATIONS[op_id]
+    flask_url = op.path.replace("{", "<").replace("}", ">")
+    return webapp.route("/geospatial_map/v1" + flask_url, methods=[op.verb])
+
+
+@geospatial_map_route(OperationID.GetStatus)
+@requires_scope(Scope.DirectAutomatedTest)
+def geospatial_map_status():
+    raise NotImplementedError()
+
+
+@geospatial_map_route(OperationID.PutGeospatialDataSource)
+@requires_scope(Scope.DirectAutomatedTest)
+def geospatial_map_put_data_source(geospatial_data_source_id: str):
+    raise NotImplementedError()
+
+
+@geospatial_map_route(OperationID.GetGeospatialDataSourceStatus)
+@requires_scope(Scope.DirectAutomatedTest)
+def geospatial_map_get_data_source_status(geospatial_data_source_id: str):
+    raise NotImplementedError()
+
+
+@geospatial_map_route(OperationID.ListGeospatialDataSources)
+@requires_scope(Scope.DirectAutomatedTest)
+def geospatial_map_list_data_sources():
+    raise NotImplementedError()
+
+
+@geospatial_map_route(OperationID.QueryGeospatialMap)
+@requires_scope(Scope.Query)
+def geospatial_map_query():
+    try:
+        req: GeospatialMapQueryRequest = ImplicitDict.parse(
+            flask.request.json, GeospatialMapQueryRequest
+        )
+    except ValueError as e:
+        return (
+            flask.jsonify(
+                {"error": f"Could not parse GeospatialMapQueryRequest: {str(e)}"}
+            ),
+            400,
+        )
+
+    results = []
+    for _ in req.checks:
+        # TODO: Actually evaluate check (always returns Present currently)
+        results.append(
+            GeospatialMapCheckResult(
+                features_selection_outcome=GeospatialMapCheckResultFeaturesSelectionOutcome.Present
+            )
+        )
+
+    return GeospatialMapQueryReply(results=results)

--- a/monitoring/monitorlib/clients/geospatial_info/client.py
+++ b/monitoring/monitorlib/clients/geospatial_info/client.py
@@ -1,0 +1,35 @@
+from abc import ABC, abstractmethod
+from typing import List
+
+from monitoring.monitorlib.clients.geospatial_info.querying import (
+    GeospatialFeatureQueryResponse,
+    GeospatialFeatureCheck,
+)
+from monitoring.monitorlib.fetch import QueryError
+from monitoring.uss_qualifier.configurations.configuration import ParticipantID
+
+
+class GeospatialInfoError(QueryError):
+    pass
+
+
+class GeospatialInfoClient(ABC):
+    """Client to interact with a USS as a user/app asking for geospatial information and as the test director preparing for tests involving geospatial information."""
+
+    participant_id: ParticipantID
+
+    def __init__(self, participant_id: ParticipantID):
+        self.participant_id = participant_id
+
+    # ===== Emulation of user/app actions =====
+
+    @abstractmethod
+    def query_geospatial_features(
+        self, checks: List[GeospatialFeatureCheck]
+    ) -> GeospatialFeatureQueryResponse:
+        """Instruct the USS to emulate a normal user/app trying to check for the specified geospatial information.
+
+        Raises:
+            * GeospatialInfoError
+        """
+        raise NotImplementedError()

--- a/monitoring/monitorlib/clients/geospatial_info/client_geospatial_map.py
+++ b/monitoring/monitorlib/clients/geospatial_info/client_geospatial_map.py
@@ -1,0 +1,71 @@
+from typing import List
+
+from implicitdict import ImplicitDict
+from monitoring.monitorlib.clients.geospatial_info.client import (
+    GeospatialInfoClient,
+    GeospatialInfoError,
+)
+from monitoring.monitorlib.clients.geospatial_info.querying import (
+    GeospatialFeatureCheck,
+    GeospatialFeatureQueryResponse,
+    GeospatialFeatureCheckResult,
+)
+from monitoring.monitorlib.fetch import query_and_describe, QueryType
+from monitoring.monitorlib.infrastructure import UTMClientSession
+from monitoring.uss_qualifier.configurations.configuration import ParticipantID
+from uas_standards.interuss.automated_testing.geospatial_map.v1.api import (
+    OPERATIONS,
+    OperationID,
+    GeospatialMapQueryRequest,
+    GeospatialMapQueryReply,
+)
+from uas_standards.interuss.automated_testing.geospatial_map.v1.constants import Scope
+
+
+class GeospatialMapClient(GeospatialInfoClient):
+    _session: UTMClientSession
+
+    def __init__(self, session: UTMClientSession, participant_id: ParticipantID):
+        super(GeospatialMapClient, self).__init__(participant_id)
+        self._session = session
+
+    def query_geospatial_features(
+        self, checks: List[GeospatialFeatureCheck]
+    ) -> GeospatialFeatureQueryResponse:
+        req_checks = [c.to_geospatial_map() for c in checks]
+
+        op = OPERATIONS[OperationID.QueryGeospatialMap]
+        req = GeospatialMapQueryRequest(checks=req_checks)
+        query = query_and_describe(
+            client=self._session,
+            verb=op.verb,
+            url=op.path,
+            query_type=QueryType.InterUSSGeospatialMapV1QueryGeospatialMap,
+            participant_id=self.participant_id,
+            json=req,
+            scope=Scope.Query,
+        )
+        if query.status_code != 200:
+            raise GeospatialInfoError(
+                f"Attempt to query geospatial map features returned status {query.status_code} rather than 200 as expected",
+                query,
+            )
+        try:
+            api_result = ImplicitDict.parse(
+                query.response.json, GeospatialMapQueryReply
+            )
+        except ValueError as e:
+            raise GeospatialInfoError(
+                f"Response to geospatial map query could not be parsed: {str(e)}", query
+            )
+
+        # API-agnostic and API-specific response formats are currently wire-compatible
+        results = [
+            ImplicitDict.parse(r, GeospatialFeatureCheckResult)
+            for r in api_result.results
+        ]
+
+        return GeospatialFeatureQueryResponse(
+            queries=[query],
+            results=results,
+        )

--- a/monitoring/monitorlib/clients/geospatial_info/querying.py
+++ b/monitoring/monitorlib/clients/geospatial_info/querying.py
@@ -1,0 +1,102 @@
+from enum import Enum
+from typing import Optional, List
+
+from implicitdict import ImplicitDict, StringBasedDateTime
+from uas_standards.interuss.automated_testing.geospatial_map.v1 import (
+    api as geospatial_map_api,
+)
+
+from monitoring.monitorlib.fetch import Query
+from monitoring.monitorlib.geo import LatLngPoint
+from monitoring.monitorlib.geotemporal import Volume4D
+
+
+class OperationalImpact(str, Enum):
+    """The specified outcome if a user attempted to plan a flight."""
+
+    Block = "Block"
+    """The geospatial feature would cause rejection of that flight (the USS would decline to plan the flight)."""
+
+    Advise = "Advise"
+    """The geospatial feature would cause the USS to accompany a successful flight plan (if the flight was successfully planned) with an advisory or condition provided to the operator."""
+
+    BlockOrAdvise = "BlockOrAdvise"
+    """The geospatial feature would cause one of 'Block' or 'Advise' to be be true."""
+
+
+class GeospatialFeatureFilter(ImplicitDict):
+    """Filters to select only a subset of geospatial features.  Only geospatial features which are applicable to all specified criteria within this filter set should be selected."""
+
+    # TODO: Add position
+
+    volumes4d: Optional[List[Volume4D]]
+    """If specified, only select geospatial features at least partially intersecting one or more of these volumes."""
+
+    # TODO: Add after & before
+
+    restriction_source: Optional[str]
+    """If specified, only select geospatial features originating from the named source.  The acceptable values for this field will be established by the test designers and will generally be used to limit responses to only the intended datasets under test even when the USS may have more additional geospatial features from other sources that may otherwise be relevant."""
+
+    operation_rule_set: Optional[str]
+    """If specified, only select geospatial features that would be relevant when planning an operation under the specified rule set.  The acceptable values for this field will be established by the test designers and will generally correspond to sets of rules under which the system under test plans operations."""
+
+    resulting_operational_impact: Optional[OperationalImpact]
+    """If specified, only select geospatial features that would cause the specified outcome if a user attempted to plan a flight applicable to all the other criteria in this filter set."""
+
+    def to_geospatial_map(self) -> geospatial_map_api.GeospatialFeatureFilterSet:
+        result = geospatial_map_api.GeospatialFeatureFilterSet()
+        if "volumes4d" in self and self.volumes4d:
+            result.volumes4d = [v.to_geospatial_map_api() for v in self.volumes4d]
+        if "restriction_source" in self and self.restriction_source:
+            result.restriction_source = self.restriction_source
+        if "operation_rule_set" in self and self.operation_rule_set:
+            result.operation_rule_set = self.operation_rule_set
+        if "resulting_operational_impact" in self and self.resulting_operational_impact:
+            result.resulting_operational_impact = (
+                geospatial_map_api.GeospatialFeatureFilterSetResultingOperationalImpact(
+                    self.resulting_operational_impact
+                )
+            )
+        return result
+
+
+class GeospatialFeatureCheck(ImplicitDict):
+    filter_sets: Optional[List[GeospatialFeatureFilter]]
+    """Select geospatial features which match any of the specified filter sets."""
+
+    def to_geospatial_map(self) -> geospatial_map_api.GeospatialMapCheck:
+        return geospatial_map_api.GeospatialMapCheck(
+            filter_sets=[fs.to_geospatial_map() for fs in self.filter_sets]
+        )
+
+
+class SelectionOutcome(str, Enum):
+    """Indication of whether one or more applicable geospatial features were selected."""
+
+    Present = "Present"
+    """One or more applicable geospatial features were selected."""
+
+    Absent = "Absent"
+    """No applicable geospatial features were selected."""
+
+    UnsupportedFilter = "UnsupportedFilter"
+    """Applicable geospatial features could not be selected because one or more filter criteria are not supported by the USS."""
+
+    Error = "Error"
+    """An error or condition not enumerated above occurred."""
+
+
+class GeospatialFeatureCheckResult(ImplicitDict):
+    features_selection_outcome: SelectionOutcome
+    """Indication of whether one or more applicable geospatial features were selected according to the selection criteria of the corresponding check."""
+
+    message: Optional[str]
+    """A human-readable description of why the unsuccessful `features_selection_outcome` was reported.  Should only be populated when appropriate according to the value of the `features_selection_outcome` field."""
+
+
+class GeospatialFeatureQueryResponse(ImplicitDict):
+    queries: List[Query]
+    """Queries used to accomplish this activity."""
+
+    results: List[GeospatialFeatureCheckResult]
+    """Responses to each of the `checks` in the request.  The number of entries in this array should match the number of entries in the `checks` field of the request."""

--- a/monitoring/monitorlib/fetch/__init__.py
+++ b/monitoring/monitorlib/fetch/__init__.py
@@ -329,6 +329,11 @@ class QueryType(str, Enum):
         "interuss.automated_testing.flight_planning.v1.DeleteFlightPlan"
     )
 
+    # InterUSS automated testing geospatial_map interface
+    InterUSSGeospatialMapV1QueryGeospatialMap = (
+        "interuss.automated_testing.geospatial_map.v1.QueryGeospatialMap"
+    )
+
     # InterUSS RID observation interface
     InterUSSRIDObservationV1GetDisplayData = (
         "interuss.automated_testing.rid.v1.observation.getDisplayData"

--- a/monitoring/monitorlib/geo.py
+++ b/monitoring/monitorlib/geo.py
@@ -23,6 +23,9 @@ from uas_standards.interuss.automated_testing.rid.v1 import (
     injection as f3411testing_injection,
 )
 from uas_standards.interuss.automated_testing.flight_planning.v1 import api as fp_api
+from uas_standards.interuss.automated_testing.geospatial_map.v1 import (
+    api as geospatial_map_api,
+)
 
 EARTH_CIRCUMFERENCE_KM = 40075
 EARTH_CIRCUMFERENCE_M = EARTH_CIRCUMFERENCE_KM * 1000
@@ -396,6 +399,12 @@ class Volume3D(ImplicitDict):
         if self.altitude_upper:
             kwargs["altitude_upper"] = self.altitude_upper.to_flight_planning_api()
         return fp_api.Volume3D(**kwargs)
+
+    def to_geospatial_map_api(self) -> geospatial_map_api.Volume3D:
+        # geospatial_map API Volume3D is currently wire-compatible with flight_planning API
+        return ImplicitDict.parse(
+            self.to_flight_planning_api(), geospatial_map_api.Volume3D
+        )
 
     @staticmethod
     def from_f3548v21(vol: Union[f3548v21.Volume3D, dict]) -> Volume3D:

--- a/monitoring/monitorlib/geotemporal.py
+++ b/monitoring/monitorlib/geotemporal.py
@@ -10,6 +10,9 @@ import s2sphere as s2sphere
 from monitoring.monitorlib.transformations import Transformation
 from uas_standards.astm.f3548.v21 import api as f3548v21
 from uas_standards.interuss.automated_testing.flight_planning.v1 import api as fp_api
+from uas_standards.interuss.automated_testing.geospatial_map.v1 import (
+    api as geospatial_map_api,
+)
 from uas_standards.interuss.automated_testing.scd.v1 import api as interuss_scd_api
 
 from monitoring.monitorlib import geo
@@ -234,6 +237,14 @@ class Volume4D(ImplicitDict):
         if self.time_end:
             kwargs["time_end"] = fp_api.Time(value=self.time_end)
         return fp_api.Volume4D(**kwargs)
+
+    def to_geospatial_map_api(self) -> geospatial_map_api.Volume4D:
+        kwargs = {"volume": self.volume.to_geospatial_map_api()}
+        if self.time_start:
+            kwargs["time_start"] = geospatial_map_api.Time(value=self.time_start)
+        if self.time_end:
+            kwargs["time_end"] = geospatial_map_api.Time(value=self.time_end)
+        return geospatial_map_api.Volume4D(**kwargs)
 
 
 class Volume4DCollection(List[Volume4D]):

--- a/monitoring/uss_qualifier/configurations/dev/geospatial_comprehension.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/geospatial_comprehension.yaml
@@ -4,14 +4,19 @@ v1:
     resources:
       resource_declarations:
         example_feature_check_table: {$ref: 'library/resources.yaml#/example_feature_check_table'}
+
+        utm_auth: {$ref: 'library/environment.yaml#/utm_auth'}
+        geospatial_info_provider: {$ref: 'library/environment.yaml#/geospatial_info_provider'}
     action:
       test_scenario:
         scenario_type: scenarios.interuss.geospatial_map.GeospatialFeatureComprehension
         resources:
+          geospatial_info_provider: geospatial_info_provider
           table: example_feature_check_table
     execution:
       stop_fast: true
   artifacts:
     raw_report: {}
+    sequence_view: {}
   validation:
     $ref: ./library/validation.yaml#/normal_test

--- a/monitoring/uss_qualifier/configurations/dev/library/environment_containers.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/library/environment_containers.yaml
@@ -29,6 +29,7 @@ utm_auth:
       - utm.availability_arbitration
       # InterUSS versioning automated testing
       - interuss.versioning.read_system_versions
+      - interuss.geospatial_map.query
       # For authentication test purposes.
       # Remove if the authentication provider pointed to by AUTH_SPEC does not support it.
       - ""
@@ -272,3 +273,15 @@ scd_version_providers:
       - participant_id: uss2
         interuss:
           base_url: http://scdsc.uss2.localutm/versioning
+
+# ===== Geospatial map providers =====
+
+geospatial_info_provider:
+  $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
+  resource_type: resources.geospatial_info.GeospatialInfoProviderResource
+  dependencies:
+    auth_adapter: utm_auth
+  specification:
+    geospatial_info_provider:
+      participant_id: uss1
+      geospatial_map_v1_base_url: http://geoawareness.uss1.localutm/geospatial_map/v1

--- a/monitoring/uss_qualifier/configurations/dev/library/environment_localhost.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/library/environment_localhost.yaml
@@ -29,6 +29,7 @@ utm_auth:
       - utm.availability_arbitration
       # InterUSS versioning automated testing
       - interuss.versioning.read_system_versions
+      - interuss.geospatial_map.query
       # For authentication test purposes
       - ""
 
@@ -271,3 +272,15 @@ scd_version_providers:
       - participant_id: uss2
         interuss:
           base_url: http://localhost:8094/versioning
+
+# ===== Geospatial map providers =====
+
+geospatial_info_provider:
+  $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
+  resource_type: resources.geospatial_info.GeospatialInfoProviderResource
+  dependencies:
+    auth_adapter: utm_auth
+  specification:
+    geospatial_info_provider:
+      participant_id: uss1
+      geospatial_map_v1_base_url: http://localhost:8076/geospatial_map/v1

--- a/monitoring/uss_qualifier/resources/geospatial_info/__init__.py
+++ b/monitoring/uss_qualifier/resources/geospatial_info/__init__.py
@@ -1,0 +1,1 @@
+from .geospatial_info_providers import GeospatialInfoProviderResource

--- a/monitoring/uss_qualifier/resources/geospatial_info/geospatial_info_providers.py
+++ b/monitoring/uss_qualifier/resources/geospatial_info/geospatial_info_providers.py
@@ -1,0 +1,80 @@
+from typing import Optional
+from urllib.parse import urlparse
+
+from implicitdict import ImplicitDict
+from monitoring.monitorlib.clients.geospatial_info.client import GeospatialInfoClient
+from monitoring.monitorlib.clients.geospatial_info.client_geospatial_map import (
+    GeospatialMapClient,
+)
+from monitoring.monitorlib.infrastructure import AuthAdapter, UTMClientSession
+from monitoring.uss_qualifier.configurations.configuration import ParticipantID
+from monitoring.uss_qualifier.resources.communications import AuthAdapterResource
+from monitoring.uss_qualifier.resources.resource import Resource
+from uas_standards.interuss.automated_testing.geospatial_map.v1.constants import (
+    Scope as ScopeGeospatialMap,
+)
+
+
+class GeospatialInfoProviderConfiguration(ImplicitDict):
+    participant_id: str
+    """ID of the geospatial information provider for which geospatial data can be queried"""
+
+    geospatial_map_v1_base_url: Optional[str]
+    """Base URL for the geospatial information provider's implementation of the interfaces/automated_testing/geospatial_map/v1/geospatial_map.yaml API"""
+
+    timeout_seconds: Optional[float] = None
+    """Number of seconds to allow for requests to this geospatial information provider.  If None, use default."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(**kwargs)
+        if "geospatial_map_v1_base_url" in self and self.geospatial_map_v1_base_url:
+            try:
+                urlparse(self.geospatial_map_v1_base_url)
+            except ValueError:
+                raise ValueError(
+                    "GeospatialInfoProviderConfiguration.geospatial_map_v1_base_url must be a URL"
+                )
+
+    def to_client(self, auth_adapter: AuthAdapter) -> GeospatialInfoClient:
+        if "geospatial_map_v1_base_url" in self and self.geospatial_map_v1_base_url:
+            session = UTMClientSession(
+                self.geospatial_map_v1_base_url, auth_adapter, self.timeout_seconds
+            )
+            return GeospatialMapClient(session, self.participant_id)
+        raise ValueError(
+            "Could not construct GeospatialInfoClient from provided configuration"
+        )
+
+
+class GeospatialInfoProviderSpecification(ImplicitDict):
+    geospatial_info_provider: GeospatialInfoProviderConfiguration
+
+
+class GeospatialInfoProviderResource(Resource[GeospatialInfoProviderSpecification]):
+    client: GeospatialInfoClient
+    participant_id: ParticipantID
+
+    def __init__(
+        self,
+        specification: GeospatialInfoProviderSpecification,
+        auth_adapter: AuthAdapterResource,
+    ):
+        if (
+            "geospatial_map_v1_base_url" in specification.geospatial_info_provider
+            and specification.geospatial_info_provider.geospatial_map_v1_base_url
+        ):
+            auth_adapter.assert_scopes_available(
+                scopes_required={
+                    ScopeGeospatialMap.Query: "query geospatial map features from USSs under test",
+                },
+                consumer_name=f"{self.__class__.__name__} using geospatial_map v1 API",
+            )
+        else:
+            raise NotImplementedError(
+                "The means by which to interact with the geospatial information provider is not currently supported in GeospatialInfoProviderResource (geospatial_map_v1_base_url was not specified)"
+            )
+
+        self.client = specification.geospatial_info_provider.to_client(
+            auth_adapter.adapter
+        )
+        self.participant_id = specification.geospatial_info_provider.participant_id

--- a/monitoring/uss_qualifier/scenarios/interuss/geospatial_map/geospatial_feature_comprehension.md
+++ b/monitoring/uss_qualifier/scenarios/interuss/geospatial_map/geospatial_feature_comprehension.md
@@ -16,14 +16,18 @@ This test acts as a user viewing a USS's geospatial map and queries areas and fe
 
 The test steps for this test scenario are generated dynamically according to the definitions in the Feature Check Table.  The checks for each step are the same and are documented below.
 
-#### Blocking geospatial features present check
+#### ⚠️ Geospatial query succeeded check
+
+If the geospatial query to the USS did not succeed or return a valid response, this check will fail.
+
+#### ⚠️ Blocking geospatial features present check
 
 When the test designer specifies that a particular Feature Check has an expected result of "Block", that means querying a USS for geospatial features that would result in blocking a flight with the other specified characteristics should find matching geospatial features.  Upon performing this query, if this test finds no such matching geospatial features, this check will fail.
 
-#### Advisory geospatial features present check
+#### ⚠️ Advisory geospatial features present check
 
 When the test designer specifies that a particular Feature Check has an expected result of "Advise", that means querying a USS for geospatial features that would result in advisories or conditions for a flight with the other specified characteristics should find matching geospatial features.  Upon performing this query, if the test finds no such matching geospatial features, this check will fail.
 
-#### No blocking or advisory features present
+#### ⚠️ No blocking or advisory features present
 
 When the test designer specifies that a particular Feature Check has an expected result of "Neither" (neither Block nor Advise), that means querying a USS for geospatial features that would result in blocking or producing advisories or conditions for a flight with the other specified characteristics should find no matching geospatial features.  Upon performing this query, if the test finds any such matching geospatial features, this check will fail.

--- a/monitoring/uss_qualifier/scenarios/interuss/geospatial_map/geospatial_feature_comprehension.md
+++ b/monitoring/uss_qualifier/scenarios/interuss/geospatial_map/geospatial_feature_comprehension.md
@@ -6,6 +6,10 @@ This test acts as a user viewing a USS's geospatial map and queries areas and fe
 
 ## Resources
 
+### geospatial_info_provider
+
+[GeospatialInfoProviderResource](../../../resources/geospatial_info/geospatial_info_providers.py) providing access to the USS under test providing geospatial information in this scenario.
+
 ### table
 
 [Feature Check Table](../../../resources/interuss/geospatial_map/feature_check_table.py) consisting of a list of Feature Check rows.  Each Feature Check row will cause this test to query the geospatial map of each USS under test according to the information in that Feature Check row.  This test will then perform checks according to the expected outcomes from those queries, according to the Feature Check row.

--- a/monitoring/uss_qualifier/scenarios/interuss/geospatial_map/geospatial_feature_comprehension.md
+++ b/monitoring/uss_qualifier/scenarios/interuss/geospatial_map/geospatial_feature_comprehension.md
@@ -22,7 +22,7 @@ The test steps for this test scenario are generated dynamically according to the
 
 #### ⚠️ Geospatial query succeeded check
 
-If the geospatial query to the USS did not succeed or return a valid response, this check will fail.
+If the geospatial query to the USS did not succeed or did not return a valid response, this check will fail.
 
 #### ⚠️ Blocking geospatial features present check
 

--- a/monitoring/uss_qualifier/scenarios/interuss/geospatial_map/geospatial_feature_comprehension.py
+++ b/monitoring/uss_qualifier/scenarios/interuss/geospatial_map/geospatial_feature_comprehension.py
@@ -156,6 +156,8 @@ class GeospatialFeatureComprehension(TestScenario):
                         details=f"Expected exactly 1 geospatial info query result, but instead received {len(resp.results)}",
                         query_timestamps=query_timestamps,
                     )
+                    self.end_test_step()
+                    continue
 
             # Check whether the response was correct
             with self.check(

--- a/schemas/monitoring/monitorlib/fetch/Query.json
+++ b/schemas/monitoring/monitorlib/fetch/Query.json
@@ -72,6 +72,7 @@
         "interuss.automated_testing.flight_planning.v1.ClearArea",
         "interuss.automated_testing.flight_planning.v1.UpsertFlightPlan",
         "interuss.automated_testing.flight_planning.v1.DeleteFlightPlan",
+        "interuss.automated_testing.geospatial_map.v1.QueryGeospatialMap",
         "interuss.automated_testing.rid.v1.observation.getDisplayData",
         "interuss.automated_testing.rid.v1.observation.getDetails",
         "interuss.automated_testing.rid.v1.injection.createTest",

--- a/schemas/monitoring/uss_qualifier/resources/geospatial_info/geospatial_info_providers/GeospatialInfoProviderConfiguration.json
+++ b/schemas/monitoring/uss_qualifier/resources/geospatial_info/geospatial_info_providers/GeospatialInfoProviderConfiguration.json
@@ -1,0 +1,33 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/uss_qualifier/resources/geospatial_info/geospatial_info_providers/GeospatialInfoProviderConfiguration.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "monitoring.uss_qualifier.resources.geospatial_info.geospatial_info_providers.GeospatialInfoProviderConfiguration, as defined in monitoring/uss_qualifier/resources/geospatial_info/geospatial_info_providers.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "geospatial_map_v1_base_url": {
+      "description": "Base URL for the geospatial information provider's implementation of the interfaces/automated_testing/geospatial_map/v1/geospatial_map.yaml API",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "participant_id": {
+      "description": "ID of the geospatial information provider for which geospatial data can be queried",
+      "type": "string"
+    },
+    "timeout_seconds": {
+      "description": "Number of seconds to allow for requests to this geospatial information provider.  If None, use default.",
+      "type": [
+        "number",
+        "null"
+      ]
+    }
+  },
+  "required": [
+    "participant_id"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/uss_qualifier/resources/geospatial_info/geospatial_info_providers/GeospatialInfoProviderSpecification.json
+++ b/schemas/monitoring/uss_qualifier/resources/geospatial_info/geospatial_info_providers/GeospatialInfoProviderSpecification.json
@@ -1,0 +1,18 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/uss_qualifier/resources/geospatial_info/geospatial_info_providers/GeospatialInfoProviderSpecification.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "monitoring.uss_qualifier.resources.geospatial_info.geospatial_info_providers.GeospatialInfoProviderSpecification, as defined in monitoring/uss_qualifier/resources/geospatial_info/geospatial_info_providers.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "geospatial_info_provider": {
+      "$ref": "GeospatialInfoProviderConfiguration.json"
+    }
+  },
+  "required": [
+    "geospatial_info_provider"
+  ],
+  "type": "object"
+}


### PR DESCRIPTION
This PR implements minimal geospatial map querying in the geospatial feature comprehension scenario.  To do this, a generic geospatial info client is added along with one concrete implementation (the one that works with InterUSS's geospatial_map automated testing API).  This client is provided to the test scenario via a new geospatial info provider resource.  To allow the scenario to pass, a trivial implementation of the query endpoint is added to mock_uss.

querying.py contains API-agnostic data objects for geospatial information providers, similar to how the flight planner client supports (in an API-agnostic way) both the newer v1 flight_planner API and the legacy scd injection API.  The actual (current) structure of these data objects is mostly a direct copy of the geospatial_map API, but this separate definition of internal objects will decouple API development from client development.

This PR is awfully large despite trying to limit everything to what is minimum-viable due to 1) trying to exercise all parts (could implement mock_uss endpoints in a single PR, but nothing would exercise it without building separate tests we wouldn't want to maintain long-term) and 2) a fair amount of boilerplate in the API-agnostic client and imports for different files.  It can be easily split into the pieces below, but the downside of doing so would be that test coverage would not be great until all pieces were merged.

* geospatial_map endpoints support in mock_uss
* generic geospatial info client
* specific geospatial_map implementation of geospatial info client
* geospatial info provider resource
* provide new resource to scenario
* run and evaluate query in scenario

I'll be happy to split if necessary for effective review.