### PR TITLE
[uss_qualifier] scd subscrptions: stop considering 404 a success, add was_not_found

### DIFF
--- a/monitoring/mock_uss/tracer/subscriptions.py
+++ b/monitoring/mock_uss/tracer/subscriptions.py
@@ -151,7 +151,7 @@ def unsubscribe_rid(
 def unsubscribe_scd(subscription_id: str, scd_client: UTMClientSession) -> None:
     logger = context.tracer_logger
     get_result = fetch.scd.get_subscription(scd_client, subscription_id)
-    if not get_result.success:
+    if not (get_result.success or get_result.was_not_found):
         logfile = logger.log_new(
             SCDUnsubscribe(
                 existing_subscription=get_result,

--- a/monitoring/monitorlib/fetch/scd.py
+++ b/monitoring/monitorlib/fetch/scd.py
@@ -375,12 +375,21 @@ def constraints(
 class FetchedSubscription(fetch.Query):
     @property
     def success(self) -> bool:
+        """Returns true if a subscription could be successfully fetched."""
         return not self.errors
+
+    @property
+    def was_not_found(self) -> bool:
+        """
+        Returns true if the subscription was not found.
+        Any http return code different from 404 will cause this to be False.
+        """
+        return self.status_code == 404
 
     @property
     def errors(self) -> List[str]:
         if self.status_code == 404:
-            return []
+            return ["Subscription not found"]
         if self.status_code != 200:
             return ["Request to get Subscription failed ({})".format(self.status_code)]
         if self.json_result is None:

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_interactions.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_interactions.py
@@ -325,7 +325,7 @@ class SubscriptionInteractions(TestScenario):
                     "Get Subscription by ID",
                     other_dss.participant_id,
                 ) as check:
-                    if not other_dss_sub.success:
+                    if not (other_dss_sub.success or other_dss_sub.was_not_found):
                         check.record_failed(
                             summary="Get subscription query failed",
                             details=f"Failed to retrieved a subscription from DSS with code {other_dss_sub.status_code}: {other_dss_sub.error_message}",

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_interactions_deletion.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_interactions_deletion.py
@@ -140,7 +140,7 @@ class SubscriptionInteractionsDeletion(TestScenario):
                 ) as check:
                     other_dss_sub = other_dss.get_subscription(sub_id)
                     self.record_query(other_dss_sub)
-                    if not other_dss_sub.success:
+                    if not (other_dss_sub.success or other_dss_sub.was_not_found):
                         check.record_failed(
                             summary="Get subscription query failed",
                             details=f"Failed to retrieved a subscription from DSS with code {other_dss_sub.status_code}: {other_dss_sub.error_message}",

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_simple.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_simple.py
@@ -417,7 +417,7 @@ class SubscriptionSimple(TestScenario):
             fetched_sub = self._dss.get_subscription(sub_id)
             self.record_query(fetched_sub)
             with self.check("Get subscription query succeeds", self._pid) as check:
-                if not fetched_sub.success:
+                if not (fetched_sub.success or fetched_sub.was_not_found):
                     check.record_failed(
                         "Get subscription by ID failed",
                         details=f"Get subscription by ID failed with status code {fetched_sub.status_code}",


### PR DESCRIPTION
`class FetchedSubscription(fetch.Query)` currently considers receiving a 404 from the DSS a success (ie, the `success` property will return True).

This is not strictly correct and can lead to confusion: a 404 will now cause `success` to be false. Callers that need to differentiate between a failure and a 404 may use `was_not_found` which will only be true if the returned code was 404.

Split out of #720 