### PR TITLE
[uss_qualifier/scenarios/utm/nominal_planning/conflict_higher_priority] Migrate scenario away from FlightIntent

### DIFF
--- a/monitoring/uss_qualifier/scenarios/flight_planning/activate_priority_conflict_flight_intent.md
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/activate_priority_conflict_flight_intent.md
@@ -2,16 +2,16 @@
 
 This page describes the content of a common test step where a user flight intent should be denied activation because of
 a conflict with a higher priority flight intent.
-See `activate_priority_conflict_flight_intent` in [prioritization_test_steps.py](prioritization_test_steps.py).
+See `activate_priority_conflict_flight` in [prioritization_test_steps.py](prioritization_test_steps.py).
 
-## Incorrectly activated check
+## 🛑 Incorrectly activated check
 
 If the USS successfully activates the flight or otherwise fails to indicate a conflict, it means they failed to detect
 the conflict with the pre-existing flight.
 Therefore, this check will fail if the USS indicates success in activating the flight from the user flight intent,
 per **[astm.f3548.v21.SCD0025](../../requirements/astm/f3548/v21.md)**.
 
-## Failure check
+## 🛑 Failure check
 
 All flight intent data provided was complete and correct. It should have been processed successfully, allowing the USS
 to reject or accept the flight. If the USS indicates that the injection attempt failed, this check will fail per

--- a/monitoring/uss_qualifier/scenarios/flight_planning/modify_activated_priority_conflict_flight_intent.md
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/modify_activated_priority_conflict_flight_intent.md
@@ -2,16 +2,16 @@
 
 This page describes the content of a common test step where a user flight intent should be denied modification because
 of a conflict with a higher priority flight intent.
-See `modify_activated_priority_conflict_flight_intent` in [prioritization_test_steps.py](prioritization_test_steps.py).
+See `modify_activated_priority_conflict_flight` in [prioritization_test_steps.py](prioritization_test_steps.py).
 
-## Incorrectly modified check
+## 🛑 Incorrectly modified check
 
 If the USS successfully modifies the flight or otherwise fails to indicate a conflict, it means they failed to detect
 the conflict with the pre-existing flight.
 Therefore, this check will fail if the USS indicates success in modifying the flight from the user flight intent,
 per **[astm.f3548.v21.SCD0030](../../requirements/astm/f3548/v21.md)**.
 
-## Failure check
+## 🛑 Failure check
 
 All flight intent data provided was complete and correct. It should have been processed successfully, allowing the USS
 to reject or accept the flight. If the USS indicates that the injection attempt failed, this check will fail per

--- a/monitoring/uss_qualifier/scenarios/flight_planning/modify_planned_priority_conflict_flight_intent.md
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/modify_planned_priority_conflict_flight_intent.md
@@ -2,16 +2,16 @@
 
 This page describes the content of a common test step where a user flight intent should be denied modification because
 of a conflict with a higher priority flight intent.
-See `modify_planned_priority_conflict_flight_intent` in [prioritization_test_steps.py](prioritization_test_steps.py).
+See `modify_planned_priority_conflict_flight` in [prioritization_test_steps.py](prioritization_test_steps.py).
 
-## Incorrectly modified check
+## 🛑 Incorrectly modified check
 
 If the USS successfully modifies the flight or otherwise fails to indicate a conflict, it means they failed to detect
 the conflict with the pre-existing flight.
 Therefore, this check will fail if the USS indicates success in modifying the flight from the user flight intent,
 per **[astm.f3548.v21.SCD0020](../../requirements/astm/f3548/v21.md)**.
 
-## Failure check
+## 🛑 Failure check
 
 All flight intent data provided was complete and correct. It should have been processed successfully, allowing the USS
 to reject or accept the flight. If the USS indicates that the injection attempt failed, this check will fail per

--- a/monitoring/uss_qualifier/scenarios/flight_planning/plan_priority_conflict_flight_intent.md
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/plan_priority_conflict_flight_intent.md
@@ -2,16 +2,16 @@
 
 This page describes the content of a common test step where a user flight intent should be denied planning because of
 a conflict with a higher priority flight intent.
-See `plan_priority_conflict_flight_intent` in [prioritization_test_steps.py](prioritization_test_steps.py).
+See `plan_priority_conflict_flight` in [prioritization_test_steps.py](prioritization_test_steps.py).
 
-## Incorrectly planned check
+## 🛑 Incorrectly planned check
 
 If the USS successfully plans the flight or otherwise fails to indicate a conflict, it means they failed to detect the
 conflict with the pre-existing flight.
 Therefore, this check will fail if the USS indicates success in creating the flight from the user flight intent,
 per **[astm.f3548.v21.SCD0015](../../requirements/astm/f3548/v21.md)**.
 
-## Failure check
+## 🛑 Failure check
 
 All flight intent data provided was complete and correct. It should have been processed successfully, allowing the USS
 to reject or accept the flight. If the USS indicates that the injection attempt failed, this check will fail per

