### PR TITLE
[uss_qualifier] Replace has_private_address by new resource TestExclusionResource

### DIFF
--- a/monitoring/uss_qualifier/configurations/dev/dss_probing.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/dss_probing.yaml
@@ -15,6 +15,8 @@ v1:
         netrid_dss_instances_v22a: { $ref: 'library/environment.yaml#/netrid_dss_instances_v22a' }
         netrid_dss_instances_v19: { $ref: 'library/environment.yaml#/netrid_dss_instances_v19' }
         che_non_conflicting_flights: {$ref: 'library/resources.yaml#/che_non_conflicting_flights'}
+
+        test_exclusions: { $ref: 'library/resources.yaml#/test_exclusions' }
     non_baseline_inputs:
       - v1.test_run.resources.resource_declarations.utm_auth
       - v1.test_run.resources.resource_declarations.second_utm_auth
@@ -35,6 +37,7 @@ v1:
           problematically_big_area: kentland_problematically_big_area
           second_utm_auth: second_utm_auth
           flight_intents: che_non_conflicting_flights
+          test_exclusions: test_exclusions
     execution:
       stop_fast: true
   artifacts:

--- a/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml
@@ -28,6 +28,7 @@ v1:
           second_utm_auth: second_utm_auth
           planning_area: planning_area
           problematically_big_area: problematically_big_area
+          test_exclusions: test_exclusions
 
     # When a test run is executed, a "baseline signature" is computed uniquely identifying the "baseline" of the test,
     # usually excluding exactly what systems are participating in the test (the "environment").  This is a list of
@@ -145,10 +146,8 @@ v1:
                   # Participants using a DSS instance they do not provide should be listed as users of that DSS (so that they can take credit for USS requirements enforced by the DSS)
                   - mock_uss  # mock_uss uses this DSS instance; it does not provide its own instance
                 base_url: http://dss.uss1.localutm
-                has_private_address: true
               - participant_id: uss2_dss
                 base_url: http://dss.uss2.localutm
-                has_private_address: true
 
         # Mock USS that can be used in tests for flight planning, modifying data sharing behavior and recording interactions
         mock_uss:
@@ -162,6 +161,14 @@ v1:
         # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
         # ========== Environment ==========
         # =================================
+
+        # Controls tests behavior
+        test_exclusions:
+          $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
+          resource_type: resources.dev.TestExclusionsResource
+          specification:
+            # Tests should allow private addresses that are not publicly addressable since this configuration runs locally
+            allow_private_addresses: true
 
         # Means by which uss_qualifier can discover which subscription ('sub' claim of its tokes) it is described by
         utm_client_identity:

--- a/monitoring/uss_qualifier/configurations/dev/library/environment_containers.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/library/environment_containers.yaml
@@ -108,11 +108,11 @@ netrid_dss_instances_v19:
       - participant_id: uss1
         rid_version: F3411-19
         base_url: http://dss.uss1.localutm
-        has_private_address: true
+        has_private_address: true  # TODO monitoring#739: not used on its own anymore, to be removed alongside local_debug
       - participant_id: uss2
         rid_version: F3411-19
         base_url: http://dss.uss2.localutm
-        has_private_address: true
+        has_private_address: true  # TODO monitoring#739: not used on its own anymore, to be removed alongside local_debug
 
 netrid_dss_instances_v22a:
   $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
@@ -124,11 +124,11 @@ netrid_dss_instances_v22a:
       - participant_id: uss1
         rid_version: F3411-22a
         base_url: http://dss.uss1.localutm/rid/v2
-        has_private_address: true
+        has_private_address: true  # TODO monitoring#739: not used on its own anymore, to be removed alongside local_debug
       - participant_id: uss2
         rid_version: F3411-22a
         base_url: http://dss.uss2.localutm/rid/v2
-        has_private_address: true
+        has_private_address: true  # TODO monitoring#739: not used on its own anymore, to be removed alongside local_debug
 
 netrid_dss_instance_v19:
   $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
@@ -139,7 +139,7 @@ netrid_dss_instance_v19:
     participant_id: uss1
     rid_version: F3411-19
     base_url: http://dss.uss1.localutm
-    has_private_address: true
+    has_private_address: true  # TODO monitoring#739: not used on its own anymore, to be removed alongside local_debug
 
 netrid_dss_instance_v22a:
   $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
@@ -150,7 +150,7 @@ netrid_dss_instance_v22a:
     participant_id: uss1
     rid_version: F3411-22a
     base_url: http://dss.uss1.localutm/rid/v2
-    has_private_address: true
+    has_private_address: true  # TODO monitoring#739: not used on its own anymore, to be removed alongside local_debug
 
 # ===== Flight planning =====
 
@@ -201,7 +201,6 @@ scd_dss:
   specification:
     participant_id: uss1
     base_url: http://dss.uss1.localutm
-    has_private_address: true
 
 scd_dss_instances:
   $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
