### PR TITLE
[uss_qualifier] Add environment cleanup scenario to F3548-21 test suite

### DIFF
--- a/monitoring/uss_qualifier/suites/astm/utm/f3548_21.md
+++ b/monitoring/uss_qualifier/suites/astm/utm/f3548_21.md
@@ -22,8 +22,9 @@
     1. Scenario: [Off-Nominal planning: down USS](../../../scenarios/astm/utm/off_nominal_planning/down_uss.md) ([`scenarios.astm.utm.DownUSS`](../../../scenarios/astm/utm/off_nominal_planning/down_uss.py))
 10. Action generator: [`action_generators.flight_planning.FlightPlannerCombinations`](../../../action_generators/flight_planning/planner_combinations.py)
     1. Scenario: [Off-Nominal planning: down USS with equal priority conflicts not permitted](../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md) ([`scenarios.astm.utm.DownUSSEqualPriorityNotPermitted`](../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.py))
-11. Scenario: [ASTM F3548-21 evaluate system versions](../../../scenarios/astm/utm/versioning/evaluate_system_versions.md) ([`scenarios.astm.utm.versioning.evaluate_system_versions.EvaluateSystemVersions`](../../../scenarios/astm/utm/versioning/evaluate_system_versions.py))
-12. Scenario: [ASTM F3548 UTM aggregate checks](../../../scenarios/astm/utm/aggregate_checks.md) ([`scenarios.astm.utm.AggregateChecks`](../../../scenarios/astm/utm/aggregate_checks.py))
+11. Scenario: [ASTM F3548 flight planners preparation](../../../scenarios/astm/utm/prep_planners.md) ([`scenarios.astm.utm.PrepareFlightPlanners`](../../../scenarios/astm/utm/prep_planners.py))
+12. Scenario: [ASTM F3548-21 evaluate system versions](../../../scenarios/astm/utm/versioning/evaluate_system_versions.md) ([`scenarios.astm.utm.versioning.evaluate_system_versions.EvaluateSystemVersions`](../../../scenarios/astm/utm/versioning/evaluate_system_versions.py))
+13. Scenario: [ASTM F3548 UTM aggregate checks](../../../scenarios/astm/utm/aggregate_checks.md) ([`scenarios.astm.utm.AggregateChecks`](../../../scenarios/astm/utm/aggregate_checks.py))
 
 ## [Checked requirements](../../README.md#checked-requirements)
 

--- a/monitoring/uss_qualifier/suites/astm/utm/f3548_21.yaml
+++ b/monitoring/uss_qualifier/suites/astm/utm/f3548_21.yaml
@@ -223,6 +223,17 @@ actions:
         - uss1
   on_failure: Continue
 - test_scenario:
+    scenario_type: scenarios.astm.utm.PrepareFlightPlanners  # TODO: Convert this to a scenario which only clears the area (does not check readiness)
+    resources:
+      flight_planners: flight_planners
+      mock_uss: mock_uss?
+      dss: dss
+      flight_intents: invalid_flight_intents
+      flight_intents2: priority_preemption_flights?
+      flight_intents3: conflicting_flights?
+      flight_intents4: non_conflicting_flights?
+  on_failure: Continue
+- test_scenario:
     scenario_type: scenarios.astm.utm.versioning.evaluate_system_versions.EvaluateSystemVersions
     resources:
       test_env_version_providers: test_env_version_providers


### PR DESCRIPTION
Currently, if there is a problem with a USS during execution of the F3548-21 test suite, that USS may leave a dangling operational intent in the DSS.  This is less of an issue as long as that participant is always participating since the next test run starts off by instructing participants to clear the area, but that participant is not always participating.  So, they may leave a dangling operational intent and then another test run without them as a participant would be blocked due to the dangling operational intent.

This PR addresses (but does not fully solve) this issue by adding another instance of the "Prepare flight planners" scenario (whose primary activity is to clear the area) to the end of the test suite.  This should substantially increase the chances that the environment is left clean at the end of the test run.

"Prepare flight planners" is not quite what we want because we don't care about retrieving and evaluating the USSs' statuses any more, but checking readiness is cheap and the developer effort to make a separate scenario is probably not justified at this time.  A TODO annotates this tech debt.

Note that the cleanup scenario is not the very last scenario -- instead, it is the last scenario that may reasonably cause the environment to be left dirty.  Putting it before EvaluateSystemVersions and AggregateChecks means that a critical issue in either of those scenarios will not prevent cleanup from occurring (because it has already occurred at that point).