### PR TITLE
[uss_qualifier] Fix subscription times

### DIFF
--- a/monitoring/monitorlib/clients/flight_planning/flight_info.py
+++ b/monitoring/monitorlib/clients/flight_planning/flight_info.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from enum import Enum
 from typing import Optional, List
 
@@ -409,6 +410,32 @@ class FlightInfo(ImplicitDict):
                 self.uspace_flight_authorisation, scd_api.FlightAuthorisationData
             )
         return scd_api.InjectFlightRequest(**kwargs)
+
+    def get_f3548v21_op_intent_state(self) -> f3548v21.OperationalIntentState:
+        usage_state = self.basic_information.usage_state
+        uas_state = self.basic_information.uas_state
+        if uas_state == UasState.Nominal:
+            if usage_state == AirspaceUsageState.Planned:
+                return f3548v21.OperationalIntentState.Accepted
+            elif usage_state == AirspaceUsageState.InUse:
+                return f3548v21.OperationalIntentState.Activated
+            else:
+                raise NotImplementedError(
+                    f"Unsupported operator AirspaceUsageState '{usage_state}' with UasState '{uas_state}'"
+                )
+        elif usage_state == AirspaceUsageState.InUse:
+            if uas_state == UasState.OffNominal:
+                return f3548v21.OperationalIntentState.Nonconforming
+            elif uas_state == UasState.Contingent:
+                return f3548v21.OperationalIntentState.Contingent
+            else:
+                raise NotImplementedError(
+                    f"Unsupported operator UasState '{uas_state}' with AirspaceUsageState '{usage_state}'"
+                )
+        else:
+            raise NotImplementedError(
+                f"Unsupported combination of operator AirspaceUsageState '{usage_state}' and UasState '{uas_state}'"
+            )
 
 
 class ExecutionStyle(str, Enum):