@@ -214,10 +213,8 @@ scd_dss_instances:
         user_participant_ids:
           - mock_uss
         base_url: http://dss.uss1.localutm
-        has_private_address: true
       - participant_id: uss2
         base_url: http://dss.uss2.localutm
-        has_private_address: true
 
 # ===== DSS CockroachDB nodes =====
 

--- a/monitoring/uss_qualifier/configurations/dev/library/environment_localhost.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/library/environment_localhost.yaml
@@ -107,11 +107,11 @@ netrid_dss_instances_v19:
       - participant_id: uss1
         rid_version: F3411-19
         base_url: http://localhost:8082
-        has_private_address: true
+        has_private_address: true  # TODO monitoring#739: not used on its own anymore, to be removed alongside local_debug
       - participant_id: uss2
         rid_version: F3411-19
         base_url: http://localhost:8082
-        has_private_address: true
+        has_private_address: true  # TODO monitoring#739: not used on its own anymore, to be removed alongside local_debug
 
 netrid_dss_instances_v22a:
   $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
@@ -123,11 +123,11 @@ netrid_dss_instances_v22a:
       - participant_id: uss1
         rid_version: F3411-22a
         base_url: http://localhost:8082/rid/v2
-        has_private_address: true
+        has_private_address: true  # TODO monitoring#739: not used on its own anymore, to be removed alongside local_debug
       - participant_id: uss2
         rid_version: F3411-22a
         base_url: http://localhost:8082/rid/v2
-        has_private_address: true
+        has_private_address: true  # TODO monitoring#739: not used on its own anymore, to be removed alongside local_debug
 
 netrid_dss_instance_v19:
   $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
@@ -138,7 +138,7 @@ netrid_dss_instance_v19:
     participant_id: uss1
     rid_version: F3411-19
     base_url: http://localhost:8082
-    has_private_address: true
+    has_private_address: true  # TODO monitoring#739: not used on its own anymore, to be removed alongside local_debug
 
 netrid_dss_instance_v22a:
   $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
@@ -149,7 +149,7 @@ netrid_dss_instance_v22a:
     participant_id: uss1
     rid_version: F3411-22a
     base_url: http://localhost:8082/rid/v2
-    has_private_address: true
+    has_private_address: true  # TODO monitoring#739: not used on its own anymore, to be removed alongside local_debug
 
 # ===== Flight planning =====
 
@@ -200,7 +200,6 @@ scd_dss:
   specification:
     participant_id: uss1
     base_url: http://localhost:8082
-    has_private_address: true
 
 scd_dss_instances:
   $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
@@ -213,10 +212,8 @@ scd_dss_instances:
         user_participant_ids:
           - mock_uss
         base_url: http://localhost:8082
-        has_private_address: true
       - participant_id: uss2
         base_url: http://localhost:8082
-        has_private_address: true
 
 # ===== DSS CockroachDB nodes =====
 

--- a/monitoring/uss_qualifier/configurations/dev/library/resources.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/library/resources.yaml
@@ -386,3 +386,11 @@ locality_che:
   resource_type: resources.interuss.mock_uss.locality.LocalityResource
   specification:
     locality_code: CHE
+
+# ===== Test Exclusions =====
+
+test_exclusions:
+  $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
+  resource_type: resources.dev.TestExclusionsResource
+  specification:
+    allow_private_addresses: true

--- a/monitoring/uss_qualifier/configurations/dev/message_signing.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/message_signing.yaml
@@ -40,6 +40,7 @@ v1:
           specification:
             participant_id: mock_uss
             mock_uss_base_url: http://host.docker.internal:8074
+        test_exclusions: { $ref: 'library/resources.yaml#/test_exclusions' }
     non_baseline_inputs:
       - v1.test_run.resources.resource_declarations.utm_auth
       - v1.test_run.resources.resource_declarations.all_flight_planners
@@ -63,6 +64,7 @@ v1:
           second_utm_auth: second_utm_auth
           planning_area: che_planning_area
           problematically_big_area: che_problematically_big_area
+          test_exclusions: test_exclusions
     execution:
       stop_fast: true
 

--- a/monitoring/uss_qualifier/configurations/dev/netrid_v19.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/netrid_v19.yaml
@@ -14,6 +14,8 @@ v1:
         netrid_service_providers_v19: {$ref: 'library/environment.yaml#/netrid_service_providers_v19'}
         netrid_observers_v19: {$ref: 'library/environment.yaml#/netrid_observers_v19'}
         netrid_dss_instances_v19: {$ref: 'library/environment.yaml#/netrid_dss_instances_v19'}
+
+        test_exclusions: { $ref: 'library/resources.yaml#/test_exclusions' }
     non_baseline_inputs:
       - v1.test_run.resources.resource_declarations.utm_auth
       - v1.test_run.resources.resource_declarations.netrid_service_providers_v19
@@ -32,6 +34,7 @@ v1:
           id_generator: id_generator
           service_area: kentland_service_area
           problematically_big_area: au_problematically_big_area
+          test_exclusions: test_exclusions
     execution:
       stop_fast: true
   artifacts:

