### PR TITLE
[uss_qualifier/configurations] Disable availability arbitration tests in UTM Implementation US config

### DIFF
--- a/monitoring/uss_qualifier/configurations/dev/utm_implementation_us_lib/baseline.libsonnet
+++ b/monitoring/uss_qualifier/configurations/dev/utm_implementation_us_lib/baseline.libsonnet
@@ -409,7 +409,7 @@ function(env) {
               count: {
                 // We currently expect this amount of skipped scenarios: making it an equality
                 // to make sure this is reduced if some scenarios start to be executed
-                equal_to: 9,
+                equal_to: 11,
               },
             },
           },

--- a/monitoring/uss_qualifier/configurations/dev/utm_implementation_us_lib/local/env.libsonnet
+++ b/monitoring/uss_qualifier/configurations/dev/utm_implementation_us_lib/local/env.libsonnet
@@ -17,7 +17,6 @@ function(participants) {
           'interuss.versioning.read_system_versions',
           // ASTM F3548-21 USS emulation roles
           'utm.strategic_coordination',
-          'utm.availability_arbitration',
         ],
       },
     },


### PR DESCRIPTION
The US UTM Implementation is not currently using availability arbitration and therefore access tokens with that scope cannot be obtained in that context.  This PR reflects the situation in the test configuration attempting to mirror/track that project's usage of InterUSS automated testing.