### PR TITLE
[dss] update dss version to v0.15.0-rc1, add required scope to mock_uss

### DIFF
--- a/build/dev/docker-compose.yaml
+++ b/build/dev/docker-compose.yaml
@@ -43,7 +43,7 @@ services:
 
   dss:
     hostname: dss.uss1.localutm
-    image: interuss/dss:v0.14.0
+    image: interuss/dss:v0.15.0-rc1
     volumes:
       - $PWD/../test-certs:/var/test-certs:ro
       - dss_component_coordination:/var/dss_component_coordination

--- a/monitoring/monitorlib/clients/scd.py
+++ b/monitoring/monitorlib/clients/scd.py
@@ -52,7 +52,7 @@ def create_operational_intent_reference(
     url = "/dss/v1/operational_intent_references/{}".format(id)
     subject = f"createOperationalIntentReference to {url}"
     query = fetch.query_and_describe(
-        utm_client, "PUT", url, json=req, scope=scd.SCOPE_SC
+        utm_client, "PUT", url, json=req, scopes=[scd.SCOPE_SC, scd.SCOPE_CM_SA]
     )
     if query.status_code != 200 and query.status_code != 201:
         raise QueryError(
@@ -84,7 +84,7 @@ def update_operational_intent_reference(
     url = "/dss/v1/operational_intent_references/{}/{}".format(id, ovn)
     subject = f"updateOperationalIntentReference to {url}"
     query = fetch.query_and_describe(
-        utm_client, "PUT", url, json=req, scope=scd.SCOPE_SC
+        utm_client, "PUT", url, json=req, scopes=[scd.SCOPE_SC, scd.SCOPE_CM_SA]
     )
     if query.status_code != 200 and query.status_code != 201:
         raise QueryError(

--- a/monitoring/monitorlib/infrastructure.py
+++ b/monitoring/monitorlib/infrastructure.py
@@ -13,6 +13,7 @@ ALL_SCOPES = [
     "dss.write.identification_service_areas",
     "dss.read.identification_service_areas",
     "utm.strategic_coordination",
+    "utm.conformance_monitoring_sa",
     "utm.constraint_management",
     "utm.constraint_consumption",
 ]

--- a/monitoring/uss_qualifier/resources/astm/f3548/v21/dss.py
+++ b/monitoring/uss_qualifier/resources/astm/f3548/v21/dss.py
@@ -271,7 +271,15 @@ class DSSInstance(object):
         Raises:
             * QueryError: if request failed, if HTTP status code is different than 200 or 201, or if the parsing of the response failed.
         """
+        scopes = [Scope.StrategicCoordination]
         self._uses_scope(Scope.StrategicCoordination)
+        if state in [
+            OperationalIntentState.Nonconforming,
+            OperationalIntentState.Contingent,
+        ]:
+            scopes.append(Scope.ConformanceMonitoringForSituationalAwareness)
+            self._uses_scope(Scope.ConformanceMonitoringForSituationalAwareness)
+
         oi_uuid = str(uuid.uuid4()) if oi_id is None else oi_id
         create = ovn is None
         if create:
@@ -299,7 +307,7 @@ class DSSInstance(object):
             url,
             query_type,
             self.participant_id,
-            scope=Scope.StrategicCoordination,
+            scopes=scopes,
             json=req,
         )
         if (create and query.status_code == 201) or (

--- a/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss.py
@@ -73,6 +73,7 @@ class DownUSS(TestScenario):
             {
                 Scope.StrategicCoordination: "search for operational intent references to verify outcomes of planning activities and retrieve operational intent details",
                 Scope.AvailabilityArbitration: "declare virtual USS down in DSS",
+                Scope.ConformanceMonitoringForSituationalAwareness: "create operational intent references in an off-nominal state",
             }
         )
 


### PR DESCRIPTION
Updates to the DSS version that correctly checks for scopes when doing operational intent reference state transitions.

The mock_uss now needs the relevant scope, which was not requested up to now.

The function to create operational intents in `dss.py` also required a tweak to include the necessary scope when the requested state is off-nominal.