### PR TITLE
[uss_qualifier] Add CI config targeted at US UTM Implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,17 @@ jobs:
         cd monitoring/uss_qualifier
         make test
 
+  uss_qualifier-utm_implementation_us-test:
+    name: uss_qualifier configurations.dev.utm_implementation_us tests
+    uses: ./.github/workflows/monitoring-test.yml
+    with:
+      name: uss_qualifier-utm_implementation_us-test
+      script: |
+        export CONFIG_NAME="configurations.dev.utm_implementation_us"
+
+        cd monitoring/uss_qualifier
+        make test
+
   uss_qualifier-netrid_v22a-test:
     name: uss_qualifier configurations.dev.netrid_v22a tests
     uses: ./.github/workflows/monitoring-test.yml
@@ -171,7 +182,22 @@ jobs:
 
   publish-gh-pages:
     name: Publish GitHub Pages
-    needs: [hygiene-tests, mock_uss-test, uss_qualifier-noop-test, uss_qualifier-geoawareness_cis-test, uss_qualifier-generate_rid_test_data-test, uss_qualifier-geospatial_comprehension-test, uss_qualifier-general_flight_auth-test, uss_qualifier-message_signing-test, uss_qualifier-dss_probing-test, uss_qualifier-f3548_self_contained-test, uss_qualifier-netrid_v22a-test, uss_qualifier-netrid_v19-test, uss_qualifier-uspace-test, prober-test]
+    needs:
+      - hygiene-tests
+      - mock_uss-test
+      - uss_qualifier-noop-test
+      - uss_qualifier-geoawareness_cis-test
+      - uss_qualifier-generate_rid_test_data-test
+      - uss_qualifier-geospatial_comprehension-test
+      - uss_qualifier-general_flight_auth-test
+      - uss_qualifier-message_signing-test
+      - uss_qualifier-dss_probing-test
+      - uss_qualifier-f3548_self_contained-test
+      - uss_qualifier-utm_implementation_us-test
+      - uss_qualifier-netrid_v22a-test
+      - uss_qualifier-netrid_v19-test
+      - uss_qualifier-uspace-test
+      - prober-test
     if: ${{ always() && contains(join(needs.*.result, ','), 'success') }}
     runs-on: ubuntu-latest
     permissions:

--- a/github_pages/static/index.md
+++ b/github_pages/static/index.md
@@ -24,6 +24,11 @@ These reports were generated during continuous integration for the most recent P
 * [Sequence view](./artifacts/uss_qualifier/reports/f3548_self_contained/sequence)
 * [Tested requirements](./artifacts/uss_qualifier/reports/f3548_self_contained/gate3)
 
+### [US UTM Implementation test configuration](https://github.com/interuss/monitoring/blob/main/monitoring/uss_qualifier/configurations/dev/utm_implementation_us.yaml)
+
+* [Sequence view](./artifacts/uss_qualifier/reports/utm_implementation_us/sequence)
+* [Tested requirements](./artifacts/uss_qualifier/reports/utm_implementation_us/scd)
+
 ### [ASTM F3411-22a test configuration](https://github.com/interuss/monitoring/blob/main/monitoring/uss_qualifier/configurations/dev/netrid_v22a.yaml)
 
 * [Sequence view](./artifacts/uss_qualifier/reports/netrid_v22a/sequence)

