### PR TITLE
[uss_qualifier] Have make_artifacts use configuration from report by default

### DIFF
--- a/monitoring/uss_qualifier/README.md
+++ b/monitoring/uss_qualifier/README.md
@@ -34,7 +34,9 @@ Note that all baseline test configurations using local mocks can be run with `mo
 
 ### Artifacts
 
-Part of a configuration defines artifacts that should be produced by the test run.  The raw output of the test run is a raw TestRunReport, which can be produced with the `raw_report` artifact option and has the file name `report.json`.  Given a `report.json`, any other artifacts can be generated with [`make_artifacts.sh`](./make_artifacts.sh).  From the repository root, for instance: `monitoring/uss_qualifier/make_artifacts.sh configurations.personal.my_artifacts file://output/report.json`.  That command loads the report at monitoring/uss_qualifier/output/report.json along with the configuration at monitoring/configurations/personal/my_artifacts.yaml and write the artifacts defined in the my_artifacts configuration.
+Part of a configuration defines artifacts that should be produced by the test run.  The raw output of the test run is a raw TestRunReport, which can be produced with the `raw_report` artifact option and has the file name `report.json`.  Given a `report.json`, any other artifacts can be generated with [`make_artifacts.sh`](./make_artifacts.sh).  From the repository root, for instance: `monitoring/uss_qualifier/make_artifacts.sh file://output/report.json configurations.personal.my_artifacts`.  That command loads the report at monitoring/uss_qualifier/output/report.json along with the configuration at monitoring/configurations/personal/my_artifacts.yaml and write the artifacts defined in the my_artifacts configuration.
+
+To regenerate artifacts using just a raw TestRunReport (using the configuration embedded in the TestRunReport), only specify the report.  For example: `monitoring/uss_qualifier/make_artifacts.sh file://output/report.json`
 
 ### Local testing
 

--- a/monitoring/uss_qualifier/make_artifacts.sh
+++ b/monitoring/uss_qualifier/make_artifacts.sh
@@ -2,11 +2,11 @@
 
 set -eo pipefail
 
-if [[ $# -lt 2 ]]; then
-  echo "Usage: $0 <CONFIG_NAME(s)> <REPORT_NAME(s)> [<OUTPUT_PATH>]"
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <CONFIG_NAME(s)> [<REPORT_NAME(s)> [<OUTPUT_PATH>]]"
   echo "Generates artifacts according to the specified configuration(s) using the specified report(s)"
-  echo "<CONFIG_NAME>: Location of the configuration file (or multiple locations separated by commas)."
   echo "<REPORT_NAME>: Location of the report file (or multiple locations separated by commas).  Relative paths are relative to this folder.  Use file:// prefix to explicitly specify file-based location."
+  echo "<CONFIG_NAME>: Location of the configuration file (or multiple locations separated by commas)."
   echo "<OUTPUT_PATH>: Location to which artifacts should be written (defaults to output/<SIMPLE_CONFIG_NAME>)"
   exit 1
 fi
@@ -26,14 +26,15 @@ cd monitoring || exit 1
 make image
 )
 
-CONFIG_NAME="${1}"
-
-REPORT_NAME="${2}"
-
+REPORT_NAME="${1}"
 echo "Reading report(s) from: ${REPORT_NAME}"
-echo "Generating artifacts from configuration(s): ${CONFIG_NAME}"
+MAKE_ARTIFACTS_OPTIONS="--report $REPORT_NAME"
 
-MAKE_ARTIFACTS_OPTIONS="--config $CONFIG_NAME --report $REPORT_NAME"
+if [ "$#" -gt 1 ]; then
+  CONFIG_NAME="${2}"
+  echo "Generating artifacts from configuration(s): ${CONFIG_NAME}"
+  MAKE_ARTIFACTS_OPTIONS="$MAKE_ARTIFACTS_OPTIONS --config $CONFIG_NAME"
+fi
 
 if [ "$#" -gt 2 ]; then
   OUTPUT_PATH="${3}"


### PR DESCRIPTION
An empirically-common use case is for someone to receive a bare report.json and then need to generate the relevant human-friendly artifacts from it.  This PR supports this use case by making explicit specification of a configuration optional when calling make_artifacts.  When not specified, the configuration embedded within the provided report(s) will be used to specify the artifacts to be generated.