### PR TITLE
[mock_uss] Improve mock_uss behavior visibility

### DIFF
--- a/monitoring/mock_uss/__init__.py
+++ b/monitoring/mock_uss/__init__.py
@@ -76,6 +76,7 @@ def require_config_value(config_key: str) -> None:
 
 from monitoring.mock_uss import config
 from monitoring.mock_uss import routes as basic_routes
+from monitoring.mock_uss import logging
 
 if SERVICE_GEOAWARENESS in webapp.config[config.KEY_SERVICES]:
     enabled_services.add(SERVICE_GEOAWARENESS)

--- a/monitoring/mock_uss/logging.py
+++ b/monitoring/mock_uss/logging.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import Optional, List
+
+import flask
+from flask import Request, Response
+import loguru
+from loguru import logger
+
+from monitoring.mock_uss import webapp
+
+
+def _get_request_id(req: Request) -> str:
+    return f"[{os.getpid()}] {req.date} {req.method} {req.url}"
+
+
+class RequestLogger(object):
+    _request_id: str
+    _loguru_hook: Optional[int] = None
+    _report_log: bool = True
+    messages: List[str]
+
+    def __init__(self):
+        self.messages = []
+
+    def add_to_loguru(self) -> None:
+        self._request_id = _get_request_id(flask.request)
+        self._loguru_hook = logger.add(
+            self.log,
+            format="[{time:YYYY-MM-DD HH:mm:ss.SSS} {level: <8} {name}:{function}:{line}] {message}",
+        )
+
+    def log(self, msg: loguru.Message) -> None:
+        if self._report_log and _get_request_id(flask.request) == self._request_id:
+            self.messages.append(msg)
+
+    def do_not_report(self) -> None:
+        self._report_log = False
+
+    def get_response(self, resp: Response) -> Response:
+        if self._report_log and resp.is_json and self.messages:
+            body = resp.json
+            if "log_messages" not in body:
+                body["log_messages"] = self.messages
+            resp.data = json.dumps(body)
+        return resp
+
+    def remove_from_loguru(self) -> None:
+        if self._loguru_hook is not None:
+            logger.remove(self._loguru_hook)
+            self._loguru_hook = None
+
+
+_REQUEST_LOGGER_FIELD = "request_logger"
+
+
+def get_request_logger() -> Optional[RequestLogger]:
+    if hasattr(flask.request, _REQUEST_LOGGER_FIELD):
+        return getattr(flask.request, _REQUEST_LOGGER_FIELD)
+    else:
+        return None
+
+
+def disable_log_reporting_for_request():
+    request_logger = get_request_logger()
+    if request_logger is not None:
+        request_logger.do_not_report()
+
+
+@webapp.before_request
+def begin_request_log() -> None:
+    request_logger = RequestLogger()
+    request_logger.add_to_loguru()
+    setattr(flask.request, _REQUEST_LOGGER_FIELD, request_logger)
+
+
+@webapp.after_request
+def add_request_log(resp: Response):
+    request_logger = get_request_logger()
+    if request_logger is not None:
+        return request_logger.get_response(resp)
+    else:
+        return resp
+
+
+@webapp.teardown_request
+def end_request_log(e: Optional[BaseException]) -> None:
+    request_logger = get_request_logger()
+    if request_logger is not None:
+        request_logger.remove_from_loguru()

--- a/monitoring/uss_qualifier/resources/interuss/mock_uss/client.py
+++ b/monitoring/uss_qualifier/resources/interuss/mock_uss/client.py
@@ -102,7 +102,6 @@ class MockUSSClient(object):
         url = "{}/mock_uss/interuss_logging/logs?from_time={}".format(
             self.base_url, from_time
         )
-        logger.debug(f"Getting interactions from {from_time} : {url}")
         query = fetch.query_and_describe(
             self.session,
             "GET",


### PR DESCRIPTION
When automated testing fails because of a failure in mock_uss, it is often difficult to determine what happened, and even more difficult for participants without access to mock_uss's logs.  This PR attempts to improve visibility into mock_uss's behavior, primarily by attaching log messages generated while fulfilling a request to that request's response.  This will unfortunately not address the need to debug behavior when a request to mock_uss times out (for instance, if notifying other USSs takes a long time) since uss_qualifier will not have the response for that issue, but it should address a number of other behavior visibility needs.

In addition, this PR adds a full stack trace to 400 and 500 responses to more rapidly identify the problem.  Finally, logging is disabled for the root /status endpoint because that endpoint is polled constantly for liveness and pollutes the logs when it is logged.

Note that one side effect of this change is that report size will grow somewhat due to inclusion of the log messages from mock_uss (in the query responses logged by uss_qualifier).