--- a/monitoring/uss_qualifier/configurations/dev/README.md
+++ b/monitoring/uss_qualifier/configurations/dev/README.md
@@ -1,0 +1,69 @@
+# Development test configurations
+
+The [test configurations](../README.md) in this folder represent common/useful test situations.
+
+## [dss_probing](dss_probing.yaml)
+
+Runs all tests available for an InterUSS DSS implementation deployment.
+
+## [f3548_self_contained](f3548_self_contained.yaml)
+
+A self-contained (all content is contained in a single YAML configuration file) test configuration which happens to test compliance to ASTM F3548-21 requirements in a particular regulatory environment.
+
+This configuration is a good example to start from to understand
+
+## [general_flight_auth](general_flight_auth.jsonnet)
+
+Demonstration of a test where a list of flight planning attempts has a corresponding list of expected outcomes.
+
+Demonstrates the use of jsonnet as a file format.
+
+## [generate_rid_test_data](generate_rid_test_data.yaml)
+
+Demonstrates simple in-configuration test suite definition with short test actions that don't have external dependencies.
+
+## [geoawareness_cis](geoawareness_cis.yaml)
+
+Demonstration of a test where a list of expected geospatial map feature queries has the corresponding expected outcomes.
+
+## [message_signing](message_signing.yaml)
+
+Exercise of automated tests for message signing (not well-developed yet).
+
+
+## [netrid_v19](netrid_v19.yaml)
+
+Verification of ASTM F3411-19 network remote identification requirements.
+
+## [netrid_v22a](netrid_v22a.yaml)
+
+Verification of ASTM F3411-22a network remote identification requirements.
+
+## [noop](noop.yaml)
+
+Simple configuration performing nearly no action to verify that uss_qualifier runs correctly.
+
+## [uspace](uspace.yaml)
+
+Verifies requirements for U-space Service Providers using ASTM standards (F3411-22a + F3548-21) as means of compliance.
+
+## [uspace_f3548](uspace_f3548.yaml)
+
+Same configuration as [uspace](#uspace), except only the portions related to ASTM F3548-21 verification are executed (other parts are skipped).
+
+## [utm_implementation_us](utm_implementation_us.yaml)
+
+Intended to be an InterUSS interpretation of how to verify the requirements of the [US Shared Airspace group](https://github.com/utmimplementationus/getstarted) verified via automated testing as documented in their [Requirements Traceability Matrix for Strategic Coordination](https://github.com/utmimplementationus/getstarted/blob/main/docs/Strategic_Coordination_Compliance_Matrix_v1.0.xlsx).  Note that this is merely InterUSS's interpretation of the publicly-available information for that project and this test configuration may not exactly match the test configuration actually in use by that group (which is not organizationally affiliated with InterUSS).  InterUSS welcomes contributions to change this test configuration to better align with the intent of that group.
+
+The baseline portion of the test configuration is found in [utm_implementation_us.yaml](utm_implementation_us.yaml) and the environmental portion of the test configuration is found in [utm_implementation_us_env.yaml](utm_implementation_us_env.yaml).  To adapt this configuration to target a non-local ecosystem and USS, only changes to the environmental file should be necessary.  These two files may be copied into the [personal](../personal) folder to make modifications without affecting git-tracked files.
+
+### Environment characteristics
+
+Some characteristics of this pseudo-regulatory environment are:
+
+1. ASTM F3548-21 is being used
+2. Participants perform Strategic Coordination only
+3. Only one priority level is defined (level 0) and conflicts are not permitted at that priority level
+4. No participant is authorized to perform Conformance Monitoring for Situational Awareness
+5. No participant is authorized to act as availability arbitrator outside DSS functionality verification
+6. No constraints are used (management nor processing)

--- a/monitoring/uss_qualifier/configurations/dev/utm_implementation_us.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/utm_implementation_us.yaml
@@ -1,0 +1,335 @@
+# See the file below (in the `schemas` folder of this repo) for the schema this file's content follows
+$content_schema: monitoring/uss_qualifier/configurations/configuration/USSQualifierConfiguration.json
+
+# This configuration uses the v1 configuration schema
+v1:
+  # This block defines how to perform a test run
+  test_run:
+    # This block defines which test action uss_qualifier should run, and what resources from the pool should be used
+    action:
+      test_suite:
+        # suite_type is a FileReference (defined in uss_qualifier/file_io.py) to a test suite definition (see uss_qualifier/suites/README.md)
+        suite_type: suites.astm.utm.f3548_21
+
+        # Mapping of <resource name in test suite> to <resource name in resource pool>
+        resources:
+          id_generator: id_generator
+          utm_client_identity: utm_client_identity
+          test_env_version_providers: test_env_version_providers
+          prod_env_version_providers: prod_env_version_providers
+          flight_planners: flight_planners
+          flight_planners_to_clear: flight_planners
+          conflicting_flights: conflicting_flights
+          invalid_flight_intents: invalid_flight_intents
+          non_conflicting_flights: non_conflicting_flights
+          dss: dss
+          dss_instances: dss_instances
+          mock_uss: mock_uss
+          second_utm_auth: second_utm_auth
+          planning_area: planning_area
+          problematically_big_area: problematically_big_area
+          system_identity: system_identity
+          # dss_crdb_cluster: dss_crdb_cluster  # TODO: Provide once local DSS uses a multi-node cluster
+
+    # When a test run is executed, a "baseline signature" is computed uniquely identifying the "baseline" of the test,
+    # usually excluding exactly what systems are participating in the test (the "environment").  This is a list of
+    # elements within this configuration to exclude from the configuration when computing the baseline signature.
+    non_baseline_inputs:
+      - v1.test_run.resources.resource_declarations.utm_auth
+      - v1.test_run.resources.resource_declarations.second_utm_auth
+      - v1.test_run.resources.resource_declarations.test_env_version_providers
+      - v1.test_run.resources.resource_declarations.prod_env_version_providers
+      - v1.test_run.resources.resource_declarations.flight_planners
+      - v1.test_run.resources.resource_declarations.dss
+      - v1.test_run.resources.resource_declarations.dss_instances
+      - v1.test_run.resources.resource_declarations.mock_uss
+      - v1.test_run.resources.resource_declarations.dss_crdb_cluster
+      - v1.artifacts.tested_requirements[0].aggregate_participants
+      - v1.artifacts.tested_requirements[0].participant_requirements
+
+    # This block defines all the resources available in the resource pool.
+    # All resources defined below should be used either
+    #   1) directly in the test suite or
+    #   2) to create another resource in the pool (see, e.g., `utm_auth` as it relates to `dss` below)
+    resources:
+      resource_declarations:
+        # =================================
+        # ========== Environment ==========
+        # vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
+
+        $ref: "./utm_implementation_us_env.yaml#/resource_declarations"
+
+        # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        # ========== Environment ==========
+        # =================================
+
+        # Means by which uss_qualifier can discover which subscription ('sub' claim of its tokes) it is described by
+        utm_client_identity:
+          resource_type: resources.communications.ClientIdentityResource
+          dependencies:
+            auth_adapter: utm_auth
+          specification:
+            # Audience and scope to be used to issue a dummy query, should it be required to discover the subscription
+            whoami_audience: localhost
+            whoami_scope: utm.strategic_coordination
+
+        # Means by which uss_qualifier generates identifiers
+        id_generator:
+          $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
+          resource_type: resources.interuss.IDGeneratorResource
+          dependencies:
+            client_identity: utm_client_identity
+
+        # Area that will be used for queries and resource creation that are geo-located
+        planning_area:
+          $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
+          resource_type: resources.astm.f3548.v21.PlanningAreaResource
+          specification:
+            base_url: https://uss_qualifier.test.utm/dummy_base_url
+            volume:
+              outline_polygon:
+                vertices:
+                  - lat: 37.1853
+                    lng: -80.6140
+                  - lat: 37.2148
+                    lng: -80.6140
+                  - lat: 37.2148
+                    lng: -80.5440
+                  - lat: 37.1853
+                    lng: -80.5440
+              altitude_lower:
+                value: 0
+                reference: W84
+                units: M
+              altitude_upper:
+                value: 3048
+                reference: W84
+                units: M
+
+        # An area designed to be soo big as to be refused by systems queries with it.
+        problematically_big_area:
+          $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
+          resource_type: resources.VerticesResource
+          specification:
+            vertices:
+              - lat: 33
+                lng: -96
+              - lat: 32
+                lng: -96
+              - lat: 32
+                lng: -95
+              - lat: 33
+                lng: -95
+
+        # Details of conflicting flights (used in nominal planning scenario)
+        conflicting_flights:
+          resource_type: resources.flight_planning.FlightIntentsResource
+          specification:
+            file:
+              path: file://./test_data/flight_intents/standard/conflicting_flights.yaml
+            transformations:
+              - relative_translation:
+                  # Put these flight intents in an appropriate area in Texas
+                  degrees_north: 32.3716
+                  degrees_east: -95.3216
+
+                  # EGM96 geoid is 27.3 meters below the WGS84 ellipsoid at 32.3716, -95.3216
+                  # Ground level starts at roughly 143m above the EGM96 geoid
+                  # Therefore, ground level is at roughly 116m above the WGS84 ellipsoid
+                  meters_up: 116
+
+        # Details of flights with invalid operational intents (used in flight intent validation scenario)
+        invalid_flight_intents:
+          resource_type: resources.flight_planning.FlightIntentsResource
+          specification:
+            intent_collection:
+              $ref: test_data.flight_intents.standard.invalid_flight_intents
+            transformations:
+              - relative_translation:
+                  degrees_north: 32.3716
+                  degrees_east: -95.3216
+                  meters_up: 116
+
+        # Details of non-conflicting flights (used in data validation scenario)
+        non_conflicting_flights:
+          resource_type: resources.flight_planning.FlightIntentsResource
+          specification:
+            intent_collection:
+              $ref: test_data.flight_intents.standard.non_conflicting
+            transformations:
+              - relative_translation:
+                  degrees_north: 32.3716
+                  degrees_east: -95.3216
+                  meters_up: 116
+
+        # Name of the system under test for which the system version should be obtained from participants who provide version information
+        system_identity:
+          resource_type: resources.versioning.SystemIdentityResource
+          specification:
+            system_identity: us.utm_implementation
+
+    # How to execute a test run using this configuration
+    execution:
+      # Since we expect no failed checks and want to stop execution immediately if there are any failed checks, we set
+      # this parameter to true.
+      stop_fast: true
+
+  # This block defines artifacts related to the test run.  Note that all paths are
+  # relative to where uss_qualifier is executed from, and are located inside the
+  # Docker container executing uss_qualifier.
+  artifacts:
+    # Write out full report content
+    raw_report: {}
+
+    # Write out a human-readable reports of the F3548-21 requirements tested
+    tested_requirements:
+      - report_name: scd
+        aggregate_participants:
+          # =================================
+          # ========== Environment ==========
+          # vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
+
+          $ref: "./utm_implementation_us_env.yaml#/aggregate_participants"
+
+          # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+          # ========== Environment ==========
+          # =================================
+        requirement_collections:
+          "Basic SCD with DSS provision":
+            requirements:
+              - astm.f3548.v21.GEN0100
+              - astm.f3548.v21.GEN0105
+              - astm.f3548.v21.GEN0300
+              - astm.f3548.v21.GEN0305
+              - astm.f3548.v21.GEN0310
+              - astm.f3548.v21.OPIN0015
+              - astm.f3548.v21.OPIN0020
+              - astm.f3548.v21.OPIN0025
+              - astm.f3548.v21.OPIN0030
+              - astm.f3548.v21.OPIN0035
+              - astm.f3548.v21.OPIN0040
+              - astm.f3548.v21.USS0005
+              - astm.f3548.v21.SCD0035
+              - astm.f3548.v21.SCD0040
+              - astm.f3548.v21.SCD0045
+              - astm.f3548.v21.SCD0050
+              - astm.f3548.v21.SCD0075
+              - astm.f3548.v21.SCD0080
+              - astm.f3548.v21.SCD0085
+              - astm.f3548.v21.GEN0500
+              - astm.f3548.v21.USS0105
+              - astm.f3548.v21.DSS0005,1
+              - astm.f3548.v21.DSS0005,2
+              - astm.f3548.v21.DSS0005,5
+              - astm.f3548.v21.DSS0015
+              - astm.f3548.v21.DSS0020
+              - astm.f3548.v21.DSS0100,1
+              - astm.f3548.v21.DSS0200
+              - astm.f3548.v21.DSS0205
+              - astm.f3548.v21.DSS0210,1a
+              - astm.f3548.v21.DSS0210,1b
+              - astm.f3548.v21.DSS0210,1c
+              - astm.f3548.v21.DSS0210,1d
+              - astm.f3548.v21.DSS0210,1e
+              - astm.f3548.v21.DSS0210,1f
+              - astm.f3548.v21.DSS0210,1g
+              - astm.f3548.v21.DSS0210,1h
+              - astm.f3548.v21.DSS0210,1i
+              - astm.f3548.v21.DSS0210,2a
+              - astm.f3548.v21.DSS0210,2b
+              - astm.f3548.v21.DSS0210,2c
+              - astm.f3548.v21.DSS0210,2d
+              - astm.f3548.v21.DSS0210,2e
+              - astm.f3548.v21.DSS0210,2f
+              - astm.f3548.v21.DSS0210,A2-7-2,1a
+              - astm.f3548.v21.DSS0210,A2-7-2,1b
+              - astm.f3548.v21.DSS0210,A2-7-2,1c
+              - astm.f3548.v21.DSS0210,A2-7-2,1d
+              - astm.f3548.v21.DSS0210,A2-7-2,2a
+              - astm.f3548.v21.DSS0210,A2-7-2,2b
+              - astm.f3548.v21.DSS0210,A2-7-2,3a
+              - astm.f3548.v21.DSS0210,A2-7-2,3b
+              - astm.f3548.v21.DSS0210,A2-7-2,4a
+              - astm.f3548.v21.DSS0210,A2-7-2,4b
+              - astm.f3548.v21.DSS0210,A2-7-2,4c
+              - astm.f3548.v21.DSS0210,A2-7-2,4d
+              - astm.f3548.v21.DSS0210,A2-7-2,5a
+              - astm.f3548.v21.DSS0210,A2-7-2,5b
+              - astm.f3548.v21.DSS0210,A2-7-2,5c
+              - astm.f3548.v21.DSS0210,A2-7-2,7
+              - astm.f3548.v21.DSS0215
+              - astm.f3548.v21.DSS0300
+              - interuss.automated_testing.flight_planning.ClearArea
+              - interuss.automated_testing.flight_planning.DeleteFlightSuccess
+              - interuss.automated_testing.flight_planning.ExpectedBehavior
+              - interuss.automated_testing.flight_planning.FlightCoveredByOperationalIntent
+              - interuss.automated_testing.flight_planning.ImplementAPI
+              - interuss.automated_testing.flight_planning.Readiness
+              - interuss.f3548.notification_requirements.NoDssEntityNoNotification
+          "Basic SCD without DSS provision":
+            requirements:
+              - astm.f3548.v21.GEN0100
+              - astm.f3548.v21.GEN0105
+              - astm.f3548.v21.GEN0300
+              - astm.f3548.v21.GEN0305
+              - astm.f3548.v21.GEN0310
+              - astm.f3548.v21.OPIN0015
+              - astm.f3548.v21.OPIN0020
+              - astm.f3548.v21.OPIN0025
+              - astm.f3548.v21.OPIN0030
+              - astm.f3548.v21.OPIN0035
+              - astm.f3548.v21.OPIN0040
+              - astm.f3548.v21.USS0005
+              - astm.f3548.v21.SCD0035
+              - astm.f3548.v21.SCD0040
+              - astm.f3548.v21.SCD0045
+              - astm.f3548.v21.SCD0050
+              - astm.f3548.v21.SCD0075
+              - astm.f3548.v21.SCD0080
+              - astm.f3548.v21.SCD0085
+              - astm.f3548.v21.GEN0500
+              - astm.f3548.v21.USS0105
+              - interuss.automated_testing.flight_planning.ClearArea
+              - interuss.automated_testing.flight_planning.DeleteFlightSuccess
+              - interuss.automated_testing.flight_planning.ExpectedBehavior
+              - interuss.automated_testing.flight_planning.FlightCoveredByOperationalIntent
+              - interuss.automated_testing.flight_planning.ImplementAPI
+              - interuss.automated_testing.flight_planning.Readiness
+              - interuss.f3548.notification_requirements.NoDssEntityNoNotification
+        participant_requirements:
+          # =================================
+          # ========== Environment ==========
+          # vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
+
+          $ref: "./utm_implementation_us_env.yaml#/participant_requirements"
+
+          # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+          # ========== Environment ==========
+          # =================================
+
+    # Write out a human-readable report showing the sequence of events of the test
+    sequence_view: {}
+
+  # This block defines whether to return an error code from the execution of uss_qualifier, based on the content of the
+  # test run report.  All the criteria must be met to return a successful code.
+  validation:
+    criteria:
+      # applicability indicates which test report elements the pass_condition applies to
+      - applicability:
+          # We want to make sure no test scenarios had execution errors
+          test_scenarios: {}
+        pass_condition:
+          each_element:
+            has_execution_error: false
+      - applicability:
+          # We also want to make sure there are no failed checks...
+          failed_checks:
+            # ...at least, no failed checks with severity higher than "Low".
+            has_severity:
+              higher_than: Low
+        pass_condition:
+          # When considering all the applicable elements...
+          elements:
+            # ...the number of applicable elements should be zero.
+            count:
+              equal_to: 0

--- a/monitoring/uss_qualifier/configurations/dev/utm_implementation_us_env.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/utm_implementation_us_env.yaml
@@ -1,0 +1,123 @@
+# This file contains the environmental (non-baseline) parameters for the utm_implementation_us.yaml test configuration.
+# Top-level keys are $referenced by utm_implementation_us.yaml.
+
+resource_declarations:
+  # Means by which uss_qualifier can obtain authorization to make requests in an ASTM USS ecosystem
+  utm_auth:
+    # resource_type is a ResourceTypeName (defined in uss_qualifier/resources/definitions.py)
+    resource_type: resources.communications.AuthAdapterResource
+    specification:
+      # To avoid putting secrets in configuration files, the auth spec (including sensitive information) will be read from the AUTH_SPEC environment variable
+      environment_variable_containing_auth_spec: AUTH_SPEC
+      scopes_authorized:
+        # InterUSS flight_planning v1 automated testing API
+        - interuss.flight_planning.direct_automated_test
+        - interuss.flight_planning.plan
+        # InterUSS versioning automated testing API
+        - interuss.versioning.read_system_versions
+        # ASTM F3548-21 USS emulation roles
+        - utm.strategic_coordination
+        - utm.availability_arbitration
+        # For authentication test purposes.
+        # Remove if the authentication provider pointed to by AUTH_SPEC does not support it.
+        # - ""
+
+  # A second auth adapter, for DSS tests that require a second set of credentials for accessing the ecosystem.
+  # Note that the 'sub' claim of the tokens obtained through this adepter MUST be different from the first auth adapter.
+  second_utm_auth:
+    resource_type: resources.communications.AuthAdapterResource
+    specification:
+      environment_variable_containing_auth_spec: AUTH_SPEC_2
+      scopes_authorized:
+        - utm.strategic_coordination
+
+  # Means by which to obtain the versions of participants' systems under test (in the test environment).
+  test_env_version_providers:
+    resource_type: resources.versioning.VersionProvidersResource
+    dependencies:
+      auth_adapter: utm_auth
+    specification:
+      instances:
+        - participant_id: uss1_core
+          interuss:
+            base_url: http://scdsc.uss1.localutm/versioning
+        - participant_id: uss2_core
+          interuss:
+            base_url: http://scdsc.uss2.localutm/versioning
+
+  # Means by which to obtain the versions of participants' production systems (in a real test, these would be different URLs than test_env_version_providers above).
+  prod_env_version_providers:
+    resource_type: resources.versioning.VersionProvidersResource
+    dependencies:
+      auth_adapter: utm_auth
+    specification:
+      instances:
+        - participant_id: uss1_core
+          interuss:
+            base_url: http://scdsc.uss1.localutm/versioning
+        - participant_id: uss2_core
+          interuss:
+            base_url: http://scdsc.uss2.localutm/versioning
+
+  # Set of USSs capable of being tested as flight planners
+  flight_planners:
+    resource_type: resources.flight_planning.FlightPlannersResource
+    dependencies:
+      auth_adapter: utm_auth
+    specification:
+      flight_planners:
+        # uss1 is the mock_uss directly exposing flight planning functionality
+        - participant_id: uss1_core
+          v1_base_url: http://scdsc.uss1.localutm/flight_planning/v1
+        # uss2 is another mock_uss directly exposing flight planning functionality
+        - participant_id: uss2_core
+          v1_base_url: http://scdsc.uss2.localutm/flight_planning/v1
+
+  # Location of DSS instance that can be used to verify flight planning outcomes
+  dss:
+    resource_type: resources.astm.f3548.v21.DSSInstanceResource
+    dependencies:
+      auth_adapter: utm_auth
+    specification:
+      # A USS that hosts a DSS instance is also a participant in the test, even if they don't fulfill any other roles
+      participant_id: uss1_dss
+      base_url: http://dss.uss1.localutm
+
+  dss_instances:
+    resource_type: resources.astm.f3548.v21.DSSInstancesResource
+    dependencies:
+      auth_adapter: utm_auth
+    specification:
+      dss_instances:
+        - participant_id: uss1_dss
+          user_participant_ids:
+            # Participants using a DSS instance they do not provide should be listed as users of that DSS (so that they can take credit for USS requirements enforced by the DSS)
+            - mock_uss  # mock_uss uses this DSS instance; it does not provide its own instance
+          base_url: http://dss.uss1.localutm
+          has_private_address: true
+        - participant_id: uss2_dss
+          base_url: http://dss.uss2.localutm
+          has_private_address: true
+
+  # Mock USS that can be used in tests for flight planning, modifying data sharing behavior and recording interactions
+  mock_uss:
+    resource_type: resources.interuss.mock_uss.client.MockUSSResource
+    dependencies:
+      auth_adapter: utm_auth
+    specification:
+      participant_id: mock_uss
+      mock_uss_base_url: http://scdsc.log.uss6.localutm
+
+
+aggregate_participants:
+  uss1:
+    - uss1_core
+    - uss1_dss
+  uss2:
+    - uss2_core
+    - uss2_dss
+
+
+participant_requirements:
+  uss1: Basic SCD with DSS provision
+  uss2: Basic SCD without DSS provision


### PR DESCRIPTION
With the [public announcement](https://github.com/utmimplementationus/getstarted) of the US UTM Implementation, this PR aims to create a CI-targeted test configuration reflecting the testing needs of that project as closely as practical.  This will allow the f3548_self_contained test configuration to diverge from this project to more fully exercise the F3548-21 tests not used in that project while maintaining a useful resource for users interested or taking part in that activity.

This PR also adds a simple documentation index of the dev test configurations to make their purposes more accessible.