### PR TITLE
[uss_qualifier] prepare SCD auth check scenario to check different endpoint groups

### DIFF
--- a/monitoring/uss_qualifier/resources/astm/f3548/v21/dss.py
+++ b/monitoring/uss_qualifier/resources/astm/f3548/v21/dss.py
@@ -579,6 +579,31 @@ class DSSInstanceResource(Resource[DSSInstanceSpecification]):
     def get_authorized_scopes(self) -> Set[str]:
         return self._auth_adapter.scopes.copy()
 
+    @property
+    def participant_id(self) -> str:
+        return self._specification.participant_id
+
+    @property
+    def base_url(self) -> str:
+        return self._specification.base_url
+
+    def get_authorized_scope_not_in(self, ignored_scopes: List[str]) -> Optional[str]:
+        """Returns a scope that this DSS Resource is allowed to use but that is not any of the ones that are passed
+        in 'ignored_scopes'. If no such scope is found, None is returned.
+
+        This function is mostly meant to be used from scenarios that are testing authentication and authorization of endpoints.
+
+        The output of this function is deterministic.
+        """
+        available_scopes_scd = self.get_authorized_scopes()
+        for to_ignore in ignored_scopes:
+            available_scopes_scd.discard(to_ignore)
+
+        if len(available_scopes_scd) > 0:
+            return sorted(available_scopes_scd)[0]
+
+        return None
+
     def get_instance(self, scopes_required: Dict[str, str]) -> DSSInstance:
         """Get a client object ready to be used.
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/authentication/sub_api_validator.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/authentication/sub_api_validator.py
@@ -6,7 +6,6 @@ from uas_standards.astm.f3548.v21.api import (
     OperationID,
     QuerySubscriptionParameters,
 )
-from uas_standards.astm.f3548.v21.constants import Scope
 
 from monitoring.monitorlib import fetch
 from monitoring.monitorlib.fetch import QueryType


### PR DESCRIPTION
This PR prepares the `AuthenticationValidation` scenario for checking the endpoints for constraint references and USS availability states.

For those, the notion of a 'wrong' scope is different than for subscriptions and SCD, as the wront scope for SCD might be the correct one for setting a USS availability state.

(PRs introducing the checks for the other endpoints will follow – this is just a preparatory cleanup)