### PR TITLE
[mock_uss] avoid full file scan when querying interaction log

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,10 @@ presubmit: hygiene-tests monitoring-tests
 .PHONY: restart-all
 restart-all: stop-uss-mocks down-locally start-locally start-uss-mocks
 
+# For local development when restarts of the mock USS are frequently required
+.PHONY: restart-mock-uss
+restart-mock-uss: stop-uss-mocks start-uss-mocks
+
 # To be run locally whenever a direct dependency has been updated in requirements.in
 .PHONY: update-pinned-dependencies
 update-pinned-dependencies:

--- a/Makefile
+++ b/Makefile
@@ -116,8 +116,8 @@ presubmit: hygiene-tests monitoring-tests
 restart-all: stop-uss-mocks down-locally start-locally start-uss-mocks
 
 # For local development when restarts of the mock USS are frequently required
-.PHONY: restart-mock-uss
-restart-mock-uss: stop-uss-mocks start-uss-mocks
+.PHONY: restart-uss-mocks
+restart-uss-mocks: stop-uss-mocks start-uss-mocks
 
 # To be run locally whenever a direct dependency has been updated in requirements.in
 .PHONY: update-pinned-dependencies

--- a/monitoring/mock_uss/interaction_logging/logger.py
+++ b/monitoring/mock_uss/interaction_logging/logger.py
@@ -1,19 +1,21 @@
-import os
 import datetime
+import json
+import os
 
 import flask
-import json
 
 from monitoring.mock_uss import webapp, require_config_value
 from monitoring.mock_uss.interaction_logging.config import KEY_INTERACTIONS_LOG_DIR
+from monitoring.monitorlib.clients import QueryHook, query_hooks
 from monitoring.monitorlib.clients.mock_uss.interactions import (
     Interaction,
     QueryDirection,
 )
-from monitoring.monitorlib.clients import QueryHook, query_hooks
 from monitoring.monitorlib.fetch import Query, describe_flask_query, QueryType
 
 require_config_value(KEY_INTERACTIONS_LOG_DIR)
+
+LOGGED_INTERACTION_TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 
 
 def log_interaction(direction: QueryDirection, query: Query) -> None:
@@ -22,21 +24,19 @@ def log_interaction(direction: QueryDirection, query: Query) -> None:
         direction: Whether this interaction was initiated or handled by this system.
         query: Full description of the interaction to log.
     """
-    interaction: Interaction = Interaction(query=query, direction=direction)
-    method = query.request.method
-    log_file(f"{direction}_{method}", interaction)
+    log_file(
+        code=f"{direction.value}_{query.request.method}",
+        content=Interaction(query=query, direction=direction),
+    )
 
 
 def log_file(code: str, content: Interaction) -> None:
     log_path = webapp.config[KEY_INTERACTIONS_LOG_DIR]
     n = len(os.listdir(log_path))
-    basename = "{:06d}_{}_{}".format(
-        n, code, datetime.datetime.now().strftime("%H%M%S_%f")
+    basename = "{:06d}_{}_{}.json".format(
+        n, code, datetime.datetime.now().strftime(LOGGED_INTERACTION_TIMESTAMP_FORMAT)
     )
-    logname = "{}.json".format(basename)
-    fullname = os.path.join(log_path, logname)
-
-    with open(fullname, "w") as f:
+    with open(os.path.join(log_path, basename), "w") as f:
         json.dump(content, f)
 
 

--- a/monitoring/mock_uss/interaction_logging/routes_interactions_log.py
+++ b/monitoring/mock_uss/interaction_logging/routes_interactions_log.py
@@ -45,7 +45,6 @@ def interaction_logs() -> Tuple[Response, int]:
         # Parse the interaction time from the file name:
         fname_parts = fname.split("_")
         if len(fname_parts) != 4:
-            # TODO: should we consider failing hard here, to let users know something is likely very wrong?
             logger.warning(
                 f"Skipping file {fname} as it does not match the expected format"
             )

--- a/monitoring/mock_uss/interaction_logging/routes_interactions_log.py
+++ b/monitoring/mock_uss/interaction_logging/routes_interactions_log.py
@@ -1,6 +1,6 @@
-import datetime
 import json
 import os
+from datetime import datetime
 from typing import Tuple, List
 
 from flask import request, jsonify, Response
@@ -10,6 +10,9 @@ from loguru import logger
 from monitoring.mock_uss import webapp
 from monitoring.mock_uss.auth import requires_scope
 from monitoring.mock_uss.interaction_logging.config import KEY_INTERACTIONS_LOG_DIR
+from monitoring.mock_uss.interaction_logging.logger import (
+    LOGGED_INTERACTION_FILENAME_TIMESTAMP_FORMAT,
+)
 from monitoring.monitorlib.clients.mock_uss.interactions import (
     Interaction,
     ListLogsResponse,
@@ -17,8 +20,6 @@ from monitoring.monitorlib.clients.mock_uss.interactions import (
 from monitoring.monitorlib.scd_automated_testing.scd_injection_api import (
     SCOPE_SCD_QUALIFIER_INJECT,
 )
-
-CLIENT_CLOCK_SKEW_BUFFER = datetime.timedelta(seconds=5)
 
 
 @webapp.route("/mock_uss/interuss_logging/logs", methods=["GET"])
@@ -37,49 +38,38 @@ def interaction_logs() -> Tuple[Response, int]:
         raise ValueError(f"Configured log path {log_path} does not exist")
 
     # individual interactions are logged to a file of the form <index>_<direction>_<method>_<timestamp>.json, eg
-    # 000001_Incoming_GET_2023-08-30T20:48:21.900000Z.json
+    # 000001_Incoming_GET_2023-08-30T20-48-21.900000Z.json
     interactions: List[Interaction] = []
+
     for fname in os.listdir(log_path):
         # Parse the interaction time from the file name:
         fname_parts = fname.split("_")
         if len(fname_parts) != 4:
-            # We may just want to fail hard here to let users know something is likely very wrong
+            # TODO: should we consider failing hard here, to let users know something is likely very wrong?
             logger.warning(
                 f"Skipping file {fname} as it does not match the expected format"
             )
             continue
-        interaction_time_str = fname_parts[3].split(".")[0]
-        interaction_time = StringBasedDateTime(interaction_time_str)
-        # Add a buffer to look slightly before the from_time to account for possible clock skew and the fact
-        # that the timestamp used in the filename is based on the mock_uss clock, not the event time
-        # from the perspective of the client.
-        if interaction_time.datetime < (from_time.datetime - CLIENT_CLOCK_SKEW_BUFFER):
+        interaction_time = StringBasedDateTime(
+            datetime.strptime(
+                fname_parts[3].removesuffix(".json"),
+                LOGGED_INTERACTION_FILENAME_TIMESTAMP_FORMAT,
+            )
+        )
+        if interaction_time.datetime < from_time.datetime:
             continue
         with open(os.path.join(log_path, fname), "r") as f:
             try:
                 obj = json.load(f)
                 interaction = ImplicitDict.parse(obj, Interaction)
-                if "received_at" in interaction.query.request:
-                    if (
-                        interaction.query.request.received_at.datetime
-                        >= from_time.datetime
-                    ):
-                        interactions.append(interaction)
-                elif "initiated_at" in interaction.query.request:
-                    if (
-                        interaction.query.request.initiated_at.datetime
-                        >= from_time.datetime
-                    ):
-                        interactions.append(interaction)
-                else:
-                    raise ValueError(
-                        f"There is no received_at or initiated_at field in the request in {fname}"
-                    )
-
+                if interaction.interaction_time() >= from_time.datetime:
+                    interactions.append(interaction)
             except (KeyError, ValueError) as e:
                 msg = f"Error occurred in reading interaction from file {fname}: {e}"
                 raise type(e)(msg)
 
+    # Sort by interaction time
+    interactions.sort(key=lambda i: i.interaction_time())
     return jsonify(ListLogsResponse(interactions=interactions)), 200
 
 

--- a/monitoring/mock_uss/interaction_logging/routes_interactions_log.py
+++ b/monitoring/mock_uss/interaction_logging/routes_interactions_log.py
@@ -1,30 +1,33 @@
-from typing import Tuple, List
+import datetime
 import json
 import os
+from typing import Tuple, List
+
+from flask import request, jsonify, Response
 from implicitdict import ImplicitDict, StringBasedDateTime
-from flask import request, jsonify
 from loguru import logger
 
 from monitoring.mock_uss import webapp
 from monitoring.mock_uss.auth import requires_scope
-from monitoring.monitorlib.scd_automated_testing.scd_injection_api import (
-    SCOPE_SCD_QUALIFIER_INJECT,
-)
+from monitoring.mock_uss.interaction_logging.config import KEY_INTERACTIONS_LOG_DIR
 from monitoring.monitorlib.clients.mock_uss.interactions import (
     Interaction,
     ListLogsResponse,
 )
+from monitoring.monitorlib.scd_automated_testing.scd_injection_api import (
+    SCOPE_SCD_QUALIFIER_INJECT,
+)
 
-from monitoring.mock_uss.interaction_logging.config import KEY_INTERACTIONS_LOG_DIR
+CLIENT_CLOCK_SKEW_BUFFER = datetime.timedelta(seconds=5)
 
 
 @webapp.route("/mock_uss/interuss_logging/logs", methods=["GET"])
 @requires_scope(SCOPE_SCD_QUALIFIER_INJECT)
-def interaction_logs() -> Tuple[str, int]:
+def interaction_logs() -> Tuple[Response, int]:
     """
     Returns all the interaction logs with requests that were
     received or initiated between 'from_time' and now
