### PR TITLE
[uss_qualifier] add utm.conformance_monitoring_sa to f3548_self_contained's scopes_authorized

### DIFF
--- a/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml
@@ -67,6 +67,7 @@ v1:
               - utm.strategic_coordination
               - utm.availability_arbitration
               - utm.constraint_management
+              - utm.conformance_monitoring_sa
               # For authentication test purposes.
               # Remove if the authentication provider pointed to by AUTH_SPEC does not support it.
               - ""


### PR DESCRIPTION
Noticed that the self contained suite had warnings about a missing scope:

```
2024-06-11 12:37:57.281 | WARNING  | monitoring.uss_qualifier.suites.suite:__init__:275 - Skipping action 13 (ActionType.TestScenario scenarios.astm.utm.dss.CRDBAccess) because Test suite action to run ActionType.TestScenario scenarios.astm.utm.dss.CRDBAccess could not find required resource ID "dss_crdb_cluster" used to populate child resource ID "crdb_cluster"
2024-06-11 12:37:57.344 | WARNING  | monitoring.uss_qualifier.suites.suite:__init__:275 - Skipping action 13 (ActionType.TestScenario scenarios.astm.utm.dss.CRDBAccess) because Test suite action to run ActionType.TestScenario scenarios.astm.utm.dss.CRDBAccess could not find required resource ID "dss_crdb_cluster" used to populate child resource ID "crdb_cluster"
2024-06-11 12:37:57.387 | WARNING  | monitoring.uss_qualifier.suites.suite:__init__:275 - Skipping action 4 (ActionType.ActionGenerator action_generators.flight_planning.FlightPlannerCombinations) because Test suite action to run ActionType.ActionGenerator action_generators.flight_planning.FlightPlannerCombinations could not find required resource ID "priority_preemption_flights" used to populate child resource ID "priority_preemption_flights"
2024-06-11 12:37:57.659 | WARNING  | monitoring.uss_qualifier.suites.suite:__init__:275 - Skipping action 8 (ActionType.ActionGenerator action_generators.flight_planning.FlightPlannerCombinations) because AuthAdapterResource provided to monitoring.uss_qualifier.resources.astm.f3548.v21.dss.DSSInstanceResource is not declared (in its resource specification) as authorized to obtain scope `utm.conformance_monitoring_sa` which it requires to create operational intent references in an off-nominal state.  Update `scopes_authorized` to include `utm.conformance_monitoring_sa` to provide this authorization.  7 scopes currently declared as authorized for AuthAdapterResource: , interuss.flight_planning.direct_automated_test, utm.availability_arbitration, utm.strategic_coordination, interuss.versioning.read_system_versions, interuss.flight_planning.plan, utm.constraint_management
2024-06-11 12:37:57.670 | WARNING  | monitoring.uss_qualifier.suites.suite:__init__:275 - Skipping action 9 (ActionType.ActionGenerator action_generators.flight_planning.FlightPlannerCombinations) because AuthAdapterResource provided to monitoring.uss_qualifier.resources.astm.f3548.v21.dss.DSSInstanceResource is not declared (in its resource specification) as authorized to obtain scope `utm.conformance_monitoring_sa` which it requires to create operational intent references in an off-nominal state.  Update `scopes_authorized` to include `utm.conformance_monitoring_sa` to provide this authorization.  7 scopes currently declared as authorized for AuthAdapterResource: , interuss.flight_planning.direct_automated_test, utm.availability_arbitration, utm.strategic_coordination, interuss.versioning.read_system_versions, interuss.flight_planning.plan, utm.constraint_management
```

After the addition, this is reduced to:

```
2024-06-11 12:42:52.085 | WARNING  | monitoring.uss_qualifier.suites.suite:__init__:275 - Skipping action 13 (ActionType.TestScenario scenarios.astm.utm.dss.CRDBAccess) because Test suite action to run ActionType.TestScenario scenarios.astm.utm.dss.CRDBAccess could not find required resource ID "dss_crdb_cluster" used to populate child resource ID "crdb_cluster"
2024-06-11 12:42:52.147 | WARNING  | monitoring.uss_qualifier.suites.suite:__init__:275 - Skipping action 13 (ActionType.TestScenario scenarios.astm.utm.dss.CRDBAccess) because Test suite action to run ActionType.TestScenario scenarios.astm.utm.dss.CRDBAccess could not find required resource ID "dss_crdb_cluster" used to populate child resource ID "crdb_cluster"
2024-06-11 12:42:52.190 | WARNING  | monitoring.uss_qualifier.suites.suite:__init__:275 - Skipping action 4 (ActionType.ActionGenerator action_generators.flight_planning.FlightPlannerCombinations) because Test suite action to run ActionType.ActionGenerator action_generators.flight_planning.FlightPlannerCombinations could not find required resource ID "priority_preemption_flights" used to populate child resource ID "priority_preemption_flights"
```

This seems more in line with what the self_contained suite should be able to test, and the test suite still succeeds.

(There still is the action number 4 that I'm not sure should be skipped)