### PR TITLE
[uss_qualifier] Extend durations of standard flight intents

### DIFF
--- a/monitoring/uss_qualifier/configurations/dev/library/resources.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/library/resources.yaml
@@ -197,7 +197,7 @@ che_conflicting_flights:
     file:
       path: file://./test_data/flight_intents/standard/conflicting_flights.yaml
       # Note that this hash_sha512 field can be safely deleted if the content changes
-      hash_sha512: b5432d496928aaa1876acc754e9ffa12f407809a014fa90e23f450c013fb20e2321328d48a419bc129276f7e9e26002c0fea6fec9baf3952b60daec6197de6b7
+      hash_sha512: 86fa219becf3b32a924716d9cc57155fbe4da6e42133c6fd6e50c989e27b337b525b833b35dbde1982c37331ad905bb56b0355cbe20eabb791abe512dc4df610
     transformations:
       - relative_translation:
           degrees_north: 46.9748

--- a/monitoring/uss_qualifier/resources/flight_planning/flight_intent_validation.py
+++ b/monitoring/uss_qualifier/resources/flight_planning/flight_intent_validation.py
@@ -19,7 +19,7 @@ from monitoring.uss_qualifier.resources.flight_planning.flight_intent import (
 
 FlightIntentName = str
 
-MAX_TEST_RUN_DURATION = timedelta(minutes=30)
+MAX_TEST_RUN_DURATION = timedelta(minutes=45)
 """The longest a test run might take (to estimate flight intent timestamps prior to scenario execution)"""
 
 

--- a/monitoring/uss_qualifier/scenarios/flight_planning/prep_planners.py
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/prep_planners.py
@@ -20,7 +20,7 @@ from monitoring.uss_qualifier.resources.interuss.mock_uss.client import (
     MockUSSResource,
 )
 
-MAX_TEST_DURATION = timedelta(minutes=15)
+MAX_TEST_DURATION = timedelta(minutes=45)
 """The maximum time the tests depending on the area being clear might last."""
 
 

--- a/monitoring/uss_qualifier/test_data/flight_intents/standard/conflicting_flights.yaml
+++ b/monitoring/uss_qualifier/test_data/flight_intents/standard/conflicting_flights.yaml
@@ -31,7 +31,7 @@ intents:
               offset_from:
                 starting_from:
                   time_during_test: TimeOfEvaluation
-                offset: 8m
+                offset: 45m
 
       astm_f3548_21:
         priority: 0
@@ -116,7 +116,7 @@ intents:
               offset_from:
                 starting_from:
                   time_during_test: TimeOfEvaluation
-                offset: 8m
+                offset: 45m
 
       astm_f3548_21:
         priority: 100

--- a/monitoring/uss_qualifier/test_data/flight_intents/standard/flight_auths.yaml
+++ b/monitoring/uss_qualifier/test_data/flight_intents/standard/flight_auths.yaml
@@ -8,7 +8,7 @@ standard:
     - ASTMNetRID
   connectivity_methods:
     - cellular
-  endurance_minutes: 30
+  endurance_minutes: 50
   emergency_procedure_url: https://example.interussplatform.org/emergency
   operator_id: CHEo5kut30e0mt01-qwe
   uas_id: ''

--- a/monitoring/uss_qualifier/test_data/flight_intents/standard/invalid_flight_intents.yaml
+++ b/monitoring/uss_qualifier/test_data/flight_intents/standard/invalid_flight_intents.yaml
@@ -26,7 +26,7 @@ intents:
                 starting_from:
                   time_during_test: StartOfScenario
                 offset: -1s
-            duration: 10m
+            duration: 45m
 
       astm_f3548_21:
         priority: 0

--- a/monitoring/uss_qualifier/test_data/flight_intents/standard/non_conflicting.yaml
+++ b/monitoring/uss_qualifier/test_data/flight_intents/standard/non_conflicting.yaml
@@ -26,7 +26,7 @@ intents:
                 starting_from:
                   time_during_test: StartOfScenario
                 offset: -1s
-            duration: 5m
+            duration: 45m
 
       astm_f3548_21:
         priority: 0
@@ -61,7 +61,7 @@ intents:
                 starting_from:
                   time_during_test: StartOfScenario
                 offset: -1s
-            duration: 5m
+            duration: 45m
 
       astm_f3548_21:
         priority: 0


### PR DESCRIPTION
This PR band-aids #648 while a longer-term fix can be implemented.  The problem is that older scenarios are rendering flight intents from templates once at instantiation (which is at the beginning of the test run) and therefore time references like TimeOfEvaluation and StartOfScenario don't work (instead using StartOfTestRun instead).  This means that relatively short flights are entirely in the past when a long test run gets around to running the scenario in which they're used.

The long-term fix is to render FligthInfoTemplates just before usage (TimeOfEvaluation), but extending the duration of the flight intents should at least stop the flight end times from being in the past in the meantime.