### PR TITLE
[uss_qualifier] Separate flight_planners_to_clear from flight_planners under test in F3548-21 suite

### DIFF
--- a/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml
@@ -18,6 +18,7 @@ v1:
           test_env_version_providers: test_env_version_providers
           prod_env_version_providers: prod_env_version_providers
           flight_planners: flight_planners
+          flight_planners_to_clear: flight_planners
           conflicting_flights: conflicting_flights
           invalid_flight_intents: invalid_flight_intents
           non_conflicting_flights: non_conflicting_flights
@@ -36,6 +37,7 @@ v1:
       - v1.test_run.resources.resource_declarations.second_utm_auth
       - v1.test_run.resources.resource_declarations.test_env_version_providers
       - v1.test_run.resources.resource_declarations.flight_planners
+      - v1.test_run.resources.resource_declarations.flight_planners_to_clear
       - v1.test_run.resources.resource_declarations.dss
       - v1.test_run.resources.resource_declarations.dss_instances
       - v1.test_run.resources.resource_declarations.mock_uss

--- a/monitoring/uss_qualifier/suites/astm/utm/f3548_21.yaml
+++ b/monitoring/uss_qualifier/suites/astm/utm/f3548_21.yaml
@@ -3,6 +3,7 @@ resources:
   test_env_version_providers: resources.versioning.VersionProvidersResource?
   prod_env_version_providers: resources.versioning.VersionProvidersResource?
   flight_planners: resources.flight_planning.FlightPlannersResource
+  flight_planners_to_clear: resources.flight_planning.FlightPlannersResource
   dss: resources.astm.f3548.v21.DSSInstanceResource
   dss_instances: resources.astm.f3548.v21.DSSInstancesResource?
   dss_crdb_cluster: resources.interuss.crdb.CockroachDBClusterResource?
@@ -34,7 +35,7 @@ actions:
 - test_scenario:
     scenario_type: scenarios.astm.utm.PrepareFlightPlanners
     resources:
-      flight_planners: flight_planners
+      flight_planners: flight_planners_to_clear
       mock_uss: mock_uss?
       dss: dss
       flight_intents: invalid_flight_intents

--- a/monitoring/uss_qualifier/suites/faa/uft/message_signing.yaml
+++ b/monitoring/uss_qualifier/suites/faa/uft/message_signing.yaml
@@ -29,6 +29,7 @@ actions:
       non_conflicting_flights: non_conflicting_flights
       priority_preemption_flights: priority_preemption_flights
       flight_planners: flight_planners
+      flight_planners_to_clear: flight_planners
       nominal_planning_selector: combination_selector
       invalid_flight_intents: invalid_flight_intents
       priority_planning_selector: combination_selector

--- a/monitoring/uss_qualifier/suites/uspace/flight_auth.yaml
+++ b/monitoring/uss_qualifier/suites/uspace/flight_auth.yaml
@@ -29,6 +29,7 @@ actions:
       invalid_flight_intents: invalid_flight_intents
       non_conflicting_flights: non_conflicting_flights
       flight_planners: flight_planners?
+      flight_planners_to_clear: flight_planners?
       mock_uss: mock_uss
       dss: dss
       dss_instances: dss_instances


### PR DESCRIPTION
Currently, a participant is either part of the F3548-21 test suite or they are not part of the test suite.  This can be problematic if a participant who previously participated is removed from the configuration temporarily, or if there are multiple configurations with different participants.  In that case, a participant that is not part of current test may have left content behind in the ecosystem (though #719 already mitigates this somewhat), but since they are not part of the current test, they will not be asked to clear out that content at the beginning of the test.

This PR addresses that issue by adding a separate `flight_planners_to_clear` resource to the F3548-21 test suite.  In most cases (including all the CI configurations), this resource can simply be the same resource as the main `flight_planners` resource -- this results in no behavioral change from before.  But, to mitigate the issue above, the test designer can instead provide a separate resource specifying all the flight planners in the environment as `flight_planners_to_clear`.  In that case, those flight planners will be asked to clear the area, but then only the normal `flight_planners` will proceed to be tested.

Note that this is a breaking change for existing test configurations using the F3548-21 suite -- they will need to explicitly add `flight_planners_to_clear: flight_planners` to their suite declaration (as this PR does for the applicable CI configurations).