### PR TITLE
[uss_qualifier] Fix dynamic checks

### DIFF
--- a/monitoring/uss_qualifier/scenarios/interuss/flight_authorization/general_flight_authorization.py
+++ b/monitoring/uss_qualifier/scenarios/interuss/flight_authorization/general_flight_authorization.py
@@ -127,7 +127,8 @@ class GeneralFlightAuthorization(TestScenario):
                     name=c.name,
                     url=c.url,
                     applicable_requirements=row.requirement_ids,
-                    has_todo=False,
+                    has_todo=c.has_todo,
+                    severity=c.severity,
                 )
                 for c in checks
             ]

--- a/monitoring/uss_qualifier/scenarios/interuss/geospatial_map/geospatial_feature_comprehension.py
+++ b/monitoring/uss_qualifier/scenarios/interuss/geospatial_map/geospatial_feature_comprehension.py
@@ -59,9 +59,7 @@ class GeospatialFeatureComprehension(TestScenario):
                 )
             check_name = _CHECK_NAMES[row.expected_result]
             original_check = [
-                c
-                for c in self._current_case.steps[0].checks
-                if c.name == check_name
+                c for c in self._current_case.steps[0].checks if c.name == check_name
             ][0]
             # Note that we are duck-typing a List[str] into a List[RequirementID] for applicable_requirements, but this
             # should be ok as the requirements are only used as strings from this point.

--- a/monitoring/uss_qualifier/scenarios/interuss/geospatial_map/geospatial_feature_comprehension.py
+++ b/monitoring/uss_qualifier/scenarios/interuss/geospatial_map/geospatial_feature_comprehension.py
@@ -58,8 +58,8 @@ class GeospatialFeatureComprehension(TestScenario):
                     f"expected_result {row.expected_result} is not yet supported"
                 )
             check_name = _CHECK_NAMES[row.expected_result]
-            check_url = [
-                c.url
+            original_check = [
+                c
                 for c in self._current_case.steps[0].checks
                 if c.name == check_name
             ][0]
@@ -67,9 +67,10 @@ class GeospatialFeatureComprehension(TestScenario):
             # should be ok as the requirements are only used as strings from this point.
             check = TestCheckDocumentation(
                 name=check_name,
-                url=check_url,
+                url=original_check.url,
                 applicable_requirements=row.requirement_ids,
-                has_todo=False,
+                has_todo=original_check.has_todo,
+                severity=original_check.severity,
             )
             doc = TestStepDocumentation(
                 name=row.geospatial_check_id,


### PR DESCRIPTION
In InterUSS's general flight authorization and geospatial feature comprehension scenarios, test checks for dynamic test steps are generated programmatically from the scenario configuration.  Prior to this PR, the check severity was not populated from the prototype check -- this PR fixes that problem, and also copies TODO status in case any of the checks acquire a TODO label later.