--- a/monitoring/uss_qualifier/configurations/dev/netrid_v22a.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/netrid_v22a.yaml
@@ -14,6 +14,8 @@ v1:
         netrid_service_providers_v22a: {$ref: 'library/environment.yaml#/netrid_service_providers_v22a'}
         netrid_observers_v22a: {$ref: 'library/environment.yaml#/netrid_observers_v22a'}
         netrid_dss_instances_v22a: {$ref: 'library/environment.yaml#/netrid_dss_instances_v22a'}
+
+        test_exclusions: { $ref: 'library/resources.yaml#/test_exclusions' }
     non_baseline_inputs:
       - v1.test_run.resources.resource_declarations.utm_auth
       - v1.test_run.resources.resource_declarations.netrid_service_providers_v22a
@@ -32,6 +34,7 @@ v1:
           id_generator: id_generator
           service_area: kentland_service_area
           problematically_big_area: au_problematically_big_area
+          test_exclusions: test_exclusions
     execution:
       stop_fast: true
   artifacts:

--- a/monitoring/uss_qualifier/configurations/dev/uspace.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/uspace.yaml
@@ -28,6 +28,8 @@ v1:
         netrid_service_providers_v22a: {$ref: 'library/environment.yaml#/netrid_service_providers_v22a'}
         netrid_observers_v22a: {$ref: 'library/environment.yaml#/netrid_observers_v22a'}
         netrid_dss_instances_v22a: {$ref: 'library/environment.yaml#/netrid_dss_instances_v22a'}
+
+        test_exclusions: { $ref: 'library/resources.yaml#/test_exclusions' }
     non_baseline_inputs:
       - v1.test_run.resources.resource_declarations.utm_auth
       - v1.test_run.resources.resource_declarations.mock_uss_instances_scdsc
@@ -71,6 +73,8 @@ v1:
           service_area: kentland_service_area
           planning_area: che_planning_area
           problematically_big_area: au_problematically_big_area
+
+          test_exclusions: test_exclusions
         specification:
           mock_uss_instances_source: mock_uss_instances
           locality_source: locality
@@ -102,6 +106,8 @@ v1:
                 service_area: service_area
                 planning_area: planning_area
                 problematically_big_area: problematically_big_area
+
+                test_exclusions: test_exclusions
     execution:
       stop_fast: true
   artifacts:

--- a/monitoring/uss_qualifier/configurations/dev/utm_implementation_us_lib/baseline.libsonnet
+++ b/monitoring/uss_qualifier/configurations/dev/utm_implementation_us_lib/baseline.libsonnet
@@ -31,6 +31,7 @@ function(env) {
             problematically_big_area: 'problematically_big_area',
             system_identity: 'system_identity',
             // dss_crdb_cluster: dss_crdb_cluster  # TODO: Provide once local DSS uses a multi-node cluster
+            test_exclusions: 'test_exclusions',
           },
         },
       },
@@ -58,6 +59,15 @@ function(env) {
       //   2) to create another resource in the pool
       resources: {
         resource_declarations: env.resource_declarations + {
+
+          // Controls tests behavior
+          test_exclusions: {
+            resource_type: 'resources.dev.TestExclusionsResource',
+            specification: {
+              // Tests should allow private addresses that are not publicly addressable since this configuration runs locally
+              allow_private_addresses: true,
+            },
+          },
 
           // Means by which uss_qualifier can discover which subscription ('sub' claim of its tokes) it is described by
           utm_client_identity: {

--- a/monitoring/uss_qualifier/configurations/dev/utm_implementation_us_lib/uss1.libsonnet
+++ b/monitoring/uss_qualifier/configurations/dev/utm_implementation_us_lib/uss1.libsonnet
@@ -44,7 +44,6 @@
           'mock_uss',  // mock_uss uses this DSS instance; it does not provide its own instance
         ],
         base_url: 'http://dss.uss1.localutm',
-        has_private_address: true, // This should be removed for production systems
       },
     ]
   }

--- a/monitoring/uss_qualifier/configurations/dev/utm_implementation_us_lib/uss2.libsonnet
+++ b/monitoring/uss_qualifier/configurations/dev/utm_implementation_us_lib/uss2.libsonnet
@@ -40,7 +40,6 @@
       {
         participant_id: 'uss2_dss',
         base_url: 'http://dss.uss2.localutm',
-        has_private_address: true, // This should be removed for production systems
       },
     ]
   }

--- a/monitoring/uss_qualifier/configurations/interuss/library/environment.yaml
+++ b/monitoring/uss_qualifier/configurations/interuss/library/environment.yaml
@@ -59,11 +59,9 @@ netrid_dss_instances_v19:
       - participant_id: uss1
         rid_version: F3411-19
         base_url: https://dss.ci.google-interuss.uspace.dev
-        has_private_address: false
       - participant_id: uss2
         rid_version: F3411-19
         base_url: https://dss.ci.aws-interuss.uspace.dev
