### PR TITLE
[monitorlib, uss_qualifier] Add deprecation mechanism and apply to deprecated functionality

### DIFF
--- a/monitoring/monitorlib/deprecation.py
+++ b/monitoring/monitorlib/deprecation.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import os
+import traceback
+from dataclasses import dataclass
+from typing import List, Optional
+
+from loguru import logger
+
+import monitoring
+
+
+@dataclass
+class CallSite(object):
+    func: str
+    file: str
+    line: Optional[int]
+
+    def __init__(self, func: str, file: str, line: Optional[int] = None):
+        """Define a site that may call a deprecated function.
+
+        Args:
+            func: Name of the calling function.  May include traceback shorthands like <dictcomp>.
+            file: Filename starting with the `monitoring` folder.  Example: monitoring/monitorlib/deprecation.py
+            line: Line in file where call site is located, if this should be checked to match.
+        """
+        self.func = func
+        self.file = file
+        self.line = line
+
+    @staticmethod
+    def from_frame_summary(stack: List[traceback.FrameSummary]) -> CallSite:
+        monitoring_path = os.path.dirname(monitoring.__file__)
+
+        i = -1
+        func_name = stack[i].name
+        while stack[i].name.startswith("<"):
+            i -= 1
+            func_name = stack[i].name
+            if i == 0:
+                break
+
+        if stack[i].filename.startswith(monitoring_path):
+            filename = os.path.join(
+                "monitoring", stack[-1].filename[len(monitoring_path) + 1 :]
+            )
+        else:
+            filename = stack[-1].filename
+        return CallSite(func=func_name, file=filename, line=stack[-1].lineno)
+
+
+class DeprecatedUsageError(RuntimeError):
+    pass
+
+
+def assert_deprecated(legacy_callers: Optional[List[CallSite]] = None) -> None:
+    """Assert that the function calling this function is deprecated.
+
+    If the calling function is not explicitly listed in legacy_callers, then a DeprecatedUsageError will be thrown.
+    Generally, the deprecated function should not be used in new development.  However, if it must be used in new
+    development, or if the calling function location has been refactored, the legacy_callers of the deprecated function
+    can be updated to include the call site to be allowed.
+
+    If legacy_callers is not specified, a warning will be logged for all usage of the deprecated function
+
+    Args:
+        legacy_callers: List of CallSites that may call the deprecated function.  If omitted, a warning will be logged
+            for all usages of the deprecated function rather than raising an exception.
+
+    Raises:
+        * DeprecatedUsageError if the calling function is not an explicitly-identified legacy caller.
+    """
+    stack = traceback.extract_stack()
+
+    deprecated_site = CallSite.from_frame_summary(stack[0:-1])
+    site = CallSite.from_frame_summary(stack[0:-2])
+    msg = f"`{site.func}` in {site.file} (line {site.line}) called deprecated function `{deprecated_site.func}` in {deprecated_site.file} (line {deprecated_site.line}).  New use of deprecated functionality is generally not allowed."
+
+    if legacy_callers is not None:
+        base_dir = os.path.abspath(
+            os.path.join(os.path.dirname(monitoring.__file__), "..")
+        )
+        for legacy_caller in legacy_callers:
+            # Make sure the assert_deprecated assertion is valid
+            if not os.path.exists(os.path.join(base_dir, legacy_caller.file)):
+                raise ValueError(
+                    f"assert_deprecated specified legacy_caller file {legacy_caller.file}, but that file does not exist."
+                )
+
+            # See if the calling site is a legacy caller
+            if (
+                site.file == legacy_caller.file
+                and site.func == legacy_caller.func
+                and (legacy_caller.line is None or site.line == legacy_caller.line)
+            ):
+                # Calling site is specified as a legacy caller so do nothing
+                return
+
+        # Calling site is not specified as a legacy caller
+        msg += "  If this usage is important or is merely a refactoring, the legacy_callers of the deprecated function may be updated."
+        raise DeprecatedUsageError(msg)
+    else:
+        logger.warning(msg)

--- a/monitoring/uss_qualifier/resources/flight_planning/flight_intent.py
+++ b/monitoring/uss_qualifier/resources/flight_planning/flight_intent.py
@@ -4,21 +4,33 @@ import json
 from typing import Optional, Dict, List
 
 import arrow
