### PR TITLE
[mock_uss, uss_qualifier] Fix geospatial comprehension scenario

### DIFF
--- a/monitoring/mock_uss/f3548v21/flight_planning.py
+++ b/monitoring/mock_uss/f3548v21/flight_planning.py
@@ -256,7 +256,7 @@ def _convert_altitudes(volumes: Volume4DCollection) -> Volume4DCollection:
             if v.volume.altitude_lower:
                 if v.volume.altitude_lower.reference == AltitudeDatum.W84:
                     kwargs["altitude_lower"] = v.volume.altitude_lower
-                else:
+                elif v.volume.altitude_lower.reference == AltitudeDatum.SFC:
                     if v.volume.altitude_lower.units != DistanceUnits.M:
                         raise NotImplementedError(
                             "AGL altitudes with feet are not yet implemented"
@@ -266,10 +266,14 @@ def _convert_altitudes(volumes: Volume4DCollection) -> Volume4DCollection:
                         reference=AltitudeDatum.W84,
                         units=v.volume.altitude_lower.units,
                     )
+                else:
+                    raise NotImplementedError(
+                        f"{v.volume.altitude_lower.reference} altitude datum not yet supported"
+                    )
             if v.volume.altitude_upper:
                 if v.volume.altitude_upper.reference == AltitudeDatum.W84:
                     kwargs["altitude_upper"] = v.volume.altitude_upper
-                else:
+                elif v.volume.altitude_upper.reference == AltitudeDatum.SFC:
                     if v.volume.altitude_upper.units != DistanceUnits.M:
                         raise NotImplementedError(
                             "AGL altitudes with feet are not yet implemented"
@@ -278,6 +282,10 @@ def _convert_altitudes(volumes: Volume4DCollection) -> Volume4DCollection:
                         value=v.volume.altitude_upper.value + GROUND_ELEVATION,
                         reference=AltitudeDatum.W84,
                         units=v.volume.altitude_upper.units,
+                    )
+                else:
+                    raise NotImplementedError(
+                        f"{v.volume.altitude_upper.reference} altitude datum not yet supported"
                     )
             v2 = Volume4D(volume=Volume3D(**kwargs))
             if v.time_start:

--- a/monitoring/mock_uss/f3548v21/flight_planning.py
+++ b/monitoring/mock_uss/f3548v21/flight_planning.py
@@ -11,6 +11,7 @@ from monitoring.monitorlib.clients.flight_planning.flight_info import (
     FlightInfo,
 )
 from monitoring.monitorlib.fetch import QueryError
+from monitoring.monitorlib.geo import AltitudeDatum, Volume3D, Altitude, DistanceUnits
 from monitoring.monitorlib.scd import priority_of
 from monitoring.uss_qualifier.resources.overrides import apply_overrides
 from uas_standards.astm.f3548.v21 import api as f3548_v21
@@ -20,7 +21,7 @@ from uas_standards.interuss.automated_testing.scd.v1 import api as scd_api
 from monitoring.mock_uss.f3548v21 import utm_client
 from monitoring.mock_uss.flights.database import FlightRecord, db
 from monitoring.monitorlib.clients import scd as scd_client
-from monitoring.monitorlib.geotemporal import Volume4DCollection
+from monitoring.monitorlib.geotemporal import Volume4DCollection, Volume4D
 from monitoring.monitorlib.locality import Locality
 
 
