### PR TITLE
[uss_qualifier] allow setting an end-time when resolving flight intents (new enum entry)

### DIFF
--- a/monitoring/monitorlib/geotemporal.py
+++ b/monitoring/monitorlib/geotemporal.py
@@ -69,7 +69,10 @@ class Volume4DTemplate(ImplicitDict):
             time_start = None
 
         if self.end_time is not None:
-            time_end = self.end_time.resolve(times)
+            if TimeDuringTest.Volume4DEndTime in times:
+                time_end = times[TimeDuringTest.Volume4DEndTime]
+            else:
+                time_end = self.end_time.resolve(times)
         else:
             time_end = None
 

--- a/monitoring/monitorlib/temporal.py
+++ b/monitoring/monitorlib/temporal.py
@@ -72,6 +72,10 @@ class TimeDuringTest(str, Enum):
     TimeOfEvaluation = "TimeOfEvaluation"
     """The time at which a TestTime was resolved to an absolute time; generally close to 'now'."""
 
+    Volume4DEndTime = "Volume4DEndTime"
+    """The time to use as the end time of a resolved Volume4D. Useful to allow a flight intent's state to be updated
+    without updating the end time of its area."""
+
 
 class TestTime(ImplicitDict):
     """Exactly one of the time option fields of this object must be specified."""

--- a/monitoring/uss_qualifier/scenarios/astm/utm/subscription_notifications/receive_notifications_for_awareness/receive_notifications_for_awareness.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/subscription_notifications/receive_notifications_for_awareness/receive_notifications_for_awareness.py
@@ -157,13 +157,20 @@ class ReceiveNotificationsForAwareness(TestScenario):
         self.end_test_scenario()
 
     def _receive_notification_successfully_when_activated_test_case(
-        self, times: Dict[TimeDuringTest, Time]
+        self, times_in: Dict[TimeDuringTest, Time]
     ):
+        times = times_in.copy()
         times[TimeDuringTest.TimeOfEvaluation] = Time(arrow.utcnow().datetime)
 
+        # Resolve planned flights
         flight_1_planned = self.flight_1_planned.resolve(times)
-        flight_1_activated = self.flight_1_activated.resolve(times)
         flight_2_planned = self.flight_2_planned.resolve(times)
+
+        # Resolve activated flight (keep the same end time)
+        times[
+            TimeDuringTest.Volume4DEndTime
+        ] = flight_1_planned.basic_information.area.time_end
+        flight_1_activated = self.flight_1_activated.resolve(times)
 
         resolved_extents = flight_info.extents_of(
             [flight_1_planned, flight_1_activated, flight_2_planned]

--- a/schemas/monitoring/monitorlib/temporal/TestTime.json
+++ b/schemas/monitoring/monitorlib/temporal/TestTime.json
@@ -53,7 +53,8 @@
       "enum": [
         "StartOfTestRun",
         "StartOfScenario",
-        "TimeOfEvaluation"
+        "TimeOfEvaluation",
+        "Volume4DEndTime"
       ],
       "type": [
         "string",


### PR DESCRIPTION
This is a short proposal to address #461:

The idea is to extend the `TimeDuringTest` enum with an entry representing the end time to use for an area being resolved.

The upside of this approach is that it requires very little change. The downside is that one needs to be careful with which instance of the `times` dict is being modified.

An alternative would be to give an optional parameter to the `resolve` function



