### PR TITLE
[build] only install ARM-specific dependencies on an ARM architecture

### DIFF
--- a/monitoring/Dockerfile
+++ b/monitoring/Dockerfile
@@ -17,13 +17,15 @@ FROM python:3.12.4-slim
 #   curl: Useful debugging utility
 #   gcc: Required to build various packages
 #   ca-certificates: Needed to accurately validate TLS connections
-RUN apt-get update --fix-missing && apt-get install -y openssl curl libgeos-dev gcc && apt-get install ca-certificates
+RUN apt-get update --fix-missing && apt-get install -y make openssl curl libgeos-dev gcc g++ && apt-get install ca-certificates
 
 # Required to build in an ARM environment
 #   gevent: libffi-dev libssl-dev python3-dev build-essential
 #   lxml: libxml2-dev libxslt-dev
 #   h5py: pkg-config libhdf5-dev
-RUN apt-get install -y libffi-dev libssl-dev python3-dev build-essential libxml2-dev libxslt-dev pkg-config libhdf5-dev
+RUN if [ "$(uname -m)" = "aarch64" ]; then \
+    apt-get install -y libffi-dev libssl-dev python3-dev build-essential libxml2-dev libxslt-dev pkg-config libhdf5-dev \
+; fi
 
 # Install the necessary Python packages from requirements.txt
 RUN mkdir -p /app/monitoring


### PR DESCRIPTION
In the spirit of not installing things where they are not required, this PR adds a check for the local architecture and only installs the arm-specific dependencies when indeed needed.

Notes:
 - explicitly add `make` to the first package install: it is required by jsonnet and probably included implicity via the ARM dependencies
 - we need to install additional tools for ARM because the base image will behave slightly differently depending on the architecture when the requirements are pip install'ed, probably because some dependencies have differing installation procedures depending on the architecture.
 - x86 should be seen as the default architecture we target (that's what is available in CI), and we add what is missing for arm in order to make developer's and users life easier
