### PR TITLE
[build] add --fix-missing to apt-get update call in monitoring Docker file

### DIFF
--- a/monitoring/Dockerfile
+++ b/monitoring/Dockerfile
@@ -17,7 +17,7 @@ FROM python:3.12-slim
 #   curl: Useful debugging utility
 #   gcc: Required to build various packages
 #   ca-certificates: Needed to accurately validate TLS connections
-RUN apt-get update && apt-get install -y openssl curl libgeos-dev gcc && apt-get install ca-certificates
+RUN apt-get update --fix-missing && apt-get install -y openssl curl libgeos-dev gcc && apt-get install ca-certificates
 
 # Required to build in an ARM environment
 #   gevent: libffi-dev libssl-dev python3-dev build-essential


### PR DESCRIPTION
From the current `main`,  with a cleaned up docker cache, I run into the following issue related to building the `monitoring/Dockerfile` when running `make format`:

```
[...]
1.368 E: Failed to fetch http://deb.debian.org/debian/pool/main/p/python3.11/python3.11-minimal_3.11.2-6_arm64.deb  404  Not Found [IP: 199.232.18.132 80]
1.368 E: Failed to fetch http://deb.debian.org/debian/pool/main/p/python3.11/libpython3.11-stdlib_3.11.2-6_arm64.deb  404  Not Found [IP: 199.232.18.132 80]
1.368 E: Failed to fetch http://deb.debian.org/debian/pool/main/p/python3.11/libpython3.11_3.11.2-6_arm64.deb  404  Not Found [IP: 199.232.18.132 80]
1.368 E: Failed to fetch http://deb.debian.org/debian/pool/main/p/python3.11/libpython3.11-dev_3.11.2-6_arm64.deb  404  Not Found [IP: 199.232.18.132 80]
1.368 E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
1.368 Fetched 62.3 MB in 0s (133 MB/s)
------
Dockerfile:26
--------------------
  24 |     #   lxml: libxml2-dev libxslt-dev
  25 |     #   h5py: pkg-config libhdf5-dev
  26 | >>> RUN apt-get install -y libffi-dev libssl-dev python3-dev build-essential libxml2-dev libxslt-dev pkg-config libhdf5-dev
  27 |     
[...]
```
Applying the suggested fix (appending `--fix-missing` to the `apt-get update` invocation) fixes the problem locally.