### PR TITLE
[uss_qualifier/documentation] Print diff information when test suite documentation needs updates

### DIFF
--- a/monitoring/uss_qualifier/suites/documentation/format_documentation.py
+++ b/monitoring/uss_qualifier/suites/documentation/format_documentation.py
@@ -1,4 +1,5 @@
 import argparse
+import difflib
 import os
 import sys
 
@@ -41,7 +42,14 @@ def main(lint: bool) -> int:
         changes = True
         if lint:
             print(
-                f"Test suite documentation must be regenerated with `make format`: {suite_doc_file}"
+                f"vvv Begin diff of expected content versus existing content for {suite_doc_file}"
+            )
+            for line in difflib.unified_diff(
+                existing_content.split("\n"), suite_doc_content.split("\n")
+            ):
+                print(line)
+            print(
+                f"^^^ Test suite documentation must be regenerated with `make format`: {suite_doc_file}"
             )
         else:
             with open(suite_doc_file, "w") as f:


### PR DESCRIPTION
This PR attempts to investigate #620 by printing to console the diff between existing and expected content when the content differs.  This should also be useful beyond troubleshooting to more immediately see what is mismatched.