-
 from implicitdict import ImplicitDict, StringBasedDateTime
+
+from monitoring.monitorlib.deprecation import assert_deprecated, CallSite
+from uas_standards.interuss.automated_testing.scd.v1.api import InjectFlightRequest
+
 from monitoring.monitorlib.clients.flight_planning.flight_info_template import (
     FlightInfoTemplate,
 )
 from monitoring.monitorlib.temporal import Time, TimeDuringTest
 from monitoring.monitorlib.transformations import Transformation
-
 from monitoring.uss_qualifier.resources.files import ExternalFile
 from monitoring.uss_qualifier.resources.overrides import apply_overrides
-from uas_standards.interuss.automated_testing.scd.v1.api import InjectFlightRequest
 
 
 class FlightIntent(ImplicitDict):
     """DEPRECATED.  Use FlightInfoTemplate instead."""
+
+    def __init__(self, *args, **kwargs):
+        super(FlightIntent, self).__init__(*args, **kwargs)
+        assert_deprecated(
+            legacy_callers=[
+                CallSite(
+                    "from_flight_info_template",
+                    "monitoring/uss_qualifier/resources/flight_planning/flight_intent.py",
+                ),
+            ]
+        )
 
     reference_time: StringBasedDateTime
     """The time that all other times in the FlightInjectionAttempt are relative to. If this FlightInjectionAttempt is initiated by uss_qualifier at t_test, then each t_volume_original timestamp within test_injection should be adjusted to t_volume_adjusted such that t_volume_adjusted = t_test + planning_time when t_volume_original = reference_time"""
@@ -28,6 +40,46 @@ class FlightIntent(ImplicitDict):
 
     @staticmethod
     def from_flight_info_template(info_template: FlightInfoTemplate) -> FlightIntent:
+        assert_deprecated(
+            legacy_callers=[
+                CallSite(
+                    "unpack_flight_intents",
+                    "monitoring/uss_qualifier/resources/flight_planning/flight_intents_resource.py",
+                ),
+                CallSite(
+                    "__init__",
+                    "monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/get_op_data_validation.py",
+                ),
+                CallSite(
+                    "__init__",
+                    "monitoring/uss_qualifier/scenarios/astm/utm/flight_intent_validation/flight_intent_validation.py",
+                ),
+                CallSite(
+                    "__init__",
+                    "monitoring/uss_qualifier/scenarios/astm/utm/flight_intent_validation/flight_intent_validation.py",
+                ),
+                CallSite(
+                    "__init__",
+                    "monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.py",
+                ),
+                CallSite(
+                    "__init__",
+                    "monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.py",
+                ),
+                CallSite(
+                    "__init__",
+                    "monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss.py",
+                ),
+                CallSite(
+                    "__init__",
+                    "monitoring/uss_qualifier/scenarios/astm/utm/subscription_notifications/receive_notifications_for_awareness/receive_notifications_for_awareness.py",
+                ),
+                CallSite(
+                    "__init__",
+                    "monitoring/uss_qualifier/scenarios/uspace/flight_auth/validation.py",
+                ),
+            ]
+        )
         t_now = Time(arrow.utcnow().datetime)
         times = {
             TimeDuringTest.StartOfTestRun: t_now,

--- a/monitoring/uss_qualifier/scenarios/flight_planning/test_steps.py
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/test_steps.py
@@ -1,6 +1,7 @@
 import inspect
 from typing import Optional, Tuple, Iterable, Set, Dict, Union
 
+from monitoring.monitorlib.deprecation import assert_deprecated, CallSite
 from uas_standards.interuss.automated_testing.flight_planning.v1.api import (
     BasicFlightPlanInformationUsageState,
     BasicFlightPlanInformationUasState,
@@ -22,8 +23,6 @@ from monitoring.monitorlib.clients.flight_planning.flight_info import (
     ExecutionStyle,
 )
 from monitoring.monitorlib.fetch import QueryError, Query
-
-from uas_standards.astm.f3548.v21.api import OperationalIntentState
 
 from uas_standards.interuss.automated_testing.scd.v1.api import (
     InjectFlightRequest,
@@ -76,6 +75,46 @@ def plan_flight_intent(
       * The injection response.
       * The ID of the injected flight if it is returned, None otherwise.
     """
+    assert_deprecated(
+        legacy_callers=[
+            CallSite(
+                "_validate_ended_cancellation",
+                "monitoring/uss_qualifier/scenarios/astm/utm/flight_intent_validation/flight_intent_validation.py",
+            ),
+            CallSite(
+                "_validate_precision_intersection",
+                "monitoring/uss_qualifier/scenarios/astm/utm/flight_intent_validation/flight_intent_validation.py",
+            ),
+            CallSite(
+                "_attempt_modify_planned_flight_conflict",
+                "monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.py",
+            ),
+            CallSite(
+                "_attempt_plan_flight_conflict",
+                "monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.py",
+            ),
+            CallSite(
+                "_modify_activated_flight_preexisting_conflict",
+                "monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.py",
+            ),
+            CallSite(
+                "_attempt_modify_planned_flight_conflict",
+                "monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.py",
+            ),
+            CallSite(
+                "_attempt_plan_flight_conflict",
+                "monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.py",
+            ),
+            CallSite(
+                "_modify_activated_flight_conflict_preexisting",
+                "monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.py",
+            ),
+            CallSite(
+                "_plan_valid_flight",
+                "monitoring/uss_qualifier/scenarios/uspace/flight_auth/validation.py",
+            ),
+        ]
+    )
     expect_flight_intent_state(
         flight_intent,
         BasicFlightPlanInformationUsageState.Planned,
@@ -255,6 +294,102 @@ def submit_flight_intent(
       * The injection response.
       * The ID of the injected flight if it is returned, None otherwise.
     """
+    assert_deprecated(
+        legacy_callers=[
+            CallSite(
+                "_attempt_invalid",
+                "monitoring/uss_qualifier/scenarios/astm/utm/flight_intent_validation/flight_intent_validation.py",
+            ),
+            CallSite(
+                "_validate_precision_intersection",
+                "monitoring/uss_qualifier/scenarios/astm/utm/flight_intent_validation/flight_intent_validation.py",
+            ),
+            CallSite(
+                "_modify_activated_flight_preexisting_conflict",
+                "monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.py",
+            ),
+            CallSite(
+                "_plan_flight_conflict_planned",
+                "monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss.py",
+            ),
+            CallSite(
+                "_plan_flight_conflict_activated",
+                "monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.py",
+            ),
+            CallSite(
+                "_plan_flight_conflict_contingent",
+                "monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.py",
+            ),
+            CallSite(
+                "_plan_flight_conflict_nonconforming",
+                "monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.py",
+            ),
+            CallSite(
+                "activate_conflict_flight_intent",
+                "monitoring/uss_qualifier/scenarios/flight_planning/prioritization_test_steps.py",
+            ),
+            CallSite(
+                "activate_permitted_conflict_flight_intent",
+                "monitoring/uss_qualifier/scenarios/flight_planning/prioritization_test_steps.py",
+            ),
+            CallSite(
+                "activate_priority_conflict_flight_intent",
+                "monitoring/uss_qualifier/scenarios/flight_planning/prioritization_test_steps.py",
+            ),
+            CallSite(
+                "modify_activated_conflict_flight_intent",
+                "monitoring/uss_qualifier/scenarios/flight_planning/prioritization_test_steps.py",
+            ),
+            CallSite(
+                "modify_activated_permitted_conflict_flight_intent",
+                "monitoring/uss_qualifier/scenarios/flight_planning/prioritization_test_steps.py",
+            ),
+            CallSite(
+                "modify_activated_priority_conflict_flight_intent",
+                "monitoring/uss_qualifier/scenarios/flight_planning/prioritization_test_steps.py",
+            ),
+            CallSite(
+                "modify_planned_conflict_flight_intent",
+                "monitoring/uss_qualifier/scenarios/flight_planning/prioritization_test_steps.py",
+            ),
+            CallSite(
+                "modify_planned_permitted_conflict_flight_intent",
+                "monitoring/uss_qualifier/scenarios/flight_planning/prioritization_test_steps.py",
+            ),
+            CallSite(
+                "modify_planned_priority_conflict_flight_intent",
+                "monitoring/uss_qualifier/scenarios/flight_planning/prioritization_test_steps.py",
+            ),
+            CallSite(
+                "plan_conflict_flight_intent",
+                "monitoring/uss_qualifier/scenarios/flight_planning/prioritization_test_steps.py",
+            ),
+            CallSite(
+                "plan_permitted_conflict_flight_intent",
+                "monitoring/uss_qualifier/scenarios/flight_planning/prioritization_test_steps.py",
+            ),
+            CallSite(
+                "plan_priority_conflict_flight_intent",
+                "monitoring/uss_qualifier/scenarios/flight_planning/prioritization_test_steps.py",
+            ),
+            CallSite(
+                "activate_flight_intent",
+                "monitoring/uss_qualifier/scenarios/flight_planning/test_steps.py",
+            ),
+            CallSite(
+                "modify_activated_flight_intent",
+                "monitoring/uss_qualifier/scenarios/flight_planning/test_steps.py",
+            ),
+            CallSite(
+                "modify_planned_flight_intent",
+                "monitoring/uss_qualifier/scenarios/flight_planning/test_steps.py",
+            ),
+            CallSite(
+                "plan_flight_intent",
+                "monitoring/uss_qualifier/scenarios/flight_planning/test_steps.py",
+            ),
+        ]
+    )
     if expected_results.intersection(failed_checks.keys()):
         raise ValueError(
             f"expected and unexpected results overlap: {expected_results.intersection(failed_checks.keys())}"
@@ -319,6 +454,26 @@ def delete_flight_intent(
 
     Returns: The deletion response.
     """
+    assert_deprecated(
+        legacy_callers=[
+            CallSite(
+                "_validate_ended_cancellation",
+                "monitoring/uss_qualifier/scenarios/astm/utm/flight_intent_validation/flight_intent_validation.py",
+            ),
+            CallSite(
+                "_attempt_modify_activated_flight_conflict",
+                "monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.py",
+            ),
+            CallSite(
+                "_attempt_plan_flight_conflict",
+                "monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.py",
+            ),
+            CallSite(
+                "_modify_activated_flight_conflict_preexisting",
+                "monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.py",
+            ),
+        ]
+    )
     with scenario.check(
         "Successful deletion", [flight_planner.participant_id]
     ) as check:
@@ -361,6 +516,30 @@ def cleanup_flights(
     * `scenario` is currently cleaning up (cleanup has started)
     * "Successful flight deletion" check declared for cleanup phase in `scenario`'s documentation
     """
+    assert_deprecated(
+        legacy_callers=[
+            CallSite(
+                "cleanup",
+                "monitoring/uss_qualifier/scenarios/astm/utm/flight_intent_validation/flight_intent_validation.py",
+            ),
+            CallSite(
+                "cleanup",
+                "monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.py",
+            ),
+            CallSite(
+                "cleanup",
+                "monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.py",
+            ),
+            CallSite(
+                "cleanup",
+                "monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss.py",
+            ),
+            CallSite(
+                "cleanup",
+                "monitoring/uss_qualifier/scenarios/uspace/flight_auth/validation.py",
+            ),
+        ]
+    )
     for flight_planner in flight_planners:
         removed = []
         to_remove = flight_planner.created_flight_ids.copy()


### PR DESCRIPTION
Some functionality in this repo is marked as deprecated with the idea that it shouldn't be used in new development, but it isn't worth the time right now to immediately remove existing usages.  This idea has not been sufficient to keep deprecated functionality from being used in new development, so this PR introduces programmatic assurance that deprecated functionality is not accidentally used in new development.  Functions marked deprecated with the new functionality may only be called from the specifically-enumerated list of legacy callers (function, file tuples) or else an exception is thrown.  For developers wanting to quickly start the deprecation process but don't have the time to identify all legacy callers, a lightweight version of this programmatic deprecation assertion is provided which merely prints a warning to the log whenever the deprecated functionality is used.