### PR TITLE
[uss_qualifier] Fix legacy value format for env variable

### DIFF
--- a/monitoring/Dockerfile
+++ b/monitoring/Dockerfile
@@ -48,7 +48,7 @@ RUN mkdir -p /app/uss-host-files
 HEALTHCHECK CMD sh /app/health_check.sh
 
 # Discover `monitoring` module in Python
-ENV PYTHONPATH /app
+ENV PYTHONPATH=/app
 
 # This image should be built by passing in `version` and `commit_hash` based on information from git (see `make image`)
 # This version information becomes available in the environment variables specified below


### PR DESCRIPTION
When executing run_locally script for uss_qualifier, warning appears for an deprecated key value format for environment variable being used in monitoring/Dockerfile

**Steps to reproduce the behavior**
- Go to monitoring/uss_qualifier
- Execute ./run_locally
- When script is starting,this warning should be logged as shown in screenshot section

**Difference from expected behavior**
- USS qualifier script should be executed without syntax warnings.

**Possible solution**
Update PYTHONPATH env key value format to ENV key=value

**Screenshots**
![image](https://github.com/user-attachments/assets/fc362800-48c3-49ed-b1dd-fcbba9558d3a)


**System on which behavior was encountered**
OS: Ubuntu Linux 22.04.4 LTS 64 bits
Python version: 3.10.12

**Codebase information**

Author: Julien Perrochet <julien.perrochet@orbitalize.com>
Date:   Mon Jul 15 12:37:46 2024 +0200

    [uss_qualifier] acces proper activity result field in down_uss.py (#731)
    
    Read the correct field when running the check for the planned activity's result

![image](https://github.com/user-attachments/assets/1b7e9b5e-4728-4f1e-8feb-b95a0a0020bb)

(END)