### PR TITLE
[uss_qualifier/scenarios/utm/validate_shared_operational_intent] Validate operational intent state

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/utm/test_steps.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/test_steps.py
@@ -220,6 +220,7 @@ class OpIntentValidator(object):
         if oi_ref is None:
             return None
 
+        self._check_op_intent_reference(flight_intent, oi_ref)
         self._check_op_intent_details(flight_intent, oi_ref)
 
         # Check telemetry if intent is off-nominal
@@ -377,6 +378,20 @@ class OpIntentValidator(object):
                 oi_ref = self._new_oi_ref
 
         return oi_ref
+
+    def _check_op_intent_reference(
+        self, flight_intent: FlightInfo, oi_ref: OperationalIntentReference
+    ):
+        with self._scenario.check(
+            "Operational intent state is correct",
+            [self._flight_planner.participant_id],
+        ) as check:
+            if flight_intent.get_f3548v21_op_intent_state() != oi_ref.state:
+                check.record_failed(
+                    summary="Operational intent state does not match user's flight intent",
+                    details=f"Expected state {flight_intent.get_f3548v21_op_intent_state()} but got state {oi_ref.state}",
+                    query_timestamps=[self._after_query.request.timestamp],
+                )
 
     def _check_op_intent_details(
         self, flight_intent: FlightInfo, oi_ref: OperationalIntentReference

--- a/monitoring/uss_qualifier/scenarios/astm/utm/validate_shared_operational_intent.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/validate_shared_operational_intent.md
@@ -17,6 +17,10 @@ If an activated operational intent is expected to exist after it has been modifi
 in the DSS, this means that there is an active flight without a corresponding operational intent, then this check will
 fail per **[interuss.automated_testing.flight_planning.FlightCoveredByOperationalIntent](../../../requirements/interuss/automated_testing/flight_planning.md)**.
 
+## 🛑 Operational intent state is correct check
+
+If the state of the operational intent found in the DSS does not match the user's flight intent, this check will fail per **[interuss.automated_testing.flight_planning.ExpectedBehavior](../../../requirements/interuss/automated_testing/flight_planning.md)**.
+
 ## 🛑 Operational intent details retrievable check
 
 If the operational intent details for the flight cannot be retrieved from the USS, this check will fail per **[astm.f3548.v21.USS0105](../../../requirements/astm/f3548/v21.md)** and **[astm.f3548.v21.OPIN0025](../../../requirements/astm/f3548/v21.md)**.


### PR DESCRIPTION
This adds a check that validates that the operational intent published to the DSS matches the user's flight intent. 