### PR TITLE
[uss_qualifier/templates] fix warning for deprecated escape char in templates.py

### DIFF
--- a/monitoring/uss_qualifier/reports/templates.py
+++ b/monitoring/uss_qualifier/reports/templates.py
@@ -69,7 +69,7 @@ class TemplateRenderer:
         rendered_configuration = json.dumps(
             InjectedConfiguration(self._template.configuration, report=self._report)
         ).replace(
-            "</", "<\/"
+            "</", "<\\d/"
         )  # Replace closing html tags in json strings
         injected_configuration = f"""
 <script id="interuss_report_json" type="application/json">


### PR DESCRIPTION
When executing run_locally script for uss_qualifier, syntax warning appears for an deprecated escape character was being used in uss_qualifier/reports/templates.py 

**Steps to reproduce the behavior**
1. Go to moniroting/uss_qualifier
2. Execute ./run_locally
3. When script is starting,this syntax warning should be logged as shown in screenshot section 

**Difference from expected behavior**
USS qualififer script should be executed without syntax warnings.

**Possible solution**
Changed the deprecated character to \d

**Screenshots**
![image](https://github.com/interuss/monitoring/assets/154645321/ca8b914b-189c-41bd-96cc-70b9afc4172e)

**System on which behavior was encountered**
OS: Ubuntu Linux 22.04.4 LTS 64 bits
Python version: 3.10.12

**Codebase information**
*Output of `git log -n 1`*:
![image](https://github.com/interuss/monitoring/assets/154645321/fe0b91a3-613e-49ef-9dbc-47fb23b1af24)


**Output of `git status`**:
Author: Benjamin Pelletier <BenjaminPelletier@users.noreply.github.com>
Date:   Fri May 10 15:00:59 2024 +0000

    [docs] Add more how-it-works documentation for uss_qualifier (#684)
    
    Add more how-it-works documentation for uss_qualifier
(END)

