### PR TITLE
[uss_qualifier] SCD failed authentication response check properly attributes check

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/authentication/generic.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/authentication/generic.py
@@ -19,6 +19,7 @@ class GenericAuthValidator:
         dss: DSSInstance,
         valid_scope: Scope,
     ):
+        self._pid = dss.participant_id
         self._scenario = scenario
         self._authenticated_session = dss.client
         self._invalid_token_session = UTMClientSession(
@@ -84,7 +85,7 @@ class GenericAuthValidator:
         """Verifies that the passed query response's body is a valid ErrorResponse, as per the OpenAPI spec."""
 
         with self._scenario.check(
-            "Unauthorized requests return the proper error message body"
+            "Unauthorized requests return the proper error message body", self._pid
         ) as check:
             errors = schema_validation.validate(
                 F3548_21.OpenAPIPath,

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/authentication/oir_api_validator.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/authentication/oir_api_validator.py
@@ -172,7 +172,8 @@ class OperationalIntentRefAuthValidator:
                 )
 
         with self._scenario.check(
-            "Create operational intent reference response format conforms to spec"
+            "Create operational intent reference response format conforms to spec",
+            self._pid,
         ) as check:
             try:
                 oir_resp = ImplicitDict.parse(
@@ -347,7 +348,8 @@ class OperationalIntentRefAuthValidator:
                 )
 
         with self._scenario.check(
-            "Mutate operational intent reference response format conforms to spec"
+            "Mutate operational intent reference response format conforms to spec",
+            self._pid,
         ) as check:
             try:
                 parsed_oir = ImplicitDict.parse(


### PR DESCRIPTION
Adds participant ID to various non-attributed checks in the SCD endpoint authentication scenario.

Every `.check` invocation in the `monitoring/uss_qualifier/scenarios/astm/utm/dss/authentication` directory is now attributed.

resolves #642 