### PR TITLE
[uss_qualifier] scd auth: only cleanup availability if the relevant part of the scenario runs

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/authentication/authentication_validation.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/authentication/authentication_validation.py
@@ -361,7 +361,9 @@ class AuthenticationValidation(TestScenario):
         test_step_fragments.cleanup_sub(self, self._scd_dss, self._test_id)
 
         # Make sure the test ID for uss availability is set to 'Unknown'
-        self._ensure_availability_is_unknown()
+        # if we are testing availabilities
+        if self._availability_dss:
+            self._ensure_availability_is_unknown()
 
     def _ensure_no_active_subs_exist(self):
         test_step_fragments.cleanup_active_subs(


### PR DESCRIPTION
`self._availability_dss` is [only set](https://github.com/interuss/monitoring/blob/4f4a63a3f8b40f5c93f933aba9ed8472daafa8a0/monitoring/uss_qualifier/scenarios/astm/utm/dss/authentication/authentication_validation.py#L174) when the relevant scopes are available.

The cleanup logic in `def _ensure_test_entities_dont_exist()` was not checking whether or not that field is available.

Note that the method might also be missing a similar check for the `_scd_dss`, but this will be addressed in a separate PR.

Closes #781 