### PR TITLE
[uss_qualifier] down_uss scenarios properly check area has been cleared

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss.md
@@ -49,6 +49,10 @@ Delete any leftover operational intent references created at DSS by virtual USS.
 #### 🛑 Successful operational intents cleanup check
 If the search for operational intent references or their deletion fail, this check fails per **[astm.f3548.v21.DSS0005,2](../../../../requirements/astm/f3548/v21.md)** or **[astm.f3548.v21.DSS0005,1](../../../../requirements/astm/f3548/v21.md)**, respectively.
 
+### [Verify area is clear test step](../clear_area_validation.md)
+
+This scenario requires the area to have been cleared of operational intents. If it has not, this test step will raise a failed check.
+
 ## Plan Flight 1 in conflict with accepted operational intent managed by down USS test case
 This test case aims at testing requirement **[astm.f3548.v21.SCD0005](../../../../requirements/astm/f3548/v21.md)**.
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional
 import arrow
 
 from monitoring.monitorlib.fetch import QueryError
-from monitoring.monitorlib.geotemporal import Volume4DCollection
+from monitoring.monitorlib.geotemporal import Volume4DCollection, Volume4D
 from monitoring.uss_qualifier.common_data_definitions import Severity
 from uas_standards.astm.f3548.v21.api import (
     OperationalIntentState,
@@ -27,6 +27,9 @@ from monitoring.uss_qualifier.resources.flight_planning.flight_planner import (
 )
 from monitoring.uss_qualifier.resources.flight_planning.flight_planners import (
     FlightPlannerResource,
+)
+from monitoring.uss_qualifier.scenarios.astm.utm.clear_area_validation import (
+    validate_clear_area,
 )
 from monitoring.uss_qualifier.scenarios.astm.utm.test_steps import (
     OpIntentValidator,
@@ -160,6 +163,15 @@ class DownUSS(TestScenario):
 
         self.begin_test_step("Clear operational intents created by virtual USS")
         self._clear_op_intents()
+        self.end_test_step()
+
+        self.begin_test_step("Verify area is clear")
+        validate_clear_area(
+            self,
+            self.dss,
+            [Volume4D.from_f3548v21(self._intents_extent)],
+            ignore_self=True,
+        )
         self.end_test_step()
 
     def _put_conflicting_op_intent_step(

--- a/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md
@@ -50,6 +50,10 @@ Delete any leftover operational intents created at DSS by virtual USS.
 #### Successful operational intents cleanup check
 If the search for operational intent references or their deletion fail, this check fails per **[astm.f3548.v21.DSS0005,2](../../../../requirements/astm/f3548/v21.md)** or **[astm.f3548.v21.DSS0005,1](../../../../requirements/astm/f3548/v21.md)**, respectively.
 
+### [Verify area is clear test step](../clear_area_validation.md)
+
+This scenario requires the area to have been cleared of operational intents. If it has not, this test step will raise a failed check.
+
 ## Plan Flight 2 in conflict with activated operational intent managed by down USS test case
 This test case aims at testing requirement **[astm.f3548.v21.SCD0010](../../../../requirements/astm/f3548/v21.md)**.
 


### PR DESCRIPTION
This addresses the part of #670 related to checking the area has been cleared in the DownUSS and DownUSSEqualPriorityNotPermitted scenarios.

My best guess is that DownUSSEqualPriorityNotPermitted needs a clean area, because existing flights might have a conflicting priority and prevent the scenario from being properly executed.

As for DownUSS, it _might_ support having a non-empty area, but the additional test step having been added in the reused `_setup()` function in the DownUSS class (which DownUSSEqualPriorityNotPermitted inherits from), it currently also required a clear area.