### PR TITLE
Resolve python warnings

### DIFF
--- a/monitoring/deployment_manager/deploylib/crdb_sql.py
+++ b/monitoring/deployment_manager/deploylib/crdb_sql.py
@@ -85,7 +85,9 @@ def get_monitoring_user(
     )
 
     # Compute validity
-    valid_until = (datetime.datetime.utcnow() + datetime.timedelta(days=2)).isoformat()
+    valid_until = (
+        datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=2)
+    ).isoformat()
     execute_sql(
         client,
         namespace,

--- a/monitoring/loadtest/locust_files/ISA.py
+++ b/monitoring/loadtest/locust_files/ISA.py
@@ -16,7 +16,7 @@ class ISA(client.USS):
 
     @task(10)
     def create_isa(self):
-        time_start = datetime.datetime.utcnow()
+        time_start = datetime.datetime.now(datetime.UTC)
         time_end = time_start + datetime.timedelta(minutes=60)
         isa_uuid = str(uuid.uuid4())
 
@@ -47,8 +47,8 @@ class ISA(client.USS):
             print("Nothing to pick from isa_dict for UPDATE")
             return
 
-        time_start = datetime.datetime.utcnow()
-        time_end = datetime.datetime.utcnow() + datetime.timedelta(minutes=2)
+        time_start = datetime.datetime.now(datetime.UTC)
+        time_end = datetime.datetime.now(datetime.UTC) + datetime.timedelta(minutes=2)
         resp = self.client.put(
             "/identification_service_areas/{}/{}".format(target_isa, target_version),
             json={

--- a/monitoring/loadtest/locust_files/Sub.py
+++ b/monitoring/loadtest/locust_files/Sub.py
@@ -24,7 +24,7 @@ class Sub(client.USS):
 
     @task(100)
     def create_sub(self):
-        time_start = datetime.datetime.utcnow()
+        time_start = datetime.datetime.now(datetime.UTC)
         time_end = time_start + datetime.timedelta(minutes=60)
         sub_uuid = str(uuid.uuid4())
 
@@ -67,8 +67,8 @@ class Sub(client.USS):
             print("Nothing to pick from sub_dict for UPDATE")
             return
 
-        time_start = datetime.datetime.utcnow()
-        time_end = datetime.datetime.utcnow() + datetime.timedelta(minutes=2)
+        time_start = datetime.datetime.now(datetime.UTC)
+        time_end = datetime.datetime.now(datetime.UTC) + datetime.timedelta(minutes=2)
         resp = self.client.put(
             "/subscriptions/{}/{}".format(target_sub, target_version),
             json={

--- a/monitoring/mock_uss/interaction_logging/logger.py
+++ b/monitoring/mock_uss/interaction_logging/logger.py
@@ -56,13 +56,13 @@ query_hooks.append(InteractionLoggingHook())
 # https://stackoverflow.com/a/67856316
 @webapp.before_request
 def interaction_log_before_request():
-    flask.Flask.custom_profiler = {"start": datetime.datetime.utcnow()}
+    flask.Flask.custom_profiler = {"start": datetime.datetime.now(datetime.UTC)}
 
 
 @webapp.after_request
 def interaction_log_after_request(response):
     elapsed_s = (
-        datetime.datetime.utcnow() - flask.current_app.custom_profiler["start"]
+        datetime.datetime.now(datetime.UTC) - flask.current_app.custom_profiler["start"]
     ).total_seconds()
     # TODO: Make this configurable instead of hardcoding exactly these query types
     if "/uss/v1/" in flask.request.url:

--- a/monitoring/mock_uss/scd_injection/routes_injection.py
+++ b/monitoring/mock_uss/scd_injection/routes_injection.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 from typing import Tuple, Optional, List, Dict
 
 import flask
@@ -339,7 +339,7 @@ def scdsc_clear_area() -> Tuple[str, int]:
         outcome=ClearAreaOutcome(
             success=clear_resp.success,
             message="See `details` field in response for more information",
-            timestamp=StringBasedDateTime(datetime.utcnow()),
+            timestamp=StringBasedDateTime(datetime.now(UTC)),
         ),
     )
     resp["request"] = req

--- a/monitoring/mock_uss/server.py
+++ b/monitoring/mock_uss/server.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 from multiprocessing import Process
 import os
 import signal
@@ -175,7 +175,7 @@ class MockUSS(flask.Flask):
                 with db as tx:
                     assert isinstance(tx, Database)
                     tx.most_recent_periodic_check = StringBasedDateTime(
-                        datetime.utcnow()
+                        datetime.now(UTC)
                     )
 
                     # Cancel the loop if we're stopping

--- a/monitoring/mock_uss/tracer/kml.py
+++ b/monitoring/mock_uss/tracer/kml.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 import glob
 import os
 import re
@@ -37,10 +37,10 @@ class Stopwatch(object):
     elapsed_time: timedelta = timedelta(seconds=0)
 
     def __enter__(self):
-        self._start_time = datetime.utcnow()
+        self._start_time = datetime.now(UTC)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.elapsed_time += datetime.utcnow() - self._start_time
+        self.elapsed_time += datetime.now(UTC) - self._start_time
 
 
 class VolumeType(str, Enum):

--- a/monitoring/mock_uss/tracer/routes/observation_areas.py
+++ b/monitoring/mock_uss/tracer/routes/observation_areas.py
@@ -1,6 +1,6 @@
 import os
 import uuid
-from datetime import datetime
+from datetime import datetime, UTC
 from typing import Tuple, List, Union
 
 import arrow
@@ -218,7 +218,7 @@ def tracer_import_observation_areas() -> Union[Tuple[str, int], flask.Response]:
 @webapp.shutdown_task("observation areas cleanup")
 def _shutdown():
     logger.info(
-        f"Cleaning up observation areas from PID {os.getpid()} at {datetime.utcnow()}..."
+        f"Cleaning up observation areas from PID {os.getpid()} at {datetime.now(UTC)}..."
     )
 
     with db as tx:

--- a/monitoring/mock_uss/tracer/routes/ui.py
+++ b/monitoring/mock_uss/tracer/routes/ui.py
@@ -62,7 +62,9 @@ def tracer_download_logs():
         for log in logs:
             with open(os.path.join(context.tracer_logger.log_path, log), "r") as f:
                 zip_file.writestr(log, f.read())
-    zip_name = f"logs_{datetime.datetime.utcnow().isoformat().split('.')[0]}.zip"
+    zip_name = (
+        f"logs_{datetime.datetime.now(datetime.UTC).isoformat().split('.')[0]}.zip"
+    )
     return flask.Response(
         zip_buffer.getvalue(),
         mimetype="application/zip",
@@ -168,7 +170,7 @@ def tracer_kmls(kml):
 @webapp.route("/tracer/kml/historical.kml")
 @ui_auth.login_required
 def tracer_kml_historical():
-    kml_name = f"historical_{datetime.datetime.utcnow().isoformat().split('.')[0]}.kml"
+    kml_name = f"historical_{datetime.datetime.now(datetime.UTC).isoformat().split('.')[0]}.kml"
     return flask.Response(
         render_historical_kml(context.tracer_logger.log_path),
         mimetype="application/vnd.google-earth.kml+xml",

--- a/monitoring/mock_uss/tracer/template.py
+++ b/monitoring/mock_uss/tracer/template.py
@@ -5,7 +5,7 @@ from monitoring.monitorlib import formatting
 def _print_time_range(t0: str, t1: str) -> str:
     if not t0 and not t1:
         return ""
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.UTC)
     if t0.endswith("Z"):
         t0 = t0[0:-1]
     if t1.endswith("Z"):

--- a/monitoring/mock_uss/tracer/tracer_poll.py
+++ b/monitoring/mock_uss/tracer/tracer_poll.py
@@ -108,7 +108,7 @@ def poll_isas(area: ObservationArea, logger: tracerlog.Logger) -> None:
     rid_client = context.get_client(area.f3411.auth_spec, area.f3411.dss_base_url)
     box = get_latlngrect_vertices(make_latlng_rect(area.area.volume))
 
-    t0 = datetime.datetime.utcnow()
+    t0 = datetime.datetime.now(datetime.UTC)
     result = fetch.rid.isas(
         box,
         area.area.time_start.datetime,
@@ -116,7 +116,7 @@ def poll_isas(area: ObservationArea, logger: tracerlog.Logger) -> None:
         area.f3411.rid_version,
         rid_client,
     )
-    t1 = datetime.datetime.utcnow()
+    t1 = datetime.datetime.now(datetime.UTC)
 
     log_new = False
     last_result = None
@@ -148,7 +148,7 @@ def poll_ops(
     area: ObservationArea, scd_client: UTMClientSession, logger: tracerlog.Logger
 ) -> None:
     box = make_latlng_rect(area.area.volume)
-    t0 = datetime.datetime.utcnow()
+    t0 = datetime.datetime.now(datetime.UTC)
     if "operational_intents" not in context.scd_cache:
         context.scd_cache["operational_intents"]: Dict[
             str, fetch.scd.FetchedEntity
@@ -160,7 +160,7 @@ def poll_ops(
         area.area.time_end.datetime,
         operation_cache=context.scd_cache["operational_intents"],
     )
-    t1 = datetime.datetime.utcnow()
+    t1 = datetime.datetime.now(datetime.UTC)
 
     log_new = False
     last_result = None
@@ -193,7 +193,7 @@ def poll_constraints(
     area: ObservationArea, scd_client: UTMClientSession, logger: tracerlog.Logger
 ) -> None:
     box = make_latlng_rect(area.area.volume)
-    t0 = datetime.datetime.utcnow()
+    t0 = datetime.datetime.now(datetime.UTC)
     if "constraints" not in context.scd_cache:
         context.scd_cache["constraints"]: Dict[str, fetch.scd.FetchedEntity] = {}
     result = fetch.scd.constraints(
@@ -203,7 +203,7 @@ def poll_constraints(
         area.area.time_end.datetime,
         constraint_cache=context.scd_cache["constraints"],
     )
-    t1 = datetime.datetime.utcnow()
+    t1 = datetime.datetime.now(datetime.UTC)
 
     log_new = False
     last_result = None

--- a/monitoring/monitorlib/auth.py
+++ b/monitoring/monitorlib/auth.py
@@ -23,7 +23,7 @@ from google.oauth2 import service_account
 
 from monitoring.monitorlib.infrastructure import AuthAdapter, AuthSpec
 
-_UNIX_EPOCH = datetime.datetime.utcfromtimestamp(0)
+_UNIX_EPOCH = datetime.datetime.fromtimestamp(0, datetime.UTC)
 
 
 class NoAuth(AuthAdapter):
@@ -61,7 +61,9 @@ class NoAuth(AuthAdapter):
 
     # Overrides method in AuthAdapter
     def issue_token(self, intended_audience: str, scopes: List[str]) -> str:
-        timestamp = int((datetime.datetime.utcnow() - _UNIX_EPOCH).total_seconds())
+        timestamp = int(
+            (datetime.datetime.now(datetime.UTC) - _UNIX_EPOCH).total_seconds()
+        )
         claims = {
             "sub": self.sub,
             "client_id": self.sub,
@@ -127,7 +129,9 @@ class InvalidTokenSignatureAuth(AuthAdapter):
         self.sub = sub
 
     def issue_token(self, intended_audience: str, scopes: List[str]) -> str:
-        timestamp = int((datetime.datetime.utcnow() - _UNIX_EPOCH).total_seconds())
+        timestamp = int(
+            (datetime.datetime.now(datetime.UTC) - _UNIX_EPOCH).total_seconds()
+        )
         claims = {
             "sub": self.sub,
             "client_id": self.sub,
@@ -421,7 +425,7 @@ class SignedRequest(AuthAdapter):
             "client_id": self._client_id,
             "scope": " ".join(scopes),
             "resource": intended_audience,
-            "current_timestamp": datetime.datetime.utcnow().isoformat() + "Z",
+            "current_timestamp": datetime.datetime.now(datetime.UTC).isoformat() + "Z",
         }
         payload = "&".join([k + "=" + v for k, v in query.items()])
 
@@ -469,7 +473,7 @@ class SignedRequest(AuthAdapter):
                 ),
                 "@signature-params": "({});created={}".format(
                     " ".join('"{}"'.format(c) for c in components),
-                    int(datetime.datetime.utcnow().timestamp()),
+                    int(datetime.datetime.now(datetime.UTC).timestamp()),
                 ),
             }
             components.append("@signature-params")

--- a/monitoring/monitorlib/fetch/__init__.py
+++ b/monitoring/monitorlib/fetch/__init__.py
@@ -85,7 +85,7 @@ def describe_flask_request(request: flask.Request) -> RequestDescription:
     kwargs = {
         "method": request.method,
         "url": request.url,
-        "received_at": StringBasedDateTime(datetime.datetime.utcnow()),
+        "received_at": StringBasedDateTime(datetime.datetime.now(datetime.UTC)),
         "headers": headers,
     }
     data = request.data.decode("utf-8")
@@ -155,7 +155,7 @@ def describe_response(resp: requests.Response) -> ResponseDescription:
         "code": resp.status_code,
         "headers": headers,
         "elapsed_s": resp.elapsed.total_seconds(),
-        "reported": StringBasedDateTime(datetime.datetime.utcnow()),
+        "reported": StringBasedDateTime(datetime.datetime.now(datetime.UTC)),
     }
     try:
         kwargs["json"] = resp.json()
@@ -171,7 +171,7 @@ def describe_aiohttp_response(
         "code": status,
         "headers": headers,
         "elapsed_s": duration.total_seconds(),
-        "reported": StringBasedDateTime(datetime.datetime.utcnow()),
+        "reported": StringBasedDateTime(datetime.datetime.now(datetime.UTC)),
         "json": resp_json,
     }
 
@@ -183,7 +183,7 @@ def describe_flask_response(resp: flask.Response, elapsed_s: float):
     kwargs = {
         "code": resp.status_code,
         "headers": headers,
-        "reported": StringBasedDateTime(datetime.datetime.utcnow()),
+        "reported": StringBasedDateTime(datetime.datetime.now(datetime.UTC)),
         "elapsed_s": elapsed_s,
     }
     try:
@@ -596,7 +596,7 @@ def query_and_describe(
     # `max_retries`, however we do not want to mutate the provided Session.  Instead, retry only on errors we explicitly
     # consider retryable.
     for attempt in range(ATTEMPTS):
-        t0 = datetime.datetime.utcnow()
+        t0 = datetime.datetime.now(datetime.UTC)
         try:
             return describe_query(
                 client.request(verb, url, **req_kwargs),
@@ -646,7 +646,7 @@ def query_and_describe(
 
             break
         finally:
-            t1 = datetime.datetime.utcnow()
+            t1 = datetime.datetime.now(datetime.UTC)
 
     # Reconstruct request similar to the one in the query (which is not
     # accessible at this point)

--- a/monitoring/monitorlib/fetch/rid.py
+++ b/monitoring/monitorlib/fetch/rid.py
@@ -1216,7 +1216,7 @@ def all_flights(
     enhanced_details: bool = False,
     dss_participant_id: Optional[str] = None,
 ) -> FetchedFlights:
-    t = datetime.datetime.utcnow()
+    t = datetime.datetime.now(datetime.UTC)
     isa_list = isas(
         geo.get_latlngrect_vertices(area),
         t,

--- a/monitoring/monitorlib/infrastructure.py
+++ b/monitoring/monitorlib/infrastructure.py
@@ -18,7 +18,7 @@ ALL_SCOPES = [
     "utm.constraint_consumption",
 ]
 
-EPOCH = datetime.datetime.utcfromtimestamp(0)
+EPOCH = datetime.datetime.fromtimestamp(0, datetime.UTC)
 TOKEN_REFRESH_MARGIN = datetime.timedelta(seconds=15)
 CLIENT_TIMEOUT = 10  # seconds
 
@@ -52,7 +52,7 @@ class AuthAdapter(object):
             token = self._tokens[intended_audience][scope_string]
         payload = jwt.decode(token, options={"verify_signature": False})
         expires = EPOCH + datetime.timedelta(seconds=payload["exp"])
-        if datetime.datetime.utcnow() > expires - TOKEN_REFRESH_MARGIN:
+        if datetime.datetime.now(datetime.UTC) > expires - TOKEN_REFRESH_MARGIN:
             token = self.issue_token(intended_audience, scopes)
         self._tokens[intended_audience][scope_string] = token
         return {"Authorization": "Bearer " + token}

--- a/monitoring/prober/rid/v1/test_isa_expiry.py
+++ b/monitoring/prober/rid/v1/test_isa_expiry.py
@@ -32,7 +32,7 @@ def test_ensure_clean_workspace(ids, session_ridv1):
 
 @default_scope(Scope.Write)
 def test_create(ids, session_ridv1):
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(seconds=5)
 
     resp = session_ridv1.put(

--- a/monitoring/prober/rid/v1/test_isa_simple.py
+++ b/monitoring/prober/rid/v1/test_isa_simple.py
@@ -40,7 +40,7 @@ def test_ensure_clean_workspace(ids, session_ridv1):
 @default_scope(Scope.Write)
 def test_create_isa(ids, session_ridv1):
     """ASTM Compliance Test: DSS0030_A_PUT_ISA."""
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(minutes=60)
 
     req_body = {
@@ -137,7 +137,7 @@ def test_get_isa_by_search(ids, session_ridv1):
 
 @default_scope(Scope.Read)
 def test_get_isa_by_search_earliest_time_included(ids, session_ridv1):
-    earliest_time = datetime.datetime.utcnow() + datetime.timedelta(minutes=59)
+    earliest_time = datetime.datetime.now(datetime.UTC) + datetime.timedelta(minutes=59)
     resp = session_ridv1.get(
         "{}?area={}&earliest_time={}".format(
             ISA_PATH,
@@ -151,7 +151,7 @@ def test_get_isa_by_search_earliest_time_included(ids, session_ridv1):
 
 @default_scope(Scope.Read)
 def test_get_isa_by_search_earliest_time_excluded(ids, session_ridv1):
-    earliest_time = datetime.datetime.utcnow() + datetime.timedelta(minutes=61)
+    earliest_time = datetime.datetime.now(datetime.UTC) + datetime.timedelta(minutes=61)
     resp = session_ridv1.get(
         "{}?area={}&earliest_time={}".format(
             ISA_PATH,
@@ -165,7 +165,7 @@ def test_get_isa_by_search_earliest_time_excluded(ids, session_ridv1):
 
 @default_scope(Scope.Read)
 def test_get_isa_by_search_latest_time_included(ids, session_ridv1):
-    latest_time = datetime.datetime.utcnow() + datetime.timedelta(minutes=1)
+    latest_time = datetime.datetime.now(datetime.UTC) + datetime.timedelta(minutes=1)
     resp = session_ridv1.get(
         "{}?area={}&latest_time={}".format(
             ISA_PATH,
@@ -179,7 +179,7 @@ def test_get_isa_by_search_latest_time_included(ids, session_ridv1):
 
 @default_scope(Scope.Read)
 def test_get_isa_by_search_latest_time_excluded(ids, session_ridv1):
-    latest_time = datetime.datetime.utcnow() - datetime.timedelta(minutes=1)
+    latest_time = datetime.datetime.now(datetime.UTC) - datetime.timedelta(minutes=1)
     resp = session_ridv1.get(
         "{}?area={}&latest_time={}".format(
             ISA_PATH,

--- a/monitoring/prober/rid/v1/test_isa_simple_heavy_traffic_concurrent.py
+++ b/monitoring/prober/rid/v1/test_isa_simple_heavy_traffic_concurrent.py
@@ -91,7 +91,7 @@ def test_ensure_clean_workspace(ids, session_ridv1):
 
 @default_scope(Scope.Write)
 def test_create_isa_concurrent(ids, session_ridv1_async):
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(minutes=60)
     req = _make_isa_request(time_start, time_end)
     resp_map = {}

--- a/monitoring/prober/rid/v1/test_isa_validation.py
+++ b/monitoring/prober/rid/v1/test_isa_validation.py
@@ -37,7 +37,7 @@ def test_ensure_clean_workspace(ids, session_ridv1):
 
 @default_scope(Scope.Write)
 def test_isa_huge_area(ids, session_ridv1):
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(minutes=60)
 
     resp = session_ridv1.put(
@@ -63,7 +63,7 @@ def test_isa_huge_area(ids, session_ridv1):
 
 @default_scope(Scope.Write)
 def test_isa_empty_vertices(ids, session_ridv1):
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(minutes=60)
 
     resp = session_ridv1.put(
@@ -89,7 +89,7 @@ def test_isa_empty_vertices(ids, session_ridv1):
 
 @default_scope(Scope.Write)
 def test_isa_missing_footprint(ids, session_ridv1):
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(minutes=60)
 
     resp = session_ridv1.put(
@@ -112,7 +112,7 @@ def test_isa_missing_footprint(ids, session_ridv1):
 
 @default_scope(Scope.Write)
 def test_isa_missing_spatial_volume(ids, session_ridv1):
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(minutes=60)
 
     resp = session_ridv1.put(
@@ -143,7 +143,7 @@ def test_isa_missing_extents(ids, session_ridv1):
 
 @default_scope(Scope.Write)
 def test_isa_start_time_in_past(ids, session_ridv1):
-    time_start = datetime.datetime.utcnow() - datetime.timedelta(minutes=10)
+    time_start = datetime.datetime.now(datetime.UTC) - datetime.timedelta(minutes=10)
     time_end = time_start + datetime.timedelta(minutes=60)
 
     resp = session_ridv1.put(
@@ -172,7 +172,7 @@ def test_isa_start_time_in_past(ids, session_ridv1):
 
 @default_scope(Scope.Write)
 def test_isa_start_time_after_time_end(ids, session_ridv1):
-    time_start = datetime.datetime.utcnow() + datetime.timedelta(minutes=10)
+    time_start = datetime.datetime.now(datetime.UTC) + datetime.timedelta(minutes=10)
     time_end = time_start - datetime.timedelta(minutes=5)
 
     resp = session_ridv1.put(
@@ -201,7 +201,7 @@ def test_isa_start_time_after_time_end(ids, session_ridv1):
 
 @default_scope(Scope.Write)
 def test_isa_not_on_earth(ids, session_ridv1):
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(minutes=60)
 
     resp = session_ridv1.put(

--- a/monitoring/prober/rid/v1/test_subscription_isa_interactions.py
+++ b/monitoring/prober/rid/v1/test_subscription_isa_interactions.py
@@ -56,7 +56,7 @@ def test_ensure_clean_workspace(ids, session_ridv1):
 
 @default_scope(Scope.Write)
 def test_create_isa(ids, session_ridv1):
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(minutes=60)
 
     resp = session_ridv1.put(
@@ -81,7 +81,7 @@ def test_create_isa(ids, session_ridv1):
 
 @default_scope(Scope.Read)
 def test_create_subscription(ids, session_ridv1):
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(minutes=60)
 
     resp = session_ridv1.put(
@@ -116,7 +116,7 @@ def test_modify_isa(ids, session_ridv1):
     version = resp.json()["service_area"]["version"]
 
     # Then modify it.
-    time_end = datetime.datetime.utcnow() + datetime.timedelta(minutes=60)
+    time_end = datetime.datetime.now(datetime.UTC) + datetime.timedelta(minutes=60)
     resp = session_ridv1.put(
         "{}/{}/{}".format(ISA_PATH, ids(ISA_TYPE), version),
         json={

--- a/monitoring/prober/rid/v1/test_subscription_isa_slightly_overlapping.py
+++ b/monitoring/prober/rid/v1/test_subscription_isa_slightly_overlapping.py
@@ -55,7 +55,7 @@ def test_ensure_clean_workspace(ids, session_ridv1):
 
 @default_scope(Scope.Write)
 def test_create_isa(ids, session_ridv1):
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(minutes=60)
 
     resp = session_ridv1.put(
@@ -80,7 +80,7 @@ def test_create_isa(ids, session_ridv1):
 
 @default_scope(Scope.Read)
 def test_create_subscription(ids, session_ridv1):
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(minutes=60)
 
     resp = session_ridv1.put(

--- a/monitoring/prober/rid/v1/test_subscription_simple.py
+++ b/monitoring/prober/rid/v1/test_subscription_simple.py
@@ -50,7 +50,7 @@ def test_sub_does_not_exist(ids, session_ridv1):
 @default_scope(Scope.Read)
 def test_create_sub(ids, session_ridv1):
     """ASTM Compliance Test: DSS0030_C_PUT_SUB."""
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(minutes=60)
 
     req_body = {

--- a/monitoring/prober/rid/v1/test_subscription_validation.py
+++ b/monitoring/prober/rid/v1/test_subscription_validation.py
@@ -48,7 +48,7 @@ def test_ensure_clean_workspace(ids, session_ridv1):
 
 @default_scope(Scope.Read)
 def test_create_sub_empty_vertices(ids, session_ridv1):
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(seconds=10)
 
     resp = session_ridv1.put(
@@ -73,7 +73,7 @@ def test_create_sub_empty_vertices(ids, session_ridv1):
 
 @default_scope(Scope.Read)
 def test_create_sub_missing_footprint(ids, session_ridv1):
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(seconds=10)
 
     resp = session_ridv1.put(
@@ -95,7 +95,7 @@ def test_create_sub_missing_footprint(ids, session_ridv1):
 
 @default_scope(Scope.Read)
 def test_create_sub_with_huge_area(ids, session_ridv1):
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(seconds=10)
 
     resp = session_ridv1.put(
@@ -121,7 +121,7 @@ def test_create_sub_with_huge_area(ids, session_ridv1):
 @default_scope(Scope.Read)
 def test_create_too_many_subs(ids, session_ridv1):
     """ASTM Compliance Test: DSS0050_MAX_SUBS_PER_AREA."""
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(seconds=30)
 
     # create 1 more than the max allowed Subscriptions per area
@@ -185,7 +185,7 @@ def test_create_too_many_subs(ids, session_ridv1):
 @default_scope(Scope.Read)
 def test_create_sub_with_too_long_end_time(ids, session_ridv1):
     """ASTM Compliance Test: DSS0060_MAX_SUBS_DURATION."""
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(
         hours=(NetDSSMaxSubscriptionDurationHours + 1)
     )
@@ -211,7 +211,7 @@ def test_create_sub_with_too_long_end_time(ids, session_ridv1):
 @default_scope(Scope.Read)
 def test_update_sub_with_too_long_end_time(ids, session_ridv1):
     """ASTM Compliance Test: DSS0060_MAX_SUBS_DURATION."""
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(seconds=10)
 
     resp = session_ridv1.put(

--- a/monitoring/prober/rid/v1/test_token_validation.py
+++ b/monitoring/prober/rid/v1/test_token_validation.py
@@ -37,7 +37,7 @@ def test_ensure_clean_workspace(ids, session_ridv1):
 
 
 def test_put_isa_with_read_only_scope_token(ids, session_ridv1):
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(minutes=60)
 
     resp = session_ridv1.put(
@@ -62,7 +62,7 @@ def test_put_isa_with_read_only_scope_token(ids, session_ridv1):
 
 
 def test_create_isa(ids, session_ridv1):
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(minutes=60)
 
     resp = session_ridv1.put(

--- a/monitoring/prober/rid/v2/test_isa_expiry.py
+++ b/monitoring/prober/rid/v2/test_isa_expiry.py
@@ -36,7 +36,7 @@ def test_ensure_clean_workspace_v2(ids, session_ridv2):
 
 @default_scope(Scope.ServiceProvider)
 def test_create(ids, session_ridv2):
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(seconds=5)
 
     resp = session_ridv2.put(

--- a/monitoring/prober/rid/v2/test_isa_simple.py
+++ b/monitoring/prober/rid/v2/test_isa_simple.py
@@ -46,7 +46,7 @@ def test_ensure_clean_workspace(ids, session_ridv2):
 @default_scope(Scope.ServiceProvider)
 def test_create_isa(ids, session_ridv2):
     """ASTM Compliance Test: DSS0030_A_PUT_ISA."""
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(minutes=60)
 
     req_body = {
@@ -146,7 +146,7 @@ def test_get_isa_by_search(ids, session_ridv2):
 
 @default_scope(Scope.DisplayProvider)
 def test_get_isa_by_search_earliest_time_included(ids, session_ridv2):
-    earliest_time = datetime.datetime.utcnow() + datetime.timedelta(minutes=59)
+    earliest_time = datetime.datetime.now(datetime.UTC) + datetime.timedelta(minutes=59)
     resp = session_ridv2.get(
         "{}?area={}&earliest_time={}".format(
             ISA_PATH,
@@ -160,7 +160,7 @@ def test_get_isa_by_search_earliest_time_included(ids, session_ridv2):
 
 @default_scope(Scope.DisplayProvider)
 def test_get_isa_by_search_earliest_time_excluded(ids, session_ridv2):
-    earliest_time = datetime.datetime.utcnow() + datetime.timedelta(minutes=61)
+    earliest_time = datetime.datetime.now(datetime.UTC) + datetime.timedelta(minutes=61)
     resp = session_ridv2.get(
         "{}?area={}&earliest_time={}".format(
             ISA_PATH,
@@ -174,7 +174,7 @@ def test_get_isa_by_search_earliest_time_excluded(ids, session_ridv2):
 
 @default_scope(Scope.DisplayProvider)
 def test_get_isa_by_search_latest_time_included(ids, session_ridv2):
-    latest_time = datetime.datetime.utcnow() + datetime.timedelta(minutes=1)
+    latest_time = datetime.datetime.now(datetime.UTC) + datetime.timedelta(minutes=1)
     resp = session_ridv2.get(
         "{}?area={}&latest_time={}".format(
             ISA_PATH,
@@ -188,7 +188,7 @@ def test_get_isa_by_search_latest_time_included(ids, session_ridv2):
 
 @default_scope(Scope.DisplayProvider)
 def test_get_isa_by_search_latest_time_excluded(ids, session_ridv2):
-    latest_time = datetime.datetime.utcnow() - datetime.timedelta(minutes=1)
+    latest_time = datetime.datetime.now(datetime.UTC) - datetime.timedelta(minutes=1)
     resp = session_ridv2.get(
         "{}?area={}&latest_time={}".format(
             ISA_PATH,

--- a/monitoring/prober/rid/v2/test_isa_validation.py
+++ b/monitoring/prober/rid/v2/test_isa_validation.py
@@ -42,7 +42,7 @@ def test_ensure_clean_workspace(ids, session_ridv2):
 
 @default_scope(Scope.ServiceProvider)
 def test_isa_huge_area(ids, session_ridv2):
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(minutes=60)
 
     resp = session_ridv2.put(
@@ -68,7 +68,7 @@ def test_isa_huge_area(ids, session_ridv2):
 
 @default_scope(Scope.ServiceProvider)
 def test_isa_empty_vertices(ids, session_ridv2):
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(minutes=60)
 
     resp = session_ridv2.put(
@@ -94,7 +94,7 @@ def test_isa_empty_vertices(ids, session_ridv2):
 
 @default_scope(Scope.ServiceProvider)
 def test_isa_missing_outline(ids, session_ridv2):
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(minutes=60)
 
     resp = session_ridv2.put(
@@ -117,7 +117,7 @@ def test_isa_missing_outline(ids, session_ridv2):
 
 @default_scope(Scope.ServiceProvider)
 def test_isa_missing_volume(ids, session_ridv2):
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(minutes=60)
 
     resp = session_ridv2.put(
@@ -151,7 +151,7 @@ def test_isa_missing_extents(ids, session_ridv2):
 
 @default_scope(Scope.ServiceProvider)
 def test_isa_start_time_in_past(ids, session_ridv2):
-    time_start = datetime.datetime.utcnow() - datetime.timedelta(minutes=10)
+    time_start = datetime.datetime.now(datetime.UTC) - datetime.timedelta(minutes=10)
     time_end = time_start + datetime.timedelta(minutes=60)
 
     resp = session_ridv2.put(
@@ -180,7 +180,7 @@ def test_isa_start_time_in_past(ids, session_ridv2):
 
 @default_scope(Scope.ServiceProvider)
 def test_isa_start_time_after_time_end(ids, session_ridv2):
-    time_start = datetime.datetime.utcnow() + datetime.timedelta(minutes=10)
+    time_start = datetime.datetime.now(datetime.UTC) + datetime.timedelta(minutes=10)
     time_end = time_start - datetime.timedelta(minutes=5)
 
     resp = session_ridv2.put(
@@ -209,7 +209,7 @@ def test_isa_start_time_after_time_end(ids, session_ridv2):
 
 @default_scope(Scope.ServiceProvider)
 def test_isa_not_on_earth(ids, session_ridv2):
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(minutes=60)
 
     resp = session_ridv2.put(

--- a/monitoring/prober/rid/v2/test_subscription_isa_interactions.py
+++ b/monitoring/prober/rid/v2/test_subscription_isa_interactions.py
@@ -61,7 +61,7 @@ def test_ensure_clean_workspace(ids, session_ridv2):
 
 @default_scope(Scope.ServiceProvider)
 def test_create_isa(ids, session_ridv2):
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(minutes=60)
 
     resp = session_ridv2.put(
@@ -86,7 +86,7 @@ def test_create_isa(ids, session_ridv2):
 
 @default_scope(Scope.DisplayProvider)
 def test_create_subscription(ids, session_ridv2):
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(minutes=60)
 
     resp = session_ridv2.put(
@@ -123,7 +123,7 @@ def test_modify_isa(ids, session_ridv2):
     version = resp.json()["service_area"]["version"]
 
     # Then modify it.
-    time_end = datetime.datetime.utcnow() + datetime.timedelta(minutes=60)
+    time_end = datetime.datetime.now(datetime.UTC) + datetime.timedelta(minutes=60)
     resp = session_ridv2.put(
         "{}/{}/{}".format(ISA_PATH, ids(ISA_TYPE), version),
         json={

--- a/monitoring/prober/rid/v2/test_subscription_simple.py
+++ b/monitoring/prober/rid/v2/test_subscription_simple.py
@@ -52,7 +52,7 @@ def test_sub_does_not_exist(ids, session_ridv2):
 @default_scope(Scope.DisplayProvider)
 def test_create_sub(ids, session_ridv2):
     """ASTM Compliance Test: DSS0030_C_PUT_SUB."""
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(minutes=60)
 
     req_body = {

--- a/monitoring/prober/rid/v2/test_subscription_validation.py
+++ b/monitoring/prober/rid/v2/test_subscription_validation.py
@@ -50,7 +50,7 @@ def test_ensure_clean_workspace(ids, session_ridv2):
 
 @default_scope(Scope.DisplayProvider)
 def test_create_sub_empty_vertices(ids, session_ridv2):
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(seconds=10)
 
     resp = session_ridv2.put(
@@ -75,7 +75,7 @@ def test_create_sub_empty_vertices(ids, session_ridv2):
 
 @default_scope(Scope.DisplayProvider)
 def test_create_sub_missing_outline_polygon(ids, session_ridv2):
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(seconds=10)
 
     resp = session_ridv2.put(
@@ -97,7 +97,7 @@ def test_create_sub_missing_outline_polygon(ids, session_ridv2):
 
 @default_scope(Scope.DisplayProvider)
 def test_create_sub_with_huge_area(ids, session_ridv2):
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(seconds=10)
 
     resp = session_ridv2.put(
@@ -123,7 +123,7 @@ def test_create_sub_with_huge_area(ids, session_ridv2):
 @default_scope(Scope.DisplayProvider)
 def test_create_too_many_subs(ids, session_ridv2):
     """ASTM Compliance Test: DSS0050_MAX_SUBS_PER_AREA."""
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(seconds=30)
 
     # create 1 more than the max allowed Subscriptions per area
@@ -185,7 +185,7 @@ def test_create_too_many_subs(ids, session_ridv2):
 @default_scope(Scope.DisplayProvider)
 def test_create_sub_with_too_long_end_time(ids, session_ridv2):
     """ASTM Compliance Test: DSS0060_MAX_SUBS_DURATION."""
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(
         hours=(NetDSSMaxSubscriptionDurationHours + 1)
     )
@@ -211,7 +211,7 @@ def test_create_sub_with_too_long_end_time(ids, session_ridv2):
 @default_scope(Scope.DisplayProvider)
 def test_update_sub_with_too_long_end_time(ids, session_ridv2):
     """ASTM Compliance Test: DSS0060_MAX_SUBS_DURATION."""
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(seconds=10)
 
     resp = session_ridv2.put(

--- a/monitoring/prober/rid/v2/test_token_validation.py
+++ b/monitoring/prober/rid/v2/test_token_validation.py
@@ -42,7 +42,7 @@ def test_ensure_clean_workspace(ids, session_ridv2):
 
 
 def test_put_isa_with_read_only_scope_token(ids, session_ridv2):
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(minutes=60)
 
     resp = session_ridv2.put(
@@ -67,7 +67,7 @@ def test_put_isa_with_read_only_scope_token(ids, session_ridv2):
 
 
 def test_create_isa(ids, session_ridv2):
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(minutes=60)
 
     resp = session_ridv2.put(

--- a/monitoring/prober/scd/test_constraint_simple.py
+++ b/monitoring/prober/scd/test_constraint_simple.py
@@ -37,7 +37,7 @@ CONSTRAINT_TYPE = register_resource_type(1, "Single constraint")
 
 
 def _make_c1_request():
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(minutes=60)
     return {
         "extents": [
@@ -73,7 +73,7 @@ def test_constraint_does_not_exist_get(ids, scd_api, scd_session):
 def test_constraint_does_not_exist_query(ids, scd_api, scd_session):
     if scd_session is None:
         return
-    time_now = datetime.datetime.utcnow()
+    time_now = datetime.datetime.now(datetime.UTC)
 
     auths = (SCOPE_CM, SCOPE_CP)
 
@@ -217,7 +217,7 @@ def test_get_constraint_by_search(ids, scd_api, scd_session):
 @default_scope(SCOPE_CM)
 @depends_on(test_create_constraint)
 def test_get_constraint_by_search_earliest_time_included(ids, scd_api, scd_session):
-    earliest_time = datetime.datetime.utcnow() + datetime.timedelta(minutes=59)
+    earliest_time = datetime.datetime.now(datetime.UTC) + datetime.timedelta(minutes=59)
     resp = scd_session.post(
         "/constraint_references/query",
         json={
@@ -236,7 +236,7 @@ def test_get_constraint_by_search_earliest_time_included(ids, scd_api, scd_sessi
 @default_scope(SCOPE_CM)
 @depends_on(test_create_constraint)
 def test_get_constraint_by_search_earliest_time_excluded(ids, scd_api, scd_session):
-    earliest_time = datetime.datetime.utcnow() + datetime.timedelta(minutes=61)
+    earliest_time = datetime.datetime.now(datetime.UTC) + datetime.timedelta(minutes=61)
     resp = scd_session.post(
         "/constraint_references/query",
         json={
@@ -255,7 +255,7 @@ def test_get_constraint_by_search_earliest_time_excluded(ids, scd_api, scd_sessi
 @default_scope(SCOPE_CM)
 @depends_on(test_create_constraint)
 def test_get_constraint_by_search_latest_time_included(ids, scd_api, scd_session):
-    latest_time = datetime.datetime.utcnow() + datetime.timedelta(minutes=1)
+    latest_time = datetime.datetime.now(datetime.UTC) + datetime.timedelta(minutes=1)
     resp = scd_session.post(
         "/constraint_references/query",
         json={
@@ -274,7 +274,7 @@ def test_get_constraint_by_search_latest_time_included(ids, scd_api, scd_session
 @default_scope(SCOPE_CM)
 @depends_on(test_create_constraint)
 def test_get_constraint_by_search_latest_time_excluded(ids, scd_api, scd_session):
-    latest_time = datetime.datetime.utcnow() - datetime.timedelta(minutes=1)
+    latest_time = datetime.datetime.now(datetime.UTC) - datetime.timedelta(minutes=1)
     resp = scd_session.post(
         "/constraint_references/query",
         json={

--- a/monitoring/prober/scd/test_constraints_with_subscriptions.py
+++ b/monitoring/prober/scd/test_constraints_with_subscriptions.py
@@ -33,7 +33,7 @@ SUB3_TYPE = register_resource_type(5, "Constraint subscription 3")
 
 
 def _make_c1_request():
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(minutes=60)
     return {
         "extents": [
@@ -51,7 +51,7 @@ def _make_c1_request():
 
 
 def _make_sub_req(base_url: str, notify_ops: bool, notify_constraints: bool) -> Dict:
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(minutes=60)
     return {
         "extents": Volume4D.from_values(

--- a/monitoring/prober/scd/test_operation_simple.py
+++ b/monitoring/prober/scd/test_operation_simple.py
@@ -34,7 +34,7 @@ def test_ensure_clean_workspace(ids, scd_api, scd_session):
 
 
 def _make_op1_request():
-    time_start = datetime.datetime.utcnow() + datetime.timedelta(minutes=20)
+    time_start = datetime.datetime.now(datetime.UTC) + datetime.timedelta(minutes=20)
     time_end = time_start + datetime.timedelta(minutes=60)
     return {
         "extents": [
@@ -61,7 +61,7 @@ def test_op_does_not_exist_get(ids, scd_api, scd_session):
 def test_op_does_not_exist_query(
     ids, scd_api, scd_session, scd_session_cp, scd_session_cm
 ):
-    time_now = datetime.datetime.utcnow()
+    time_now = datetime.datetime.now(datetime.UTC)
     end_time = time_now + datetime.timedelta(hours=1)
     resp = scd_session.post(
         "/operational_intent_references/query",
@@ -236,7 +236,7 @@ def test_get_op_by_search(ids, scd_api, scd_session):
 @default_scope(SCOPE_SC)
 @depends_on(test_create_op)
 def test_get_op_by_search_earliest_time_included(ids, scd_api, scd_session):
-    earliest_time = datetime.datetime.utcnow() + datetime.timedelta(minutes=59)
+    earliest_time = datetime.datetime.now(datetime.UTC) + datetime.timedelta(minutes=59)
     resp = scd_session.post(
         "/operational_intent_references/query",
         json={
@@ -254,7 +254,7 @@ def test_get_op_by_search_earliest_time_included(ids, scd_api, scd_session):
 @default_scope(SCOPE_SC)
 @depends_on(test_create_op)
 def test_get_op_by_search_earliest_time_excluded(ids, scd_api, scd_session):
-    earliest_time = datetime.datetime.utcnow() + datetime.timedelta(minutes=81)
+    earliest_time = datetime.datetime.now(datetime.UTC) + datetime.timedelta(minutes=81)
     resp = scd_session.post(
         "/operational_intent_references/query",
         json={
@@ -272,7 +272,7 @@ def test_get_op_by_search_earliest_time_excluded(ids, scd_api, scd_session):
 @default_scope(SCOPE_SC)
 @depends_on(test_create_op)
 def test_get_op_by_search_latest_time_included(ids, scd_api, scd_session):
-    latest_time = datetime.datetime.utcnow() + datetime.timedelta(minutes=20)
+    latest_time = datetime.datetime.now(datetime.UTC) + datetime.timedelta(minutes=20)
     resp = scd_session.post(
         "/operational_intent_references/query",
         json={
@@ -342,7 +342,7 @@ def test_get_op_by_query_other_uss(ids, scd_session2):
 @default_scope(SCOPE_SC)
 @depends_on(test_create_op)
 def test_get_op_by_search_latest_time_excluded(ids, scd_api, scd_session):
-    latest_time = datetime.datetime.utcnow() + datetime.timedelta(minutes=1)
+    latest_time = datetime.datetime.now(datetime.UTC) + datetime.timedelta(minutes=1)
     resp = scd_session.post(
         "/operational_intent_references/query",
         json={

--- a/monitoring/prober/scd/test_operation_simple_heavy_traffic.py
+++ b/monitoring/prober/scd/test_operation_simple_heavy_traffic.py
@@ -35,7 +35,7 @@ ovn_map = {}
 # Generate request with volumes that cover a circle area that initially centered at (-56, 178)
 # The circle's center lat shifts 0.001 degree (111 meters) per sequential idx change
 def _make_op_request(idx):
-    time_start = datetime.datetime.utcnow() + datetime.timedelta(minutes=20)
+    time_start = datetime.datetime.now(datetime.UTC) + datetime.timedelta(minutes=20)
     time_end = time_start + datetime.timedelta(minutes=60)
     lat = -56 - 0.001 * idx
     return {
@@ -72,7 +72,7 @@ def test_ops_do_not_exist_get(ids, scd_api, scd_session):
 @for_api_versions(scd.API_0_3_17)
 @default_scope(SCOPE_SC)
 def test_ops_do_not_exist_query(ids, scd_api, scd_session):
-    time_now = datetime.datetime.utcnow()
+    time_now = datetime.datetime.now(datetime.UTC)
     end_time = time_now + datetime.timedelta(hours=1)
 
     resp = scd_session.post(
@@ -159,7 +159,7 @@ def test_get_ops_by_search(ids, scd_api, scd_session):
 @for_api_versions(scd.API_0_3_17)
 @default_scope(SCOPE_SC)
 def test_get_ops_by_search_earliest_time_included(ids, scd_api, scd_session):
-    earliest_time = datetime.datetime.utcnow() + datetime.timedelta(minutes=59)
+    earliest_time = datetime.datetime.now(datetime.UTC) + datetime.timedelta(minutes=59)
     resp = scd_session.post(
         "/operational_intent_references/query",
         json={
@@ -178,7 +178,7 @@ def test_get_ops_by_search_earliest_time_included(ids, scd_api, scd_session):
 @for_api_versions(scd.API_0_3_17)
 @default_scope(SCOPE_SC)
 def test_get_ops_by_search_earliest_time_excluded(ids, scd_api, scd_session):
-    earliest_time = datetime.datetime.utcnow() + datetime.timedelta(minutes=81)
+    earliest_time = datetime.datetime.now(datetime.UTC) + datetime.timedelta(minutes=81)
     resp = scd_session.post(
         "/operational_intent_references/query",
         json={
@@ -195,7 +195,7 @@ def test_get_ops_by_search_earliest_time_excluded(ids, scd_api, scd_session):
 @for_api_versions(scd.API_0_3_17)
 @default_scope(SCOPE_SC)
 def test_get_ops_by_search_latest_time_included(ids, scd_api, scd_session):
-    latest_time = datetime.datetime.utcnow() + datetime.timedelta(minutes=20)
+    latest_time = datetime.datetime.now(datetime.UTC) + datetime.timedelta(minutes=20)
     resp = scd_session.post(
         "/operational_intent_references/query",
         json={
@@ -214,7 +214,7 @@ def test_get_ops_by_search_latest_time_included(ids, scd_api, scd_session):
 @for_api_versions(scd.API_0_3_17)
 @default_scope(SCOPE_SC)
 def test_get_ops_by_search_latest_time_excluded(ids, scd_api, scd_session):
-    latest_time = datetime.datetime.utcnow() + datetime.timedelta(minutes=1)
+    latest_time = datetime.datetime.now(datetime.UTC) + datetime.timedelta(minutes=1)
     resp = scd_session.post(
         "/operational_intent_references/query",
         json={

--- a/monitoring/prober/scd/test_operation_simple_heavy_traffic_concurrent.py
+++ b/monitoring/prober/scd/test_operation_simple_heavy_traffic_concurrent.py
@@ -64,7 +64,7 @@ def _make_op_request_with_extents(extents):
 # The circle's center lat shifts 0.1 degree (11.1 km) per sequential idx change
 # The altitude and time window won't change with idx
 def _make_op_request_differ_in_2d(idx):
-    time_start = datetime.datetime.utcnow() + datetime.timedelta(minutes=20)
+    time_start = datetime.datetime.now(datetime.UTC) + datetime.timedelta(minutes=20)
     time_end = time_start + datetime.timedelta(minutes=60)
     lat = _calculate_lat(idx)
 
@@ -78,7 +78,7 @@ def _make_op_request_differ_in_2d(idx):
 # The altitude starts with [0, 19] and increases 20 per sequential idx change
 # The 2D area and time window won't change with idx
 def _make_op_request_differ_in_altitude(idx):
-    time_start = datetime.datetime.utcnow() + datetime.timedelta(minutes=20)
+    time_start = datetime.datetime.now(datetime.UTC) + datetime.timedelta(minutes=20)
     time_end = time_start + datetime.timedelta(minutes=60)
     delta = 20
     alt0 = delta * idx
@@ -96,7 +96,9 @@ def _make_op_request_differ_in_altitude(idx):
 def _make_op_request_differ_in_time(idx, time_gap):
     delta = 10
     time_start = (
-        datetime.datetime.utcnow() + time_gap + datetime.timedelta(minutes=delta * idx)
+        datetime.datetime.now(datetime.UTC)
+        + time_gap
+        + datetime.timedelta(minutes=delta * idx)
     )
     time_end = time_start + datetime.timedelta(minutes=delta - 1)
 
@@ -236,7 +238,7 @@ def test_ensure_clean_workspace(ids, scd_api, scd_session):
 @for_api_versions(scd.API_0_3_17)
 @default_scope(SCOPE_SC)
 def test_create_ops_concurrent(ids, scd_api, scd_session_async):
-    start_time = datetime.datetime.utcnow()
+    start_time = datetime.datetime.now(datetime.UTC)
     assert len(ovn_map) == 0
     op_req_map = {}
     op_resp_map = {}
@@ -317,7 +319,7 @@ def test_create_ops_concurrent(ids, scd_api, scd_session_async):
         ovn_map[op_id] = op["ovn"]
     assert len(ovn_map) == len(OP_TYPES)
     print(
-        f"\n{inspect.stack()[0][3]} time_taken: {datetime.datetime.utcnow() - start_time}"
+        f"\n{inspect.stack()[0][3]} time_taken: {datetime.datetime.now(datetime.UTC) - start_time}"
     )
 
 
@@ -326,7 +328,7 @@ def test_create_ops_concurrent(ids, scd_api, scd_session_async):
 @for_api_versions(scd.API_0_3_17)
 @depends_on(test_create_ops_concurrent)
 def test_get_ops_by_ids_concurrent(ids, scd_api, scd_session_async):
-    start_time = datetime.datetime.utcnow()
+    start_time = datetime.datetime.now(datetime.UTC)
     op_resp_map = {}
     # Get operations concurrently
     loop = asyncio.get_event_loop()
@@ -353,7 +355,7 @@ def test_get_ops_by_ids_concurrent(ids, scd_api, scd_session_async):
         assert op["uss_base_url"] == BASE_URL
         assert op["version"] == 1
     print(
-        f"\n{inspect.stack()[0][3]} time_taken: {datetime.datetime.utcnow() - start_time}"
+        f"\n{inspect.stack()[0][3]} time_taken: {datetime.datetime.now(datetime.UTC) - start_time}"
     )
 
 
@@ -363,7 +365,7 @@ def test_get_ops_by_ids_concurrent(ids, scd_api, scd_session_async):
 @default_scope(SCOPE_SC)
 @depends_on(test_create_ops_concurrent)
 def test_get_ops_by_search_concurrent(ids, scd_api, scd_session_async):
-    start_time = datetime.datetime.utcnow()
+    start_time = datetime.datetime.now(datetime.UTC)
     op_resp_map = {}
     total_found_ids = set()
 
@@ -392,7 +394,7 @@ def test_get_ops_by_search_concurrent(ids, scd_api, scd_session_async):
 
     assert len(_intersection(map(ids, OP_TYPES), total_found_ids)) == len(OP_TYPES)
     print(
-        f"\n{inspect.stack()[0][3]} time_taken: {datetime.datetime.utcnow() - start_time}"
+        f"\n{inspect.stack()[0][3]} time_taken: {datetime.datetime.now(datetime.UTC) - start_time}"
     )
 
 
@@ -402,7 +404,7 @@ def test_get_ops_by_search_concurrent(ids, scd_api, scd_session_async):
 @default_scope(SCOPE_SC)
 @depends_on(test_create_ops_concurrent)
 def test_mutate_ops_concurrent(ids, scd_api, scd_session, scd_session_async):
-    start_time = datetime.datetime.utcnow()
+    start_time = datetime.datetime.now(datetime.UTC)
     op_req_map = {}
     op_resp_map = {}
     op_map = {}
@@ -425,7 +427,7 @@ def test_mutate_ops_concurrent(ids, scd_api, scd_session, scd_session_async):
         )
     )
     print(
-        f"\n{inspect.stack()[0][3]} time_taken: {datetime.datetime.utcnow() - start_time}"
+        f"\n{inspect.stack()[0][3]} time_taken: {datetime.datetime.now(datetime.UTC) - start_time}"
     )
     for req_map, resp in zip(op_req_map.items(), results):
         op_id = req_map[0]
@@ -470,7 +472,7 @@ def test_mutate_ops_concurrent(ids, scd_api, scd_session, scd_session_async):
 @for_api_versions(scd.API_0_3_17)
 @depends_on(test_mutate_ops_concurrent)
 def test_delete_op_concurrent(ids, scd_api, scd_session_async):
-    start_time = datetime.datetime.utcnow()
+    start_time = datetime.datetime.now(datetime.UTC)
     op_resp_map = {}
 
     # Delete operations concurrently
@@ -493,7 +495,7 @@ def test_delete_op_concurrent(ids, scd_api, scd_session_async):
     for resp in op_resp_map.values():
         assert resp["status_code"] == 200, resp["content"]
     print(
-        f"\n{inspect.stack()[0][3]} time_taken: {datetime.datetime.utcnow() - start_time}"
+        f"\n{inspect.stack()[0][3]} time_taken: {datetime.datetime.now(datetime.UTC) - start_time}"
     )
 
 

--- a/monitoring/prober/scd/test_operation_special_cases.py
+++ b/monitoring/prober/scd/test_operation_special_cases.py
@@ -93,7 +93,7 @@ def test_op_query_not_area_too_large(scd_api, scd_session):
 @default_scope(SCOPE_SC)
 def test_id_conversion_bug(ids, scd_api, scd_session):
     sub_uuid = ids(SUB_TYPE)
-    time_ref = datetime.datetime.utcnow() + datetime.timedelta(days=1)
+    time_ref = datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=1)
     time_start = datetime.datetime(time_ref.year, time_ref.month, time_ref.day, 1, 30)
     time_end = datetime.datetime(time_ref.year, time_ref.month, time_ref.day, 22, 15)
     req = {

--- a/monitoring/prober/scd/test_operations_simple.py
+++ b/monitoring/prober/scd/test_operations_simple.py
@@ -39,7 +39,7 @@ sub2_version = None
 
 
 def _make_op1_request():
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(minutes=60)
     return {
         "extents": [
@@ -55,7 +55,7 @@ def _make_op1_request():
 
 
 def _make_op2_request():
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(minutes=60)
     return {
         "extents": [
@@ -130,7 +130,7 @@ def test_op1_does_not_exist_get_2(ids, scd_api, scd_session2):
 def test_op1_does_not_exist_query_1(ids, scd_api, scd_session, scd_session2):
     if scd_session is None:
         return
-    time_now = datetime.datetime.utcnow()
+    time_now = datetime.datetime.now(datetime.UTC)
     end_time = time_now + datetime.timedelta(hours=1)
     resp = scd_session.post(
         "/operational_intent_references/query",
@@ -154,7 +154,7 @@ def test_op1_does_not_exist_query_1(ids, scd_api, scd_session, scd_session2):
 def test_op1_does_not_exist_query_2(ids, scd_api, scd_session, scd_session2):
     if scd_session2 is None:
         return
-    time_now = datetime.datetime.utcnow()
+    time_now = datetime.datetime.now(datetime.UTC)
     end_time = time_now + datetime.timedelta(hours=1)
     resp = scd_session2.post(
         "/operational_intent_references/query",
@@ -269,7 +269,7 @@ def test_create_op2_no_ovn(ids, scd_api, scd_session, scd_session2):
 def test_create_op2sub(ids, scd_api, scd_session, scd_session2):
     if scd_session2 is None:
         return
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(minutes=70)
     req = {
         "extents": Volume4D.from_values(
@@ -378,7 +378,7 @@ def test_create_op2(ids, scd_api, scd_session, scd_session2):
 def test_read_ops_from_uss1(ids, scd_api, scd_session, scd_session2):
     if scd_session is None:
         return
-    time_now = datetime.datetime.utcnow()
+    time_now = datetime.datetime.now(datetime.UTC)
     end_time = time_now + datetime.timedelta(hours=1)
     resp = scd_session.post(
         "/operational_intent_references/query",
@@ -410,7 +410,7 @@ def test_read_ops_from_uss1(ids, scd_api, scd_session, scd_session2):
 def test_read_ops_from_uss2(ids, scd_api, scd_session, scd_session2):
     if scd_session2 is None:
         return
-    time_now = datetime.datetime.utcnow()
+    time_now = datetime.datetime.now(datetime.UTC)
     end_time = time_now + datetime.timedelta(hours=1)
     resp = scd_session2.post(
         "/operational_intent_references/query",
@@ -548,7 +548,7 @@ def test_delete_dependent_sub(ids, scd_api, scd_session, scd_session2):
 def test_mutate_sub2(ids, scd_api, scd_session, scd_session2):
     if scd_session2 is None:
         return
-    time_now = datetime.datetime.utcnow()
+    time_now = datetime.datetime.now(datetime.UTC)
     time_start = time_now - datetime.timedelta(minutes=1)
     time_end = time_now + datetime.timedelta(minutes=61)
 

--- a/monitoring/prober/scd/test_subscription_queries.py
+++ b/monitoring/prober/scd/test_subscription_queries.py
@@ -29,7 +29,7 @@ FOOTPRINT_SPACING_M = 10000
 
 
 def _make_sub1_req(scd_api):
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(minutes=60)
     lat = LAT0 - latitude_degrees(FOOTPRINT_SPACING_M)
     req = {
@@ -44,7 +44,7 @@ def _make_sub1_req(scd_api):
 
 
 def _make_sub2_req(scd_api):
-    time_start = datetime.datetime.utcnow() + datetime.timedelta(hours=2)
+    time_start = datetime.datetime.now(datetime.UTC) + datetime.timedelta(hours=2)
     time_end = time_start + datetime.timedelta(minutes=60)
     req = {
         "extents": Volume4D.from_values(
@@ -60,7 +60,7 @@ def _make_sub2_req(scd_api):
 
 
 def _make_sub3_req(scd_api):
-    time_start = datetime.datetime.utcnow() + datetime.timedelta(hours=4)
+    time_start = datetime.datetime.now(datetime.UTC) + datetime.timedelta(hours=4)
     time_end = time_start + datetime.timedelta(minutes=60)
     lat = LAT0 + latitude_degrees(FOOTPRINT_SPACING_M)
     req = {
@@ -190,7 +190,7 @@ def test_search_footprint(ids, scd_api, scd_session):
 @for_api_versions(scd.API_0_3_17)
 @default_scope(SCOPE_SC)
 def test_search_time(ids, scd_api, scd_session):
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(minutes=1)
 
     resp = scd_session.post(
@@ -229,7 +229,7 @@ def test_search_time(ids, scd_api, scd_session):
     assert ids(SUB2_TYPE) not in result_ids
     assert ids(SUB3_TYPE) not in result_ids
 
-    time_start = datetime.datetime.utcnow() + datetime.timedelta(hours=4)
+    time_start = datetime.datetime.now(datetime.UTC) + datetime.timedelta(hours=4)
     time_end = time_start + datetime.timedelta(minutes=1)
 
     resp = scd_session.post(
@@ -274,7 +274,7 @@ def test_search_time(ids, scd_api, scd_session):
 @for_api_versions(scd.API_0_3_17)
 @default_scope(SCOPE_SC)
 def test_search_time_footprint(ids, scd_api, scd_session):
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(hours=2.5)
     lat = LAT0 + latitude_degrees(FOOTPRINT_SPACING_M)
     resp = scd_session.post(

--- a/monitoring/prober/scd/test_subscription_query_time.py
+++ b/monitoring/prober/scd/test_subscription_query_time.py
@@ -40,7 +40,7 @@ def test_subscription_with_invalid_start_time(ids, scd_api, scd_session):
     if scd_session is None:
         return
 
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(hours=2.5)
     req = _make_sub_req(time_start, time_end, 200, 1000, 500, scd_api)
     req["extents"]["time_start"]["value"] = "something-invalid"

--- a/monitoring/prober/scd/test_subscription_simple.py
+++ b/monitoring/prober/scd/test_subscription_simple.py
@@ -34,7 +34,7 @@ def test_ensure_clean_workspace(ids, scd_api, scd_session):
 
 
 def _make_sub1_req(scd_api):
-    time_start = datetime.datetime.utcnow()
+    time_start = datetime.datetime.now(datetime.UTC)
     time_end = time_start + datetime.timedelta(minutes=60)
     req = {
         "extents": Volume4D.from_values(
@@ -134,7 +134,7 @@ def test_get_sub_by_id(ids, scd_api, scd_session):
 def test_get_sub_by_search(ids, scd_api, scd_session):
     if scd_session is None:
         return
-    time_now = datetime.datetime.utcnow()
+    time_now = datetime.datetime.now(datetime.UTC)
     resp = scd_session.post(
         "/subscriptions/query",
         json={
@@ -218,7 +218,7 @@ def test_get_deleted_sub_by_id(ids, scd_api, scd_session):
 def test_get_deleted_sub_by_search(ids, scd_api, scd_session):
     if scd_session is None:
         return
-    time_now = datetime.datetime.utcnow()
+    time_now = datetime.datetime.now(datetime.UTC)
     resp = scd_session.post(
         "/subscriptions/query",
         json={

--- a/monitoring/prober/scd/test_subscription_update_validation.py
+++ b/monitoring/prober/scd/test_subscription_update_validation.py
@@ -33,7 +33,7 @@ sub_id = None
 
 
 def _make_op_req():
-    time_start = datetime.datetime.utcnow() + datetime.timedelta(minutes=20)
+    time_start = datetime.datetime.now(datetime.UTC) + datetime.timedelta(minutes=20)
     time_end = time_start + datetime.timedelta(minutes=60)
     return {
         "extents": [
@@ -114,7 +114,7 @@ def test_mutate_sub_shrink_2d(scd_api, scd_session):
     existing_sub = resp.json().get("subscription", None)
     assert existing_sub is not None
 
-    time_start = datetime.datetime.utcnow() + datetime.timedelta(minutes=20)
+    time_start = datetime.datetime.now(datetime.UTC) + datetime.timedelta(minutes=20)
     time_end = time_start + datetime.timedelta(minutes=60)
     req = _make_sub_req(time_start, time_end, 0, 1000, 50, scd_api)
     req["notify_for_constraints"] = True
@@ -136,7 +136,7 @@ def test_mutate_sub_shrink_altitude(scd_api, scd_session):
     existing_sub = resp.json().get("subscription", None)
     assert existing_sub is not None
 
-    time_start = datetime.datetime.utcnow() + datetime.timedelta(minutes=20)
+    time_start = datetime.datetime.now(datetime.UTC) + datetime.timedelta(minutes=20)
     time_end = time_start + datetime.timedelta(minutes=60)
     req = _make_sub_req(time_start, time_end, 200, 1000, 500, scd_api)
     req["notify_for_constraints"] = True
@@ -158,7 +158,7 @@ def test_mutate_sub_shrink_time(scd_api, scd_session):
     existing_sub = resp.json().get("subscription", None)
     assert existing_sub is not None
 
-    time_start = datetime.datetime.utcnow() + datetime.timedelta(minutes=20)
+    time_start = datetime.datetime.now(datetime.UTC) + datetime.timedelta(minutes=20)
     time_end = time_start + datetime.timedelta(minutes=40)
     req = _make_sub_req(time_start, time_end, 0, 1000, 500, scd_api)
     req["notify_for_constraints"] = True
@@ -180,7 +180,7 @@ def test_mutate_sub_not_shrink(scd_api, scd_session):
     existing_sub = resp.json().get("subscription", None)
     assert existing_sub is not None
 
-    time_start = datetime.datetime.utcnow() + datetime.timedelta(minutes=20)
+    time_start = datetime.datetime.now(datetime.UTC) + datetime.timedelta(minutes=20)
     time_end = time_start + datetime.timedelta(minutes=60)
     req = _make_sub_req(time_start, time_end, 0, 1000, 500, scd_api)
     req["notify_for_constraints"] = True

--- a/monitoring/uss_qualifier/reports/report.py
+++ b/monitoring/uss_qualifier/reports/report.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, UTC
 from typing import List, Optional, Dict, Tuple, Any, Union, Set, Iterator, Callable
 
 from implicitdict import ImplicitDict, StringBasedDateTime
@@ -201,7 +201,7 @@ class ErrorReport(ImplicitDict):
         return ErrorReport(
             type=str(inspection.fullname(e.__class__)),
             message=str(e),
-            timestamp=StringBasedDateTime(datetime.utcnow()),
+            timestamp=StringBasedDateTime(datetime.now(UTC)),
             stacktrace=stacktrace_string(e),
         )
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/heavy_traffic_concurrent.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/heavy_traffic_concurrent.py
@@ -1,6 +1,6 @@
 import asyncio
 import typing
-from datetime import datetime
+from datetime import datetime, UTC
 from typing import List, Dict
 
 import arrow
@@ -209,12 +209,12 @@ class HeavyTrafficConcurrent(GenericTestScenario):
                 url,
             )
             prep = self._dss.client.prepare_request(r)
-            t0 = datetime.utcnow()
+            t0 = datetime.now(UTC)
             req_descr = describe_request(prep, t0)
             status, headers, resp_json = await self._async_session.get(
                 url=url, scope=self._read_scope()
             )
-            duration = datetime.utcnow() - t0
+            duration = datetime.now(UTC) - t0
             rq = Query(
                 request=req_descr,
                 response=describe_aiohttp_response(
@@ -238,12 +238,12 @@ class HeavyTrafficConcurrent(GenericTestScenario):
                 json=payload,
             )
             prep = self._dss.client.prepare_request(r)
-            t0 = datetime.utcnow()
+            t0 = datetime.now(UTC)
             req_descr = describe_request(prep, t0)
             status, headers, resp_json = await self._async_session.put(
                 url=url, json=payload, scope=self._write_scope()
             )
-            duration = datetime.utcnow() - t0
+            duration = datetime.now(UTC) - t0
             rq = Query(
                 request=req_descr,
                 response=describe_aiohttp_response(
@@ -262,12 +262,12 @@ class HeavyTrafficConcurrent(GenericTestScenario):
                 url,
             )
             prep = self._dss.client.prepare_request(r)
-            t0 = datetime.utcnow()
+            t0 = datetime.now(UTC)
             req_descr = describe_request(prep, t0)
             status, headers, resp_json = await self._async_session.delete(
                 url=url, scope=self._write_scope()
             )
-            duration = datetime.utcnow() - t0
+            duration = datetime.now(UTC) - t0
             rq = Query(
                 request=req_descr,
                 response=describe_aiohttp_response(

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/isa_expiry.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/isa_expiry.py
@@ -69,7 +69,7 @@ class ISAExpiry(GenericTestScenario):
         but it should not appear in searches anymore.
         """
 
-        start_time = datetime.datetime.utcnow()
+        start_time = datetime.datetime.now(datetime.UTC)
         end_time = start_time + datetime.timedelta(seconds=5)
 
         # Create a short-lived ISA of a few seconds

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/isa_validation.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/isa_validation.py
@@ -175,7 +175,9 @@ class ISAValidation(GenericTestScenario):
             )
 
     def _isa_start_time_in_past(self):
-        time_start = datetime.datetime.utcnow() - datetime.timedelta(minutes=10)
+        time_start = datetime.datetime.now(datetime.UTC) - datetime.timedelta(
+            minutes=10
+        )
         time_end = time_start + datetime.timedelta(minutes=60)
 
         with self.check(

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/subscription_validation.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/subscription_validation.py
@@ -213,7 +213,7 @@ class SubscriptionValidation(GenericTestScenario):
             self._dss_wrapper.cleanup_sub(sub_id=self._sub_id)
 
     def _default_subscription_params(self, duration: datetime.timedelta) -> Dict:
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.UTC)
         return dict(
             area_vertices=[vertex.as_s2sphere() for vertex in self._isa.footprint],
             alt_lo=self._isa.altitude_min,

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/dss_wrapper.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/dss_wrapper.py
@@ -1020,7 +1020,7 @@ class DSSWrapper(object):
             method=method,
             url=url_path,
             json=json,
-            timestamp=datetime.datetime.utcnow(),
+            timestamp=datetime.datetime.now(datetime.UTC),
         )
 
         resp = self._dss.client.put(url_path, json=json)
@@ -1032,7 +1032,7 @@ class DSSWrapper(object):
                 json=resp.json(),
                 body=resp.content,
                 headers=resp.headers,
-                reported=StringBasedDateTime(datetime.datetime.utcnow()),
+                reported=StringBasedDateTime(datetime.datetime.now(datetime.UTC)),
             ),
         )
         self._scenario.record_query(q)

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_interactions.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_interactions.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 from typing import Dict, List, Set
 
 from uas_standards.astm.f3548.v21.api import (
@@ -191,7 +191,7 @@ class SubscriptionInteractions(TestScenario):
                 key=[current_oir.ovn for current_oir in self._current_oirs.values()],
                 state=OperationalIntentState.Accepted,
                 uss_base_url="https://example.interuss.org/oir_base_url",
-                time_start=datetime.utcnow(),
+                time_start=datetime.now(UTC),
                 time_end=self._time_end + timedelta(minutes=10),
                 subscription_id=None,
                 implicit_sub_base_url="https://example.interuss.org/sub_base_url",
@@ -238,7 +238,7 @@ class SubscriptionInteractions(TestScenario):
                 key=[current_oir.ovn for current_oir in self._current_oirs.values()],
                 state=OperationalIntentState.Accepted,
                 uss_base_url="https://example.interuss.org/oir_base_url_bis",  # dummy modification of the OIR
-                time_start=datetime.utcnow(),
+                time_start=datetime.now(UTC),
                 time_end=self._time_end + timedelta(minutes=10),
                 subscription_id=self._current_oirs[oir_id].subscription_id,
             )
@@ -352,7 +352,7 @@ class SubscriptionInteractions(TestScenario):
             sub_id = self._sub_ids[i]
             sub_params = self._planning_area.get_new_subscription_params(
                 subscription_id=sub_id,
-                start_time=datetime.utcnow(),
+                start_time=datetime.now(UTC),
                 duration=timedelta(seconds=SUBSCRIPTION_EXPIRY_DELAY_SEC),
                 notify_for_op_intents=True,
                 notify_for_constraints=False,
@@ -420,7 +420,7 @@ class SubscriptionInteractions(TestScenario):
         self.begin_test_case("Setup")
 
         # Subscription from now to 20 minutes in the future
-        self._time_start = datetime.utcnow()
+        self._time_start = datetime.now(UTC)
         self._time_end = self._time_start + timedelta(minutes=20)
 
         # Multiple runs of the scenario seem to rely on the same instance:

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_interactions_deletion.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_interactions_deletion.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 from typing import Dict, List
 
 from uas_standards.astm.f3548.v21.api import (
@@ -263,7 +263,7 @@ class SubscriptionInteractionsDeletion(TestScenario):
     def _setup_case(self):
         self.begin_test_case("Setup")
 
-        self._time_start = datetime.utcnow()
+        self._time_start = datetime.now(UTC)
         self._time_end = self._time_start + timedelta(minutes=20)
 
         self._current_subs = {}

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_validation.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_validation.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 from typing import Dict, Any
 
 from uas_standards.astm.f3548.v21.constants import (
@@ -132,7 +132,7 @@ class SubscriptionValidation(TestScenario):
         - trying to mutate an existing subscription to be too long
         """
 
-        start_time = datetime.utcnow() - timedelta(minutes=1)
+        start_time = datetime.now(UTC) - timedelta(minutes=1)
         # This is 10 minutes too long
         invalid_duration = timedelta(hours=DSSMaxSubscriptionDurationHours, minutes=10)
 

--- a/monitoring/uss_qualifier/scenarios/dev/noop.py
+++ b/monitoring/uss_qualifier/scenarios/dev/noop.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, UTC
 
 from monitoring.monitorlib.delay import sleep
 from monitoring.uss_qualifier.resources.dev import NoOpResource
@@ -18,12 +18,12 @@ class NoOp(TestScenario):
 
         self.record_note(
             "Start time",
-            f"Starting at {datetime.utcnow().isoformat()}Z, sleeping for {self.sleep_secs}s...",
+            f"Starting at {datetime.now(UTC).isoformat()}Z, sleeping for {self.sleep_secs}s...",
         )
 
         sleep(self.sleep_secs, "the no-op scenario sleeps for the specified time")
 
-        self.record_note("End time", f"Ending at {datetime.utcnow().isoformat()}Z.")
+        self.record_note("End time", f"Ending at {datetime.now(UTC).isoformat()}Z.")
 
         self.end_test_step()
         self.end_test_case()

--- a/monitoring/uss_qualifier/scenarios/scenario.py
+++ b/monitoring/uss_qualifier/scenarios/scenario.py
@@ -1,6 +1,6 @@
 import traceback
 from abc import ABC, abstractmethod
-from datetime import datetime
+from datetime import datetime, UTC
 from enum import Enum
 import inspect
 from typing import Callable, Dict, List, Optional, TypeVar, Union, Set, Type
@@ -274,7 +274,7 @@ class GenericTestScenario(ABC):
             name=self.documentation.name,
             scenario_type=self.declaration.scenario_type,
             documentation_url=self.documentation.url,
-            start_time=StringBasedDateTime(datetime.utcnow()),
+            start_time=StringBasedDateTime(datetime.now(UTC)),
             cases=[],
         )
 
@@ -343,7 +343,7 @@ class GenericTestScenario(ABC):
         self._case_report = TestCaseReport(
             name=self._current_case.name,
             documentation_url=self._current_case.url,
-            start_time=StringBasedDateTime(datetime.utcnow()),
+            start_time=StringBasedDateTime(datetime.now(UTC)),
             steps=[],
         )
         self._scenario_report.cases.append(self._case_report)
@@ -373,7 +373,7 @@ class GenericTestScenario(ABC):
         self._step_report = TestStepReport(
             name=self._current_step.name,
             documentation_url=self._current_step.url,
-            start_time=StringBasedDateTime(datetime.utcnow()),
+            start_time=StringBasedDateTime(datetime.now(UTC)),
             failed_checks=[],
             passed_checks=[],
         )
@@ -468,7 +468,7 @@ class GenericTestScenario(ABC):
 
     def end_test_step(self) -> TestStepReport:
         self._expect_phase(ScenarioPhase.RunningTestStep)
-        self._step_report.end_time = StringBasedDateTime(datetime.utcnow())
+        self._step_report.end_time = StringBasedDateTime(datetime.now(UTC))
         self._current_step = None
         report = self._step_report
         self._step_report = None
@@ -477,14 +477,14 @@ class GenericTestScenario(ABC):
 
     def end_test_case(self) -> None:
         self._expect_phase(ScenarioPhase.ReadyForTestStep)
-        self._case_report.end_time = StringBasedDateTime(datetime.utcnow())
+        self._case_report.end_time = StringBasedDateTime(datetime.now(UTC))
         self._current_case = None
         self._case_report = None
         self._phase = ScenarioPhase.ReadyForTestCase
 
     def end_test_scenario(self) -> None:
         self._expect_phase(ScenarioPhase.ReadyForTestCase)
-        self._scenario_report.end_time = StringBasedDateTime(datetime.utcnow())
+        self._scenario_report.end_time = StringBasedDateTime(datetime.now(UTC))
         self._phase = ScenarioPhase.ReadyForCleanup
 
     def go_to_cleanup(self) -> None:
@@ -508,7 +508,7 @@ class GenericTestScenario(ABC):
         self._step_report = TestStepReport(
             name=self._current_step.name,
             documentation_url=self._current_step.url,
-            start_time=StringBasedDateTime(datetime.utcnow()),
+            start_time=StringBasedDateTime(datetime.now(UTC)),
             failed_checks=[],
             passed_checks=[],
         )
@@ -525,7 +525,7 @@ class GenericTestScenario(ABC):
 
     def end_cleanup(self) -> None:
         self._expect_phase(ScenarioPhase.CleaningUp)
-        self._step_report.end_time = StringBasedDateTime(datetime.utcnow())
+        self._step_report.end_time = StringBasedDateTime(datetime.now(UTC))
         self._phase = ScenarioPhase.Complete
 
     def ensure_cleanup_ended(self) -> None:
@@ -535,7 +535,7 @@ class GenericTestScenario(ABC):
         end_cleanup was called."""
         self._expect_phase({ScenarioPhase.CleaningUp, ScenarioPhase.Complete})
         if self._phase == ScenarioPhase.CleaningUp:
-            self._step_report.end_time = StringBasedDateTime(datetime.utcnow())
+            self._step_report.end_time = StringBasedDateTime(datetime.now(UTC))
             self._phase = ScenarioPhase.Complete
 
     def record_execution_error(self, e: Exception) -> None:

--- a/monitoring/uss_qualifier/suites/suite.py
+++ b/monitoring/uss_qualifier/suites/suite.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, UTC
 import json
 import re
 from typing import Dict, List, Optional, Union, Iterator
@@ -289,7 +289,7 @@ class TestSuite(object):
             name=self.definition.name,
             suite_type=self.declaration.type_name,
             documentation_url=self.documentation_url,
-            start_time=StringBasedDateTime(datetime.utcnow()),
+            start_time=StringBasedDateTime(datetime.now(UTC)),
             actions=[],
             capability_evaluations=[],
         )
@@ -357,7 +357,7 @@ def _run_actions(
                     f"Action {a} indicated an unrecognized reaction to failure: {str(action.declaration.on_failure)}"
                 )
     report.successful = success
-    report.end_time = StringBasedDateTime(datetime.utcnow())
+    report.end_time = StringBasedDateTime(datetime.now(UTC))
 
 
 @dataclass

--- a/requirements.in
+++ b/requirements.in
@@ -16,7 +16,7 @@ flask==2.3.3
 Flask-Login==0.6.3  # mock_uss tracer
 geojson===2.5.0  # uss_qualifier
 gevent==24.2.1  # mock_uss / gunicorn worker
-google-auth==1.6.3
+google-auth==2.32.0
 graphviz==0.20.1  # uss_qualifier
 gunicorn==20.1.0
 implicitdict==2.3.0
@@ -37,7 +37,7 @@ pyjwt==2.4.0
 pykml==0.2.0
 pyopenssl  # No specific version target because we always want the latest SSL/TLS support
 pyproj==3.6.1  # uss_qualifier
-pytest==6.2.4
+pytest==8.3.2
 pytest-mock==3.6.1
 pyyaml==6.0.1
 requests==2.31.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -98,7 +98,6 @@ attrs==23.2.0 \
     # via
     #   aiohttp
     #   jsonschema
-    #   pytest
 bc-jsonpath-ng==1.5.9 \
     --hash=sha256:51c3ba65884654ec7be91288b23e1b65bd0b5188acdc51bc80ecfc365a54b77c \
     --hash=sha256:5e72d78887521469f8a52966f6f0664ec3d59dcb2cebf85b8131867a241c84ec
@@ -618,9 +617,9 @@ geventhttpclient==2.2.0 \
     --hash=sha256:f85d0461431976eba91f7c699e853f3b1fc322d178af1fcdbaac4e87c9c497fb \
     --hash=sha256:ff447a3dc6ac7c55cda41f663226cafa62cf4fabb3fe31a4bc0c8bc491e1ef26
     # via locust
-google-auth==1.6.3 \
-    --hash=sha256:0f7c6a64927d34c1a474da92cfc59e552a5d3b940d3266606c6a28b72888b9e4 \
-    --hash=sha256:20705f6803fd2c4d1cc2dcb0df09d4dfcb9a7d51fd59e94a3a28231fd93119ed
+google-auth==2.32.0 \
+    --hash=sha256:49315be72c55a6a37d62819e3573f6b416aca00721f7e3e31a008d928bf64022 \
+    --hash=sha256:53326ea2ebec768070a94bee4e1b9194c9646ea0c2bd72422785bd0f9abfad7b
     # via
     #   -r requirements.in
     #   kubernetes
@@ -1157,9 +1156,9 @@ pem==21.2.0 \
     --hash=sha256:64afb669f05502c071d0706ee66e51471718ae248ba39624919da7b4ea73506e \
     --hash=sha256:c491833b092662626fd58a87375d450637d4ee94996ad9bbbd42593428e93e5a
     # via -r requirements.in
-pluggy==0.13.1 \
-    --hash=sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0 \
-    --hash=sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d
+pluggy==1.5.0 \
+    --hash=sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1 \
+    --hash=sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669
     # via pytest
 ply==3.11 \
     --hash=sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3 \
@@ -1258,10 +1257,6 @@ pvlib==0.10.1 \
     --hash=sha256:1f7c223429a767af868d73210db78e2fdf18cbb57ab36a0e1402962426fc5c29 \
     --hash=sha256:76f08efe6dc99e2e573e1e9b4fe70f7b76e1b324dde1ed7f26b47a00ce500533
     # via -r requirements.in
-py==1.11.0 \
-    --hash=sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719 \
-    --hash=sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378
-    # via pytest
 pyasn1==0.6.0 \
     --hash=sha256:3a35ab2c4b5ef98e17dfdec8ab074046fbda76e281c5a706ccd82328cfc8f64c \
     --hash=sha256:cca4bb0f2df5504f02f6f8a775b6e416ff9b0b3b16f7ee80b5a3153d9b804473
@@ -1351,9 +1346,9 @@ pyrsistent==0.20.0 \
     --hash=sha256:f920385a11207dc372a028b3f1e1038bb244b3ec38d448e6d8e43c6b3ba20e98 \
     --hash=sha256:fed2c3216a605dc9a6ea50c7e84c82906e3684c4e80d2908208f662a6cbf9022
     # via jsonschema
-pytest==6.2.4 \
-    --hash=sha256:50bcad0a0b9c5a72c8e4e7c9855a3ad496ca6a881a3641b4260605450772c54b \
-    --hash=sha256:91ef2131a9bd6be8f76f1f08eac5c5317221d6ad1e143ae03894b862e8976890
+pytest==8.3.2 \
+    --hash=sha256:4ba08f9ae7dcf84ded419494d229b48d0903ea6407b030eaec46df5e6a73bba5 \
+    --hash=sha256:c132345d12ce551242c87269de812483f5bcc87cdbb4722e48487ba194f9fdce
     # via
     #   -r requirements.in
     #   pytest-mock
@@ -1603,7 +1598,6 @@ six==1.16.0 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
     # via
-    #   google-auth
     #   kubernetes
     #   python-dateutil
 structlog==21.5.0 \
@@ -1617,10 +1611,6 @@ text-unidecode==1.3 \
     --hash=sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8 \
     --hash=sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93
     # via faker
-toml==0.10.2 \
-    --hash=sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b \
-    --hash=sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f
-    # via pytest
 typing-extensions==4.11.0 \
     --hash=sha256:83f085bd5ca59c80295fc2a82ab5dac679cbe02b9f33f7d83af68e241bea51b0 \
     --hash=sha256:c1f94d72897edaf4ce775bb7558d5b79d8126906a14ea5ed1635921406c0387a


### PR DESCRIPTION
Resolves most of the python warnings generated during `make check-monitoring`.

In particular, this addresses:
- `mock_uss > make test`
- `uss_qualifier > make unit_test`
- `prober > make test`