--- a/monitoring/monitorlib/mutate/scd.py
+++ b/monitoring/monitorlib/mutate/scd.py
@@ -124,7 +124,7 @@ def upsert_subscription(
 
 def build_upsert_subscription_params(
     area_vertices: s2sphere.LatLngRect,
-    start_time: datetime.datetime,
+    start_time: Optional[datetime.datetime],
     end_time: datetime.datetime,
     base_url: str,
     notify_for_op_intents: bool,

--- a/monitoring/uss_qualifier/resources/astm/f3548/v21/subscription_params.py
+++ b/monitoring/uss_qualifier/resources/astm/f3548/v21/subscription_params.py
@@ -65,8 +65,6 @@ class SubscriptionParams(ImplicitDict):
             A dict to be passed as the request body when calling the subscription creation or update API.
 
         """
-        if not self.start_time:
-            self.start_time = arrow.utcnow().datetime
         return mutate.build_upsert_subscription_params(
             area_vertices=area,
             start_time=self.start_time,

--- a/monitoring/uss_qualifier/resources/astm/f3548/v21/subscription_params.py
+++ b/monitoring/uss_qualifier/resources/astm/f3548/v21/subscription_params.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime
 from typing import List, Optional, Self
 
+import arrow
 import s2sphere
 from implicitdict import ImplicitDict
 from uas_standards.astm.f3548.v21.api import PutSubscriptionParameters
@@ -28,7 +29,7 @@ class SubscriptionParams(ImplicitDict):
     max_alt_m: Optional[float]
     """Maximum altitude in meters"""
 
-    start_time: datetime.datetime
+    start_time: Optional[datetime.datetime] = None
     """Start time of subscription"""
 
     end_time: datetime.datetime
@@ -64,6 +65,8 @@ class SubscriptionParams(ImplicitDict):
             A dict to be passed as the request body when calling the subscription creation or update API.
 
         """
+        if not self.start_time:
+            self.start_time = arrow.utcnow().datetime
         return mutate.build_upsert_subscription_params(
             area_vertices=area,
             start_time=self.start_time,
@@ -84,7 +87,7 @@ class SubscriptionParams(ImplicitDict):
             area_vertices=self.area_vertices,
             min_alt_m=self.min_alt_m,
             max_alt_m=self.max_alt_m,
-            start_time=self.start_time + shift,
+            start_time=self.start_time + shift if self.start_time else None,
             end_time=self.end_time + shift,
             base_url=self.base_url,
             notify_for_op_intents=self.notify_for_op_intents,

--- a/monitoring/uss_qualifier/resources/flight_planning/flight_intent.py
+++ b/monitoring/uss_qualifier/resources/flight_planning/flight_intent.py
@@ -43,10 +43,6 @@ class FlightIntent(ImplicitDict):
         assert_deprecated(
             legacy_callers=[
                 CallSite(
-                    "unpack_flight_intents",
-                    "monitoring/uss_qualifier/resources/flight_planning/flight_intents_resource.py",
-                ),
-                CallSite(
                     "__init__",
                     "monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/get_op_data_validation.py",
                 ),

--- a/monitoring/uss_qualifier/resources/flight_planning/flight_intents_resource.py
+++ b/monitoring/uss_qualifier/resources/flight_planning/flight_intents_resource.py
@@ -52,27 +52,3 @@ class FlightIntentsResource(Resource[FlightIntentsSpecification]):
 
     def get_flight_intents(self) -> Dict[FlightIntentID, FlightInfoTemplate]:
         return self._intent_collection.resolve()
-
-
-def unpack_flight_intents(
-    flight_intents: FlightIntentsResource, flight_identifiers: List[str]
-):
-    """
-    Extracts the specified flight identifiers from the passed FlightIntentsResource
-    """
-    flight_intents = {
-        k: FlightIntent.from_flight_info_template(v)
-        for k, v in flight_intents.get_flight_intents().items()
-        if k in flight_identifiers
-    }
-
-    extents = []
-    for intent in flight_intents.values():
-        extents.extend(intent.request.operational_intent.volumes)
-        extents.extend(intent.request.operational_intent.off_nominal_volumes)
-
-    intents_extent = Volume4DCollection.from_interuss_scd_api(
-        extents
-    ).bounding_volume.to_f3548v21()
-
-    return intents_extent, flight_intents

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.py
@@ -105,6 +105,7 @@ class OIRSynchronization(TestScenario):
             volume=self._planning_area.volume,
         )
 
+    def run(self, context: ExecutionContext):
         self._oir_params = self._planning_area.get_new_operational_intent_ref_params(
             key=[],
             state=OperationalIntentState.Accepted,
@@ -115,8 +116,6 @@ class OIRSynchronization(TestScenario):
             implicit_sub_base_url=None,
             implicit_sub_for_constraints=None,
         )
-
-    def run(self, context: ExecutionContext):
 
         # Check that we actually have at least one other DSS to test against:
         if not self._dss_read_instances:

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/subscription_synchronization.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/subscription_synchronization.py
@@ -150,6 +150,15 @@ class SubscriptionSynchronization(TestScenario):
             )
         )
 
+        if second_utm_auth is not None:
+            # Build a second DSSWrapper identical to the first but with the other auth adapter
+            self._dss_separate_creds = self._dss.with_different_auth(
+                second_utm_auth, scopes_primary
+            )
+        else:
+            self._dss_separate_creds = None
+
+    def run(self, context: ExecutionContext):
         self._sub_params = self._planning_area.get_new_subscription_params(
             subscription_id=self._sub_id,
             # Set this slightly in the past: we will update the subscriptions
@@ -160,16 +169,6 @@ class SubscriptionSynchronization(TestScenario):
             notify_for_op_intents=True,
             notify_for_constraints=False,
         )
-
-        if second_utm_auth is not None:
-            # Build a second DSSWrapper identical to the first but with the other auth adapter
-            self._dss_separate_creds = self._dss.with_different_auth(
-                second_utm_auth, scopes_primary
-            )
-        else:
-            self._dss_separate_creds = None
-
-    def run(self, context: ExecutionContext):
 
         # Check that we actually have at least one other DSS to test against:
         if not self._dss_read_instances:


### PR DESCRIPTION
Currently, a number of uss_qualifier scenarios evaluate/generate timestamps upon scenario instantiation (which happens very close to the start of the test run) but the scenario doesn't run until much later (10-15 minutes).  This results in a number of problems, but one specific problem is that at least scenarios.astm.utm.dss.synchronization.SubscriptionSynchronization attempts to emplace a subscription in the DSS with an end time that is "far" in the past.  The DSS does not allow any subscription to be created whose start time is in the past, but has a [5 minute tolerance](https://github.com/interuss/dss/blob/8a1a5e902df1aec8050074e182c22613a81aaa87/pkg/scd/models/subscriptions.go#L21) regarding "now".  Because of the large gap between scenario instantiation and scenario execution, SubscriptionSynchronization's old timestamps are beyond this threshold and the DSS rejects its subscription emplacement attempts because the start time is more than 5 minutes in the past on certain test runs.

This PR resolves this problem for that scenario particularly by migrating it to use FlightInfoTemplates, and this also removes one of the legacy references to deprecated FlightIntent functionality.  The places in other subscription scenarios where time stamps are computed are moved from instantiation into execution as well to pre-emptively address any similar issues until timestamps are handled more robustly.