-        has_private_address: false
 
 netrid_dss_instances_v22a:
   $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
@@ -75,11 +73,9 @@ netrid_dss_instances_v22a:
       - participant_id: uss1
         rid_version: F3411-22a
         base_url: https://dss.ci.google-interuss.uspace.dev/rid/v2
-        has_private_address: false
       - participant_id: uss2
         rid_version: F3411-22a
         base_url: https://dss.ci.aws-interuss.uspace.dev/rid/v2
-        has_private_address: false
 
 # ===== F3548 =====
 
@@ -91,7 +87,6 @@ scd_dss:
   specification:
     participant_id: uss1
     base_url: https://dss.ci.google-interuss.uspace.dev
-    has_private_address: false
 
 scd_dss_instances:
   $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
@@ -102,10 +97,8 @@ scd_dss_instances:
     dss_instances:
       - participant_id: uss1
         base_url: https://dss.ci.google-interuss.uspace.dev
-        has_private_address: false
       - participant_id: uss2
         base_url: https://dss.ci.aws-interuss.uspace.dev
-        has_private_address: false
 
 dss_crdb_cluster:
   $content_schema: monitoring/uss_qualifier/resources/interuss/crdb/crdb/CockroachDBClusterResource.json

--- a/monitoring/uss_qualifier/resources/astm/f3411/dss.py
+++ b/monitoring/uss_qualifier/resources/astm/f3411/dss.py
@@ -22,7 +22,9 @@ class DSSInstanceSpecification(ImplicitDict):
     base_url: str
     """Base URL for the DSS instance according to the ASTM F3411 API appropriate to the specified rid_version"""
 
-    has_private_address: Optional[bool]
+    has_private_address: Optional[
+        bool
+    ]  # TODO monitoring#739: not used on its own anymore, to be removed alongside local_debug
     """Whether this DSS instance is expected to have a private address that is not publicly addressable."""
 
     local_debug: Optional[bool]
@@ -50,7 +52,6 @@ class DSSInstance(object):
     participant_id: ParticipantID
     rid_version: RIDVersion
     base_url: str
-    has_private_address: bool = False
     local_debug: bool = False
     client: infrastructure.UTMClientSession
 
@@ -58,7 +59,9 @@ class DSSInstance(object):
         self,
         participant_id: ParticipantID,
         base_url: str,
-        has_private_address: Optional[bool],
+        has_private_address: Optional[
+            bool
+        ],  # TODO monitoring#739: not used on its own anymore, to be removed alongside local_debug
         local_debug: Optional[bool],
         rid_version: RIDVersion,
         auth_adapter: infrastructure.AuthAdapter,
@@ -69,7 +72,6 @@ class DSSInstance(object):
         self.client = infrastructure.UTMClientSession(base_url, auth_adapter)
 
         if has_private_address is not None:
-            self.has_private_address = has_private_address
             self.local_debug = True
         if local_debug is not None:
             self.local_debug = local_debug
@@ -79,7 +81,6 @@ class DSSInstance(object):
             self.participant_id == other.participant_id
             and self.rid_version == other.rid_version
             and self.base_url == other.base_url
-            and self.has_private_address == other.has_private_address
             and self.local_debug == other.local_debug
         )
 

--- a/monitoring/uss_qualifier/resources/astm/f3548/v21/dss.py
+++ b/monitoring/uss_qualifier/resources/astm/f3548/v21/dss.py
@@ -67,9 +67,6 @@ class DSSInstanceSpecification(ImplicitDict):
     base_url: str
     """Base URL for the DSS instance according to the ASTM F3548-21 API"""
 
-    has_private_address: Optional[bool]
-    """Whether this DSS instance is expected to have a private address that is not publicly addressable."""
-
     def __init__(self, *args, **kwargs):
         super().__init__(**kwargs)
         try:
@@ -82,7 +79,6 @@ class DSSInstance(object):
     participant_id: str
     user_participant_ids: List[str]
     base_url: str
-    has_private_address: bool = False
     client: infrastructure.UTMClientSession
     _scopes_authorized: Set[str]
 
@@ -91,15 +87,12 @@ class DSSInstance(object):
         participant_id: str,
         user_participant_ids: List[str],
         base_url: str,
-        has_private_address: Optional[bool],
         auth_adapter: infrastructure.AuthAdapter,
         scopes_authorized: List[str],
     ):
         self.participant_id = participant_id
         self.user_participant_ids = user_participant_ids
         self.base_url = base_url
-        if has_private_address is not None:
-            self.has_private_address = has_private_address
         self.client = infrastructure.UTMClientSession(base_url, auth_adapter)
         self._scopes_authorized = set(
             s.value if isinstance(s, Enum) else s for s in scopes_authorized
@@ -135,7 +128,6 @@ class DSSInstance(object):
             participant_id=self.participant_id,
             user_participant_ids=self.user_participant_ids,
             base_url=self.base_url,
-            has_private_address=self.has_private_address,
             auth_adapter=auth_adapter.adapter,
             scopes_authorized=list(scopes_required),
         )
