### PR TITLE
[uss_qualifier] Fix bug in Evaluate system versions test scenario

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/utm/versioning/evaluate_system_versions.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/versioning/evaluate_system_versions.py
@@ -200,7 +200,9 @@ class EvaluateSystemVersions(TestScenario):
                             details=f"When queried for the version of the '{self._system_identity}' system, earlier response indicated '{resp.system_version}' but later response indicated '{test_env_versions[q.participant_id].version}'",
                             query_timestamps=[
                                 q.request.timestamp,
-                                test_env_versions[q.participant_id].query.request.timestamp,
+                                test_env_versions[
+                                    q.participant_id
+                                ].query.request.timestamp,
                             ],
                         )
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/versioning/evaluate_system_versions.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/versioning/evaluate_system_versions.py
@@ -200,7 +200,7 @@ class EvaluateSystemVersions(TestScenario):
                             details=f"When queried for the version of the '{self._system_identity}' system, earlier response indicated '{resp.system_version}' but later response indicated '{test_env_versions[q.participant_id].version}'",
                             query_timestamps=[
                                 q.request.timestamp,
-                                test_env_versions[q.participant_id].query.timestamp,
+                                test_env_versions[q.participant_id].query.request.timestamp,
                             ],
                         )
 


### PR DESCRIPTION
A particular failure in this test scenario is missing the intermediate `request` field, instead attempting to reference the `timestamp` field directly from the `Query` (where it doesn't exist).  This PR fixes that bug.  The bug is unfortunately only revealed when that particular check fails.