### PR TITLE
[uss_qualifier] check constraint reference synchronization across multiple DSS instances

### DIFF
--- a/monitoring/monitorlib/schema_validation.py
+++ b/monitoring/monitorlib/schema_validation.py
@@ -70,6 +70,14 @@ class F3548_21(str, Enum):
     )
     AirspaceConflictResponse = "components.schemas.AirspaceConflictResponse"
 
+    ChangeConstraintReferenceResponse = (
+        "components.schemas.ChangeConstraintReferenceResponse"
+    )
+    GetConstraintReferenceResponse = "components.schemas.GetConstraintReferenceResponse"
+    QueryConstraintReferenceResponse = (
+        "components.schemas.QueryConstraintReferenceResponse"
+    )
+
 
 _openapi_content_cache: Dict[str, dict] = {}
 

--- a/monitoring/prober/infrastructure.py
+++ b/monitoring/prober/infrastructure.py
@@ -100,7 +100,7 @@ ResourceType = int
 resource_type_code_descriptions: Dict[ResourceType, str] = {}
 
 
-# Next code: 390
+# Next code: 391
 def register_resource_type(code: int, description: str) -> ResourceType:
     """Register that the specified code refers to the described resource.
 

--- a/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml
@@ -66,6 +66,7 @@ v1:
               # ASTM F3548-21 USS emulation roles
               - utm.strategic_coordination
               - utm.availability_arbitration
+              - utm.constraint_management
               # For authentication test purposes.
               # Remove if the authentication provider pointed to by AUTH_SPEC does not support it.
               - ""

--- a/monitoring/uss_qualifier/configurations/dev/library/environment_containers.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/library/environment_containers.yaml
@@ -27,6 +27,7 @@ utm_auth:
       - utm.strategic_coordination
       - utm.conformance_monitoring_sa
       - utm.availability_arbitration
+      - utm.constraint_management
       # InterUSS versioning automated testing
       - interuss.versioning.read_system_versions
       - interuss.geospatial_map.query

--- a/monitoring/uss_qualifier/configurations/dev/library/environment_localhost.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/library/environment_localhost.yaml
@@ -27,6 +27,7 @@ utm_auth:
       - utm.strategic_coordination
       - utm.conformance_monitoring_sa
       - utm.availability_arbitration
+      - utm.constraint_management
       # InterUSS versioning automated testing
       - interuss.versioning.read_system_versions
       - interuss.geospatial_map.query

--- a/monitoring/uss_qualifier/resources/astm/f3548/v21/planning_area.py
+++ b/monitoring/uss_qualifier/resources/astm/f3548/v21/planning_area.py
@@ -9,6 +9,7 @@ from uas_standards.astm.f3548.v21.api import (
     EntityID,
     PutOperationalIntentReferenceParameters,
     ImplicitSubscriptionParameters,
+    PutConstraintReferenceParameters,
 )
 
 from monitoring.monitorlib.geo import make_latlng_rect, Volume3D
@@ -99,6 +100,29 @@ class PlanningAreaSpecification(ImplicitDict):
             )
             if implicit_sub_base_url
             else None,
+        )
+
+    def get_new_constraint_ref_params(
+        self,
+        time_start: datetime.datetime,
+        time_end: datetime.datetime,
+    ) -> PutConstraintReferenceParameters:
+        """
+        Builds a PutConstraintReferenceParameters object that can be used against the DSS OCR API.
+
+        The extents contained in these parameters contain a single 4DVolume, which may not be entirely realistic,
+        but is sufficient in situations where the content of the CR is irrelevant as long as it is valid, such
+        as for testing authentication or parameter validation.
+        """
+        return PutConstraintReferenceParameters(
+            extents=[
+                Volume4D(
+                    volume=self.volume,
+                    time_start=Time(time_start),
+                    time_end=Time(time_end),
+                ).to_f3548v21()
+            ],
+            uss_base_url=self.base_url,
         )
 
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/clean_workspace.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/clean_workspace.md
@@ -28,3 +28,18 @@ If the DSS cannot be queried for the existing test ID, the DSS is likely not imp
 ## 🛑 Subscription can be deleted check
 
 **[astm.f3548.v21.DSS0005,5](../../../../requirements/astm/f3548/v21.md)** requires the implementation of the DSS endpoint to allow callers to delete subscriptions they created.
+
+## 🛑 Constraint references can be queried by ID check
+
+If an existing constraint reference cannot directly be queried by its ID, or if for a non-existing one the DSS replies with a status code different than 404,
+the DSS implementation is in violation of **[astm.f3548.v21.DSS0005,3](../../../../requirements/astm/f3548/v21.md)**.
+
+## 🛑 Constraint references can be searched for check
+
+A client with valid credentials should be allowed to search for constraint references in a given area.
+Otherwise, the DSS is not in compliance with **[astm.f3548.v21.DSS0005,4](../../../../requirements/astm/f3548/v21.md)**.
+
+## 🛑 Constraint reference removed check
+
+If an existing constraint cannot be deleted by its manager when providing the proper ID and OVN, the DSS implementation is in violation of
+**[astm.f3548.v21.DSS0005,3](../../../../requirements/astm/f3548/v21.md)**.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/cr/crud/create_correct.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/cr/crud/create_correct.md
@@ -1,0 +1,21 @@
+# Create constraint reference test step fragment
+
+This test step fragment validates that:
+ - a query to create a constraint reference with valid parameters succeeds
+ - the response to the query conforms to the OpenAPI specification
+ - the content of the response reflects the created constraint reference
+
+## [Query Success](./create_query.md)
+
+Check query succeeds
+
+## [Response Format](./create_format.md)
+
+Check response format
+
+## 🛑 Create constraint reference response content is correct check
+
+A successful constraint reference creation query is expected to return a body, the content of which reflects the created constraint reference.
+If the content of the response does not correspond to what was requested, the DSS is failing to implement **[astm.f3548.v21.DSS0005,3](../../../../../../../requirements/astm/f3548/v21.md)**.
+
+This check will usually be performing a series of sub-checks from the [validate](../validate) fragments.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/cr/crud/create_format.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/cr/crud/create_format.md
@@ -1,0 +1,9 @@
+# Create constraint reference response format test step fragment
+
+This test step fragment validates that a constraint references creation returns a body in the correct format.
+
+## 🛑 Create constraint reference response format conforms to spec check
+
+The response to a successful constraint reference creation query is expected to conform to the format defined by the OpenAPI specification under the `A3.1` Annex of ASTM F3548−21.
+
+If it does not, the DSS is failing to implement **[astm.f3548.v21.DSS0005,3](../../../../../../../requirements/astm/f3548/v21.md)**.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/cr/crud/create_query.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/cr/crud/create_query.md
@@ -1,0 +1,8 @@
+# Create constraint reference test step fragment
+
+This test step fragment validates that a query to create a constraint reference with valid parameters succeeds
+
+## 🛑 Create constraint reference query succeeds check
+
+As per **[astm.f3548.v21.DSS0005,3](../../../../../../../requirements/astm/f3548/v21.md)**, the DSS API must allow callers to create a constraint reference with either one or both of the
+start and end time missing, provided all the required parameters are valid.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/cr/crud/delete.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/cr/crud/delete.md
@@ -1,0 +1,20 @@
+# Delete constraint reference test step fragment
+
+This test step fragment validates that constraint references can be deleted
+
+## 🛑 Delete constraint reference query succeeds check
+
+A query to delete a constraint reference, by its owner and when the correct OVN is provided, should succeed, otherwise the DSS is in violation of **[astm.f3548.v21.DSS0005,3](../../../../../../../requirements/astm/f3548/v21.md)**.
+
+## 🛑 Delete constraint reference response format conforms to spec check
+
+The response to a successful constraint reference deletion query is expected to conform to the format defined by the OpenAPI specification under the `A3.1` Annex of ASTM F3548−21.
+
+If it does not, the DSS is failing to implement **[astm.f3548.v21.DSS0005,3](../../../../../../../requirements/astm/f3548/v21.md)**.
+
+## 🛑 Delete constraint reference response content is correct check
+
+A successful constraint reference deletion query is expected to return a body, the content of which reflects the constraint reference at the moment of deletion.
+If the content of the response does not correspond to what was requested, the DSS is failing to implement **[astm.f3548.v21.DSS0005,3](../../../../../../../requirements/astm/f3548/v21.md)**.
+
+This check will usually be performing a series of sub-checks from the [validate](../validate) fragments.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/cr/crud/read_correct.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/cr/crud/read_correct.md
@@ -1,0 +1,20 @@
+# Read constraint reference test step fragment
+
+This test step fragment validates that constraint references can be read
+
+## [Read query succeeds](./read_query.md)
+
+Check query succeeds.
+
+## 🛑 Get constraint reference response format conforms to spec check
+
+The response to a successful get constraint reference query is expected to conform to the format defined by the OpenAPI specification under the `A3.1` Annex of ASTM F3548−21.
+
+If it does not, the DSS is failing to implement **[astm.f3548.v21.DSS0005,3](../../../../../../../requirements/astm/f3548/v21.md)**.
+
+## 🛑 Get constraint reference response content is correct check
+
+A successful constraint reference creation query is expected to return a body, the content of which reflects a constraint reference that was created earlier.
+If the content of the response does not correspond to what was requested, the DSS is failing to implement **[astm.f3548.v21.DSS0005,3](../../../../../../../requirements/astm/f3548/v21.md)**.
+
+This check will usually be performing a series of sub-checks from the [validate](../validate) fragments.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/cr/crud/read_query.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/cr/crud/read_query.md
@@ -1,0 +1,7 @@
+# Read constraint reference query test step fragment
+
+This test step fragment validates that a query to retrieve a constraint reference with valid parameters succeeds.
+
+## 🛑 Get constraint reference by ID check
+
+If a constraint reference cannot be queried using its ID, the DSS is failing to meet **[astm.f3548.v21.DSS0005,3](../../../../../../../requirements/astm/f3548/v21.md)**.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/cr/crud/search_correct.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/cr/crud/search_correct.md
@@ -1,0 +1,17 @@
+# Search constraint reference test step fragment
+
+This test step fragment validates that constraint references can be searched for
+
+## [Search query succeeds](./search_query.md)
+
+Check query succeeds.
+
+## 🛑 Search constraint reference response format conforms to spec check
+
+The response to a successful constraint reference search query is expected to conform to the format defined by the OpenAPI specification under the `A3.1` Annex of ASTM F3548−21.
+
+If it does not, the DSS is failing to implement **[astm.f3548.v21.DSS0005,3](../../../../../../../requirements/astm/f3548/v21.md)**.
+
+## 🛑 Created constraint reference is in search results check
+
+If the existing constraint reference is not returned in a search that covers the area it was created for, the DSS is not properly implementing **[astm.f3548.v21.DSS0005,2](../../../../../../../requirements/astm/f3548/v21.md)**.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/cr/crud/search_query.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/cr/crud/search_query.md
@@ -1,0 +1,7 @@
+# Search constraint reference query test step fragment
+
+This test step fragment validates that a query to search for constraint references with valid parameters succeeds.
+
+## 🛑 Successful constraint reference search query check
+
+If the DSS fails to let us search in the area for which the CR was created, it is failing to meet **[astm.f3548.v21.DSS0005,3](../../../../../../../requirements/astm/f3548/v21.md)**.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/cr/crud/update_correct.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/cr/crud/update_correct.md
@@ -1,0 +1,18 @@
+# Update constraint reference test step fragment
+
+This test step fragment validates that constraint references can be updated.
+
+## [Update query succeeds](./update_query.md)
+
+Check query succeeds.
+
+## [Response Format](./update_format.md)
+
+Check response format
+
+## 🛑 Mutate constraint reference response content is correct check
+
+A successful constraint reference mutation query is expected to return a well-defined body, the content of which reflects the updated constraint reference.
+If the content of the response does not correspond to what was requested, the DSS is failing to implement **[astm.f3548.v21.DSS0005,3](../../../../../../../requirements/astm/f3548/v21.md)**.
+
+This check will usually be performing a series of sub-checks from the [validate](../validate) fragments.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/cr/crud/update_format.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/cr/crud/update_format.md
@@ -1,0 +1,9 @@
+# Update constraint reference response format test step fragment
+
+This test step fragment validates that updates to constraint references return a body in the correct format.
+
+## 🛑 Mutate constraint reference response format conforms to spec check
+
+The response to a successful constraint reference mutation query is expected to conform to the format defined by the OpenAPI specification under the `A3.1` Annex of ASTM F3548−21.
+
+If it does not, the DSS is failing to implement **[astm.f3548.v21.DSS0005,3](../../../../../../../requirements/astm/f3548/v21.md)**.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/cr/crud/update_query.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/cr/crud/update_query.md
@@ -1,0 +1,7 @@
+# Update constraint reference test step fragment
+
+This test step fragment validates that a query to update a constraint reference with valid parameters succeeds.
+
+## 🛑 Mutate constraint reference query succeeds check
+
+As per **[astm.f3548.v21.DSS0005,3](../../../../../../../requirements/astm/f3548/v21.md)**, the DSS API must allow callers to mutate a constraint reference.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/cr/sync.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/cr/sync.md
@@ -1,0 +1,70 @@
+# Synchronize constraint reference test step fragment
+
+This test step fragment validates that constraint references are properly synchronized across a set of DSS instances.
+
+## 🛑 Constraint reference can be found at every DSS check
+
+If the previously created or mutated constraint reference cannot be found at a DSS, either one of the instances at which the constraint reference was created or the one that was queried,
+is failing to implement one of the following requirements:
+
+**[astm.f3548.v21.DSS0210,2a](../../../../../../requirements/astm/f3548/v21.md)**, if the API is not working as described by the OpenAPI specification;
+**[astm.f3548.v21.DSS0215](../../../../../../requirements/astm/f3548/v21.md)**, if the DSS is returning API calls to the client before having updated its underlying distributed storage.
+
+As a result, the DSS pool under test is failing to meet **[astm.f3548.v21.DSS0020](../../../../../../requirements/astm/f3548/v21.md)**.
+
+## 🛑 Propagated constraint reference general area is synchronized check
+
+When querying a secondary DSS for constraints in the planning area that contains the propagated
+constraint, if the propagated constraint is not contained in the response, then the general area in which the
+propagated constraint is located is not synchronized across DSS instances.
+As such, either the primary or the secondary DSS fail to properly one of the following requirements:
+
+**[astm.f3548.v21.DSS0210,2e](../../../../../../requirements/astm/f3548/v21.md)**, if the API is not working as described by the OpenAPI specification;
+**[astm.f3548.v21.DSS0215](../../../../../../requirements/astm/f3548/v21.md)**, if the DSS is returning API calls to the client before having updated its underlying distributed storage.
+
+As a result, the DSS pool under test is failing to meet **[astm.f3548.v21.DSS0020](../../../../../../requirements/astm/f3548/v21.md)**.
+
+## ⚠️ Propagated constraint reference contains the correct manager check
+
+If the constraint reference returned by a DSS to which the constraint reference was synchronized to does not contain the correct manager,
+either one of the instances at which the constraint reference was created or the one that was queried,
+is failing to implement one of the following requirements:
+
+**[astm.f3548.v21.DSS0210,2b](../../../../../../requirements/astm/f3548/v21.md)**, if the API is not working as described by the OpenAPI specification;
+**[astm.f3548.v21.DSS0215](../../../../../../requirements/astm/f3548/v21.md)**, if the DSS is returning API calls to the client before having updated its underlying distributed storage.
+
+As a result, the DSS pool under test is failing to meet **[astm.f3548.v21.DSS0020](../../../../../../requirements/astm/f3548/v21.md)**.
+
+## ⚠️ Propagated constraint reference contains the correct USS base URL check
+
+If the constraint reference returned by a DSS to which the constraint reference was synchronized to does not contain the correct USS base URL,
+either one of the instances at which the constraint reference was created or the one that was queried,
+is failing to implement one of the following requirements:
+
+**[astm.f3548.v21.DSS0210,2c](../../../../../../requirements/astm/f3548/v21.md)**, if the API is not working as described by the OpenAPI specification;
+**[astm.f3548.v21.DSS0215](../../../../../../requirements/astm/f3548/v21.md)**, if the DSS is returning API calls to the client before having updated its underlying distributed storage.
+
+As a result, the DSS pool under test is failing to meet **[astm.f3548.v21.DSS0020](../../../../../../requirements/astm/f3548/v21.md)**.
+
+## ⚠️ Propagated constraint reference contains the correct start time check
+
+If the constraint reference returned by a DSS to which the constraint reference was synchronized to does not contain the correct start time,
+either one of the instances at which the constraint reference was created or the one that was queried,
+is failing to implement one of the following requirements:
+
+**[astm.f3548.v21.DSS0210,2f](../../../../../../requirements/astm/f3548/v21.md)**, if the API is not working as described by the OpenAPI specification;
+**[astm.f3548.v21.DSS0215](../../../../../../requirements/astm/f3548/v21.md)**, if the DSS is returning API calls to the client before having updated its underlying distributed storage.
+
+As a result, the DSS pool under test is failing to meet **[astm.f3548.v21.DSS0020](../../../../../../requirements/astm/f3548/v21.md)**.
+
+
+## ⚠️ Propagated constraint reference contains the correct end time check
+
+If the constraint reference returned by a DSS to which the constraint reference was synchronized to does not contain the correct end time,
+either one of the instances at which the constraint reference was created or the one that was queried,
+is failing to implement one of the following requirements:
+
+**[astm.f3548.v21.DSS0210,2f](../../../../../../requirements/astm/f3548/v21.md)**, if the API is not working as described by the OpenAPI specification;
+**[astm.f3548.v21.DSS0215](../../../../../../requirements/astm/f3548/v21.md)**, if the DSS is returning API calls to the client before having updated its underlying distributed storage.
+
+As a result, the DSS pool under test is failing to meet **[astm.f3548.v21.DSS0020](../../../../../../requirements/astm/f3548/v21.md)**.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/cr/validate/correctness.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/cr/validate/correctness.md
@@ -1,0 +1,50 @@
+# Validate the content of a constraint reference test step fragment
+
+This test step fragment attempts to validate the content of a single constraint reference returned by the DSS.
+
+Fields that require different handling based on if the constraint reference was mutated or not are covered in
+the [validate mutated constraint reference](mutated.md) and [validate non-mutated constraint reference](non_mutated.md) fragments, respectively.
+
+The code for these checks lives in the [cr_validator.py](../../../validators/cr_validator.py) class.
+
+## ⚠️ Returned constraint reference ID is correct check
+
+If the returned constraint reference ID does not correspond to the one specified in the creation parameters,
+**[astm.f3548.v21.DSS0005,3](../../../../../../../requirements/astm/f3548/v21.md)** is not respected.
+
+## ⚠️ Returned constraint reference has a manager check
+
+If the returned constraint reference has no manager defined, **[astm.f3548.v21.DSS0005,3](../../../../../../../requirements/astm/f3548/v21.md)** is not respected.
+
+## ⚠️ Returned constraint reference manager is correct check
+
+The returned manager must correspond to the identity of the client that created the constraint at the DSS,
+otherwise the DSS is in violation of **[astm.f3548.v21.DSS0005,3](../../../../../../../requirements/astm/f3548/v21.md)**.
+
+## ⚠️ Returned constraint reference has an USS base URL check
+
+If the returned constraint reference has no USS base URL defined, **[astm.f3548.v21.DSS0005,3](../../../../../../../requirements/astm/f3548/v21.md)** is not respected.
+
+## ⚠️ Returned constraint reference base URL is correct check
+
+The returned USS base URL must be prefixed with the USS base URL that was provided at constraint reference creation, otherwise the DSS is in violation of **[astm.f3548.v21.DSS0005,3](../../../../../../../requirements/astm/f3548/v21.md)**.
+
+## ⚠️ Returned constraint reference has a start time check
+
+If the returned constraint reference has no start time defined, **[astm.f3548.v21.DSS0005,3](../../../../../../../requirements/astm/f3548/v21.md)** is not respected.
+
+## ⚠️ Returned start time is correct check
+
+The returned start time must be the same as the provided one, otherwise the DSS is in violation of **[astm.f3548.v21.DSS0005,3](../../../../../../../requirements/astm/f3548/v21.md)**.
+
+## ⚠️ Returned constraint reference has an end time check
+
+constraint references need a defined end time in order to limit their duration: if the DSS omits to set the end time, it will be in violation of **[astm.f3548.v21.DSS0005,3](../../../../../../../requirements/astm/f3548/v21.md)**.
+
+## ⚠️ Returned end time is correct check
+
+The returned end time must be the same as the provided one, otherwise the DSS is in violation of **[astm.f3548.v21.DSS0005,3](../../../../../../../requirements/astm/f3548/v21.md)**.
+
+## ⚠️ Returned constraint reference has a version check
+
+If the returned constraint reference has no version defined, **[astm.f3548.v21.DSS0005,3](../../../../../../../requirements/astm/f3548/v21.md)** is not respected.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/cr/validate/mutated.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/cr/validate/mutated.md
@@ -1,0 +1,14 @@
+# Validate mutated constraint reference test step fragment
+
+This test step fragment attempts to validate a single constraint reference returned by the DSS,
+usually after it has been mutated.
+
+The code for these checks lives in the [cr_validator.py](../../../validators/cr_validator.py) class.
+
+## ⚠️ Mutated constraint reference version is updated check
+
+Following a mutation, the DSS needs to update the constraint reference version, otherwise it is in violation of **[astm.f3548.v21.DSS0005,3](../../../../../../../requirements/astm/f3548/v21.md)**.
+
+## ⚠️ Mutated constraint reference OVN is updated check
+
+Following a mutation, the DSS needs to update the constraint reference OVN, otherwise it is in violation of **[astm.f3548.v21.DSS0005,3](../../../../../../../requirements/astm/f3548/v21.md)**.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/cr/validate/non_mutated.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/cr/validate/non_mutated.md
@@ -1,0 +1,14 @@
+# Validate non-mutated constraint reference test step fragment
+
+This test step fragment attempts to validate a single constraint reference returned by the DSS,
+usually after it has been created or to confirm it has not been mutated by an action.
+
+The code for these checks lives in the [cr_validator.py](../../../validators/cr_validator.py) class.
+
+## ⚠️ Non-mutated constraint reference keeps the same version check
+
+If the version of the constraint reference is updated without there having been any mutation of the constraint reference, the DSS is in violation of **[astm.f3548.v21.DSS0005,3](../../../../../../../requirements/astm/f3548/v21.md)**.
+
+## ⚠️ Non-mutated constraint reference keeps the same OVN check
+
+If the OVN of the constraint reference is updated without there having been any mutation of the constraint reference, the DSS is in violation of **[astm.f3548.v21.DSS0005,3](../../../../../../../requirements/astm/f3548/v21.md)**.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/__init__.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/__init__.py
@@ -1,3 +1,4 @@
 from .subscription_synchronization import SubscriptionSynchronization
 from .op_intent_ref_synchronization import OIRSynchronization
 from .uss_availability_synchronization import USSAvailabilitySynchronization
+from .constraint_ref_synchronization import CRSynchronization

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md
@@ -1,0 +1,187 @@
+# ASTM SCD DSS: Constraint Reference Synchronization test scenario
+
+## Overview
+
+Verifies that all CRUD operations on constraint references performed on a given DSS instance
+are properly propagated to every other DSS instance participating in the deployment.
+
+## Resources
+
+### dss
+
+[`DSSInstanceResource`](../../../../../resources/astm/f3548/v21/dss.py) the DSS instance through which entities are created, modified and deleted.
+
+### other_instances
+
+[`DSSInstancesResource`](../../../../../resources/astm/f3548/v21/dss.py) pointing to the DSS instances used to confirm that entities are properly propagated.
+
+### id_generator
+
+[`IDGeneratorResource`](../../../../../resources/interuss/id_generator.py) providing the constraint reference ID for this scenario.
+
+### planning_area
+
+[`PlanningAreaResource`](../../../../../resources/astm/f3548/v21/planning_area.py) describes the 3D volume in which constraint reference will be created.
+
+### client_identity
+
+[`ClientIdentityResource`](../../../../../resources/communications/client_identity.py) to be used for this scenario.
+
+## Setup test case
+
+### [Ensure clean workspace test step](../clean_workspace.md)
+
+This step ensures that no constraint reference with the known test ID exists in the DSS.
+
+## CR synchronization test case
+
+This test case creates an constraint reference on the main DSS, and verifies that it is properly synchronized to the other DSS instances.
+
+It then goes on to mutate and delete it, each time confirming that all other DSSes return the expected results.
+
+### Create CR validation test step
+
+#### [Create CR](../fragments/cr/crud/create_correct.md)
+
+Verify that an constraint reference can be created on the primary DSS.
+
+#### [CR Content is correct](../fragments/cr/validate/correctness.md)
+
+Verify that the constraint reference returned by the DSS under test is properly formatted and contains the expected content.
+
+### Retrieve newly created CR test step
+
+Retrieve and validate synchronization of the created constraint at every DSS provided in `dss_instances`.
+
+#### [Get CR query](../fragments/cr/crud/read_query.md)
+
+Check that read query succeeds.
+
+#### Newly created CR can be consistently retrieved from all DSS instances check
+
+If the constraint retrieved from a secondary DSS instance is not consistent with the newly created one on the
+primary DSS instance, this check will fail per **[astm.f3548.v21.DSS0210,A2-7-2,1a](../../../../../requirements/astm/f3548/v21.md)**, **[astm.f3548.v21.DSS0210,A2-7-2,1f](../../../../../requirements/astm/f3548/v21.md)**,
+**[astm.f3548.v21.DSS0215](../../../../../requirements/astm/f3548/v21.md)** and **[astm.f3548.v21.DSS0020](../../../../../requirements/astm/f3548/v21.md)**.
+
+#### [CR is synchronized](../fragments/cr/sync.md)
+
+Confirm that each DSS provides direct access to the created constraint reference.
+Confirm that the constraint reference that was just created is properly synchronized across all DSS instances.
+
+### Search for newly created CR test step
+
+Search for and validate synchronization of the created constraint at every DSS provided in `dss_instances`.
+
+#### [Search CR](../fragments/cr/crud/search_query.md)
+
+Check that search query succeeds.
+
+#### Newly created CR can be consistently searched for from all DSS instances check
+
+If the constraint searched from a secondary DSS instance is not consistent with the newly created one on the
+primary DSS instance, this check will fail per **[astm.f3548.v21.DSS0210,A2-7-2,1a](../../../../../requirements/astm/f3548/v21.md)**, **[astm.f3548.v21.DSS0210,A2-7-2,1e](../../../../../requirements/astm/f3548/v21.md)**,
+, **[astm.f3548.v21.DSS0215](../../../../../requirements/astm/f3548/v21.md)** and **[astm.f3548.v21.DSS0020](../../../../../requirements/astm/f3548/v21.md)**.
+
+#### [CR is synchronized](../fragments/cr/sync.md)
+
+Confirm that each DSS returns the constraint in relevant search results.
+Confirm that the constraint reference that was just created is properly synchronized across all DSS instances.
+
+### Mutate CR test step
+
+This test step mutates the previously created constraint reference to verify that the DSS reacts properly: notably, it checks that the constraint reference version is updated,
+including for changes that are not directly visible, such as changing the constraint reference's footprint.
+
+#### [Update CR](../fragments/cr/crud/update_correct.md)
+
+Confirm that the constraint reference can be mutated.
+
+#### [Validate CR](../fragments/cr/validate/correctness.md)
+
+Verify that the constraint reference returned by the DSS is properly formatted and contains the correct content.
+
+#### [CR Versions are correct](../fragments/cr/validate/mutated.md)
+
+Verify that the constraint reference's version fields have been updated.
+
+### Retrieve updated CR test step
+
+Retrieve and validate synchronization of the updated constraint at every DSS provided in `dss_instances`.
+
+#### [Get CR query](../fragments/cr/crud/read_query.md)
+
+Check that read query succeeds.
+
+#### Updated CR can be consistently retrieved from all DSS instances check
+
+If the constraint retrieved from a secondary DSS instance is not consistent with the updated one on the
+primary DSS instance, this check will fail per **[astm.f3548.v21.DSS0210,A2-7-2,1b](../../../../../requirements/astm/f3548/v21.md)**, **[astm.f3548.v21.DSS0210,A2-7-2,1d](../../../../../requirements/astm/f3548/v21.md)**,
+**[astm.f3548.v21.DSS0215](../../../../../requirements/astm/f3548/v21.md)** and **[astm.f3548.v21.DSS0020](../../../../../requirements/astm/f3548/v21.md)**.
+
+#### [CR is synchronized](../fragments/cr/sync.md)
+
+Confirm that each DSS provides direct access to the updated constraint reference.
+Confirm that the constraint reference that was just updated is properly synchronized across all DSS instances.
+
+### Search for updated CR test step
+
+Search for and validate synchronization of the updated constraint at every DSS provided in `dss_instances`.
+
+#### [Search CR](../fragments/cr/crud/search_query.md)
+
+Check that search query succeeds.
+
+#### Updated CR can be consistently searched for from all DSS instances check
+
+If the constraint searched from a secondary DSS instance is not consistent with the updated one on the
+primary DSS instance, this check will fail per **[astm.f3548.v21.DSS0210,A2-7-2,1b](../../../../../requirements/astm/f3548/v21.md)**, **[astm.f3548.v21.DSS0210,A2-7-2,1e](../../../../../requirements/astm/f3548/v21.md)**,
+**[astm.f3548.v21.DSS0215](../../../../../requirements/astm/f3548/v21.md)** and **[astm.f3548.v21.DSS0020](../../../../../requirements/astm/f3548/v21.md)**.
+
+#### [CR is synchronized](../fragments/cr/sync.md)
+
+Confirm that each DSS returns the constraint in relevant search results.
+Confirm that the constraint reference that was just updated is properly synchronized across all DSS instances.
+
+### Delete CR test step
+
+Attempt to delete the constraint reference in various ways and ensure that the DSS reacts properly.
+
+This also checks that the constraint reference data returned by a successful deletion is correct.
+
+#### [Delete CR](../fragments/cr/crud/delete.md)
+
+Confirm that an constraint reference can be deleted.
+
+#### [Validate CR](../fragments/cr/validate/correctness.md)
+
+Verify that the constraint reference returned by the DSS via the deletion is properly formatted and contains the correct content.
+
+#### [CR Versions are correct](../fragments/cr/validate/non_mutated.md)
+
+Verify that the constraint reference's version fields are as expected.
+
+### Query deleted CR test step
+
+Attempt to query and search for the deleted constraint reference in various ways
+
+#### [Get CR query](../fragments/cr/crud/read_query.md)
+
+Check that read query succeeds.
+
+#### 🛑 Deleted CR cannot be retrieved from all DSS instances check
+
+If a DSS returns an constraint reference that was previously successfully deleted from the primary DSS,
+either one of the primary DSS or the DSS that returned the constraint reference is in violation of **[astm.f3548.v21.DSS0210,2a](../../../../../requirements/astm/f3548/v21.md)**, **[astm.f3548.v21.DSS0210,A2-7-2,3b](../../../../../requirements/astm/f3548/v21.md)**,
+**[astm.f3548.v21.DSS0215](../../../../../requirements/astm/f3548/v21.md)** and **[astm.f3548.v21.DSS0020](../../../../../requirements/astm/f3548/v21.md)**.
+
+#### [Search CR](../fragments/cr/crud/search_query.md)
+
+Check that search query succeeds.
+
+#### 🛑 Deleted CR cannot be searched for from all DSS instances check
+
+If a DSS returns an constraint reference that was previously successfully deleted from the primary DSS,
+either one of the primary DSS or the DSS that returned the constraint reference is in violation of **[astm.f3548.v21.DSS0210,2a](../../../../../requirements/astm/f3548/v21.md)**, **[astm.f3548.v21.DSS0210,A2-7-2,3a](../../../../../requirements/astm/f3548/v21.md)**,
+**[astm.f3548.v21.DSS0215](../../../../../requirements/astm/f3548/v21.md)** and **[astm.f3548.v21.DSS0020](../../../../../requirements/astm/f3548/v21.md)**.
+
+## [Cleanup](../clean_workspace.md)

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.py
@@ -1,0 +1,572 @@
+from datetime import datetime, timedelta
+from typing import List, Optional
+
+from uas_standards.astm.f3548.v21.api import (
+    EntityID,
+    PutConstraintReferenceParameters,
+    ConstraintReference,
+)
+from uas_standards.astm.f3548.v21.constants import Scope
+
+from monitoring.monitorlib.fetch import QueryError, Query
+from monitoring.monitorlib.geotemporal import Volume4D, Volume4DCollection
+from monitoring.prober.infrastructure import register_resource_type
+from monitoring.uss_qualifier.resources.astm.f3548.v21 import PlanningAreaResource
+from monitoring.uss_qualifier.resources.astm.f3548.v21.dss import (
+    DSSInstanceResource,
+    DSSInstancesResource,
+    DSSInstance,
+)
+from monitoring.uss_qualifier.resources.communications import ClientIdentityResource
+from monitoring.uss_qualifier.resources.interuss.id_generator import IDGeneratorResource
+from monitoring.uss_qualifier.scenarios.astm.utm.dss import test_step_fragments
+from monitoring.uss_qualifier.scenarios.astm.utm.dss.validators.cr_validator import (
+    ConstraintReferenceValidator,
+)
+from monitoring.uss_qualifier.scenarios.astm.utm.dss.validators.oir_validator import (
+    TIME_TOLERANCE_SEC,
+)
+from monitoring.uss_qualifier.scenarios.scenario import (
+    TestScenario,
+    ScenarioCannotContinueError,
+)
+from monitoring.uss_qualifier.suites.suite import ExecutionContext
+
+
+class CRSynchronization(TestScenario):
+    """
+    A scenario that checks if multiple DSS instances properly synchronize
+    constraint references.
+
+    Not in the scope of the first version of this:
+     - access rights (making sure only the manager of the OIR can mutate it)
+     - control of the area synchronization (by doing area searches against the secondaries)
+     - mutation of an entity on a secondary DSS when it was created on the primary
+     - deletion of an entity on a secondary DSS when it was created on the primary
+    """
+
+    SUB_TYPE = register_resource_type(
+        390, "Operational Intent Reference for synchronization checks"
+    )
+
+    _dss: DSSInstance
+
+    _secondary_dss_instances: List[DSSInstance]
+
+    # Base identifier for the OIR that will be created
+    _cr_id: EntityID
+
+    # Base parameters used for OIR creation
+    _cr_params: PutConstraintReferenceParameters
+
+    # Keep track of the current OIR state
+    _current_cr: Optional[ConstraintReference]
+
+    _expected_manager: str
+
+    def __init__(
+        self,
+        dss: DSSInstanceResource,
+        other_instances: DSSInstancesResource,
+        id_generator: IDGeneratorResource,
+        client_identity: ClientIdentityResource,
+        planning_area: PlanningAreaResource,
+    ):
+        """
+        Args:
+            dss: dss to test
+            other_instances: dss instances to be checked for proper synchronization
+            id_generator: will let us generate specific identifiers
+            client_identity: tells us the identity we should expect as an entity's manager
+            planning_area: An Area to use for the tests. It should be an area for which the DSS is responsible,
+                 but has no other requirements.
+
+        """
+        super().__init__()
+        scopes_primary = {
+            Scope.StrategicCoordination: "cleanup leftover subscriptions and operational intent references",
+            Scope.ConstraintManagement: "create and delete constraint references",
+        }
+        scopes_secondaries = {
+            Scope.ConstraintManagement: "read, mutate and delete constraint references"
+        }
+
+        self._dss = dss.get_instance(scopes_primary)
+        self._primary_pid = self._dss.participant_id
+
+        self._secondary_dss_instances = [
+            sec_dss.get_instance(scopes_secondaries)
+            for sec_dss in other_instances.dss_instances
+        ]
+
+        self._cr_id = id_generator.id_factory.make_id(self.SUB_TYPE)
+        self._expected_manager = client_identity.subject()
+        self._planning_area = planning_area.specification
+
+        # Build a ready-to-use 4D volume with no specified time for searching
+        # the currently active CRs
+        self._planning_area_volume4d = Volume4D(
+            volume=self._planning_area.volume,
+        )
+
+    def run(self, context: ExecutionContext):
+
+        # Check that we actually have at least one other DSS to test against:
+        if not self._secondary_dss_instances:
+            raise ScenarioCannotContinueError(
+                "Cannot run CRSynchronization scenario: no other DSS instances to test against"
+            )
+
+        self.begin_test_scenario(context)
+        self._setup_case()
+        self.begin_test_case("CR synchronization")
+
+        self.begin_test_step("Create CR validation")
+        self._create_cr_with_params(self._cr_params)
+        self.end_test_step()
+
+        self.begin_test_step("Retrieve newly created CR")
+        self._query_secondaries_and_compare(
+            "Newly created CR can be consistently retrieved from all DSS instances",
+            self._cr_params,
+        )
+        self.end_test_step()
+
+        self.begin_test_step("Search for newly created CR")
+        self._search_secondaries_and_compare(
+            "Newly created CR can be consistently searched for from all DSS instances",
+            self._cr_params,
+        )
+        self.end_test_step()
+
+        self.begin_test_step("Mutate CR")
+        self._test_mutate_oir_shift_time()
+        self.end_test_step()
+
+        self.begin_test_step("Retrieve updated CR")
+        self._query_secondaries_and_compare(
+            "Updated CR can be consistently retrieved from all DSS instances",
+            self._cr_params,
+        )
+        self.end_test_step()
+
+        self.begin_test_step("Search for updated CR")
+        self._search_secondaries_and_compare(
+            "Updated CR can be consistently searched for from all DSS instances",
+            self._cr_params,
+        )
+        self.end_test_step()
+
+        self.begin_test_step("Delete CR")
+        self._test_delete_sub()
+        self.end_test_step()
+
+        self.begin_test_step("Query deleted CR")
+        self._test_get_deleted_oir()
+        self.end_test_step()
+
+        self.end_test_case()
+        self.end_test_scenario()
+
+    def _setup_case(self):
+        self.begin_test_case("Setup")
+        # Multiple runs of the scenario seem to rely on the same instance of it:
+        # thus we need to reset the state of the scenario before running it.
+        self._current_cr = None
+        # We need times that are close to 'now': the params are set
+        # at the beginning of each scenario run.
+        self._cr_params = self._planning_area.get_new_constraint_ref_params(
+            time_start=datetime.now() - timedelta(seconds=10),
+            time_end=datetime.now() + timedelta(minutes=20),
+        )
+        self.begin_test_step("Ensure clean workspace")
+        self._ensure_clean_workspace_step()
+        self.end_test_step()
+        self.end_test_case()
+
+    def _ensure_clean_workspace_step(self):
+
+        # Delete any active CRs we might own
+        test_step_fragments.cleanup_active_constraint_refs(
+            self,
+            self._dss,
+            self._planning_area_volume4d.to_f3548v21(),
+            self._expected_manager,
+        )
+
+        # Make sure the OIR ID we are going to use is available
+        test_step_fragments.cleanup_constraint_ref(self, self._dss, self._cr_id)
+        # Drop any active subs we might own and that could interfere
+        test_step_fragments.cleanup_active_subs(
+            self, self._dss, self._planning_area_volume4d.to_f3548v21()
+        )
+
+    def _create_cr_with_params(self, creation_params: PutConstraintReferenceParameters):
+
+        with self.check(
+            "Create constraint reference query succeeds", [self._primary_pid]
+        ) as check:
+            try:
+                cr, subs, q = self._dss.put_constraint_ref(
+                    cr_id=self._cr_id,
+                    extents=creation_params.extents,
+                    uss_base_url=creation_params.uss_base_url,
+                    ovn=None,
+                )
+                self.record_query(q)
+            except QueryError as qe:
+                self.record_queries(qe.queries)
+                check.record_failed(
+                    summary="Create constraint reference failed",
+                    details=qe.msg,
+                    query_timestamps=qe.query_timestamps,
+                )
+                return
+
+        with self.check(
+            "Create constraint reference response content is correct",
+            [self._primary_pid],
+        ) as check:
+            ConstraintReferenceValidator(
+                main_check=check,
+                scenario=self,
+                expected_manager=self._expected_manager,
+                participant_id=[self._primary_pid],
+                cr_params=creation_params,
+            ).validate_created_cr(self._cr_id, new_cr=q)
+
+        self._current_cr = cr
+
+    def _query_secondaries_and_compare(
+        self,
+        main_check_name: str,
+        expected_cr_params: PutConstraintReferenceParameters,
+    ):
+        for secondary_dss in self._secondary_dss_instances:
+            with self.check(
+                "Get constraint reference by ID",
+                secondary_dss.participant_id,
+            ) as check:
+                try:
+                    oir, q = secondary_dss.get_constraint_ref(self._cr_id)
+                    self.record_query(q)
+                except QueryError as qe:
+                    self.record_queries(qe.queries)
+                    check.record_failed(
+                        summary="GET for constraint reference failed",
+                        details=f"Query for constraint reference failed: {qe.msg}",
+                        query_timestamps=qe.query_timestamps,
+                    )
+
+            involved_participants = list(
+                {self._primary_pid, secondary_dss.participant_id}
+            )
+
+            with self.check(
+                "Constraint reference can be found at every DSS",
+                involved_participants,
+            ) as check:
+                if q.status_code != 200:
+                    check.record_failed(
+                        summary="Requested constraint reference was not found at secondary DSS.",
+                        details=f"Query for constraint reference {self._cr_id} failed: {q.msg}",
+                        query_timestamps=[q.request.timestamp],
+                    )
+
+            self._validate_cr_from_secondary(
+                cr=oir,
+                q=q,
+                expected_cr_params=expected_cr_params,
+                main_check_name=main_check_name,
+                involved_participants=involved_participants,
+            )
+
+    def _search_secondaries_and_compare(
+        self,
+        main_check_name: str,
+        expected_cr_params: PutConstraintReferenceParameters,
+    ):
+        """
+        Returns:
+         True if all checks passed, False otherwise; the participant IDs if the checks did not pass.
+        """
+        for secondary_dss in self._secondary_dss_instances:
+            with self.check(
+                "Successful constraint reference search query",
+                [secondary_dss.participant_id],
+            ) as check:
+                try:
+                    crs, q = secondary_dss.find_constraint_ref(
+                        self._planning_area_volume4d
+                    )
+                    self.record_query(q)
+                except QueryError as qe:
+                    self.record_queries(qe.queries)
+                    check.record_failed(
+                        summary="Failed to search for constraint references",
+                        details=f"Failed to query constraint references: got response code {qe.cause_status_code}: {qe.msg}",
+                        query_timestamps=qe.query_timestamps,
+                    )
+
+            involved_participants = list(
+                {self._primary_pid, secondary_dss.participant_id}
+            )
+
+            with self.check(
+                "Propagated constraint reference general area is synchronized",
+                involved_participants,
+            ) as check:
+                cr: Optional[ConstraintReference] = None
+                for _cr in crs:
+                    if _cr.id == self._cr_id:
+                        cr = _cr
+                        break
+
+                if cr is None:
+                    check.record_failed(
+                        summary="Propagated CR not found",
+                        details=f"CR {self._cr_id} was not found in the secondary DSS when searched for in its expected geo-temporal extent",
+                        query_timestamps=[q.request.timestamp],
+                    )
+
+            self._validate_cr_from_secondary(
+                cr=cr,
+                q=q,
+                expected_cr_params=expected_cr_params,
+                main_check_name=main_check_name,
+                involved_participants=involved_participants,
+            )
+
+            # TODO: craft a search with an area of interest that does not intersect with the planning area,
+            #  but whose convex hull intersects with the planning area
+
+    def _validate_cr_from_secondary(
+        self,
+        cr: ConstraintReference,
+        q: Query,
+        expected_cr_params: PutConstraintReferenceParameters,
+        main_check_name: str,
+        involved_participants: List[str],
+    ):
+
+        # TODO: this main check mechanism may be removed if we are able to specify requirements to be validated in test step fragments
+
+        with self.check(main_check_name, involved_participants) as main_check:
+            with self.check(
+                "Propagated constraint reference contains the correct manager",
+                involved_participants,
+            ) as check:
+                if cr.manager != self._expected_manager:
+                    check_args = dict(
+                        summary="Propagated CR has an incorrect manager",
+                        details=f"Expected: {self._expected_manager}, Received: {cr.manager}",
+                        query_timestamps=[q.request.timestamp],
+                    )
+                    check.record_failed(**check_args)
+                    main_check.record_failed(**check_args)
+
+            with self.check(
+                "Propagated constraint reference contains the correct USS base URL",
+                involved_participants,
+            ) as check:
+                if cr.uss_base_url != expected_cr_params.uss_base_url:
+                    check_args = dict(
+                        summary="Propagated CR has an incorrect USS base URL",
+                        details=f"Expected: {expected_cr_params.base_url}, Received: {cr.uss_base_url}",
+                        query_timestamps=[q.request.timestamp],
+                    )
+                    check.record_failed(**check_args)
+                    main_check.record_failed(**check_args)
+
+            expected_volume_collection = Volume4DCollection.from_interuss_scd_api(
+                expected_cr_params.extents
+            )
+            expected_end = expected_volume_collection.time_end.datetime
+            expected_start = expected_volume_collection.time_start.datetime
+            with self.check(
+                "Propagated constraint reference contains the correct start time",
+                involved_participants,
+            ) as check:
+                if (
+                    abs(cr.time_start.value.datetime - expected_start).total_seconds()
+                    > TIME_TOLERANCE_SEC
+                ):
+                    check_args = dict(
+                        summary="Propagated CR has an incorrect start time",
+                        details=f"Expected: {expected_start}, Received: {cr.time_start}",
+                        query_timestamps=[q.request.timestamp],
+                    )
+                    check.record_failed(**check_args)
+                    main_check.record_failed(**check_args)
+
+            with self.check(
+                "Propagated constraint reference contains the correct end time",
+                involved_participants,
+            ) as check:
+                if (
+                    abs(cr.time_end.value.datetime - expected_end).total_seconds()
+                    > TIME_TOLERANCE_SEC
+                ):
+                    check_args = dict(
+                        summary="Propagated CR has an incorrect end time",
+                        details=f"Expected: {expected_end}, Received: {cr.time_end}",
+                        query_timestamps=[q.request.timestamp],
+                    )
+                    check.record_failed(**check_args)
+                    main_check.record_failed(**check_args)
+
+    def _test_mutate_oir_shift_time(self):
+        """Mutate the CR by adding 10 seconds to its start and end times.
+        This is achieved by updating the first and last element of the extents.
+        """
+
+        new_extents = (
+            Volume4DCollection.from_f3548v21(self._cr_params.extents)
+            .offset_times(timedelta(seconds=10))
+            .to_f3548v21()
+        )
+
+        self._cr_params = PutConstraintReferenceParameters(
+            extents=new_extents,
+            uss_base_url=self._cr_params.uss_base_url,
+        )
+
+        with self.check(
+            "Mutate constraint reference query succeeds", [self._primary_pid]
+        ) as check:
+            try:
+                cr, subs, q = self._dss.put_constraint_ref(
+                    extents=self._cr_params.extents,
+                    uss_base_url=self._cr_params.uss_base_url,
+                    cr_id=self._cr_id,
+                    ovn=self._current_cr.ovn,
+                )
+                self.record_query(q)
+            except QueryError as qe:
+                self.record_queries(qe.queries)
+                check.record_failed(
+                    summary="Constraint reference mutation failed",
+                    details=qe.msg,
+                    query_timestamps=qe.query_timestamps,
+                )
+
+        with self.check(
+            "Mutate constraint reference response content is correct",
+            [self._primary_pid],
+        ) as check:
+            ConstraintReferenceValidator(
+                main_check=check,
+                scenario=self,
+                expected_manager=self._expected_manager,
+                participant_id=[self._primary_pid],
+                cr_params=self._cr_params,
+            ).validate_mutated_cr(
+                expected_cr_id=self._cr_id,
+                mutated_cr=q,
+                previous_ovn=self._current_cr.ovn,
+                previous_version=self._current_cr.version,
+            )
+
+        self._current_cr = cr
+
+    def _test_delete_sub(self):
+        with self.check(
+            "Delete constraint reference query succeeds", [self._primary_pid]
+        ) as check:
+            try:
+                oir, subs, q = self._dss.delete_constraint_ref(
+                    self._cr_id, self._current_cr.ovn
+                )
+                self.record_query(q)
+            except QueryError as qe:
+                self.record_queries(qe.queries)
+                check.record_failed(
+                    summary="Constraint reference deletion on primary DSS failed",
+                    details=qe.msg,
+                    query_timestamps=qe.query_timestamps,
+                )
+
+        with self.check(
+            "Delete constraint reference response content is correct",
+            [self._primary_pid],
+        ) as check:
+            ConstraintReferenceValidator(
+                main_check=check,
+                scenario=self,
+                expected_manager=self._expected_manager,
+                participant_id=[self._primary_pid],
+                cr_params=self._cr_params,
+            ).validate_deleted_cr(
+                expected_cr_id=self._cr_id,
+                deleted_cr=q,
+                expected_ovn=self._current_cr.ovn,
+                expected_version=self._current_cr.version,
+            )
+
+        self._current_cr = None
+
+    def _test_get_deleted_oir(self):
+        for secondary_dss in self._secondary_dss_instances:
+            self._confirm_secondary_has_no_oir(secondary_dss)
+
+    def _confirm_secondary_has_no_oir(self, secondary_dss: DSSInstance):
+        with self.check(
+            "Get constraint reference by ID",
+            secondary_dss.participant_id,
+        ) as check:
+            try:
+                oir, q = secondary_dss.get_constraint_ref(self._cr_id)
+                self.record_query(q)
+            except QueryError as qe:
+                q = qe.cause
+                self.record_query(q)
+                if q.status_code != 404:
+                    check.record_failed(
+                        summary="GET for constraint reference failed",
+                        details=f"Query for constraint reference failed: {qe.msg}",
+                        query_timestamps=qe.query_timestamps,
+                    )
+
+        with self.check(
+            "Deleted CR cannot be retrieved from all DSS instances",
+            [self._primary_pid, secondary_dss.participant_id],
+        ) as check:
+            if q.status_code != 404:
+                check.record_failed(
+                    summary="Secondary DSS still has the deleted constraint reference",
+                    details=f"Expected 404, received {q.status_code}",
+                    query_timestamps=[q.request.timestamp],
+                )
+
+        with self.check(
+            "Successful constraint reference search query",
+            [secondary_dss.participant_id],
+        ) as check:
+            try:
+                crs, q = secondary_dss.find_constraint_ref(self._planning_area_volume4d)
+                self.record_query(q)
+            except QueryError as qe:
+                self.record_queries(qe.queries)
+                check.record_failed(
+                    summary="Failed to search for constraint references",
+                    details=f"Failed to query constraint references: got response code {qe.cause_status_code}: {qe.msg}",
+                    query_timestamps=qe.query_timestamps,
+                )
+
+        constraint_ref_ids = set([cr.id for cr in crs])
+        with self.check(
+            "Deleted CR cannot be searched for from all DSS instances",
+            [self._primary_pid, secondary_dss.participant_id],
+        ) as check:
+            # TODO fix same bug in OIR sync scenario
+            if self._cr_id in constraint_ref_ids:
+                check.record_failed(
+                    summary="Secondary DSS still has the deleted constraint reference",
+                    details=f"CR {self._cr_id} was found in the secondary DSS when searched for its expected geo-temporal extent",
+                    query_timestamps=[q.request.timestamp],
+                )
+
+    def cleanup(self):
+        self.begin_cleanup()
+        self._ensure_clean_workspace_step()
+        self.end_cleanup()

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/validators/cr_validator.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/validators/cr_validator.py
@@ -1,0 +1,494 @@
+from datetime import datetime
+from typing import Optional, List
+
+from implicitdict import ImplicitDict
+from uas_standards.astm.f3548.v21.api import (
+    EntityID,
+    ConstraintReference,
+    ChangeConstraintReferenceResponse,
+    EntityOVN,
+    GetConstraintReferenceResponse,
+    QueryConstraintReferencesResponse,
+    PutConstraintReferenceParameters,
+    ConstraintReference,
+    ChangeConstraintReferenceResponse,
+)
+
+from monitoring.monitorlib import schema_validation, fetch
+from monitoring.monitorlib.schema_validation import F3548_21
+from monitoring.uss_qualifier.scenarios.astm.utm.dss.validators import (
+    fail_with_schema_errors,
+)
+from monitoring.uss_qualifier.scenarios.scenario import PendingCheck, TestScenario
+
+TIME_TOLERANCE_SEC = 1
+"""tolerance when comparing created vs returned timestamps"""
+
+
+class ConstraintReferenceValidator:
+    """
+    Wraps the validation logic for an operational intent reference that was returned by a DSS
+
+    It will compare the provided CR with the parameters specified at its creation.
+    """
+
+    _main_check: PendingCheck
+    """
+    The overarching check corresponding to the general validation of a CR.
+    This check will be failed if any of the sub-checks carried out by this validator fail.
+    """
+
+    _scenario: TestScenario
+    """
+    Scenario in which this validator is being used. Will be used to register checks.
+    """
+
+    _cr_params: Optional[PutConstraintReferenceParameters]
+    _pid: List[str]
+    """Participant ID(s) to use for the checks"""
+
+    def __init__(
+        self,
+        main_check: PendingCheck,
+        scenario: TestScenario,
+        expected_manager: str,
+        participant_id: List[str],
+        cr_params: Optional[PutConstraintReferenceParameters],
+    ):
+        self._main_check = main_check
+        self._scenario = scenario
+        self._pid = participant_id
+        self._cr_params = cr_params
+        self._expected_manager = expected_manager
+        self._expected_start = cr_params.extents[0].time_start.value.datetime
+        self._expected_end = cr_params.extents[-1].time_end.value.datetime
+
+    def _fail_sub_check(
+        self, sub_check: PendingCheck, summary: str, details: str, t_dss: datetime
+    ) -> None:
+        """
+        Fail the passed sub check with the passed summary and details, and fail
+        the main check with the passed details.
+
+        Note that this method should only be used to fail sub-checks related to the CONTENT of the CR,
+        but not its FORMAT, as the main-check should only be pertaining to the content.
+
+        The provided timestamp is forwarded into the query_timestamps of the check failure.
+        """
+        sub_check.record_failed(
+            summary=summary,
+            details=details,
+            query_timestamps=[t_dss],
+        )
+
+        self._main_check.record_failed(
+            summary=f"Invalid CR returned by the DSS: {summary}",
+            details=details,
+            query_timestamps=[t_dss],
+        )
+
+    def _validate_cr(
+        self,
+        expected_entity_id: EntityID,
+        dss_cr: ConstraintReference,
+        t_dss: datetime,
+        previous_version: Optional[int],
+        expected_version: Optional[int],
+        previous_ovn: Optional[str],
+        expected_ovn: Optional[str],
+    ) -> None:
+        """
+        Args:
+            expected_entity_id: the ID we expect to find in the entity
+            dss_cr: the CR returned by the DSS
+            t_dss: timestamp of the query to the DSS for failure reporting
+            previous_ovn: previous OVN of the entity, if we are verifying a mutation
+            expected_ovn: expected OVN of the entity, if we are verifying a read query
+            previous_version: previous version of the entity, if we are verifying a mutation
+            expected_version: expected version of the entity, if we are verifying a read query
+        """
+
+        with self._scenario.check(
+            "Returned operational intent reference ID is correct", self._pid
+        ) as check:
+            if dss_cr.id != expected_entity_id:
+                self._fail_sub_check(
+                    check,
+                    summary=f"Returned CR ID is incorrect",
+                    details=f"Expected CR ID {expected_entity_id}, got {dss_cr.id}",
+                    t_dss=t_dss,
+                )
+
+        with self._scenario.check(
+            "Returned operational intent reference has a manager", self._pid
+        ) as check:
+            # Check for empty string. None should have failed the schema check earlier
+            if not dss_cr.manager:
+                self._fail_sub_check(
+                    check,
+                    summary="No CR manager was specified",
+                    details=f"Expected: {self._expected_manager}, got an empty or undefined string",
+                    t_dss=t_dss,
+                )
+
+        with self._scenario.check(
+            "Returned operational intent reference manager is correct", self._pid
+        ) as check:
+            if dss_cr.manager != self._expected_manager:
+                self._fail_sub_check(
+                    check,
+                    summary="Returned manager is incorrect",
+                    details=f"Expected. {self._expected_manager}, got {dss_cr.manager}",
+                    t_dss=t_dss,
+                )
+
+        with self._scenario.check(
+            "Returned operational intent reference has an USS base URL", self._pid
+        ) as check:
+            # If uss_base_url is not present, or it is None or Empty, we should fail:
+            if "uss_base_url" not in dss_cr or not dss_cr.uss_base_url:
+                self._fail_sub_check(
+                    check,
+                    summary="Returned CR has no USS base URL",
+                    details="The CR returned by the DSS has no USS base URL when it should have one",
+                    t_dss=t_dss,
+                )
+
+        with self._scenario.check(
+            "Returned operational intent reference base URL is correct", self._pid
+        ) as check:
+            if dss_cr.uss_base_url != self._cr_params.uss_base_url:
+                self._fail_sub_check(
+                    check,
+                    summary="Returned USS Base URL does not match provided one",
+                    details=f"Provided: {self._cr_params.uss_base_url}, Returned: {dss_cr.uss_base_url}",
+                    t_dss=t_dss,
+                )
+
+        with self._scenario.check(
+            "Returned operational intent reference has a start time", self._pid
+        ) as check:
+            if "time_start" not in dss_cr or dss_cr.time_start is None:
+                self._fail_sub_check(
+                    check,
+                    summary="Returned CR has no start time",
+                    details="The operational intent reference returned by the DSS has no start time when it should have one",
+                    t_dss=t_dss,
+                )
+
+        with self._scenario.check(
+            "Returned operational intent reference has an end time", self._pid
+        ) as check:
+            if "time_end" not in dss_cr or dss_cr.time_end is None:
+                self._fail_sub_check(
+                    check,
+                    summary="Returned CR has no end time",
+                    details="The operational intent reference returned by the DSS has no end time when it should have one",
+                    t_dss=t_dss,
+                )
+
+        with self._scenario.check("Returned start time is correct", self._pid) as check:
+            if (
+                abs(
+                    dss_cr.time_start.value.datetime - self._expected_start
+                ).total_seconds()
+                > TIME_TOLERANCE_SEC
+            ):
+                self._fail_sub_check(
+                    check,
+                    summary="Returned start time does not match provided one",
+                    details=f"Provided: {self._cr_params.start_time}, Returned: {dss_cr.time_start}",
+                    t_dss=t_dss,
+                )
+
+        with self._scenario.check("Returned end time is correct", self._pid) as check:
+            if (
+                abs(dss_cr.time_end.value.datetime - self._expected_end).total_seconds()
+                > TIME_TOLERANCE_SEC
+            ):
+                self._fail_sub_check(
+                    check,
+                    summary="Returned end time does not match provided one",
+                    details=f"Provided: {self._cr_params.end_time}, Returned: {dss_cr.time_end}",
+                    t_dss=t_dss,
+                )
+
+        # If the previous OVN is not None, we are dealing with a mutation:
+        if previous_ovn is not None:
+            with self._scenario.check(
+                "Mutated operational intent reference OVN is updated", self._pid
+            ) as check:
+                if dss_cr.ovn == previous_ovn:
+                    self._fail_sub_check(
+                        check,
+                        summary="Returned CR OVN was not updated",
+                        details=f"Expected OVN to be different from {previous_ovn}, but it was not",
+                        t_dss=t_dss,
+                    )
+
+        if expected_ovn is not None:
+            with self._scenario.check(
+                "Non-mutated operational intent reference keeps the same OVN", self._pid
+            ) as check:
+                if dss_cr.ovn != expected_ovn:
+                    self._fail_sub_check(
+                        check,
+                        summary="Returned CR OVN was updated",
+                        details=f"Expected OVN to be {expected_ovn}, Returned: {dss_cr.ovn}",
+                        t_dss=t_dss,
+                    )
+
+        # If the previous version is not None, we are dealing with a mutation:
+        if previous_version is not None:
+            with self._scenario.check(
+                "Mutated operational intent reference version is updated", self._pid
+            ) as check:
+                # TODO confirm that a mutation should imply a version update
+                if dss_cr.version == previous_version:
+                    self._fail_sub_check(
+                        check,
+                        summary="Returned CR version was not updated",
+                        details=f"Expected version to be different from {previous_ovn}, but it was not",
+                        t_dss=t_dss,
+                    )
+
+        # TODO version _might_ get incremented due to changes caused outside of the uss_qualifier
+        #  and we should probably check if it is equal or higher.
+        if expected_version is not None:
+            with self._scenario.check(
+                "Non-mutated operational intent reference keeps the same version",
+                self._pid,
+            ) as check:
+                if dss_cr.version != expected_version:
+                    self._fail_sub_check(
+                        check,
+                        summary="Returned CR version was updated",
+                        details=f"Expected version to be {expected_ovn}, Returned: {dss_cr.version}",
+                        t_dss=t_dss,
+                    )
+
+        # TODO add check for:
+        #  - subscription ID of the CR (based on passed parameters, if these were set)
+
+    def _validate_put_cr_response_schema(
+        self, cr_query: fetch.Query, t_dss: datetime, action: str
+    ) -> bool:
+        """Validate response bodies for creation and mutation of CRs.
+        Returns 'False' if the schema validation failed, 'True' otherwise.
+        """
+
+        check_name = (
+            "Create operational intent reference response format conforms to spec"
+            if action == "create"
+            else "Mutate operational intent reference response format conforms to spec"
+        )
+
+        with self._scenario.check(check_name, self._pid) as check:
+            errors = schema_validation.validate(
+                F3548_21.OpenAPIPath,
+                F3548_21.ChangeConstraintReferenceResponse,
+                cr_query.response.json,
+            )
+            if errors:
+                fail_with_schema_errors(check, errors, t_dss)
+                return False
+
+        return True
+
+    def validate_created_cr(
+        self, expected_cr_id: EntityID, new_cr: fetch.Query
+    ) -> None:
+        """Validate a CR that was just explicitly created, meaning
+        we don't have a previous version to compare to, and we expect it to not be an implicit one."""
+
+        t_dss = new_cr.request.timestamp
+
+        # Validate the response schema
+        if not self._validate_put_cr_response_schema(new_cr, t_dss, "create"):
+            return
+
+        # Expected to pass given that we validated the JSON against the schema
+        parsed_resp = ImplicitDict.parse(
+            new_cr.response.json, ChangeConstraintReferenceResponse
+        )
+
+        cr: ConstraintReference = parsed_resp.operational_intent_reference
+
+        # Validate the CR itself
+        self._validate_cr(
+            expected_entity_id=expected_cr_id,
+            dss_cr=cr,
+            t_dss=t_dss,
+            previous_version=None,
+            expected_version=None,
+            previous_ovn=None,
+            expected_ovn=None,
+        )
+
+    def validate_mutated_cr(
+        self,
+        expected_cr_id: EntityID,
+        mutated_cr: fetch.Query,
+        previous_ovn: str,
+        previous_version: int,
+    ) -> None:
+        """Validate a CR that was just mutated, meaning we have a previous version and OVN to compare to.
+        Callers must specify if this is an implicit CR or not."""
+        t_dss = mutated_cr.request.timestamp
+
+        # Validate the response schema
+        if not self._validate_put_cr_response_schema(mutated_cr, t_dss, "mutate"):
+            return
+
+        cr = ImplicitDict.parse(
+            mutated_cr.response.json, ChangeConstraintReferenceResponse
+        ).operational_intent_reference
+
+        # Validate the CR itself
+        self._validate_cr(
+            expected_entity_id=expected_cr_id,
+            dss_cr=cr,
+            t_dss=t_dss,
+            previous_version=previous_version,
+            expected_version=None,
+            previous_ovn=previous_ovn,
+            expected_ovn=None,
+        )
+
+    def validate_fetched_cr(
+        self,
+        expected_cr_id: EntityID,
+        fetched_cr: fetch.Query,
+        expected_version: int,
+        expected_ovn: EntityOVN,
+    ) -> None:
+        """Validate a CR that was directly queried by its ID."""
+
+        t_dss = fetched_cr.request.timestamp
+
+        # Validate the response schema
+        with self._scenario.check(
+            "Get operational intent reference response format conforms to spec",
+            self._pid,
+        ) as check:
+            errors = schema_validation.validate(
+                F3548_21.OpenAPIPath,
+                F3548_21.GetConstraintReferenceResponse,
+                fetched_cr.response.json,
+            )
+            if errors:
+                fail_with_schema_errors(check, errors, t_dss)
+
+        parsed_resp = fetched_cr.parse_json_result(GetConstraintReferenceResponse)
+        # Validate the CR itself
+        self._validate_cr(
+            expected_entity_id=expected_cr_id,
+            dss_cr=parsed_resp.operational_intent_reference,
+            t_dss=t_dss,
+            previous_version=None,
+            expected_version=expected_version,
+            previous_ovn=None,
+            expected_ovn=expected_ovn,
+        )
+
+    def validate_searched_cr(
+        self,
+        expected_cr_id: EntityID,
+        search_response: fetch.Query,
+        expected_ovn: str,
+        expected_version: int,
+    ) -> None:
+        """Validate a CR that was retrieved through search.
+        Note that the callers need to pass the entire response from the DSS, as the schema check
+        will be performed on the entire response, not just the CR itself.
+        However, only the expected CR is checked for the correctness of its contents."""
+
+        t_dss = search_response.request.timestamp
+
+        # Validate the response schema
+        self.validate_searched_cr_format(search_response, t_dss)
+
+        resp_parsed = search_response.parse_json_result(
+            QueryConstraintReferencesResponse
+        )
+
+        by_id = {cr.id: cr for cr in resp_parsed.operational_intent_references}
+
+        with self._scenario.check(
+            "Created operational intent reference is in search results", self._pid
+        ) as check:
+            if expected_cr_id not in by_id:
+                self._fail_sub_check(
+                    check,
+                    summary="Created CR is not present in search results",
+                    details=f"The CR with ID {expected_cr_id} was expected to be found in the search results, but these only contained the following entities: {by_id.keys()}",
+                    t_dss=t_dss,
+                )
+                # Depending on the severity defined in the documentation, the above might not raise an exception,
+                # and we should still stop here if the check failed.
+                return
+
+        cr = by_id[expected_cr_id]
+
+        # Validate the CR itself
+        self._validate_cr(
+            expected_entity_id=expected_cr_id,
+            dss_cr=cr,
+            t_dss=t_dss,
+            previous_ovn=None,
+            expected_ovn=expected_ovn,
+            previous_version=None,
+            expected_version=expected_version,
+        )
+
+    def validate_searched_cr_format(
+        self, search_response: fetch.Query, t_dss: datetime
+    ) -> None:
+        # Validate the response schema
+        with self._scenario.check(
+            "Search operational intent reference response format conforms to spec",
+            self._pid,
+        ) as check:
+            errors = schema_validation.validate(
+                F3548_21.OpenAPIPath,
+                F3548_21.QueryConstraintReferenceResponse,
+                search_response.response.json,
+            )
+            if errors:
+                fail_with_schema_errors(check, errors, t_dss)
+
+    def validate_deleted_cr(
+        self,
+        expected_cr_id: EntityID,
+        deleted_cr: fetch.Query,
+        expected_ovn: str,
+        expected_version: int,
+    ) -> None:
+
+        t_dss = deleted_cr.request.timestamp
+
+        # Validate the response schema
+        with self._scenario.check(
+            "Delete operational intent reference response format conforms to spec",
+            self._pid,
+        ) as check:
+            errors = schema_validation.validate(
+                F3548_21.OpenAPIPath,
+                F3548_21.ChangeConstraintReferenceResponse,
+                deleted_cr.response.json,
+            )
+            if errors:
+                fail_with_schema_errors(check, errors, t_dss)
+
+        cr_resp = deleted_cr.parse_json_result(ChangeConstraintReferenceResponse)
+
+        # Validate the CR itself
+        self._validate_cr(
+            expected_entity_id=expected_cr_id,
+            dss_cr=cr_resp.operational_intent_reference,
+            t_dss=t_dss,
+            previous_ovn=None,
+            expected_ovn=expected_ovn,
+            previous_version=None,
+            expected_version=expected_version,
+        )

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/validators/cr_validator.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/validators/cr_validator.py
@@ -27,7 +27,7 @@ TIME_TOLERANCE_SEC = 1
 
 class ConstraintReferenceValidator:
     """
-    Wraps the validation logic for an operational intent reference that was returned by a DSS
+    Wraps the validation logic for an constraint reference that was returned by a DSS
 
     It will compare the provided CR with the parameters specified at its creation.
     """
