### PR TITLE
[uss_qualifier] allow setting an end-time when resolving flight intents

### DIFF
--- a/monitoring/monitorlib/clients/flight_planning/flight_info_template.py
+++ b/monitoring/monitorlib/clients/flight_planning/flight_info_template.py
@@ -33,9 +33,13 @@ class BasicFlightPlanInformationTemplate(ImplicitDict):
     area: Volume4DTemplateCollection
     """User intends to or may fly anywhere in this entire area."""
 
-    def resolve(self, times: Dict[TimeDuringTest, Time]) -> BasicFlightPlanInformation:
+    def resolve(
+        self, times: Dict[TimeDuringTest, Time], force_end_time: Optional[Time] = None
+    ) -> BasicFlightPlanInformation:
         kwargs = {k: v for k, v in self.items()}
-        kwargs["area"] = Volume4DCollection([t.resolve(times) for t in self.area])
+        kwargs["area"] = Volume4DCollection(
+            [t.resolve(times, force_end_time) for t in self.area]
+        )
         return ImplicitDict.parse(kwargs, BasicFlightPlanInformation)
 
 
@@ -56,9 +60,11 @@ class FlightInfoTemplate(ImplicitDict):
     transformations: Optional[List[Transformation]]
     """If specified, transform this flight according to these transformations in order (after all templates are resolved)."""
 
-    def resolve(self, times: Dict[TimeDuringTest, Time]) -> FlightInfo:
+    def resolve(
+        self, times: Dict[TimeDuringTest, Time], force_end_time: Optional[Time] = None
+    ) -> FlightInfo:
         kwargs = {k: v for k, v in self.items() if k not in {"transformations"}}
-        basic_info = self.basic_information.resolve(times)
+        basic_info = self.basic_information.resolve(times, force_end_time)
         if "transformations" in self and self.transformations:
             for xform in self.transformations:
                 basic_info.area = [v.transform(xform) for v in basic_info.area]

--- a/monitoring/monitorlib/geotemporal.py
+++ b/monitoring/monitorlib/geotemporal.py
@@ -46,7 +46,9 @@ class Volume4DTemplate(ImplicitDict):
     transformations: Optional[List[Transformation]] = None
     """If specified, transform this volume according to these transformations in order."""
 
-    def resolve(self, times: Dict[TimeDuringTest, Time]) -> Volume4D:
+    def resolve(
+        self, times: Dict[TimeDuringTest, Time], force_end_time: Optional[Time] = None
+    ) -> Volume4D:
         """Resolve Volume4DTemplate into concrete Volume4D."""
         # Make 3D volume
         kwargs = {}
@@ -69,7 +71,10 @@ class Volume4DTemplate(ImplicitDict):
             time_start = None
 
         if self.end_time is not None:
-            time_end = self.end_time.resolve(times)
+            if force_end_time is not None:
+                time_end = force_end_time
+            else:
+                time_end = self.end_time.resolve(times)
         else:
             time_end = None
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/subscription_notifications/receive_notifications_for_awareness/receive_notifications_for_awareness.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/subscription_notifications/receive_notifications_for_awareness/receive_notifications_for_awareness.py
@@ -162,7 +162,9 @@ class ReceiveNotificationsForAwareness(TestScenario):
         times[TimeDuringTest.TimeOfEvaluation] = Time(arrow.utcnow().datetime)
 
         flight_1_planned = self.flight_1_planned.resolve(times)
-        flight_1_activated = self.flight_1_activated.resolve(times)
+        flight_1_activated = self.flight_1_activated.resolve(
+            times, force_end_time=flight_1_planned.basic_information.area.time_end
+        )
         flight_2_planned = self.flight_2_planned.resolve(times)
 
         resolved_extents = flight_info.extents_of(


### PR DESCRIPTION
This is a short proposal to address #461:

It adds an optional `force_end_time` parameter to `resolve` that lets callers specify the exact end time to use.

(Open to proposals for a better name, if anyone has ideas)

An alternative approach was tried in #656, but it came with some downsides and no real benefit compared to the present proposal.