### PR TITLE
[uss_qualifier] add a default margin when querying interactions from mock_uss

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/test_steps/expected_interactions_test_steps.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/test_steps/expected_interactions_test_steps.py
@@ -20,6 +20,9 @@ from monitoring.uss_qualifier.scenarios.astm.utm.data_exchange_validation.test_s
 )
 from monitoring.uss_qualifier.scenarios.scenario import TestScenarioType
 
+# Margin interaction lookup to prevent issues from slight clock skew
+INTERACTION_LOG_CLOCK_SKEW_MARGIN = timedelta(seconds=1)
+
 
 def expect_mock_uss_receives_op_intent_notification(
     scenario: TestScenarioType,
@@ -94,20 +97,34 @@ def mock_uss_interactions(
     since: StringBasedDateTime,
     query_params: Optional[Dict[str, str]] = None,
     is_applicable: Optional[Callable[[Interaction], bool]] = None,
+    include_clock_skew_buffer: bool = True,
 ) -> Tuple[List[Interaction], Query]:
-    """Determine if mock_uss recorded an interaction for the specified operation in the specified direction."""
+    """
+    Determine if mock_uss recorded an interaction for the specified operation in the specified direction.
 
+    if include_clock_skew_buffer is True (the default), interactions will be looked up slightly earlier than specified
+    (see the INTERACTION_LOG_CLOCK_SKEW_MARGIN constant) to prevent a small clock skew from breaking scenarios.
+    """
+
+    lookup_time = (
+        since.datetime - INTERACTION_LOG_CLOCK_SKEW_MARGIN
+        if include_clock_skew_buffer
+        else since.datetime
+    )
+    margin_message = " (includes skew margin)" if include_clock_skew_buffer else ""
     with scenario.check(
         "Mock USS interactions logs retrievable", [mock_uss.participant_id]
     ) as check:
         try:
-            interactions, query = mock_uss.get_interactions(since)
+            interactions, query = mock_uss.get_interactions(
+                StringBasedDateTime(lookup_time)
+            )
             scenario.record_query(query)
         except QueryError as e:
             for q in e.queries:
                 scenario.record_query(q)
             check.record_failed(
-                summary=f"Error from mock_uss when attempting to get interactions since {since}",
+                summary=f"Error from mock_uss when attempting to get interactions since {lookup_time }{margin_message}",
                 details=f"{str(e)}\n\nStack trace:\n{e.stacktrace}",
                 query_timestamps=[q.request.timestamp for q in e.queries],
             )


### PR DESCRIPTION
Under certain circumstances, even a slight clock skew can break qualifier scenarios that check for mock_uss interactions, depending on how tightly they set their time bounds.

This PR adds a default 5 seconds buffer to interaction queries made via the `mock_uss_interactions` utility method.

Callers that need to disable this behavior may do so by passing `include_clock_skew_buffer = False`.

For an example of clock skew breaking scenarios, see [here](https://github.com/interuss/monitoring/pull/750#issuecomment-2293111481)