### PR TITLE
[uss_qualifier] submit_flight_intent test step raises if flight intent ends in the past

### DIFF
--- a/monitoring/monitorlib/geotemporal.py
+++ b/monitoring/monitorlib/geotemporal.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import math
 from datetime import datetime, timedelta
-from typing import Optional, List, Tuple, Dict
+from typing import Optional, List, Tuple, Dict, Union
 
+import arrow
 from implicitdict import ImplicitDict, StringBasedTimeDelta
 import s2sphere as s2sphere
 
@@ -427,3 +428,31 @@ class Volume4DCollection(List[Volume4D]):
 
 class Volume4DTemplateCollection(List[Volume4DTemplate]):
     pass
+
+
+def end_time_of(
+    volume_or_volumes: Union[
+        f3548v21.Volume4D,
+        Volume4D,
+        List[Union[f3548v21.Volume4D, Volume4D]],
+        Volume4DCollection,
+    ]
+) -> Optional[Time]:
+    """Retrieve the end time of a volume or list of volumes."""
+    if isinstance(volume_or_volumes, f3548v21.Volume4D):
+        if "time_end" in volume_or_volumes and volume_or_volumes.time_end:
+            return Time(volume_or_volumes.time_end.value)
+        else:
+            return None
+    elif isinstance(volume_or_volumes, Volume4D):
+        return volume_or_volumes.time_end
+    elif isinstance(volume_or_volumes, Volume4DCollection):
+        return volume_or_volumes.time_end
+    elif isinstance(volume_or_volumes, list):
+        time_ends = [end_time_of(v) for v in volume_or_volumes]
+        if not time_ends:
+            return None
+        elif any(t is None for t in time_ends):
+            return None
+        else:
+            return max(time_ends)

--- a/monitoring/uss_qualifier/scenarios/astm/utm/flight_intent_validation/flight_intent_validation.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/flight_intent_validation/flight_intent_validation.py
@@ -275,6 +275,7 @@ class FlightIntentValidation(TestScenario):
                 {PlanningActivityResult.Failed: "Failure"},
                 self.tested_uss.client,
                 invalid_recently_ended,
+                skip_expiry_check=True,
             )
 
             validator.expect_not_shared()

--- a/monitoring/uss_qualifier/scenarios/astm/utm/flight_intent_validation/flight_intent_validation.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/flight_intent_validation/flight_intent_validation.py
@@ -275,7 +275,7 @@ class FlightIntentValidation(TestScenario):
                 {PlanningActivityResult.Failed: "Failure"},
                 self.tested_uss.client,
                 invalid_recently_ended,
-                skip_expiry_check=True,
+                may_end_in_past=True,
             )
 
             validator.expect_not_shared()

--- a/monitoring/uss_qualifier/scenarios/flight_planning/test_steps.py
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/test_steps.py
@@ -1,6 +1,8 @@
 import inspect
-from typing import Optional, Tuple, Iterable, Set, Dict, Union
+from datetime import datetime
+from typing import Optional, Tuple, Iterable, Set, Dict, Union, List
 
