### PR TITLE
[build] fix Dockerfile to also build on ARM

### DIFF
--- a/monitoring/Dockerfile
+++ b/monitoring/Dockerfile
@@ -20,6 +20,9 @@ RUN apt-get update && apt-get install -y libffi-dev libssl-dev python3-dev build
 # required for lxml to install successfully with pip (at least on an ARM environment)
 RUN apt-get update && apt-get install -y libxml2-dev libxslt-dev
 
+# required for h5py to install successfully with pip (at least on an ARM environment)
+RUN apt-get update && apt-get install -y pkg-config libhdf5-dev
+
 RUN mkdir -p /app/monitoring
 COPY ./requirements.txt /app/monitoring/requirements.txt
 RUN pip install -r /app/monitoring/requirements.txt


### PR DESCRIPTION
The Dockerfile build fails on an M2 laptop when running the `pip install` step:

When `pkg-config` is not installed:
```
error: pkg-config probably not installed: FileNotFoundError(2, 'No such file or directory')
```

Then, when `libhdf5-dev` is missing:
```
 error: libhdf5.so: cannot open shared object file: No such file or directory
```

This fixes it for my environment, and I expect it to fix it for any arm64-based image.