### PR TITLE
[uss_mock] override logic preserves type of dict implementations

### DIFF
--- a/monitoring/mock_uss/f3548v21/flight_planning.py
+++ b/monitoring/mock_uss/f3548v21/flight_planning.py
@@ -362,10 +362,12 @@ def op_intent_from_flightrecord(
             op_intent, mod_op_sharing_behavior.modify_fields, parse_result=False
         )
 
-    # TODO Sanity checks while working on this, consider removing before merging,
-    # alternatively, keep the check and ensure the exception is properly surfaced
-    if not type(op_intent) == f3548_v21.OperationalIntent:
-        raise Exception(f"Expected OperationalIntent, got {type(op_intent)} instead")
+    # Sanity check on the result of apply_overrides
+    if not isinstance(op_intent, f3548_v21.OperationalIntent):
+        raise Exception(
+            f"Expected OperationalIntent, got {type(op_intent).__name__} instead. This is likely a bug in apply_overrides."
+        )
+
     return op_intent
 
 

--- a/monitoring/mock_uss/f3548v21/flight_planning.py
+++ b/monitoring/mock_uss/f3548v21/flight_planning.py
@@ -4,25 +4,24 @@ from typing import Optional, List, Callable, Dict, Tuple
 
 import arrow
 import requests
+from uas_standards.astm.f3548.v21 import api as f3548_v21
+from uas_standards.astm.f3548.v21.constants import OiMaxVertices, OiMaxPlanHorizonDays
+from uas_standards.interuss.automated_testing.scd.v1 import api as scd_api
 
 from monitoring.mock_uss import webapp
 from monitoring.mock_uss.config import KEY_BASE_URL
+from monitoring.mock_uss.f3548v21 import utm_client
+from monitoring.mock_uss.flights.database import FlightRecord, db
+from monitoring.monitorlib.clients import scd as scd_client
 from monitoring.monitorlib.clients.flight_planning.flight_info import (
     FlightInfo,
 )
 from monitoring.monitorlib.fetch import QueryError
 from monitoring.monitorlib.geo import AltitudeDatum, Volume3D, Altitude, DistanceUnits
-from monitoring.monitorlib.scd import priority_of
-from monitoring.uss_qualifier.resources.overrides import apply_overrides
-from uas_standards.astm.f3548.v21 import api as f3548_v21
-from uas_standards.astm.f3548.v21.constants import OiMaxVertices, OiMaxPlanHorizonDays
-from uas_standards.interuss.automated_testing.scd.v1 import api as scd_api
-
-from monitoring.mock_uss.f3548v21 import utm_client
-from monitoring.mock_uss.flights.database import FlightRecord, db
-from monitoring.monitorlib.clients import scd as scd_client
 from monitoring.monitorlib.geotemporal import Volume4DCollection, Volume4D
 from monitoring.monitorlib.locality import Locality
+from monitoring.monitorlib.scd import priority_of
+from monitoring.uss_qualifier.resources.overrides import apply_overrides
 
 
 class PlanningError(Exception):
@@ -363,6 +362,10 @@ def op_intent_from_flightrecord(
             op_intent, mod_op_sharing_behavior.modify_fields, parse_result=False
         )
 
+    # TODO Sanity checks while working on this, consider removing before merging,
+    # alternatively, keep the check and ensure the exception is properly surfaced
+    if not type(op_intent) == f3548_v21.OperationalIntent:
+        raise Exception(f"Expected OperationalIntent, got {type(op_intent)} instead")
     return op_intent
 
 

--- a/monitoring/uss_qualifier/resources/overrides.py
+++ b/monitoring/uss_qualifier/resources/overrides.py
@@ -26,6 +26,11 @@ def apply_overrides(
 
 
 def _apply_overrides(base_object, overrides):
+    """
+    recursively apply the passed overrides to base_object.
+    Note that it may be mutated directly rather than copied.
+    """
+
     if base_object is None:
         return overrides
 
@@ -44,7 +49,10 @@ def _apply_overrides(base_object, overrides):
 
     elif isinstance(overrides, dict):
         if isinstance(base_object, dict):
-            result = {k: v for k, v in base_object.items()}
+            # Reuse the base object as the result to preserve its type:
+            # Eg: ImplicitDict and its subtypes implement dict, and we
+            # need to preserve their type.
+            result = base_object
         else:
             raise ValueError(
                 f"Attempted to override field with type {type(base_object)} with type {type(overrides)} ({json.dumps(base_object)} -> {json.dumps(overrides)})"

--- a/monitoring/uss_qualifier/resources/overrides.py
+++ b/monitoring/uss_qualifier/resources/overrides.py
@@ -1,3 +1,4 @@
+import copy
 import json
 from typing import TypeVar
 from implicitdict import ImplicitDict
@@ -28,7 +29,7 @@ def apply_overrides(
 def _apply_overrides(base_object, overrides):
     """
     recursively apply the passed overrides to base_object.
-    Note that it may be mutated directly rather than copied.
+    Note that the passed object won't be modified and copies made whenever necessary.
     """
 
     if base_object is None:
@@ -49,10 +50,8 @@ def _apply_overrides(base_object, overrides):
 
     elif isinstance(overrides, dict):
         if isinstance(base_object, dict):
-            # Reuse the base object as the result to preserve its type:
-            # Eg: ImplicitDict and its subtypes implement dict, and we
-            # need to preserve their type.
-            result = base_object
+            # We do a deep-copy of the base-object to preserve its type
+            result = copy.deepcopy(base_object)
         else:
             raise ValueError(
                 f"Attempted to override field with type {type(base_object)} with type {type(overrides)} ({json.dumps(base_object)} -> {json.dumps(overrides)})"


### PR DESCRIPTION
This addresses the second part of #772 