### PR TITLE
[uss_qualifier] op-data-validation: cleanup flights even if creation seemingly failed

### DIFF
--- a/monitoring/monitorlib/clients/flight_planning/client_v1.py
+++ b/monitoring/monitorlib/clients/flight_planning/client_v1.py
@@ -55,6 +55,12 @@ class V1FlightPlannerClient(FlightPlannerClient):
             for k, v in additional_fields.items():
                 req[k] = v
 
+        # We record the flight regardless of the outcome of the query that will be executed
+        # below. This should ward off unexpected exceptions, timeouts or error responses returned
+        # by the server despite the flight having been created.
+        # The cleanup logic supports cleanup attempts for flights that do not exist.
+        self.created_flight_ids.add(flight_plan_id)
+
         op = api.OPERATIONS[api.OperationID.UpsertFlightPlan]
         url = op.path.format(flight_plan_id=flight_plan_id)
         query = query_and_describe(
@@ -66,13 +72,6 @@ class V1FlightPlannerClient(FlightPlannerClient):
             participant_id=self.participant_id,
             query_type=QueryType.InterUSSFlightPlanningV1UpsertFlightPlan,
         )
-        if query.status_code != 999:
-            # We record  the flight in any situation where there might
-            # be a small chance that it was created, as a non-success HTTP code
-            # does not guarantee that a flight has not been injected,
-            # and dangling flights tend to cause issues with other tests.
-            self.created_flight_ids.add(flight_plan_id)
-
         if query.status_code != 200 and query.status_code != 201:
             raise PlanningActivityError(
                 f"Attempt to plan flight returned status {query.status_code} rather than 200 as expected",


### PR DESCRIPTION
Update the flight planning client in two ways:

 - record flight creation if any kind of HTTP response was received, even non-200 ones 
 - upon flight cleanup, do not fail if a 404(*) is received, as cleanup attempts may now happen for flights that were not created.
 
Furthermore,  the `cleanup_flights` test step now considers any 200 or 404 response a successful cleanup.

(*)  the API [will return a 404](https://github.com/interuss/automated_testing_interfaces/blob/4e07f46eb4452da761fb1658d3775d801d19312b/flight_planning/v1/flight_planning.yaml#L471) if the plan does not exist.

First part of #772 