@@ -772,7 +764,6 @@ class DSSInstanceResource(Resource[DSSInstanceSpecification]):
             and self._specification.user_participant_ids
             else [],
             self._specification.base_url,
-            self._specification.get("has_private_address"),
             self._auth_adapter.adapter,
             list(scopes_required),
         )

--- a/monitoring/uss_qualifier/resources/dev/__init__.py
+++ b/monitoring/uss_qualifier/resources/dev/__init__.py
@@ -1,1 +1,2 @@
 from .noop import NoOpResource
+from .test_exclusions import TestExclusionsResource

--- a/monitoring/uss_qualifier/resources/dev/test_exclusions.py
+++ b/monitoring/uss_qualifier/resources/dev/test_exclusions.py
@@ -1,0 +1,28 @@
+from typing import Optional
+
+from implicitdict import ImplicitDict
+
+from monitoring.uss_qualifier.resources.resource import Resource
+
+
+class TestExclusionsSpecification(ImplicitDict):
+    allow_private_addresses: Optional[bool]
+
+
+class TestExclusionsResource(Resource[TestExclusionsSpecification]):
+    """TestExclusionsResource enables control over test behavior. Should always be optional when used."""
+
+    _spec: TestExclusionsSpecification
+
+    def __init__(
+        self,
+        specification: TestExclusionsSpecification,
+    ):
+        self._spec = specification
+
+    @property
+    def allow_private_addresses(self) -> bool:
+        """Whether the test should allow private addresses that are not publicly addressable. Defaults to False if not set."""
+        if self._spec.has_field_with_value("allow_private_addresses"):
+            return self._spec.allow_private_addresses
+        return False

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/dss_wrapper.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/dss_wrapper.py
@@ -59,10 +59,6 @@ class DSSWrapper(object):
     def base_url(self) -> str:
         return self._dss.base_url
 
