### PR TITLE
[uss_qualifier] pass time-resolved extents to OpIntentValidator where relevant

### DIFF
--- a/monitoring/monitorlib/clients/flight_planning/flight_info.py
+++ b/monitoring/monitorlib/clients/flight_planning/flight_info.py
@@ -420,3 +420,10 @@ class ExecutionStyle(str, Enum):
 
     InReality = "InReality"
     """The user is communicating an actual state of reality. The USS should consider the user to be actually performing (or attempting to perform) this action, regardless of whether or not the action is allowed under relevant UTM rules."""
+
+
+def extents_off(flight_infos: List[FlightInfo]) -> Volume4D:
+    """Return the union of all volumes in the flight infos, as a single Volume4D"""
+    return sum(
+        [f.basic_information.area for f in flight_infos], Volume4DCollection([])
+    ).bounding_volume

--- a/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/get_op_data_validation.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/get_op_data_validation.py
@@ -128,16 +128,8 @@ class GetOpResponseDataValidationByUSS(TestScenario):
                 f"`{self.me()}` TestScenario requirements for flight_intents not met: {e}"
             )
 
-        extents = []
         for efi in expected_flight_intents:
-            intent = FlightIntent.from_flight_info_template(templates[efi.intent_id])
-            extents.extend(intent.request.operational_intent.volumes)
-            extents.extend(intent.request.operational_intent.off_nominal_volumes)
             setattr(self, efi.intent_id, templates[efi.intent_id])
-
-        self._intents_extent = Volume4DCollection.from_interuss_scd_api(
-            extents
-        ).bounding_volume.to_f3548v21()
 
     def run(self, context: ExecutionContext):
         times = {
@@ -170,7 +162,7 @@ class GetOpResponseDataValidationByUSS(TestScenario):
             self,
             self.mock_uss_client,
             self.dss,
-            self._intents_extent,
+            flight_2.basic_information.area.bounding_volume.to_f3548v21(),
         ) as validator:
             flight_2_planning_time = Time(arrow.utcnow().datetime)
             _, self.flight_2_id = plan_flight(
@@ -190,7 +182,7 @@ class GetOpResponseDataValidationByUSS(TestScenario):
             self,
             self.tested_uss_client,
             self.dss,
-            self._intents_extent,
+            flight_1.basic_information.area.bounding_volume.to_f3548v21(),
         ) as validator:
             flight_1_planning_time = Time(arrow.utcnow().datetime)
             plan_res, self.flight_1_id = plan_flight(
@@ -284,7 +276,7 @@ class GetOpResponseDataValidationByUSS(TestScenario):
             self,
             self.mock_uss_client,
             self.dss,
-            self._intents_extent,
+            flight_info.basic_information.area.bounding_volume.to_f3548v21(),
         ) as validator:
             flight_2_planning_time = Time(arrow.utcnow().datetime)
             _, self.flight_2_id = plan_flight(
@@ -307,7 +299,7 @@ class GetOpResponseDataValidationByUSS(TestScenario):
             self,
             self.tested_uss_client,
             self.dss,
-            self._intents_extent,
+            flight_1.basic_information.area.bounding_volume.to_f3548v21(),
         ) as validator:
             flight_1_planning_time = Time(arrow.utcnow().datetime)
             _, self.flight_1_id = submit_flight(

--- a/monitoring/uss_qualifier/scenarios/astm/utm/flight_intent_validation/flight_intent_validation.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/flight_intent_validation/flight_intent_validation.py
@@ -266,7 +266,7 @@ class FlightIntentValidation(TestScenario):
             self,
             self.tested_uss,
             self.dss,
-            self._intents_extent,
+            invalid_recently_ended.basic_information.area.bounding_volume.to_f3548v21(),
         ) as validator:
             submit_flight(
                 self,


### PR DESCRIPTION
In certain scenarios that depend on flight intents and that use the `OpIntentValidator`, the extents passed to the validator do not correspond to the geo-temporal area where the requested flight will happen.

This PR adds the computation of a resolved extent in all situations

## To discuss
 - in certain cases the resolved extent will likely be smaller than the previously used one. Is there any chance this would break some of the assumptions the original scenario developers would have made?