### PR TITLE
[uss_qualifier] Clean up data validation documentation

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md
@@ -2,18 +2,17 @@
 
 ## Description
 This test checks that the USS being tested validates the operational intents received as response to its GET request from another USS.
-mock_uss plans a nearby V-shaped operation, and provides the data that tested_uss GETs.
+mock_uss plans an operation designed to be relevant to (but not intersect) the operation tested_uss will plan, and provides the data that tested_uss GETs.
 tested_uss validates the GET response from mock_uss and accordingly plan its operation.
-Notably the following requirements:
 
-- **[astm.f3548.v21.SCD0035](../../../../requirements/astm/f3548/v21.md)**
+The primary requirement tested by this scenario is **[astm.f3548.v21.SCD0035](../../../../requirements/astm/f3548/v21.md)** because a USS cannot verify its operational intent does not conflict when it cannot obtain valid details for that operational intent.
 
 This scenario assumes that the area used in the scenario is already clear of any pre-existing flights (using, for instance, PrepareFlightPlanners scenario).
 
 ## Resources
 ### flight_intents
-FlightIntentsResource provides the two V-shaped flight intents.
-The convex hulls of the 2D footprints of the two flights intersect, but the polygons do not intersect.
+FlightIntentsResource provides the two flight intents which must be relevant to each other, but must not intersect.
+This can generally be accomplished when the convex hulls of the 2D footprints of the two flights intersect, but the polygons do not intersect.
 There is an overlap in time and altitude of the two flights.
 - flight_1
 - flight_2
@@ -31,20 +30,20 @@ DSSInstanceResource that provides access to a DSS instance where flight creation
 
 ### mock_uss plans flight 2 test step
 
-#### [Plan](../../../flight_planning/plan_flight_intent.md)
+#### [Plan successfully](../../../flight_planning/plan_flight_intent.md)
 
-Flight 2 should be successfully planned by the control USS.
+Flight 2 should be successfully planned by mock_uss.
 
-#### [Validate](../validate_shared_operational_intent.md)
+#### [Validate operational intent is shared](../validate_shared_operational_intent.md)
 
 ### tested_uss plans flight 1 test step
 
-#### [Plan](../../../flight_planning/plan_flight_intent.md)
+#### [Plan successfully](../../../flight_planning/plan_flight_intent.md)
 
-The test driver attempts to plan flight 1 via the tested USS. It checks if any conflicts with flight 2
+The test driver instructs tested_uss to attempt to plan flight 1. tested_uss checks if any conflicts with flight 2
 which is of equal priority and came first.
 
-#### [Validate](../validate_shared_operational_intent.md)
+#### [Validate operational intent is shared](../validate_shared_operational_intent.md)
 
 ### Check for notification to tested_uss due to subscription in flight 2 area test step
 In the following test step, we want to assert that tested_uss must have retrieved operational intent details from
@@ -55,38 +54,42 @@ step, we determine if tested_uss had a pre-existing subscription by:
 #### [checking if mock_uss sent a notification to tested_uss](test_steps/query_mock_uss_interactions.md)
 
 ### [Validate flight2 GET interaction, if no notification test step](test_steps/validate_get_operational_intent.md)
-This step is skipped if a notification to tested_uss was found in the previous step.
+This step is skipped if a notification to tested_uss was found in the previous step since tested_uss obtained the operational intent details of flight 2 without needing to perform a GET interaction.
 
 ### [Validate flight1 Notification sent to mock_uss test step](test_steps/validate_notification_operational_intent.md)
-tested_uss notifies flight 1 to mock_uss, due to its subscription through flight 2.
+tested_uss notifies mock_uss of flight 1, due to mock_uss's subscription covering flight 2 (which is necessarily relevant to flight 1 per test design).
 
 ### [Delete tested_uss flight test step](../../../flight_planning/delete_flight_intent.md)
-Teardown
+
+To prepare for the next test case, tested_uss's flight 1 is closed.
 
 ### [Delete mock_uss flight test step](../../../flight_planning/delete_flight_intent.md)
-Teardown
+
+To prepare for the next test case, mock_uss's flight 2 is closed.
 
 ## Flight planning prevented due to invalid data sharing test case
 
+In this test case, mock_uss is manipulated to share invalid operational intent details which should prevent tested_uss from planning since it cannot verify the absence of a conflict.
+
 ### mock_uss plans flight 2, sharing invalid operational intent data test step
 
-#### [Plan](../../../flight_planning/plan_flight_intent.md)
+#### [Plan successfully](../../../flight_planning/plan_flight_intent.md)
 
 Flight 2 should be successfully planned by the mock_uss.
 
-#### [Validate](test_steps/validate_sharing_operational_intent_but_with_invalid_interuss_data.md)
+#### [Validate invalid operational intent details shared](test_steps/validate_sharing_operational_intent_but_with_invalid_interuss_data.md)
 
 The mock_uss is instructed to share invalid data with other USS, for negative test.
 
 ### tested_uss attempts to plan flight 1, expect failure test step
 
-#### [Plan](test_steps/plan_flight_intent_expect_failed.md)
+#### [Plan unsuccessfully](test_steps/plan_flight_intent_expect_failed.md)
 
-The test driver attempts to plan the flight 1 via the tested_uss. It checks if any conflicts with flight 2
+The test driver instructs tested_uss to plan flight 1. tested_uss should (per SCD0035) check if any conflicts with flight 2
 which is of equal priority and came first.
 The planning attempt should fail because tested_uss will be unable to obtain valid operational intent details for flight 2.
 
-#### [Validate](../validate_not_shared_operational_intent.md)
+#### [Validate operational intent not shared](../validate_not_shared_operational_intent.md)
 
 Validate flight 1 is not shared with DSS, as plan failed.
 
@@ -96,7 +99,7 @@ mock_uss via a GET request.  This assertion is only valid, however, if tested_us
 intent details in a different way -- specifically, a notification due to a pre-existing subscription.  In this test
 step, we determine if tested_uss had a pre-existing subscription by:
 
-#### [checking if mock_uss sent a notification to tested_uss](test_steps/query_mock_uss_interactions.md)
+#### [Check if mock_uss sent a notification to tested_uss](test_steps/query_mock_uss_interactions.md)
 
 ### [Validate flight2 GET interaction, if no notification test step](test_steps/validate_get_operational_intent.md)
 This step is skipped if a notification to tested_uss was found in the previous step.


### PR DESCRIPTION
FAA/NASA feedback recommended making the links to the "Plan" and “Validate” test step fragments of the data validation test scenario more explicit (the same term is being used to link to different test step fragments, which can cause confusion).  This PR follows that recommendation and also cleans up some other parts of the documentation for that test scenario as well.