-    @property
-    def has_private_address(self) -> bool:
-        return self._dss.has_private_address
-
     # TODO: QueryError is not actually raised for RID functions, this function and its uses should be removed
     def _handle_query_error(
         self,

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss_interoperability.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss_interoperability.md
@@ -19,6 +19,11 @@ A resources.astm.f3411.DSSInstanceResource containing the "primary" DSS instance
 
 A resources.astm.f3411.DSSInstancesResource containing at least two DSS instances complying with ASTM F3411-19.
 
+### test_exclusions
+
+A [resources.dev.TestExclusionsResource](../../../../resources/dev/test_exclusions.py) containing test exclusions parameters like whether private addresses are allowed.
+This resource is optional.
+
 ## Test sequence legend
 
 * *P*: Primary DSS instance under test.  The sequence below is
@@ -44,10 +49,10 @@ A resources.astm.f3411.DSSInstancesResource containing at least two DSS instance
 
 ### Test environment requirements test step
 
-#### DSS instance is publicly addressable check
+#### 🛑 DSS instance is publicly addressable check
 As per **[astm.f3411.v19.DSS0210](../../../../requirements/astm/f3411/v19.md)** the DSS instance should be publicly addressable.
-As such, this check will fail if the resolved IP of the DSS host is a private IP address, unless that is explicitly
-expected.
+As such, this check will fail if the resolved IP of the DSS host is a private IP address.
+This check is skipped if the test exclusion `allow_private_addresses` is set to `True`.
 
 #### DSS instance is reachable check
 As per **[astm.f3411.v19.DSS0210](../../../../requirements/astm/f3411/v19.md)** the DSS instance should be publicly addressable.

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss_interoperability.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss_interoperability.md
@@ -19,6 +19,11 @@ A resources.astm.f3411.DSSInstanceResource containing the "primary" DSS instance
 
 A resources.astm.f3411.DSSInstancesResource containing at least two DSS instances complying with ASTM F3411-22a.
 
+### test_exclusions
+
+A [resources.dev.TestExclusionsResource](../../../../resources/dev/test_exclusions.py) containing test exclusions parameters like whether private addresses are allowed.
+This resource is optional.
+
 ## Test sequence legend
 
 * *P*: Primary DSS instance under test.  The sequence below is
@@ -44,10 +49,10 @@ the note to wait >D seconds from a particular time
 
 ### Test environment requirements test step
 
-#### DSS instance is publicly addressable check
+#### 🛑 DSS instance is publicly addressable check
 As per **[astm.f3411.v22a.DSS0210](../../../../requirements/astm/f3411/v22a.md)** the DSS instance should be publicly addressable.
-As such, this check will fail if the resolved IP of the DSS host is a private IP address, unless that is explicitly
-expected.
+As such, this check will fail if the resolved IP of the DSS host is a private IP address.
+This check is skipped if the test exclusion `allow_private_addresses` is set to `True`.
 
 #### DSS instance is reachable check
 As per **[astm.f3411.v22a.DSS0210](../../../../requirements/astm/f3411/v22a.md)** the DSS instance should be publicly addressable.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/dss_interoperability.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/dss_interoperability.md
@@ -20,6 +20,11 @@ A [resources.astm.f3548.v21.DSSInstancesResource](../../../../resources/astm/f35
 
 A [resources.astm.f3548.v21.PlanningAreaResource](../../../../resources/astm/f3548/v21/planning_area.py) containing a planning area that covers the area of interest for this
 
+### test_exclusions
+
+A [resources.dev.TestExclusionsResource](../../../../resources/dev/test_exclusions.py) containing test exclusions parameters like whether private addresses are allowed.
+This resource is optional.
+
 ## Prerequisites test case
 
 ### Test environment requirements test step
@@ -27,8 +32,8 @@ A [resources.astm.f3548.v21.PlanningAreaResource](../../../../resources/astm/f35
 #### 🛑 DSS instance is publicly addressable check
 
 As per **[astm.f3548.v21.DSS0300](../../../../requirements/astm/f3548/v21.md)** the DSS instance should be publicly addressable.
-As such, this check will fail if the resolved IP of the DSS host is a private IP address, unless that is explicitly
-expected.
+As such, this check will fail if the resolved IP of the DSS host is a private IP address.
+This check is skipped if the test exclusion `allow_private_addresses` is set to `True`.
 
 #### 🛑 DSS instance is reachable check
 As per **[astm.f3548.v21.DSS0300](../../../../requirements/astm/f3548/v21.md)** the DSS instance should be publicly addressable.

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_19.yaml
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_19.yaml
@@ -10,6 +10,7 @@ resources:
   id_generator: resources.interuss.IDGeneratorResource
   service_area: resources.netrid.ServiceAreaResource
   problematically_big_area: resources.VerticesResource
+  test_exclusions: resources.dev.TestExclusionsResource?
 actions:
   - action_generator:
       generator_type: action_generators.astm.f3411.ForEachDSS
@@ -20,6 +21,7 @@ actions:
         id_generator: id_generator
         service_area: service_area
         problematically_big_area: problematically_big_area
+        test_exclusions: test_exclusions?
       specification:
         action_to_repeat:
           test_suite:
@@ -32,6 +34,7 @@ actions:
               id_generator: id_generator
               isa: service_area
               problematically_big_area: problematically_big_area
+              test_exclusions: test_exclusions?
           on_failure: Continue
         dss_instances_source: dss_instances
         dss_instance_id: dss

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_19/dss_probing.yaml
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_19/dss_probing.yaml
@@ -7,6 +7,7 @@ resources:
   utm_client_identity: resources.communications.ClientIdentityResource
   isa: resources.netrid.ServiceAreaResource
   problematically_big_area: resources.VerticesResource
+  test_exclusions: resources.dev.TestExclusionsResource?
 actions:
   - test_scenario:
       scenario_type: scenarios.astm.netrid.v19.dss.ISASimple
@@ -53,6 +54,7 @@ actions:
       resources:
         primary_dss_instance: dss
         all_dss_instances: all_dss_instances
+        test_exclusions: test_exclusions?
   - test_scenario:
       scenario_type: scenarios.astm.netrid.v19.dss.TokenValidation
       resources:

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a.yaml
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a.yaml
@@ -10,6 +10,7 @@ resources:
   id_generator: resources.interuss.IDGeneratorResource
   service_area: resources.netrid.ServiceAreaResource
   problematically_big_area: resources.VerticesResource
+  test_exclusions: resources.dev.TestExclusionsResource?
 actions:
   - action_generator:
       generator_type: action_generators.astm.f3411.ForEachDSS
@@ -20,6 +21,7 @@ actions:
         id_generator: id_generator
         service_area: service_area
         problematically_big_area: problematically_big_area
+        test_exclusions: test_exclusions?
       specification:
         action_to_repeat:
           test_suite:
@@ -33,6 +35,7 @@ actions:
               isa: service_area
               client_identity: utm_client_identity
               problematically_big_area: problematically_big_area
+              test_exclusions: test_exclusions?
           on_failure: Continue
         dss_instances_source: dss_instances
         dss_instance_id: dss

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a/dss_probing.yaml
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a/dss_probing.yaml
@@ -7,6 +7,7 @@ resources:
   utm_client_identity: resources.communications.ClientIdentityResource
   isa: resources.netrid.ServiceAreaResource
   problematically_big_area: resources.VerticesResource
+  test_exclusions: resources.dev.TestExclusionsResource?
 actions:
   - test_scenario:
       scenario_type: scenarios.astm.netrid.v22a.dss.ISASimple
@@ -53,6 +54,7 @@ actions:
       resources:
         primary_dss_instance: dss
         all_dss_instances: all_dss_instances
+        test_exclusions: test_exclusions?
   - test_scenario:
       scenario_type: scenarios.astm.netrid.v22a.dss.TokenValidation
       resources:

--- a/monitoring/uss_qualifier/suites/astm/utm/dss_probing.yaml
+++ b/monitoring/uss_qualifier/suites/astm/utm/dss_probing.yaml
@@ -9,6 +9,7 @@ resources:
   id_generator: resources.interuss.IDGeneratorResource
   planning_area: resources.astm.f3548.v21.PlanningAreaResource
   problematically_big_area: resources.VerticesResource
+  test_exclusions: resources.dev.TestExclusionsResource?
 actions:
   - test_scenario:
       scenario_type: scenarios.astm.utm.dss.synchronization.CRSynchronization
@@ -93,6 +94,7 @@ actions:
         primary_dss_instance: dss
         all_dss_instances: all_dss_instances
         planning_area: planning_area
+        test_exclusions: test_exclusions?
   - test_scenario:
       scenario_type: scenarios.astm.utm.dss.synchronization.SubscriptionSynchronization
       resources:

--- a/monitoring/uss_qualifier/suites/astm/utm/f3548_21.yaml
+++ b/monitoring/uss_qualifier/suites/astm/utm/f3548_21.yaml
@@ -20,6 +20,7 @@ resources:
   planning_area: resources.astm.f3548.v21.PlanningAreaResource
   problematically_big_area: resources.VerticesResource
   system_identity: resources.versioning.SystemIdentityResource?
+  test_exclusions: resources.dev.TestExclusionsResource?
 local_resources:
   system_identity:
     resource_type: resources.versioning.SystemIdentityResource
@@ -54,6 +55,7 @@ actions:
       id_generator: id_generator
       planning_area: planning_area
       problematically_big_area: problematically_big_area
+      test_exclusions: test_exclusions?
     specification:
       action_to_repeat:
         test_suite:
@@ -68,6 +70,7 @@ actions:
             id_generator: id_generator
             planning_area: planning_area
             problematically_big_area: problematically_big_area
+            test_exclusions: test_exclusions?
         on_failure: Continue
       dss_instances_source: dss_instances
       dss_instance_id: dss

--- a/monitoring/uss_qualifier/suites/faa/uft/message_signing.yaml
+++ b/monitoring/uss_qualifier/suites/faa/uft/message_signing.yaml
@@ -15,6 +15,7 @@ resources:
   second_utm_auth: resources.communications.AuthAdapterResource?
   planning_area: resources.astm.f3548.v21.PlanningAreaResource
   problematically_big_area: resources.VerticesResource
+  test_exclusions: resources.dev.TestExclusionsResource?
 actions:
 - test_scenario:
     scenario_type: scenarios.faa.uft.StartMessageSigningReport
@@ -41,6 +42,7 @@ actions:
       second_utm_auth: second_utm_auth
       planning_area: planning_area
       problematically_big_area: problematically_big_area
+      test_exclusions: test_exclusions?
   on_failure: Continue
 - test_scenario:
     scenario_type: scenarios.faa.uft.FinalizeMessageSigningReport

--- a/monitoring/uss_qualifier/suites/interuss/dss/all_tests.yaml
+++ b/monitoring/uss_qualifier/suites/interuss/dss/all_tests.yaml
@@ -14,6 +14,8 @@ resources:
 
   second_utm_auth: resources.communications.AuthAdapterResource?
   flight_intents: resources.flight_planning.FlightIntentsResource?
+
+  test_exclusions: resources.dev.TestExclusionsResource?
 actions:
   - action_generator:
       generator_type: action_generators.astm.f3548.ForEachDSS
@@ -26,6 +28,7 @@ actions:
         id_generator: id_generator
         planning_area: planning_area
         problematically_big_area: problematically_big_area
+        test_exclusions: test_exclusions?
       specification:
         action_to_repeat:
           test_suite:
@@ -40,6 +43,7 @@ actions:
               id_generator: id_generator
               planning_area: planning_area
               problematically_big_area: problematically_big_area
+              test_exclusions: test_exclusions?
           on_failure: Continue
         dss_instances_source: dss_instances
         dss_instance_id: dss
@@ -53,6 +57,7 @@ actions:
         id_generator: id_generator
         service_area: service_area
         problematically_big_area: problematically_big_area
+        test_exclusions: test_exclusions?
       specification:
         action_to_repeat:
           test_suite:
@@ -65,6 +70,7 @@ actions:
               id_generator: id_generator
               isa: service_area
               problematically_big_area: problematically_big_area
+              test_exclusions: test_exclusions?
           on_failure: Continue
         dss_instances_source: dss_instances
         dss_instance_id: dss
@@ -78,6 +84,7 @@ actions:
         id_generator: id_generator
         service_area: service_area
         problematically_big_area: problematically_big_area
+        test_exclusions: test_exclusions?
       specification:
         action_to_repeat:
           test_suite:
@@ -90,6 +97,7 @@ actions:
               id_generator: id_generator
               isa: service_area
               problematically_big_area: problematically_big_area
+              test_exclusions: test_exclusions?
           on_failure: Continue
         dss_instances_source: dss_instances
         dss_instance_id: dss

--- a/monitoring/uss_qualifier/suites/uspace/flight_auth.yaml
+++ b/monitoring/uss_qualifier/suites/uspace/flight_auth.yaml
@@ -18,6 +18,7 @@ resources:
   planning_area: resources.astm.f3548.v21.PlanningAreaResource
   problematically_big_area: resources.VerticesResource
   system_identity: resources.versioning.SystemIdentityResource?
+  test_exclusions: resources.dev.TestExclusionsResource?
 actions:
 - test_suite:
     suite_type: suites.astm.utm.f3548_21
@@ -40,6 +41,7 @@ actions:
       planning_area: planning_area
       problematically_big_area: problematically_big_area
       system_identity: system_identity?
+      test_exclusions: test_exclusions?
   on_failure: Continue
 - test_scenario:
     scenario_type: scenarios.flight_planning.PrepareFlightPlannersScenario

--- a/monitoring/uss_qualifier/suites/uspace/network_identification.yaml
+++ b/monitoring/uss_qualifier/suites/uspace/network_identification.yaml
@@ -10,6 +10,7 @@ resources:
   id_generator: resources.interuss.IDGeneratorResource
   service_area: resources.netrid.ServiceAreaResource
   problematically_big_area: resources.VerticesResource
+  test_exclusions: resources.dev.TestExclusionsResource?
 actions:
 - test_suite:
     suite_type: suites.astm.netrid.f3411_22a
@@ -24,6 +25,7 @@ actions:
       id_generator: id_generator
       service_area: service_area
       problematically_big_area: problematically_big_area
+      test_exclusions: test_exclusions?
   on_failure: Abort
 - test_scenario:
     scenario_type: scenarios.uspace.netrid.msl.MSLAltitude

--- a/monitoring/uss_qualifier/suites/uspace/required_services.yaml
+++ b/monitoring/uss_qualifier/suites/uspace/required_services.yaml
@@ -25,6 +25,8 @@ resources:
   service_area: resources.netrid.ServiceAreaResource
   planning_area: resources.astm.f3548.v21.PlanningAreaResource
   problematically_big_area: resources.VerticesResource
+
+  test_exclusions: resources.dev.TestExclusionsResource?
 local_resources:
   system_identity:
     resource_type: resources.versioning.SystemIdentityResource
@@ -58,6 +60,7 @@ actions:
       planning_area: planning_area
       problematically_big_area: problematically_big_area
       system_identity: system_identity
+      test_exclusions: test_exclusions?
   on_failure: Continue
 - test_suite:
     suite_type: suites.uspace.network_identification
@@ -72,6 +75,7 @@ actions:
       id_generator: id_generator
       service_area: service_area
       problematically_big_area: problematically_big_area
+      test_exclusions: test_exclusions?
   on_failure: Continue
 participant_verifiable_capabilities:
     - id: required_services

--- a/schemas/monitoring/uss_qualifier/resources/astm/f3411/dss/DSSInstanceSpecification.json
+++ b/schemas/monitoring/uss_qualifier/resources/astm/f3411/dss/DSSInstanceSpecification.json
@@ -12,7 +12,6 @@
       "type": "string"
     },
     "has_private_address": {
-      "description": "Whether this DSS instance is expected to have a private address that is not publicly addressable.",
       "type": [
         "boolean",
         "null"

--- a/schemas/monitoring/uss_qualifier/resources/astm/f3548/v21/dss/DSSInstanceSpecification.json
+++ b/schemas/monitoring/uss_qualifier/resources/astm/f3548/v21/dss/DSSInstanceSpecification.json
@@ -11,13 +11,6 @@
       "description": "Base URL for the DSS instance according to the ASTM F3548-21 API",
       "type": "string"
     },
-    "has_private_address": {
-      "description": "Whether this DSS instance is expected to have a private address that is not publicly addressable.",
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
     "participant_id": {
       "description": "ID of the USS responsible for this DSS instance",
       "type": "string"

--- a/schemas/monitoring/uss_qualifier/resources/dev/test_exclusions/TestExclusionsSpecification.json
+++ b/schemas/monitoring/uss_qualifier/resources/dev/test_exclusions/TestExclusionsSpecification.json
@@ -1,0 +1,18 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/uss_qualifier/resources/dev/test_exclusions/TestExclusionsSpecification.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "monitoring.uss_qualifier.resources.dev.test_exclusions.TestExclusionsSpecification, as defined in monitoring/uss_qualifier/resources/dev/test_exclusions.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "allow_private_addresses": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
Address #739 

Notes:
- Many files are changed but most are configurations and suites propagating the new resource into the scenarios that use it
- For NetRID DSS resources the field `has_private_address` is kept but only because it is used to determine the value of `local_debug`. A soon-to-follow PR will move `local_debug` into `TestExclusionsResource` to clean that up completely.
- Behavior change: the 'publicly adressable' check is now skipped, before it succeeded when the flag was set.
- For the NetRID DSS interoperability scenarios, the severity of the 'publicly adressable' check is now set through the .md file and is now high (before: medium). 