@@ -229,10 +230,72 @@ def op_intent_transition_valid(
         return False
 
 
+def _convert_altitudes(volumes: Volume4DCollection) -> Volume4DCollection:
+    """F3548-21 does not accept AGL altitudes; "convert" any AGL altitudes to WGS84-HAE assuming an arbitrary ground elevation."""
+    GROUND_ELEVATION = 123  # meters WGS84-HAE
+    # TODO: Use better estimate for ground elevation
+    result = []
+    for v in volumes:
+        convert = False
+        if (
+            v.volume.altitude_lower
+            and v.volume.altitude_lower.reference != AltitudeDatum.W84
+        ):
+            convert = True
+        if (
+            v.volume.altitude_upper
+            and v.volume.altitude_upper.reference != AltitudeDatum.W84
+        ):
+            convert = True
+        if convert:
+            kwargs = {}
+            if "outline_polygon" in v.volume:
+                kwargs["outline_polygon"] = v.volume.outline_polygon
+            if "outline_circle" in v.volume:
+                kwargs["outline_circle"] = v.volume.outline_circle
+            if v.volume.altitude_lower:
+                if v.volume.altitude_lower.reference == AltitudeDatum.W84:
+                    kwargs["altitude_lower"] = v.volume.altitude_lower
+                else:
+                    if v.volume.altitude_lower.units != DistanceUnits.M:
+                        raise NotImplementedError(
+                            "AGL altitudes with feet are not yet implemented"
+                        )
+                    kwargs["altitude_lower"] = Altitude(
+                        value=v.volume.altitude_lower.value + GROUND_ELEVATION,
+                        reference=AltitudeDatum.W84,
+                        units=v.volume.altitude_lower.units,
+                    )
+            if v.volume.altitude_upper:
+                if v.volume.altitude_upper.reference == AltitudeDatum.W84:
+                    kwargs["altitude_upper"] = v.volume.altitude_upper
+                else:
+                    if v.volume.altitude_upper.units != DistanceUnits.M:
+                        raise NotImplementedError(
+                            "AGL altitudes with feet are not yet implemented"
+                        )
+                    kwargs["altitude_upper"] = Altitude(
+                        value=v.volume.altitude_upper.value + GROUND_ELEVATION,
+                        reference=AltitudeDatum.W84,
+                        units=v.volume.altitude_upper.units,
+                    )
+            v2 = Volume4D(volume=Volume3D(**kwargs))
+            if v.time_start:
+                v2.time_start = v.time_start
+            if v.time_end:
+                v2.time_end = v.time_end
+            result.append(v2)
+        else:
+            result.append(v)
+    return Volume4DCollection(result)
+
+
 def op_intent_from_flightinfo(
     flight_info: FlightInfo, flight_id: str
 ) -> f3548_v21.OperationalIntent:
-    volumes = [v.to_f3548v21() for v in flight_info.basic_information.area]
+    volumes = [
+        v.to_f3548v21() for v in _convert_altitudes(flight_info.basic_information.area)
+    ]
     off_nominal_volumes = []
 
     state = flight_info.basic_information.f3548v21_op_intent_state()

--- a/monitoring/monitorlib/geotemporal.py
+++ b/monitoring/monitorlib/geotemporal.py
@@ -366,18 +366,17 @@ class Volume4DCollection(List[Volume4D]):
         alt_lo = min(
             vol4.volume.altitude_lower.value
             for vol4 in self
-            if "altitude_lower" in vol4.volume
+            if vol4.volume.altitude_lower
         )
         alt_hi = max(
             vol4.volume.altitude_upper.value
             for vol4 in self
-            if "altitude_upper" in vol4.volume
+            if vol4.volume.altitude_upper
         )
         units = [
             vol4.volume.altitude_lower.units
             for vol4 in self
-            if "altitude_lower" in vol4.volume
-            and vol4.volume.altitude_lower.units != "M"
+            if vol4.volume.altitude_lower and vol4.volume.altitude_lower.units != "M"
         ]
         if units:
             raise NotImplementedError(
@@ -386,8 +385,7 @@ class Volume4DCollection(List[Volume4D]):
         units = [
             vol4.volume.altitude_upper.units
             for vol4 in self
-            if "altitude_upper" in vol4.volume
-            and vol4.volume.altitude_upper.units != "M"
+            if vol4.volume.altitude_upper and vol4.volume.altitude_upper.units != "M"
         ]
         if units:
             raise NotImplementedError(

--- a/monitoring/monitorlib/kml/generation.py
+++ b/monitoring/monitorlib/kml/generation.py
@@ -103,12 +103,12 @@ def make_placemark_from_volume(
     upper_coords = []
     alt_lo = (
         _distance_value_of(v4.volume.altitude_lower) - geoid_offset
-        if "altitude_lower" in v4.volume
+        if v4.volume.altitude_lower
         else 0
     )
     alt_hi = (
         _distance_value_of(v4.volume.altitude_upper) - geoid_offset
-        if "altitude_upper" in v4.volume
+        if v4.volume.altitude_upper
         else 0
     )
     for vertex in vertices:
@@ -116,13 +116,13 @@ def make_placemark_from_volume(
         upper_coords.append((vertex.lng, vertex.lat, alt_hi))
     geo = kml.MultiGeometry()
     make_sides = True
-    if "altitude_lower" in v4.volume:
+    if v4.volume.altitude_lower:
         geo.append(
             kml.Polygon(
                 kml.altitudeMode(
                     _altitude_mode_of(
                         v4.volume.altitude_lower
-                        if "altitude_lower" in v4.volume
+                        if v4.volume.altitude_lower
                         else AltitudeDatum.SFC
                     )
                 ),
@@ -137,13 +137,13 @@ def make_placemark_from_volume(
         )
     else:
         make_sides = False
-    if "altitude_upper" in v4.volume:
+    if v4.volume.altitude_upper:
         geo.append(
             kml.Polygon(
                 kml.altitudeMode(
                     _altitude_mode_of(
                         v4.volume.altitude_upper
-                        if "altitude_upper" in v4.volume
+                        if v4.volume.altitude_upper
                         else AltitudeDatum.SFC
                     )
                 ),

--- a/monitoring/uss_qualifier/configurations/dev/library/environment_localhost.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/library/environment_localhost.yaml
@@ -160,7 +160,7 @@ all_flight_planners:
   specification:
     flight_planners:
       - participant_id: uss1
-        scd_injection_base_url: http://localhost:8074/scdsc
+        v1_base_url: http://localhost:8074/flight_planning/v1
         local_debug: true
 
       - participant_id: uss2

--- a/monitoring/uss_qualifier/reports/templates/tested_requirements/participant_tested_requirements.html
+++ b/monitoring/uss_qualifier/reports/templates/tested_requirements/participant_tested_requirements.html
@@ -90,10 +90,12 @@
         <td>{{ system_version }}</td>
       </tr>
     {% endif %}
-    <tr>
-      <td>Other participants</td>
-      <td>{{ other_participants }}</td>
-    </tr>
+    {% if other_participants %}
+      <tr>
+        <td>Other participants</td>
+        <td>{{ other_participants }}</td>
+      </tr>
+    {% endif %}
     <tr>
       <td>Test run identifier</td>
       <td>TR-{{ test_run.test_run_id[0:7] }}</td>

--- a/monitoring/uss_qualifier/scenarios/interuss/geospatial_map/geospatial_feature_comprehension.md
+++ b/monitoring/uss_qualifier/scenarios/interuss/geospatial_map/geospatial_feature_comprehension.md
@@ -32,6 +32,6 @@ When the test designer specifies that a particular Feature Check has an expected
 
 When the test designer specifies that a particular Feature Check has an expected result of "Advise", that means querying a USS for geospatial features that would result in advisories or conditions for a flight with the other specified characteristics should find matching geospatial features.  Upon performing this query, if the test finds no such matching geospatial features, this check will fail.
 
-#### ⚠️ No blocking or advisory features present
+#### ⚠️ No blocking or advisory features present check
 
 When the test designer specifies that a particular Feature Check has an expected result of "Neither" (neither Block nor Advise), that means querying a USS for geospatial features that would result in blocking or producing advisories or conditions for a flight with the other specified characteristics should find no matching geospatial features.  Upon performing this query, if the test finds any such matching geospatial features, this check will fail.


### PR DESCRIPTION
This PR fixes a few issues discovered while testing InterUSS's generic flight authorization and geospatial comprehension scenarios on user-provided configurations.

Primarily, it fixes the documentation of one of the checks to include the " check" suffix which is otherwise a breaking error (because the check doesn't get defined/recognized as a check).

Also, it cleans up the tested_requirements artifact slightly by not printing an empty list of other participants.

The bulk of the lines of code changed are dedicated to not throwing errors in mock_uss with unusual altitude specifications -- SFC rather than W84, and missing lower/upper altitudes.  A common theme was that InterUSS business geo objects all have defaults for their fields, so the proper check is for boolean equivalence of the field, not whether the field is present -- that fix is made in a number of places.  A pseudo AGL routine is added that assumes a fixed ground level everyone on earth, just to avoid errors when AGL altitudes are used.  I am looking forward to cleaning this up when restructuring mock_uss's flight engine.