### PR TITLE
[uss_qualifier/scenarios/utm/nominal_planning/conflict_equal_priority_not_permitted] Migrate scenario away from FlightIntent

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md
@@ -222,7 +222,7 @@ execution will stop without failing.
 All flight intent data provided is correct, therefore it should have been
 transitioned to non-conforming state by the USS
 per **[interuss.automated_testing.flight_planning.ExpectedBehavior](../../../../../requirements/interuss/automated_testing/flight_planning.md)**.
-If the USS indicates a conflict, this check will fail. If the USS indicates that the injection attempt failed, this check will fail.
+If the USS rejects the transition, this check will fail.
 
 #### 🛑 Failure check
 All flight intent data provided was complete and correct. It should have been processed successfully, allowing the USS

--- a/monitoring/uss_qualifier/scenarios/flight_planning/activate_conflict_flight_intent.md
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/activate_conflict_flight_intent.md
@@ -2,7 +2,7 @@
 
 This page describes the content of a common test step where a user flight intent should be denied activation because of
 a non-permitted conflict with an equal priority flight intent.
-See `activate_conflict_flight_intent` in [prioritization_test_steps.py](prioritization_test_steps.py).
+See `activate_conflict_flight` in [prioritization_test_steps.py](prioritization_test_steps.py).
 
 ## 🛑 Incorrectly activated check
 

--- a/monitoring/uss_qualifier/scenarios/flight_planning/modify_activated_conflict_flight_intent.md
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/modify_activated_conflict_flight_intent.md
@@ -2,7 +2,7 @@
 
 This page describes the content of a common test step where a user flight intent should be denied modification because
 of a non-permitted conflict with an equal priority flight intent.
-See `modify_activated_conflict_flight_intent` in [prioritization_test_steps.py](prioritization_test_steps.py).
+See `modify_activated_conflict_flight` in [prioritization_test_steps.py](prioritization_test_steps.py).
 
 ## 🛑 Incorrectly modified check
 

--- a/monitoring/uss_qualifier/scenarios/flight_planning/modify_planned_conflict_flight_intent.md
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/modify_planned_conflict_flight_intent.md
@@ -2,7 +2,7 @@
 
 This page describes the content of a common test step where a user flight intent should be denied modification because
 of a non-permitted conflict with an equal priority flight intent.
-See `modify_planned_conflict_flight_intent` in [prioritization_test_steps.py](prioritization_test_steps.py).
+See `modify_planned_conflict_flight` in [prioritization_test_steps.py](prioritization_test_steps.py).
 
 ## 🛑 Incorrectly modified check
 

--- a/monitoring/uss_qualifier/scenarios/flight_planning/plan_conflict_flight_intent.md
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/plan_conflict_flight_intent.md
@@ -2,7 +2,7 @@
 
 This page describes the content of a common test step where a user flight intent should be denied planning because of
 a non-permitted conflict with an equal priority flight intent.
-See `plan_conflict_flight_intent` in [prioritization_test_steps.py](prioritization_test_steps.py).
+See `plan_conflict_flight` in [prioritization_test_steps.py](prioritization_test_steps.py).
 
 ## 🛑 Incorrectly planned check
 

--- a/monitoring/uss_qualifier/scenarios/flight_planning/prioritization_test_steps.py
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/prioritization_test_steps.py
@@ -5,24 +5,16 @@ from uas_standards.interuss.automated_testing.flight_planning.v1.api import (
     BasicFlightPlanInformationUasState,
 )
 
