### PR TITLE
[release] Fix missing file from submodules in published images

### DIFF
--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          submodules: true
           fetch-depth: 0
 
       - name: Log in to Docker Hub


### PR DESCRIPTION
Experiments with the `uss_qualifier` using the released image of monitoring v0.6.0 without cloning the repository showed that utm.yaml is missing from the published image.

After quick investigation, it seems that submodules are not checked out by the release pipeline. This PR fixes this issue.