### PR TITLE
[uss_qualifier/scenarios/utm/validate_shared_operational_intent] Stop validating SCD0100 when retrieving telemetry from USS

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/utm/test_steps.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/test_steps.py
@@ -500,14 +500,6 @@ class OpIntentValidator(object):
                     query_timestamps=[oi_tel_query.request.timestamp],
                 )
 
-            if oi_tel is None:
-                check.record_failed(
-                    summary="Warning (not a failure): USS indicated that no operational intent telemetry was available",
-                    severity=Severity.Low,
-                    details=f"Received status code {oi_tel_query.status_code} from {self._flight_planner.participant_id} when querying for details of operational intent {oi_ref.id}",
-                    query_timestamps=[oi_tel_query.request.timestamp],
-                )
-
     def _evaluate_op_intent_validation(
         self, oi_full_query: fetch.Query
     ) -> Set[OpIntentValidationFailure]:

--- a/monitoring/uss_qualifier/scenarios/astm/utm/validate_shared_operational_intent.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/validate_shared_operational_intent.md
@@ -43,6 +43,9 @@ If the operational intent details reported by the USS do not match the user's fl
 
 ## 🛑 Operational intent telemetry retrievable check
 
-If the operational intent is in an off-nominal state and that its telemetry cannot be retrieved from the USS, this check will fail per **[astm.f3548.v21.SCD0100](../../../requirements/astm/f3548/v21.md)**.
+If:
+- the operational intent is in an off-nominal state,
+- that its telemetry cannot be retrieved from the USS, and
+- that the USS does not explicitly indicate that no telemetry is available,
 
-The USS may explicitly indicate that no telemetry is available for this operational intent, in which case, as a warning, this check will fail with a low severity.
+this check will fail per **[astm.f3548.v21.USS0105](../../../requirements/astm/f3548/v21.md)**.

--- a/monitoring/uss_qualifier/suites/astm/utm/f3548_21.md
+++ b/monitoring/uss_qualifier/suites/astm/utm/f3548_21.md
@@ -403,7 +403,7 @@
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">SCD0100</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../../scenarios/astm/utm/subscription_notifications/receive_notifications_for_awareness/receive_notifications_for_awareness.md">Awareness of relevant operational intents</a><br><a href="../../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">USS0005</a></td>

--- a/monitoring/uss_qualifier/suites/faa/uft/message_signing.md
+++ b/monitoring/uss_qualifier/suites/faa/uft/message_signing.md
@@ -386,7 +386,7 @@
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">SCD0100</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../../scenarios/astm/utm/subscription_notifications/receive_notifications_for_awareness/receive_notifications_for_awareness.md">Awareness of relevant operational intents</a><br><a href="../../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">USS0005</a></td>

--- a/monitoring/uss_qualifier/suites/uspace/flight_auth.md
+++ b/monitoring/uss_qualifier/suites/uspace/flight_auth.md
@@ -387,7 +387,7 @@
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">SCD0100</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../scenarios/astm/utm/subscription_notifications/receive_notifications_for_awareness/receive_notifications_for_awareness.md">Awareness of relevant operational intents</a><br><a href="../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">USS0005</a></td>

--- a/monitoring/uss_qualifier/suites/uspace/required_services.md
+++ b/monitoring/uss_qualifier/suites/uspace/required_services.md
@@ -822,7 +822,7 @@
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">SCD0100</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../scenarios/astm/utm/subscription_notifications/receive_notifications_for_awareness/receive_notifications_for_awareness.md">Awareness of relevant operational intents</a><br><a href="../../scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md">Data Validation of GET operational intents by USS</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/flight_intent_validation/flight_intent_validation.md">Validation of operational intents</a></td>
+    <td><a href="../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">USS0005</a></td>


### PR DESCRIPTION
See https://github.com/interuss/monitoring/issues/699#issuecomment-2161025755 for context.

During the validation of a shared operational intent, if it is in an off-nominal state, the USS qualifier will attempt to retrieve its telemetry. 
It does so by validating SCD0100 but as per #699 this is incorrect.

This PR replaces the validation of SCD0100 by USS0105. 