@@ -109,7 +109,7 @@ class ConstraintReferenceValidator:
         """
 
         with self._scenario.check(
-            "Returned operational intent reference ID is correct", self._pid
+            "Returned constraint reference ID is correct", self._pid
         ) as check:
             if dss_cr.id != expected_entity_id:
                 self._fail_sub_check(
@@ -120,7 +120,7 @@ class ConstraintReferenceValidator:
                 )
 
         with self._scenario.check(
-            "Returned operational intent reference has a manager", self._pid
+            "Returned constraint reference has a manager", self._pid
         ) as check:
             # Check for empty string. None should have failed the schema check earlier
             if not dss_cr.manager:
@@ -132,7 +132,7 @@ class ConstraintReferenceValidator:
                 )
 
         with self._scenario.check(
-            "Returned operational intent reference manager is correct", self._pid
+            "Returned constraint reference manager is correct", self._pid
         ) as check:
             if dss_cr.manager != self._expected_manager:
                 self._fail_sub_check(
@@ -143,7 +143,7 @@ class ConstraintReferenceValidator:
                 )
 
         with self._scenario.check(
-            "Returned operational intent reference has an USS base URL", self._pid
+            "Returned constraint reference has an USS base URL", self._pid
         ) as check:
             # If uss_base_url is not present, or it is None or Empty, we should fail:
             if "uss_base_url" not in dss_cr or not dss_cr.uss_base_url:
@@ -155,7 +155,7 @@ class ConstraintReferenceValidator:
                 )
 
         with self._scenario.check(
-            "Returned operational intent reference base URL is correct", self._pid
+            "Returned constraint reference base URL is correct", self._pid
         ) as check:
             if dss_cr.uss_base_url != self._cr_params.uss_base_url:
                 self._fail_sub_check(
@@ -166,24 +166,24 @@ class ConstraintReferenceValidator:
                 )
 
         with self._scenario.check(
-            "Returned operational intent reference has a start time", self._pid
+            "Returned constraint reference has a start time", self._pid
         ) as check:
             if "time_start" not in dss_cr or dss_cr.time_start is None:
                 self._fail_sub_check(
                     check,
                     summary="Returned CR has no start time",
-                    details="The operational intent reference returned by the DSS has no start time when it should have one",
+                    details="The constraint reference returned by the DSS has no start time when it should have one",
                     t_dss=t_dss,
                 )
 
         with self._scenario.check(
-            "Returned operational intent reference has an end time", self._pid
+            "Returned constraint reference has an end time", self._pid
         ) as check:
             if "time_end" not in dss_cr or dss_cr.time_end is None:
                 self._fail_sub_check(
                     check,
                     summary="Returned CR has no end time",
-                    details="The operational intent reference returned by the DSS has no end time when it should have one",
+                    details="The constraint reference returned by the DSS has no end time when it should have one",
                     t_dss=t_dss,
                 )
 
@@ -216,7 +216,7 @@ class ConstraintReferenceValidator:
         # If the previous OVN is not None, we are dealing with a mutation:
         if previous_ovn is not None:
             with self._scenario.check(
-                "Mutated operational intent reference OVN is updated", self._pid
+                "Mutated constraint reference OVN is updated", self._pid
             ) as check:
                 if dss_cr.ovn == previous_ovn:
                     self._fail_sub_check(
@@ -228,7 +228,7 @@ class ConstraintReferenceValidator:
 
         if expected_ovn is not None:
             with self._scenario.check(
-                "Non-mutated operational intent reference keeps the same OVN", self._pid
+                "Non-mutated constraint reference keeps the same OVN", self._pid
             ) as check:
                 if dss_cr.ovn != expected_ovn:
                     self._fail_sub_check(
@@ -241,7 +241,7 @@ class ConstraintReferenceValidator:
         # If the previous version is not None, we are dealing with a mutation:
         if previous_version is not None:
             with self._scenario.check(
-                "Mutated operational intent reference version is updated", self._pid
+                "Mutated constraint reference version is updated", self._pid
             ) as check:
                 # TODO confirm that a mutation should imply a version update
                 if dss_cr.version == previous_version:
@@ -256,7 +256,7 @@ class ConstraintReferenceValidator:
         #  and we should probably check if it is equal or higher.
         if expected_version is not None:
             with self._scenario.check(
-                "Non-mutated operational intent reference keeps the same version",
+                "Non-mutated constraint reference keeps the same version",
                 self._pid,
             ) as check:
                 if dss_cr.version != expected_version:
@@ -278,9 +278,9 @@ class ConstraintReferenceValidator:
         """
 
         check_name = (
-            "Create operational intent reference response format conforms to spec"
+            "Create constraint reference response format conforms to spec"
             if action == "create"
-            else "Mutate operational intent reference response format conforms to spec"
+            else "Mutate constraint reference response format conforms to spec"
         )
 
         with self._scenario.check(check_name, self._pid) as check:
@@ -312,7 +312,7 @@ class ConstraintReferenceValidator:
             new_cr.response.json, ChangeConstraintReferenceResponse
         )
 
-        cr: ConstraintReference = parsed_resp.operational_intent_reference
+        cr: ConstraintReference = parsed_resp.constraint_reference
 
         # Validate the CR itself
         self._validate_cr(
@@ -342,7 +342,7 @@ class ConstraintReferenceValidator:
 
         cr = ImplicitDict.parse(
             mutated_cr.response.json, ChangeConstraintReferenceResponse
-        ).operational_intent_reference
+        ).constraint_reference
 
         # Validate the CR itself
         self._validate_cr(
@@ -368,7 +368,7 @@ class ConstraintReferenceValidator:
 
         # Validate the response schema
         with self._scenario.check(
-            "Get operational intent reference response format conforms to spec",
+            "Get constraint reference response format conforms to spec",
             self._pid,
         ) as check:
             errors = schema_validation.validate(
@@ -415,7 +415,7 @@ class ConstraintReferenceValidator:
         by_id = {cr.id: cr for cr in resp_parsed.operational_intent_references}
 
         with self._scenario.check(
-            "Created operational intent reference is in search results", self._pid
+            "Created constraint reference is in search results", self._pid
         ) as check:
             if expected_cr_id not in by_id:
                 self._fail_sub_check(
@@ -446,7 +446,7 @@ class ConstraintReferenceValidator:
     ) -> None:
         # Validate the response schema
         with self._scenario.check(
-            "Search operational intent reference response format conforms to spec",
+            "Search constraint reference response format conforms to spec",
             self._pid,
         ) as check:
             errors = schema_validation.validate(
@@ -469,7 +469,7 @@ class ConstraintReferenceValidator:
 
         # Validate the response schema
         with self._scenario.check(
-            "Delete operational intent reference response format conforms to spec",
+            "Delete constraint reference response format conforms to spec",
             self._pid,
         ) as check:
             errors = schema_validation.validate(
@@ -485,7 +485,7 @@ class ConstraintReferenceValidator:
         # Validate the CR itself
         self._validate_cr(
             expected_entity_id=expected_cr_id,
-            dss_cr=cr_resp.operational_intent_reference,
+            dss_cr=cr_resp.constraint_reference,
             t_dss=t_dss,
             previous_ovn=None,
             expected_ovn=expected_ovn,

--- a/monitoring/uss_qualifier/suites/astm/utm/dss_probing.md
+++ b/monitoring/uss_qualifier/suites/astm/utm/dss_probing.md
@@ -4,20 +4,21 @@
 
 ## [Actions](../../README.md#actions)
 
-1. Scenario: [ASTM SCD DSS: USS Availability Synchronization](../../../scenarios/astm/utm/dss/synchronization/uss_availability_synchronization.md) ([`scenarios.astm.utm.dss.synchronization.USSAvailabilitySynchronization`](../../../scenarios/astm/utm/dss/synchronization/uss_availability_synchronization.py))
-2. Scenario: [ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions](../../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md) ([`scenarios.astm.utm.dss.OpIntentReferenceStateTransitions`](../../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.py))
-3. Scenario: [ASTM SCD DSS: Subscription and entity deletion interaction](../../../scenarios/astm/utm/dss/subscription_interactions_deletion.md) ([`scenarios.astm.utm.dss.SubscriptionInteractionsDeletion`](../../../scenarios/astm/utm/dss/subscription_interactions_deletion.py))
-4. Scenario: [ASTM SCD DSS: Subscription and entity interaction](../../../scenarios/astm/utm/dss/subscription_interactions.md) ([`scenarios.astm.utm.dss.SubscriptionInteractions`](../../../scenarios/astm/utm/dss/subscription_interactions.py))
-5. Scenario: [ASTM SCD DSS: Operational Intent Reference Key Validation](../../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md) ([`scenarios.astm.utm.dss.OIRKeyValidation`](../../../scenarios/astm/utm/dss/op_intent_ref_key_validation.py))
-6. Scenario: [ASTM SCD DSS: Operational Intent Reference Synchronization](../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md) ([`scenarios.astm.utm.dss.synchronization.OIRSynchronization`](../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.py))
-7. Scenario: [ASTM SCD DSS: Interfaces authentication](../../../scenarios/astm/utm/dss/authentication/authentication_validation.md) ([`scenarios.astm.utm.dss.authentication.AuthenticationValidation`](../../../scenarios/astm/utm/dss/authentication/authentication_validation.py))
-8. Scenario: [ASTM SCD DSS: Subscription Simple](../../../scenarios/astm/utm/dss/subscription_simple.md) ([`scenarios.astm.utm.dss.SubscriptionSimple`](../../../scenarios/astm/utm/dss/subscription_simple.py))
-9. Scenario: [ASTM SCD DSS: Subscription Validation](../../../scenarios/astm/utm/dss/subscription_validation.md) ([`scenarios.astm.utm.dss.SubscriptionValidation`](../../../scenarios/astm/utm/dss/subscription_validation.py))
-10. Scenario: [ASTM F3548-21 UTM DSS Operational Intent Reference Access Control](../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md) ([`scenarios.astm.utm.dss.OpIntentReferenceAccessControl`](../../../scenarios/astm/utm/dss/op_intent_ref_access_control.py))
-11. Scenario: [ASTM F3548-21 UTM DSS interoperability](../../../scenarios/astm/utm/dss/dss_interoperability.md) ([`scenarios.astm.utm.dss.DSSInteroperability`](../../../scenarios/astm/utm/dss/dss_interoperability.py))
-12. Scenario: [ASTM SCD DSS: Subscription Synchronization](../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md) ([`scenarios.astm.utm.dss.synchronization.SubscriptionSynchronization`](../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.py))
-13. Scenario: [ASTM UTM DSS: Direct CRDB access](../../../scenarios/astm/utm/dss/crdb_access.md) ([`scenarios.astm.utm.dss.CRDBAccess`](../../../scenarios/astm/utm/dss/crdb_access.py))
-14. Scenario: [ASTM SCD DSS: Report](../../../scenarios/astm/utm/dss/report.md) ([`scenarios.astm.utm.dss.Report`](../../../scenarios/astm/utm/dss/report.py))
+1. Scenario: [ASTM SCD DSS: Constraint Reference Synchronization](../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md) ([`scenarios.astm.utm.dss.synchronization.CRSynchronization`](../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.py))
+2. Scenario: [ASTM SCD DSS: USS Availability Synchronization](../../../scenarios/astm/utm/dss/synchronization/uss_availability_synchronization.md) ([`scenarios.astm.utm.dss.synchronization.USSAvailabilitySynchronization`](../../../scenarios/astm/utm/dss/synchronization/uss_availability_synchronization.py))
+3. Scenario: [ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions](../../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md) ([`scenarios.astm.utm.dss.OpIntentReferenceStateTransitions`](../../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.py))
+4. Scenario: [ASTM SCD DSS: Subscription and entity deletion interaction](../../../scenarios/astm/utm/dss/subscription_interactions_deletion.md) ([`scenarios.astm.utm.dss.SubscriptionInteractionsDeletion`](../../../scenarios/astm/utm/dss/subscription_interactions_deletion.py))
+5. Scenario: [ASTM SCD DSS: Subscription and entity interaction](../../../scenarios/astm/utm/dss/subscription_interactions.md) ([`scenarios.astm.utm.dss.SubscriptionInteractions`](../../../scenarios/astm/utm/dss/subscription_interactions.py))
+6. Scenario: [ASTM SCD DSS: Operational Intent Reference Key Validation](../../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md) ([`scenarios.astm.utm.dss.OIRKeyValidation`](../../../scenarios/astm/utm/dss/op_intent_ref_key_validation.py))
+7. Scenario: [ASTM SCD DSS: Operational Intent Reference Synchronization](../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md) ([`scenarios.astm.utm.dss.synchronization.OIRSynchronization`](../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.py))
+8. Scenario: [ASTM SCD DSS: Interfaces authentication](../../../scenarios/astm/utm/dss/authentication/authentication_validation.md) ([`scenarios.astm.utm.dss.authentication.AuthenticationValidation`](../../../scenarios/astm/utm/dss/authentication/authentication_validation.py))
+9. Scenario: [ASTM SCD DSS: Subscription Simple](../../../scenarios/astm/utm/dss/subscription_simple.md) ([`scenarios.astm.utm.dss.SubscriptionSimple`](../../../scenarios/astm/utm/dss/subscription_simple.py))
+10. Scenario: [ASTM SCD DSS: Subscription Validation](../../../scenarios/astm/utm/dss/subscription_validation.md) ([`scenarios.astm.utm.dss.SubscriptionValidation`](../../../scenarios/astm/utm/dss/subscription_validation.py))
+11. Scenario: [ASTM F3548-21 UTM DSS Operational Intent Reference Access Control](../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md) ([`scenarios.astm.utm.dss.OpIntentReferenceAccessControl`](../../../scenarios/astm/utm/dss/op_intent_ref_access_control.py))
+12. Scenario: [ASTM F3548-21 UTM DSS interoperability](../../../scenarios/astm/utm/dss/dss_interoperability.md) ([`scenarios.astm.utm.dss.DSSInteroperability`](../../../scenarios/astm/utm/dss/dss_interoperability.py))
+13. Scenario: [ASTM SCD DSS: Subscription Synchronization](../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md) ([`scenarios.astm.utm.dss.synchronization.SubscriptionSynchronization`](../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.py))
+14. Scenario: [ASTM UTM DSS: Direct CRDB access](../../../scenarios/astm/utm/dss/crdb_access.md) ([`scenarios.astm.utm.dss.CRDBAccess`](../../../scenarios/astm/utm/dss/crdb_access.py))
+15. Scenario: [ASTM SCD DSS: Report](../../../scenarios/astm/utm/dss/report.md) ([`scenarios.astm.utm.dss.Report`](../../../scenarios/astm/utm/dss/report.py))
 
 ## [Checked requirements](../../README.md#checked-requirements)
 
@@ -29,20 +30,30 @@
     <th><a href="../../README.md#checked-in">Checked in</a></th>
   </tr>
   <tr>
-    <td rowspan="48" style="vertical-align:top;"><a href="../../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
+    <td rowspan="52" style="vertical-align:top;"><a href="../../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,1</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,2</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,3</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,4</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,5</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0015</a></td>
@@ -52,7 +63,7 @@
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0020</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/uss_availability_synchronization.md">ASTM SCD DSS: USS Availability Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/uss_availability_synchronization.md">ASTM SCD DSS: USS Availability Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0100,1</a></td>
@@ -122,17 +133,17 @@
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2a</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2b</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2c</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2d</a></td>
@@ -142,12 +153,12 @@
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2e</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2f</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,3a</a></td>
@@ -167,12 +178,12 @@
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,1a</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,1b</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,1c</a></td>
@@ -182,7 +193,17 @@
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,1d</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,1e</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,1f</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,2a</a></td>
@@ -197,12 +218,12 @@
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,3a</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,3b</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,4a</a></td>
@@ -252,7 +273,7 @@
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0215</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/uss_availability_synchronization.md">ASTM SCD DSS: USS Availability Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/uss_availability_synchronization.md">ASTM SCD DSS: USS Availability Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0300</a></td>

--- a/monitoring/uss_qualifier/suites/astm/utm/dss_probing.yaml
+++ b/monitoring/uss_qualifier/suites/astm/utm/dss_probing.yaml
@@ -11,6 +11,14 @@ resources:
   problematically_big_area: resources.VerticesResource
 actions:
   - test_scenario:
+      scenario_type: scenarios.astm.utm.dss.synchronization.CRSynchronization
+      resources:
+        dss: dss
+        other_instances: all_dss_instances
+        id_generator: id_generator
+        planning_area: planning_area
+        client_identity: utm_client_identity
+  - test_scenario:
       scenario_type: scenarios.astm.utm.dss.synchronization.USSAvailabilitySynchronization
       resources:
         dss: dss

--- a/monitoring/uss_qualifier/suites/astm/utm/f3548_21.md
+++ b/monitoring/uss_qualifier/suites/astm/utm/f3548_21.md
@@ -35,20 +35,30 @@
     <th><a href="../../README.md#checked-in">Checked in</a></th>
   </tr>
   <tr>
-    <td rowspan="74" style="vertical-align:top;"><a href="../../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
+    <td rowspan="78" style="vertical-align:top;"><a href="../../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,1</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a></td>
+    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,2</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a><br><a href="../../../scenarios/astm/utm/subscription_notifications/receive_notifications_for_awareness/receive_notifications_for_awareness.md">Awareness of relevant operational intents</a><br><a href="../../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a><br><a href="../../../scenarios/astm/utm/subscription_notifications/receive_notifications_for_awareness/receive_notifications_for_awareness.md">Awareness of relevant operational intents</a><br><a href="../../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,3</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,4</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,5</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a></td>
+    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0015</a></td>
@@ -58,7 +68,7 @@
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0020</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/uss_availability_synchronization.md">ASTM SCD DSS: USS Availability Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/uss_availability_synchronization.md">ASTM SCD DSS: USS Availability Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0100,1</a></td>
@@ -128,17 +138,17 @@
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2a</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2b</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2c</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2d</a></td>
@@ -148,12 +158,12 @@
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2e</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2f</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,3a</a></td>
@@ -173,12 +183,12 @@
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,1a</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,1b</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,1c</a></td>
@@ -188,7 +198,17 @@
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,1d</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,1e</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,1f</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,2a</a></td>
@@ -203,12 +223,12 @@
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,3a</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,3b</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,4a</a></td>
@@ -258,7 +278,7 @@
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0215</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/uss_availability_synchronization.md">ASTM SCD DSS: USS Availability Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/uss_availability_synchronization.md">ASTM SCD DSS: USS Availability Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0300</a></td>

--- a/monitoring/uss_qualifier/suites/faa/uft/message_signing.md
+++ b/monitoring/uss_qualifier/suites/faa/uft/message_signing.md
@@ -18,20 +18,30 @@
     <th><a href="../../README.md#checked-in">Checked in</a></th>
   </tr>
   <tr>
-    <td rowspan="74" style="vertical-align:top;"><a href="../../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
+    <td rowspan="78" style="vertical-align:top;"><a href="../../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,1</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a></td>
+    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,2</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a><br><a href="../../../scenarios/astm/utm/subscription_notifications/receive_notifications_for_awareness/receive_notifications_for_awareness.md">Awareness of relevant operational intents</a><br><a href="../../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a><br><a href="../../../scenarios/astm/utm/subscription_notifications/receive_notifications_for_awareness/receive_notifications_for_awareness.md">Awareness of relevant operational intents</a><br><a href="../../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,3</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,4</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,5</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a></td>
+    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0015</a></td>
@@ -41,7 +51,7 @@
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0020</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/uss_availability_synchronization.md">ASTM SCD DSS: USS Availability Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/uss_availability_synchronization.md">ASTM SCD DSS: USS Availability Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0100,1</a></td>
@@ -111,17 +121,17 @@
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2a</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2b</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2c</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2d</a></td>
@@ -131,12 +141,12 @@
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2e</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2f</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,3a</a></td>
@@ -156,12 +166,12 @@
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,1a</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,1b</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,1c</a></td>
@@ -171,7 +181,17 @@
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,1d</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,1e</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,1f</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,2a</a></td>
@@ -186,12 +206,12 @@
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,3a</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,3b</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,4a</a></td>
@@ -241,7 +261,7 @@
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0215</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/uss_availability_synchronization.md">ASTM SCD DSS: USS Availability Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/uss_availability_synchronization.md">ASTM SCD DSS: USS Availability Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0300</a></td>

--- a/monitoring/uss_qualifier/suites/interuss/dss/all_tests.md
+++ b/monitoring/uss_qualifier/suites/interuss/dss/all_tests.md
@@ -408,20 +408,30 @@
     <td><a href="../../../scenarios/astm/netrid/v22a/dss/heavy_traffic_concurrent.md">ASTM NetRID DSS: Concurrent Requests</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/isa_expiry.md">ASTM NetRID DSS: ISA Expiry</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/isa_subscription_interactions.md">ASTM NetRID DSS: ISA Subscription Interactions</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/isa_validation.md">ASTM NetRID DSS: Submitted ISA Validations</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a></td>
   </tr>
   <tr>
-    <td rowspan="48" style="vertical-align:top;"><a href="../../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
+    <td rowspan="52" style="vertical-align:top;"><a href="../../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,1</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,2</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,3</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,4</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,5</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0015</a></td>
@@ -431,7 +441,7 @@
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0020</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/uss_availability_synchronization.md">ASTM SCD DSS: USS Availability Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/uss_availability_synchronization.md">ASTM SCD DSS: USS Availability Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0100,1</a></td>
@@ -501,17 +511,17 @@
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2a</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2b</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2c</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2d</a></td>
@@ -521,12 +531,12 @@
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2e</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,2f</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,3a</a></td>
@@ -546,12 +556,12 @@
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,1a</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,1b</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,1c</a></td>
@@ -561,7 +571,17 @@
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,1d</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,1e</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,1f</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,2a</a></td>
@@ -576,12 +596,12 @@
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,3a</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,3b</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,4a</a></td>
@@ -631,7 +651,7 @@
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0215</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/uss_availability_synchronization.md">ASTM SCD DSS: USS Availability Synchronization</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/uss_availability_synchronization.md">ASTM SCD DSS: USS Availability Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0300</a></td>

--- a/monitoring/uss_qualifier/suites/uspace/flight_auth.md
+++ b/monitoring/uss_qualifier/suites/uspace/flight_auth.md
@@ -19,20 +19,30 @@
     <th><a href="../README.md#checked-in">Checked in</a></th>
   </tr>
   <tr>
-    <td rowspan="74" style="vertical-align:top;"><a href="../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
+    <td rowspan="78" style="vertical-align:top;"><a href="../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0005,1</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a></td>
+    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0005,2</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a><br><a href="../../scenarios/astm/utm/subscription_notifications/receive_notifications_for_awareness/receive_notifications_for_awareness.md">Awareness of relevant operational intents</a><br><a href="../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a><br><a href="../../scenarios/astm/utm/subscription_notifications/receive_notifications_for_awareness/receive_notifications_for_awareness.md">Awareness of relevant operational intents</a><br><a href="../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3548/v21.md">DSS0005,3</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3548/v21.md">DSS0005,4</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0005,5</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a></td>
+    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0015</a></td>
@@ -42,7 +52,7 @@
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0020</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../scenarios/astm/utm/dss/synchronization/uss_availability_synchronization.md">ASTM SCD DSS: USS Availability Synchronization</a></td>
+    <td><a href="../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../scenarios/astm/utm/dss/synchronization/uss_availability_synchronization.md">ASTM SCD DSS: USS Availability Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0100,1</a></td>
@@ -112,17 +122,17 @@
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,2a</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,2b</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,2c</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,2d</a></td>
@@ -132,12 +142,12 @@
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,2e</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,2f</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,3a</a></td>
@@ -157,12 +167,12 @@
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,1a</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,1b</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,1c</a></td>
@@ -172,7 +182,17 @@
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,1d</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,1e</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,1f</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,2a</a></td>
@@ -187,12 +207,12 @@
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,3a</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,3b</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,4a</a></td>
@@ -242,7 +262,7 @@
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0215</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../scenarios/astm/utm/dss/synchronization/uss_availability_synchronization.md">ASTM SCD DSS: USS Availability Synchronization</a></td>
+    <td><a href="../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../scenarios/astm/utm/dss/synchronization/uss_availability_synchronization.md">ASTM SCD DSS: USS Availability Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0300</a></td>

--- a/monitoring/uss_qualifier/suites/uspace/required_services.md
+++ b/monitoring/uss_qualifier/suites/uspace/required_services.md
@@ -454,20 +454,30 @@
     <td><a href="../../scenarios/astm/netrid/v22a/dss/heavy_traffic_concurrent.md">ASTM NetRID DSS: Concurrent Requests</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_expiry.md">ASTM NetRID DSS: ISA Expiry</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_subscription_interactions.md">ASTM NetRID DSS: ISA Subscription Interactions</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_validation.md">ASTM NetRID DSS: Submitted ISA Validations</a><br><a href="../../scenarios/astm/netrid/v22a/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a><br><a href="../../scenarios/astm/netrid/v22a/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a><br><a href="../../scenarios/astm/netrid/v22a/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a></td>
   </tr>
   <tr>
-    <td rowspan="74" style="vertical-align:top;"><a href="../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
+    <td rowspan="78" style="vertical-align:top;"><a href="../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0005,1</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a></td>
+    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0005,2</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a><br><a href="../../scenarios/astm/utm/subscription_notifications/receive_notifications_for_awareness/receive_notifications_for_awareness.md">Awareness of relevant operational intents</a><br><a href="../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a><br><a href="../../scenarios/astm/utm/subscription_notifications/receive_notifications_for_awareness/receive_notifications_for_awareness.md">Awareness of relevant operational intents</a><br><a href="../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3548/v21.md">DSS0005,3</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3548/v21.md">DSS0005,4</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0005,5</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a></td>
+    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_simple.md">ASTM SCD DSS: Subscription Simple</a><br><a href="../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_validation.md">ASTM SCD DSS: Subscription Validation</a><br><a href="../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0015</a></td>
@@ -477,7 +487,7 @@
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0020</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../scenarios/astm/utm/dss/synchronization/uss_availability_synchronization.md">ASTM SCD DSS: USS Availability Synchronization</a></td>
+    <td><a href="../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../scenarios/astm/utm/dss/synchronization/uss_availability_synchronization.md">ASTM SCD DSS: USS Availability Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0100,1</a></td>
@@ -547,17 +557,17 @@
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,2a</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,2b</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,2c</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,2d</a></td>
@@ -567,12 +577,12 @@
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,2e</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,2f</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,3a</a></td>
@@ -592,12 +602,12 @@
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,1a</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,1b</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,1c</a></td>
@@ -607,7 +617,17 @@
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,1d</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,1e</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,1f</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,2a</a></td>
@@ -622,12 +642,12 @@
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,3a</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,3b</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
+    <td><a href="../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0210,A2-7-2,4a</a></td>
@@ -677,7 +697,7 @@
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0215</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../scenarios/astm/utm/dss/synchronization/uss_availability_synchronization.md">ASTM SCD DSS: USS Availability Synchronization</a></td>
+    <td><a href="../../scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md">ASTM SCD DSS: Constraint Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/synchronization/subscription_synchronization.md">ASTM SCD DSS: Subscription Synchronization</a><br><a href="../../scenarios/astm/utm/dss/synchronization/uss_availability_synchronization.md">ASTM SCD DSS: USS Availability Synchronization</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0300</a></td>


### PR DESCRIPTION
Adds a scenario the checks that Constraint References are properly synchronized across a set of DSS instances.

This is a relatively big PR. The new validator and scenario are an almost 1-1 equivalent of what is done for the operational intents.

Part of the effort tracked by #434 