-    Eg - http:/.../mock_uss/interuss/log?from_time=2023-08-30T20:48:21.900000Z
+    Eg - http:/.../mock_uss/interuss_logging/logs?from_time=2023-08-30T20:48:21.900000Z
     """
     from_time_param = request.args.get("from_time", "1900-01-01T00:00:00Z")
     from_time = StringBasedDateTime(from_time_param)
@@ -33,8 +36,25 @@ def interaction_logs() -> Tuple[str, int]:
     if not os.path.exists(log_path):
         raise ValueError(f"Configured log path {log_path} does not exist")
 
+    # individual interactions are logged to a file of the form <index>_<direction>_<method>_<timestamp>.json, eg
+    # 000001_Incoming_GET_2023-08-30T20:48:21.900000Z.json
     interactions: List[Interaction] = []
     for fname in os.listdir(log_path):
+        # Parse the interaction time from the file name:
+        fname_parts = fname.split("_")
+        if len(fname_parts) != 4:
+            # We may just want to fail hard here to let users know something is likely very wrong
+            logger.warning(
+                f"Skipping file {fname} as it does not match the expected format"
+            )
+            continue
+        interaction_time_str = fname_parts[3].split(".")[0]
+        interaction_time = StringBasedDateTime(interaction_time_str)
+        # Add a buffer to look slightly before the from_time to account for possible clock skew and the fact
+        # that the timestamp used in the filename is based on the mock_uss clock, not the event time
+        # from the perspective of the client.
+        if interaction_time.datetime < (from_time.datetime - CLIENT_CLOCK_SKEW_BUFFER):
+            continue
         with open(os.path.join(log_path, fname), "r") as f:
             try:
                 obj = json.load(f)

--- a/monitoring/monitorlib/clients/mock_uss/interactions.py
+++ b/monitoring/monitorlib/clients/mock_uss/interactions.py
@@ -1,8 +1,9 @@
+from datetime import datetime
 from enum import Enum
 from typing import List
 
-from implicitdict import ImplicitDict
 import yaml
+from implicitdict import ImplicitDict
 from yaml.representer import Representer
 
 from monitoring.monitorlib.fetch import Query
@@ -19,6 +20,27 @@ class QueryDirection(str, Enum):
 class Interaction(ImplicitDict):
     query: Query
     direction: QueryDirection
+
+    def interaction_time(self) -> datetime:
+        """
+        Returns the time the interaction occurred: this returns min(received_at, initiated_at)
+        or whichever of the two is defined.
+
+        Raises ValueError if neither received_at nor initiated_at is defined.
+        """
+        if "received_at" in self.query.request and "initiated_at" in self.query.request:
+            return min(
+                self.query.request.received_at.datetime,
+                self.query.request.initiated_at.datetime,
+            )
+        elif "received_at" in self.query.request:
+            return self.query.request.received_at.datetime
+        elif "initiated_at" in self.query.request:
+            return self.query.request.initiated_at.datetime
+        else:
+            raise ValueError(
+                f"There is no received_at or initiated_at field in the interaction {self}"
+            )
 
 
 yaml.add_representer(Interaction, Representer.represent_dict)

--- a/monitoring/uss_qualifier/scenarios/astm/utm/subscription_notifications/test_steps/validate_notification_received.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/subscription_notifications/test_steps/validate_notification_received.py
@@ -150,7 +150,7 @@ def _is_notification_sent_to_url_with_op_intent_id(
 
 def _check_notification_sent_with_subscription_id_and_response(
     interactions: List[Interaction], subscription_id: str
-) -> Tuple[bool, bool, int]:
+) -> Tuple[bool, int]:
     """
     This function checks if a notification with subscription_id is found in the given interactions,
 


### PR DESCRIPTION
This PR attempts to improve the performance of the `/mock_uss/interuss_logging/logs` GET endpoint. It:
 - updates the mock USS's interaction logger to store a full timestamp of the interaction in the relevant filename 
 - updates the endpoint logic to filter out files that are older than the required time
 
 Additionally, returned interactions are now sorted before they are returned.
 
 Test plan: the qualifier is still able to run locally against an updated mock_uss, and the scenarios that rely on the `interuss_logging/logs`  endpoint are passing.
 
 This is not guaranteed to solve #677 but is very likely to improve the situation.