--- a/monitoring/uss_qualifier/scenarios/flight_planning/prioritization_test_steps.py
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/prioritization_test_steps.py
@@ -1,6 +1,5 @@
-from typing import Optional, Tuple
+from typing import Optional
 
-from uas_standards.astm.f3548.v21.api import OperationalIntentState
 from uas_standards.interuss.automated_testing.flight_planning.v1.api import (
     BasicFlightPlanInformationUsageState,
     BasicFlightPlanInformationUasState,
@@ -11,56 +10,66 @@ from uas_standards.interuss.automated_testing.scd.v1.api import (
     InjectFlightResponseResult,
     InjectFlightResponse,
 )
+
+from monitoring.monitorlib.clients.flight_planning.client import FlightPlannerClient
+from monitoring.monitorlib.clients.flight_planning.flight_info import FlightInfo
+from monitoring.monitorlib.clients.flight_planning.planning import (
+    PlanningActivityResponse,
+    PlanningActivityResult,
+    FlightPlanStatus,
+)
 from monitoring.uss_qualifier.resources.flight_planning.flight_planner import (
     FlightPlanner,
 )
 from monitoring.uss_qualifier.scenarios.flight_planning.test_steps import (
     submit_flight_intent,
     expect_flight_intent_state,
+    submit_flight,
 )
 from monitoring.uss_qualifier.scenarios.scenario import TestScenarioType
 
 
-def plan_priority_conflict_flight_intent(
+def plan_priority_conflict_flight(
     scenario: TestScenarioType,
-    flight_planner: FlightPlanner,
-    flight_intent: InjectFlightRequest,
-) -> InjectFlightResponse:
+    flight_planner: FlightPlannerClient,
+    flight_info: FlightInfo,
+    additional_fields: Optional[dict] = None,
+) -> PlanningActivityResponse:
     """Attempt to plan a flight intent that should result in a conflict with a higher priority flight intent.
 
     This function implements the test step described in plan_priority_conflict_flight_intent.md.
     It validates requirement astm.f3548.v21.SCD0015.
 
-    Returns: The injection response.
+    Returns:
+      * The injection response.
     """
     expect_flight_intent_state(
-        flight_intent,
+        flight_info,
         BasicFlightPlanInformationUsageState.Planned,
         BasicFlightPlanInformationUasState.Nominal,
         scenario,
     )
 
-    resp, _, _ = submit_flight_intent(
-        scenario,
-        "Incorrectly planned",
-        {
-            InjectFlightResponseResult.ConflictWithFlight,
-            InjectFlightResponseResult.Rejected,
+    return submit_flight(
+        scenario=scenario,
+        success_check="Incorrectly planned",
+        expected_results={
+            (PlanningActivityResult.Rejected, FlightPlanStatus.NotPlanned)
         },
-        {InjectFlightResponseResult.Failed: "Failure"},
-        flight_planner,
-        flight_intent,
-    )
+        failed_checks={PlanningActivityResult.Failed: "Failure"},
+        flight_planner=flight_planner,
+        flight_info=flight_info,
+        additional_fields=additional_fields,
+    )[0]
 
-    return resp
 
-
-def modify_planned_priority_conflict_flight_intent(
+def modify_planned_priority_conflict_flight(
     scenario: TestScenarioType,
-    flight_planner: FlightPlanner,
-    flight_intent: InjectFlightRequest,
+    flight_planner: FlightPlannerClient,
+    flight_info: FlightInfo,
     flight_id: str,
-) -> InjectFlightResponse:
+    additional_fields: Optional[dict] = None,
+) -> PlanningActivityResponse:
     """Attempt to modify a planned flight intent that should result in a conflict with a higher priority flight intent.
 
     This function implements the test step described in modify_planned_priority_conflict_flight_intent.md.
@@ -69,34 +78,37 @@ def modify_planned_priority_conflict_flight_intent(
     Returns: The injection response.
     """
     expect_flight_intent_state(
-        flight_intent,
+        flight_info,
         BasicFlightPlanInformationUsageState.Planned,
         BasicFlightPlanInformationUasState.Nominal,
         scenario,
     )
 
-    resp, _, _ = submit_flight_intent(
-        scenario,
-        "Incorrectly modified",
-        {
-            InjectFlightResponseResult.ConflictWithFlight,
-            InjectFlightResponseResult.Rejected,
+    return submit_flight(
+        scenario=scenario,
+        success_check="Incorrectly modified",
+        expected_results={
+            (PlanningActivityResult.Rejected, FlightPlanStatus.Planned),
+            (
+                PlanningActivityResult.Rejected,
+                FlightPlanStatus.Closed,
+            ),  # case where the USS closes the flight plan as a result of the rejected modification attempt
         },
-        {InjectFlightResponseResult.Failed: "Failure"},
-        flight_planner,
-        flight_intent,
-        flight_id,
-    )
+        failed_checks={PlanningActivityResult.Failed: "Failure"},
+        flight_planner=flight_planner,
+        flight_info=flight_info,
+        flight_id=flight_id,
+        additional_fields=additional_fields,
+    )[0]
 
-    return resp
 
-
-def activate_priority_conflict_flight_intent(
+def activate_priority_conflict_flight(
     scenario: TestScenarioType,
-    flight_planner: FlightPlanner,
-    flight_intent: InjectFlightRequest,
+    flight_planner: FlightPlannerClient,
+    flight_info: FlightInfo,
     flight_id: Optional[str] = None,
-) -> InjectFlightResponse:
+    additional_fields: Optional[dict] = None,
+) -> PlanningActivityResponse:
     """Attempt to activate a flight intent that should result in a conflict with a higher priority flight intent.
 
     This function implements the test step described in activate_priority_conflict_flight_intent.md.
@@ -105,34 +117,41 @@ def activate_priority_conflict_flight_intent(
     Returns: The injection response.
     """
     expect_flight_intent_state(
-        flight_intent,
+        flight_info,
         BasicFlightPlanInformationUsageState.InUse,
         BasicFlightPlanInformationUasState.Nominal,
         scenario,
     )
 
-    resp, _, _ = submit_flight_intent(
-        scenario,
-        "Incorrectly activated",
-        {
-            InjectFlightResponseResult.ConflictWithFlight,
-            InjectFlightResponseResult.Rejected,
+    return submit_flight(
+        scenario=scenario,
+        success_check="Incorrectly activated",
+        expected_results={
+            (
+                PlanningActivityResult.Rejected,
+                FlightPlanStatus.NotPlanned,
+            ),  # case where the activation was about a flight plan not previously planned
+            (PlanningActivityResult.Rejected, FlightPlanStatus.Planned),
+            (
+                PlanningActivityResult.Rejected,
+                FlightPlanStatus.Closed,
+            ),  # case where the USS closes the flight plan as a result of the rejected activation attempt
         },
-        {InjectFlightResponseResult.Failed: "Failure"},
-        flight_planner,
-        flight_intent,
-        flight_id,
-    )
+        failed_checks={PlanningActivityResult.Failed: "Failure"},
+        flight_planner=flight_planner,
+        flight_info=flight_info,
+        flight_id=flight_id,
+        additional_fields=additional_fields,
+    )[0]
 
-    return resp
 
-
-def modify_activated_priority_conflict_flight_intent(
+def modify_activated_priority_conflict_flight(
     scenario: TestScenarioType,
-    flight_planner: FlightPlanner,
-    flight_intent: InjectFlightRequest,
+    flight_planner: FlightPlannerClient,
+    flight_info: FlightInfo,
     flight_id: str,
-) -> InjectFlightResponse:
+    additional_fields: Optional[dict] = None,
+) -> PlanningActivityResponse:
     """Attempt to modify an activated flight intent that should result in a conflict with a higher priority flight intent.
 
     This function implements the test step described in modify_activated_priority_conflict_flight_intent.md.
@@ -141,26 +160,28 @@ def modify_activated_priority_conflict_flight_intent(
     Returns: The injection response.
     """
     expect_flight_intent_state(
-        flight_intent,
+        flight_info,
         BasicFlightPlanInformationUsageState.InUse,
         BasicFlightPlanInformationUasState.Nominal,
         scenario,
     )
 
-    resp, _, _ = submit_flight_intent(
-        scenario,
-        "Incorrectly modified",
-        {
-            InjectFlightResponseResult.ConflictWithFlight,
-            InjectFlightResponseResult.Rejected,
+    return submit_flight(
+        scenario=scenario,
+        success_check="Incorrectly modified",
+        expected_results={
+            (PlanningActivityResult.Rejected, FlightPlanStatus.OkToFly),
+            (
+                PlanningActivityResult.Rejected,
+                FlightPlanStatus.Closed,
+            ),  # case where the USS closes the flight plan as a result of the rejected modification attempt; note: is this actually desirable if the flight was activated?
         },
-        {InjectFlightResponseResult.Failed: "Failure"},
-        flight_planner,
-        flight_intent,
-        flight_id,
-    )
-
-    return resp
+        failed_checks={PlanningActivityResult.Failed: "Failure"},
+        flight_planner=flight_planner,
+        flight_info=flight_info,
+        flight_id=flight_id,
+        additional_fields=additional_fields,
+    )[0]
 
 
 def plan_conflict_flight_intent(


### PR DESCRIPTION
~~PR stacked on top of #664: please review only commit eeeb3582c173d6b021c5563ba3488ff4c42f13da~~ rebased

Note that this migrates the scenario, but also the directly related test step fragments.
Additionally, the severity is added in the checks of those test step fragments.

Note to reviewer: in this scenario there are some execution paths that are specific to some USS implementations. If one of those path is broken by those changes, this is likely to not be caught by the CI.