### PR TITLE
[GitHub] Add release request issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_request.md
+++ b/.github/ISSUE_TEMPLATE/release_request.md
@@ -1,0 +1,19 @@
+---
+name: Release request
+about: I would like InterUSS to make a new `monitoring` release
+labels: release-request
+---
+
+*Note: This template requests InterUSS to create a new release of the `monitoring` repository.  Delete this note and replace each of the instructions below with the appropriate information before submitting.*
+
+**What commit is it important for this release to contain?**
+
+Find the commit of the most recent change important for you to use in a release and copy its commit hash here.  [Commits to the main branch](https://github.com/interuss/monitoring/commits/main/) can be found by going to the repository root in a browser then clicking on the number of commits indicated just below the green Code button (near upper right of primary content).  Commits resolving an issue should often be linked to a merged pull request associated with the issue.
+
+**Requested timing**
+
+Indicate when you ideally need this release by.  If the request can wait 1-2 weeks, simply delete this section.  If needed sooner/more quickly, include a note about the driver behind the increased urgency.
+
+**Additional context**
+
+Add any other useful context here, or remove this section.


### PR DESCRIPTION
Because `monitoring` releases include built images, they are more reliable to use for automated testing than commits outside of a release.  This means users are likely to want to request the creation of `monitoring` releases to support automated testing activities needing certain functionality which may not otherwise be released yet.  This PR adds an issue template to facilitate this request process.