-from uas_standards.interuss.automated_testing.scd.v1.api import (
-    InjectFlightRequest,
-    InjectFlightResponseResult,
-    InjectFlightResponse,
+from monitoring.monitorlib.clients.flight_planning.flight_info import (
+    FlightInfo,
 )
-
 from monitoring.monitorlib.clients.flight_planning.client import FlightPlannerClient
-from monitoring.monitorlib.clients.flight_planning.flight_info import FlightInfo
 from monitoring.monitorlib.clients.flight_planning.planning import (
     PlanningActivityResponse,
     PlanningActivityResult,
     FlightPlanStatus,
 )
-from monitoring.uss_qualifier.resources.flight_planning.flight_planner import (
-    FlightPlanner,
-)
 from monitoring.uss_qualifier.scenarios.flight_planning.test_steps import (
-    submit_flight_intent,
     expect_flight_intent_state,
     submit_flight,
 )
@@ -184,11 +176,12 @@ def modify_activated_priority_conflict_flight(
     )[0]
 
 
-def plan_conflict_flight_intent(
+def plan_conflict_flight(
     scenario: TestScenarioType,
-    flight_planner: FlightPlanner,
-    flight_intent: InjectFlightRequest,
-) -> InjectFlightResponse:
+    flight_planner: FlightPlannerClient,
+    flight_info: FlightInfo,
+    additional_fields: Optional[dict] = None,
+) -> PlanningActivityResponse:
     """Attempt to plan a flight intent that should result in a non-permitted conflict with an equal priority flight intent.
 
     This function implements the test step described in plan_conflict_flight_intent.md.
@@ -197,33 +190,32 @@ def plan_conflict_flight_intent(
     Returns: The injection response.
     """
     expect_flight_intent_state(
-        flight_intent,
+        flight_info,
         BasicFlightPlanInformationUsageState.Planned,
         BasicFlightPlanInformationUasState.Nominal,
         scenario,
     )
 
-    resp, _, _ = submit_flight_intent(
-        scenario,
-        "Incorrectly planned",
-        {
-            InjectFlightResponseResult.ConflictWithFlight,
-            InjectFlightResponseResult.Rejected,
+    return submit_flight(
+        scenario=scenario,
+        success_check="Incorrectly planned",
+        expected_results={
+            (PlanningActivityResult.Rejected, FlightPlanStatus.NotPlanned)
         },
-        {InjectFlightResponseResult.Failed: "Failure"},
-        flight_planner,
-        flight_intent,
-    )
+        failed_checks={PlanningActivityResult.Failed: "Failure"},
+        flight_planner=flight_planner,
+        flight_info=flight_info,
+        additional_fields=additional_fields,
+    )[0]
 
-    return resp
 
-
-def modify_planned_conflict_flight_intent(
+def modify_planned_conflict_flight(
     scenario: TestScenarioType,
-    flight_planner: FlightPlanner,
-    flight_intent: InjectFlightRequest,
+    flight_planner: FlightPlannerClient,
+    flight_info: FlightInfo,
     flight_id: str,
-) -> InjectFlightResponse:
+    additional_fields: Optional[dict] = None,
+) -> PlanningActivityResponse:
     """Attempt to modify a planned flight intent that should result in a non-permitted conflict with an equal priority flight intent.
 
     This function implements the test step described in modify_planned_conflict_flight_intent.md.
@@ -232,34 +224,37 @@ def modify_planned_conflict_flight_intent(
     Returns: The injection response.
     """
     expect_flight_intent_state(
-        flight_intent,
+        flight_info,
         BasicFlightPlanInformationUsageState.Planned,
         BasicFlightPlanInformationUasState.Nominal,
         scenario,
     )
 
-    resp, _, _ = submit_flight_intent(
-        scenario,
-        "Incorrectly modified",
-        {
-            InjectFlightResponseResult.ConflictWithFlight,
-            InjectFlightResponseResult.Rejected,
+    return submit_flight(
+        scenario=scenario,
+        success_check="Incorrectly modified",
+        expected_results={
+            (PlanningActivityResult.Rejected, FlightPlanStatus.Planned),
+            (
+                PlanningActivityResult.Rejected,
+                FlightPlanStatus.Closed,
+            ),  # case where the USS closes the flight plan as a result of the rejected modification attempt
         },
-        {InjectFlightResponseResult.Failed: "Failure"},
-        flight_planner,
-        flight_intent,
-        flight_id,
-    )
+        failed_checks={PlanningActivityResult.Failed: "Failure"},
+        flight_planner=flight_planner,
+        flight_info=flight_info,
+        flight_id=flight_id,
+        additional_fields=additional_fields,
+    )[0]
 
-    return resp
 
-
-def activate_conflict_flight_intent(
+def activate_conflict_flight(
     scenario: TestScenarioType,
-    flight_planner: FlightPlanner,
-    flight_intent: InjectFlightRequest,
+    flight_planner: FlightPlannerClient,
+    flight_info: FlightInfo,
     flight_id: Optional[str] = None,
-) -> InjectFlightResponse:
+    additional_fields: Optional[dict] = None,
+) -> PlanningActivityResponse:
     """Attempt to activate a flight intent that should result in a non-permitted conflict with an equal priority flight intent.
 
     This function implements the test step described in activate_conflict_flight_intent.md.
@@ -268,34 +263,41 @@ def activate_conflict_flight_intent(
     Returns: The injection response.
     """
     expect_flight_intent_state(
-        flight_intent,
+        flight_info,
         BasicFlightPlanInformationUsageState.InUse,
         BasicFlightPlanInformationUasState.Nominal,
         scenario,
     )
 
-    resp, _, _ = submit_flight_intent(
-        scenario,
-        "Incorrectly activated",
-        {
-            InjectFlightResponseResult.ConflictWithFlight,
-            InjectFlightResponseResult.Rejected,
+    return submit_flight(
+        scenario=scenario,
+        success_check="Incorrectly activated",
+        expected_results={
+            (
+                PlanningActivityResult.Rejected,
+                FlightPlanStatus.NotPlanned,
+            ),  # case where the activation was about a flight plan not previously planned
+            (PlanningActivityResult.Rejected, FlightPlanStatus.Planned),
+            (
+                PlanningActivityResult.Rejected,
+                FlightPlanStatus.Closed,
+            ),  # case where the USS closes the flight plan as a result of the rejected activation attempt
         },
-        {InjectFlightResponseResult.Failed: "Failure"},
-        flight_planner,
-        flight_intent,
-        flight_id,
-    )
+        failed_checks={PlanningActivityResult.Failed: "Failure"},
+        flight_planner=flight_planner,
+        flight_info=flight_info,
+        flight_id=flight_id,
+        additional_fields=additional_fields,
+    )[0]
 
-    return resp
 
-
-def modify_activated_conflict_flight_intent(
+def modify_activated_conflict_flight(
     scenario: TestScenarioType,
-    flight_planner: FlightPlanner,
-    flight_intent: InjectFlightRequest,
+    flight_planner: FlightPlannerClient,
+    flight_info: FlightInfo,
     flight_id: str,
-) -> InjectFlightResponse:
+    additional_fields: Optional[dict] = None,
+) -> PlanningActivityResponse:
     """Attempt to modify an activated flight intent that should result in a non-permitted conflict with an equal priority flight intent.
 
     This function implements the test step described in modify_activated_conflict_flight_intent.md.
@@ -304,23 +306,25 @@ def modify_activated_conflict_flight_intent(
     Returns: The injection response.
     """
     expect_flight_intent_state(
-        flight_intent,
+        flight_info,
         BasicFlightPlanInformationUsageState.InUse,
         BasicFlightPlanInformationUasState.Nominal,
         scenario,
     )
 
-    resp, _, _ = submit_flight_intent(
-        scenario,
-        "Incorrectly modified",
-        {
-            InjectFlightResponseResult.ConflictWithFlight,
-            InjectFlightResponseResult.Rejected,
+    return submit_flight(
+        scenario=scenario,
+        success_check="Incorrectly modified",
+        expected_results={
+            (PlanningActivityResult.Rejected, FlightPlanStatus.OkToFly),
+            (
+                PlanningActivityResult.Rejected,
+                FlightPlanStatus.Closed,
+            ),  # case where the USS closes the flight plan as a result of the rejected modification attempt; note: is this actually desirable if the flight was activated?
         },
-        {InjectFlightResponseResult.Failed: "Failure"},
-        flight_planner,
-        flight_intent,
-        flight_id,
-    )
-
-    return resp
+        failed_checks={PlanningActivityResult.Failed: "Failure"},
+        flight_planner=flight_planner,
+        flight_info=flight_info,
+        flight_id=flight_id,
+        additional_fields=additional_fields,
+    )[0]


### PR DESCRIPTION
~~PR stacked on top of #665: please review only commit 716b5faa98595e16a9dbca317fbdf9771c4346d6~~ rebased

Note that this migrates the scenario, but also the directly related test step fragments.
Additionally, the severity is added in the checks of those test step fragments.

Note to reviewer: in this scenario there are some execution paths that are specific to some USS implementations. If one of those path is broken by those changes, this is likely to not be caught by the CI.