### PR TITLE
[loadtest] Update load test documentation

### DIFF
--- a/monitoring/loadtest/README.md
+++ b/monitoring/loadtest/README.md
@@ -22,20 +22,20 @@ for the format of these values.  Omitting this step will result in Client Initia
 ## Running in a Container
 Simply build the Docker container with the Dockerfile from the root directory. All the files are added into the container
 
-1. From the [`monitoring`](..) folder of this repository, build the monitoring image with `docker image build . -t interuss/monitoring`
-1. Run Docker container
+1. From the root folder of this repository, build the monitoring image with `make image`
+1. Run Docker container; in general:
 
     a. For ISA run: `docker run -e AUTH_SPEC="<auth spec>" -p 8089:8089 interuss/monitoring locust -f loadtest/locust_files/ISA.py`
 
     b. For Sub run: `docker run -e AUTH_SPEC="<auth spec>" -p 8089:8089 interuss/monitoring locust -f loadtest/locust_files/Sub.py`
 
-1. If testing local DSS instance, be sure that the loadtest (monitoring) container has access to the DSS container
+1. If testing local DSS instance, be sure that the loadtest (monitoring) container has access to the DSS container:
 
-    a. For ISA run: `docker run -e AUTH_SPEC="DummyOAuth(http://host.docker.internal:8085/token,uss1)" --network="interop_ecosystem_network" -p 8089:8089 interuss/monitoring locust -f loadtest/locust_files/ISA.py`
+    a. For ISA run: `docker run -e AUTH_SPEC="DummyOAuth(http://oauth.authority.localutm:8085/token,uss1)" --network="interop_ecosystem_network" -p 8089:8089 interuss/monitoring locust -f loadtest/locust_files/ISA.py`
 
-    b. For ISA run: `docker run -e AUTH_SPEC="DummyOAuth(http://host.docker.internal:8085/token,uss1)" --network="interop_ecosystem_network" -p 8089:8089 interuss/monitoring locust -f loadtest/locust_files/Sub.py`
+    b. For Sub run: `docker run -e AUTH_SPEC="DummyOAuth(http://oauth.authority.localutm:8085/token,uss1)" --network="interop_ecosystem_network" -p 8089:8089 interuss/monitoring locust -f loadtest/locust_files/Sub.py`
 
 ## Use
 1. Navigate to http://localhost:8089
 1. Start new test with number of Users to spawn and the rate to spawn them.
-1. For the Host, provide the DSS Core Service endpoint used for testing. An example of such url is: http://local_infra-dss-1:8082/v1/dss/ in case local environment is setup by [run_locally.sh](../../build/dev/run_locally.sh)
+1. For the Host, provide the DSS Core Service endpoint used for testing. An example of such url is: http://dss.uss1.localutm/v1/dss/ in case local environment is setup with `make start-locally`


### PR DESCRIPTION
Because the loadtest tool is not commonly used, its documentation was out of date with the current build and deployment practices.  This PR updates the documentation accordingly.