+import pytz
 from uas_standards.interuss.automated_testing.flight_planning.v1.api import (
     BasicFlightPlanInformationUsageState,
     BasicFlightPlanInformationUasState,
@@ -31,6 +33,7 @@ from uas_standards.interuss.automated_testing.scd.v1.api import (
     InjectFlightResponse,
     DeleteFlightResponseResult,
     DeleteFlightResponse,
+    Volume4D,
 )
 from monitoring.uss_qualifier.common_data_definitions import Severity
 from monitoring.uss_qualifier.resources.flight_planning.flight_planner import (
@@ -258,6 +261,14 @@ def submit_flight_intent(
     if expected_results.intersection(failed_checks.keys()):
         raise ValueError(
             f"expected and unexpected results overlap: {expected_results.intersection(failed_checks.keys())}"
+        )
+
+    # Using UTC _should_ be fine here: StringBasedDateTime will assume UTC if no timezone is provided
+    # the call to .localize seems required as the volume's datetime seem to be offset-unaware – something we may want to fix?
+    intent_end_time = _get_utc_end_time(flight_intent.operational_intent.volumes)
+    if intent_end_time and intent_end_time < datetime.now(pytz.UTC):
+        raise ValueError(
+            f"attempt to submit invalid flight intent: end time is in the past: {intent_end_time}"
         )
 
     with scenario.check(success_check, [flight_planner.participant_id]) as check:
@@ -492,11 +503,14 @@ def submit_flight(
     flight_id: Optional[str] = None,
     additional_fields: Optional[dict] = None,
     skip_if_not_supported: bool = False,
+    skip_expiry_check: bool = False,
 ) -> Tuple[PlanningActivityResponse, Optional[str]]:
     """Submit a flight intent with an expected result.
     A check fail is considered by default of high severity and as such will raise an ScenarioCannotContinueError.
     The severity of each failed check may be overridden if needed.
     If skip_if_not_supported=True and the USS responds that the operation is not supported, the check is skipped without failing.
+
+    If skip_expiry_check=True, this function won't raise an error if the flight intent's end time is in the past.
 
     This function does not directly implement a test step.
 
@@ -508,6 +522,15 @@ def submit_flight(
         raise ValueError(
             f"expected and unexpected results overlap: {expected_results.intersection(failed_checks.keys())}"
         )
+
+    if not skip_expiry_check:
+        # Using UTC _should_ be fine here: StringBasedDateTime will assume UTC if no timezone is provided
+        # the call to .localize seems required as the volume's datetime seem to be offset-unaware – something we may want to fix?
+        intent_end_time = flight_info.basic_information.area.time_end.datetime
+        if intent_end_time and intent_end_time < datetime.now(pytz.UTC):
+            raise ValueError(
+                f"attempt to submit invalid flight intent: end time is in the past: {intent_end_time}"
+            )
 
     with scenario.check(success_check, [flight_planner.participant_id]) as check:
         try:
@@ -698,3 +721,27 @@ def cleanup_flights_fp_client(
                         severity=Severity.Medium,
                         query_timestamps=[query.request.timestamp],
                     )
+
+
+def _ensure_utc(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        return pytz.UTC.localize(dt)
+    return dt
+
+
+def _get_utc_end_time(volumes: List[Volume4D]):
+    time_ends = [
+        volume.time_end.value.datetime
+        for volume in volumes
+        if volume.time_end is not None
+    ]
+
+    # We may receive volumes with no time_end
+    intent_end_time = None
+    if time_ends:
+        intent_end_time = max(time_ends)
+
+        if intent_end_time and intent_end_time.tzinfo is None:
+            intent_end_time = pytz.UTC.localize(intent_end_time)
+
+    return intent_end_time

--- a/monitoring/uss_qualifier/test_data/che/flight_intents/invalid_flight_auths.yaml
+++ b/monitoring/uss_qualifier/test_data/che/flight_intents/invalid_flight_auths.yaml
@@ -25,7 +25,7 @@ intents:
             start_time:
               offset_from:
                 starting_from:
-                  time_during_test: StartOfTestRun
+                  time_during_test: StartOfScenario
                 offset: -1s
             duration: 5m
 

--- a/monitoring/uss_qualifier/test_data/flight_intents/standard/invalid_flight_intents.yaml
+++ b/monitoring/uss_qualifier/test_data/flight_intents/standard/invalid_flight_intents.yaml
@@ -24,7 +24,7 @@ intents:
             start_time:
               offset_from:
                 starting_from:
-                  time_during_test: StartOfTestRun
+                  time_during_test: StartOfScenario
                 offset: -1s
             duration: 10m
 
@@ -51,7 +51,7 @@ intents:
             - start_time:
                 offset_from:
                   starting_from:
-                    time_during_test: StartOfTestRun
+                    time_during_test: StartOfScenario
                   offset: 32d
 
   invalid_recently_ended:

--- a/monitoring/uss_qualifier/test_data/flight_intents/standard/invalid_flight_intents.yaml
+++ b/monitoring/uss_qualifier/test_data/flight_intents/standard/invalid_flight_intents.yaml
@@ -26,7 +26,7 @@ intents:
                 starting_from:
                   time_during_test: StartOfTestRun
                 offset: -1s
-            duration: 5m
+            duration: 10m
 
       astm_f3548_21:
         priority: 0

--- a/monitoring/uss_qualifier/test_data/flight_intents/standard/non_conflicting.yaml
+++ b/monitoring/uss_qualifier/test_data/flight_intents/standard/non_conflicting.yaml
@@ -24,7 +24,7 @@ intents:
             start_time:
               offset_from:
                 starting_from:
-                  time_during_test: StartOfTestRun
+                  time_during_test: StartOfScenario
                 offset: -1s
             duration: 5m
 
@@ -59,7 +59,7 @@ intents:
             start_time:
               offset_from:
                 starting_from:
-                  time_during_test: StartOfTestRun
+                  time_during_test: StartOfScenario
                 offset: -1s
             duration: 5m
 


### PR DESCRIPTION
Add a check and raise if the flight intent that will be injected ends in the past, while also double the default duration for some configured `flight_intents` (see below for details)

This fixes #648 

## Open questions:

 - is this the correct place for checking the end time?
 - is raising a `ValueError` the correct approach? 
 - is the new default duration of 10 minutes reasonable? Or should we leave it unchanged, and instruct users to increase the duration if they run into the raised error?
 
 ## Testing
 
Tested updating the default `duration` in [monitoring/uss_qualifier/test_data/flight_intents/standard/invalid_flight_intents.yaml](https://github.com/interuss/monitoring/blob/e29f1b847402d5061575f098e2695cd419b20a44/monitoring/uss_qualifier/test_data/flight_intents/standard/invalid_flight_intents.yaml#L29) to 5 seconds: this causes the error to be raised locally when running the f3548 self-contained scenario
