### PR TITLE
[uss_qualifier/scenarios/conflict_equal_priority_not_permitted] Validate GEN0500 when planning nearby potentially conflicting flight

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md
@@ -154,6 +154,12 @@ Flight 1 should not have been shared with the interoperability ecosystem since i
 #### [Plan Flight 1c](../../../../flight_planning/plan_flight_intent.md)
 The smaller Flight 1c form (which doesn't conflict with Flight 2) should be successfully planned by the tested USS.
 
+#### ℹ️ Validate tested USS intersection algorithm check
+Because Flight 2 is nearby Flight 1c, successful planning of Flight 1c indicates the tested USS is complying with the portion of
+**[astm.f3548.v21.GEN0500](../../../../../requirements/astm/f3548/v21.md)** that requires a USS to indicate two 4D volumes are non-intersecting when they are separated by more than 1 cm.
+
+This check does not fail if the planning is rejected.
+
 #### [Validate Flight 1c sharing](../../validate_shared_operational_intent.md)
 
 ### Attempt to modify planned Flight 1c into conflict test step

--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.py
@@ -329,6 +329,7 @@ class ConflictEqualPriorityNotPermitted(TestScenario):
                 self,
                 self.tested_uss,
                 flight1c_planned,
+                nearby_potential_conflict=True,
             )
             flight_1_oi_ref = validator.expect_shared(flight1c_planned)
         self.end_test_step()

--- a/monitoring/uss_qualifier/suites/astm/utm/f3548_21.md
+++ b/monitoring/uss_qualifier/suites/astm/utm/f3548_21.md
@@ -303,7 +303,7 @@
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">GEN0500</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">OPIN0015</a></td>

--- a/monitoring/uss_qualifier/suites/faa/uft/message_signing.md
+++ b/monitoring/uss_qualifier/suites/faa/uft/message_signing.md
@@ -286,7 +286,7 @@
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">GEN0500</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">OPIN0015</a></td>

--- a/monitoring/uss_qualifier/suites/uspace/flight_auth.md
+++ b/monitoring/uss_qualifier/suites/uspace/flight_auth.md
@@ -287,7 +287,7 @@
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">GEN0500</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">OPIN0015</a></td>

--- a/monitoring/uss_qualifier/suites/uspace/required_services.md
+++ b/monitoring/uss_qualifier/suites/uspace/required_services.md
@@ -722,7 +722,7 @@
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">GEN0500</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">OPIN0015</a></td>


### PR DESCRIPTION
This should address #697 

Do note that the added check never fails, it only succeeds or is skipped.