### PR TITLE
[uss_qualifier] Add resource origin information and display it in sequence view

### DIFF
--- a/monitoring/uss_qualifier/action_generators/astm/f3411/for_each_dss.py
+++ b/monitoring/uss_qualifier/action_generators/astm/f3411/for_each_dss.py
@@ -72,11 +72,14 @@ class ForEachDSS(ActionGenerator[ForEachDSSSpecification]):
         dss_instances = dss_instances_resource.dss_instances
 
         self._actions = []
-        for dss_instance in dss_instances:
+        for i, dss_instance in enumerate(dss_instances):
             modified_resources = {k: v for k, v in resources.items()}
             modified_resources[
                 specification.dss_instance_id
-            ] = DSSInstanceResource.from_dss_instance(dss_instance)
+            ] = DSSInstanceResource.from_dss_instance(
+                dss_instance,
+                f"instance {i} in {dss_instances_resource.resource_origin}",
+            )
 
             self._actions.append(
                 TestSuiteAction(specification.action_to_repeat, modified_resources)

--- a/monitoring/uss_qualifier/action_generators/flight_planning/planner_combinations.py
+++ b/monitoring/uss_qualifier/action_generators/flight_planning/planner_combinations.py
@@ -93,7 +93,8 @@ class FlightPlannerCombinations(
                 )
         else:
             combination_selector = FlightPlannerCombinationSelectorResource(
-                FlightPlannerCombinationSelectorSpecification()
+                FlightPlannerCombinationSelectorSpecification(),
+                "default flight planner combination selector",
             )
 
         self._actions = []

--- a/monitoring/uss_qualifier/main.py
+++ b/monitoring/uss_qualifier/main.py
@@ -115,7 +115,9 @@ def execute_test_run(
         and config.execution.stop_when_resource_not_created
     )
     resources = create_resources(
-        config.resources.resource_declarations, stop_when_not_created
+        config.resources.resource_declarations,
+        "top-level resource pool",
+        stop_when_not_created,
     )
 
     logger.info("Instantiating top-level test suite action")

--- a/monitoring/uss_qualifier/reports/report.py
+++ b/monitoring/uss_qualifier/reports/report.py
@@ -19,6 +19,7 @@ from monitoring.uss_qualifier.reports.capability_definitions import (
     JSONPathExpression,
 )
 from monitoring.uss_qualifier.requirements.definitions import RequirementID
+from monitoring.uss_qualifier.resources.definitions import ResourceID
 from monitoring.uss_qualifier.scenarios.definitions import TestScenarioTypeName
 from monitoring.uss_qualifier.suites.definitions import TestSuiteActionDeclaration
 
@@ -220,6 +221,9 @@ class TestScenarioReport(ImplicitDict):
 
     documentation_url: str
     """URL at which this test scenario is described"""
+
+    resource_origins: Optional[Dict[ResourceID, str]]
+    """For each resource used by this test scenario, the place that resource originated."""
 
     notes: Optional[Dict[str, Note]]
     """Additional information about this scenario that may be useful"""

--- a/monitoring/uss_qualifier/reports/sequence_view/events.py
+++ b/monitoring/uss_qualifier/reports/sequence_view/events.py
@@ -283,6 +283,9 @@ def compute_tested_scenario(
         scenario_index=action_indexer.index,
         participants=scenario_participants,
         execution_error=report.execution_error if "execution_error" in report else None,
+        resource_origins=report.resource_origins
+        if "resource_origins" in report and report.resource_origins is not None
+        else {},
     )
     action_indexer.index += 1
     return scenario

--- a/monitoring/uss_qualifier/reports/sequence_view/summary_types.py
+++ b/monitoring/uss_qualifier/reports/sequence_view/summary_types.py
@@ -16,6 +16,7 @@ from monitoring.uss_qualifier.reports.report import (
     FailedCheck,
     ErrorReport,
 )
+from monitoring.uss_qualifier.resources.definitions import ResourceID
 from monitoring.uss_qualifier.scenarios.definitions import TestScenarioTypeName
 
 
@@ -142,6 +143,7 @@ class TestedScenario(object):
     epochs: List[Epoch]
     participants: Dict[ParticipantID, TestedParticipant]
     execution_error: Optional[ErrorReport]
+    resource_origins: Dict[ResourceID, str]
 
     @property
     def rows(self) -> int:

--- a/monitoring/uss_qualifier/reports/templates/sequence_view/overview.html
+++ b/monitoring/uss_qualifier/reports/templates/sequence_view/overview.html
@@ -57,7 +57,7 @@
 </div>
 
 <div id="resources_configuration_section" class="collapseable">
-  <div class="node_key" onclick="showHide(document.getElementById('resources_configuration_section'))"><h2>Resources configuration</h2></div>
+  <div class="node_key" onclick="showHide(document.getElementById('resources_configuration_section'))"><h2><a id="resources-configuration">Resources configuration</a></h2></div>
   <div class="node_value">
     {{ explorer_content("resources_configuration_tree", resources_config) }}
     {% set collapsible.queries = collapsible.queries + ["resources_configuration_tree"] %}

--- a/monitoring/uss_qualifier/reports/templates/sequence_view/scenario.html
+++ b/monitoring/uss_qualifier/reports/templates/sequence_view/scenario.html
@@ -17,6 +17,17 @@
     <h2>{{ test_scenario.name }}</h2>
   {% endif %}
   <h3>{{ test_scenario.type }}</h3>
+  <div id="resources_configuration_section" class="collapseable">
+    <div class="node_key" onclick="showHide(document.getElementById('resources_configuration_section'))"><h4>Resources</h4></div>
+    <div class="node_value">
+      <ul id="resource_origin_list">
+        {% for local_resource_id, resource_origin in test_scenario.resource_origins.items() %}
+          <li><a href="{{ test_scenario.url }}#{{ local_resource_id }}"><code>{{ local_resource_id }}</code></a> provided by <a href="./index.html#resources-configuration">{{ resource_origin }}</a></li>
+        {% endfor %}
+      </ul>
+      {% set collapsible.queries = collapsible.queries + ["resource_origin_list"] %}
+    </div>
+  </div>
   {% if kml_file %}
     <h4>
       <a href="{{ kml_file }}">KML visualization</a>

--- a/monitoring/uss_qualifier/resources/astm/f3411/dss.py
+++ b/monitoring/uss_qualifier/resources/astm/f3411/dss.py
@@ -60,8 +60,13 @@ class DSSInstanceResource(Resource[DSSInstanceSpecification]):
     dss_instance: DSSInstance
 
     def __init__(
-        self, specification: DSSInstanceSpecification, auth_adapter: AuthAdapterResource
+        self,
+        specification: DSSInstanceSpecification,
+        resource_origin: str,
+        auth_adapter: AuthAdapterResource,
     ):
+        super(DSSInstanceResource, self).__init__(specification, resource_origin)
+
         # Note that the current implementation does not support acting as just a
         # SP accessing the DSS or just a DP accessing the DSS, but this could be
         # improved.
@@ -97,9 +102,13 @@ class DSSInstancesResource(Resource[DSSInstancesSpecification]):
     def __init__(
         self,
         specification: DSSInstancesSpecification,
+        resource_origin: str,
         auth_adapter: AuthAdapterResource,
     ):
+        super(DSSInstancesResource, self).__init__(specification, resource_origin)
         self.dss_instances = [
-            DSSInstanceResource(s, auth_adapter).dss_instance
-            for s in specification.dss_instances
+            DSSInstanceResource(
+                s, f"instance {i + 1} in {resource_origin}", auth_adapter
+            ).dss_instance
+            for i, s in enumerate(specification.dss_instances)
         ]

--- a/monitoring/uss_qualifier/resources/astm/f3411/dss.py
+++ b/monitoring/uss_qualifier/resources/astm/f3411/dss.py
@@ -86,9 +86,12 @@ class DSSInstanceResource(Resource[DSSInstanceSpecification]):
         )
 
     @classmethod
-    def from_dss_instance(cls, dss_instance: DSSInstance) -> DSSInstanceResource:
+    def from_dss_instance(
+        cls, dss_instance: DSSInstance, resource_origin: str
+    ) -> DSSInstanceResource:
         self = cls.__new__(cls)
         self.dss_instance = dss_instance
+        self.resource_origin = resource_origin
         return self
 
 

--- a/monitoring/uss_qualifier/resources/astm/f3548/v21/dss.py
+++ b/monitoring/uss_qualifier/resources/astm/f3548/v21/dss.py
@@ -702,8 +702,10 @@ class DSSInstanceResource(Resource[DSSInstanceSpecification]):
     def __init__(
         self,
         specification: DSSInstanceSpecification,
+        resource_origin: str,
         auth_adapter: AuthAdapterResource,
     ):
+        super(DSSInstanceResource, self).__init__(specification, resource_origin)
         self._specification = specification
         self._auth_adapter = auth_adapter
 
@@ -789,12 +791,15 @@ class DSSInstancesResource(Resource[DSSInstancesSpecification]):
     def __init__(
         self,
         specification: DSSInstancesSpecification,
+        resource_origin: str,
         auth_adapter: AuthAdapterResource,
     ):
+        super(DSSInstancesResource, self).__init__(specification, resource_origin)
         self.dss_instances = [
             DSSInstanceResource(
                 specification=s,
+                resource_origin=f"instance {i + 1} in {resource_origin}",
                 auth_adapter=auth_adapter,
             )
-            for s in specification.dss_instances
+            for i, s in enumerate(specification.dss_instances)
         ]

--- a/monitoring/uss_qualifier/resources/astm/f3548/v21/planning_area.py
+++ b/monitoring/uss_qualifier/resources/astm/f3548/v21/planning_area.py
@@ -126,5 +126,6 @@ class PlanningAreaSpecification(ImplicitDict):
 class PlanningAreaResource(Resource[PlanningAreaSpecification]):
     specification: PlanningAreaSpecification
 
-    def __init__(self, specification: PlanningAreaSpecification):
+    def __init__(self, specification: PlanningAreaSpecification, resource_origin: str):
+        super(PlanningAreaResource, self).__init__(specification, resource_origin)
         self.specification = specification

--- a/monitoring/uss_qualifier/resources/communications/auth_adapter.py
+++ b/monitoring/uss_qualifier/resources/communications/auth_adapter.py
@@ -32,7 +32,8 @@ class AuthAdapterResource(Resource[AuthAdapterSpecification]):
     adapter: infrastructure.AuthAdapter
     scopes: Set[str]
 
-    def __init__(self, specification: AuthAdapterSpecification):
+    def __init__(self, specification: AuthAdapterSpecification, resource_origin: str):
+        super(AuthAdapterResource, self).__init__(specification, resource_origin)
         if (
             "environment_variable_containing_auth_spec" in specification
             and specification.environment_variable_containing_auth_spec

--- a/monitoring/uss_qualifier/resources/communications/client_identity.py
+++ b/monitoring/uss_qualifier/resources/communications/client_identity.py
@@ -34,8 +34,10 @@ class ClientIdentityResource(Resource[ClientIdentitySpecification]):
     def __init__(
         self,
         specification: ClientIdentitySpecification,
+        resource_origin: str,
         auth_adapter: AuthAdapterResource,
     ):
+        super(ClientIdentityResource, self).__init__(specification, resource_origin)
         self.specification = specification
         # Keep the adapter: we will only use it later at the moment it is required
         self._adapter = auth_adapter.adapter

--- a/monitoring/uss_qualifier/resources/dev/noop.py
+++ b/monitoring/uss_qualifier/resources/dev/noop.py
@@ -11,5 +11,6 @@ class NoOpSpecification(ImplicitDict):
 class NoOpResource(Resource[NoOpSpecification]):
     sleep_secs: int
 
-    def __init__(self, specification: NoOpSpecification):
+    def __init__(self, specification: NoOpSpecification, resource_origin: str):
+        super(NoOpResource, self).__init__(specification, resource_origin)
         self.sleep_secs = specification.sleep_secs

--- a/monitoring/uss_qualifier/resources/dev/test_exclusions.py
+++ b/monitoring/uss_qualifier/resources/dev/test_exclusions.py
@@ -18,7 +18,9 @@ class TestExclusionsResource(Resource[TestExclusionsSpecification]):
     def __init__(
         self,
         specification: TestExclusionsSpecification,
+        resource_origin: str,
     ):
+        super(TestExclusionsResource, self).__init__(specification, resource_origin)
         self._spec = specification
 
     @property

--- a/monitoring/uss_qualifier/resources/eurocae/ed269/source_document.py
+++ b/monitoring/uss_qualifier/resources/eurocae/ed269/source_document.py
@@ -14,6 +14,9 @@ class SourceDocument(Resource[SourceDocumentSpecification]):
     raw_document: str
     """Content of the document"""
 
-    def __init__(self, specification: SourceDocumentSpecification):
+    def __init__(
+        self, specification: SourceDocumentSpecification, resource_origin: str
+    ):
+        super(SourceDocument, self).__init__(specification, resource_origin)
         self.specification = specification
         self.raw_document = fileio.load_content(specification.url)

--- a/monitoring/uss_qualifier/resources/flight_planning/flight_intents_resource.py
+++ b/monitoring/uss_qualifier/resources/flight_planning/flight_intents_resource.py
@@ -18,7 +18,8 @@ from monitoring.uss_qualifier.resources.flight_planning.flight_intent import (
 class FlightIntentsResource(Resource[FlightIntentsSpecification]):
     _intent_collection: FlightIntentCollection
 
-    def __init__(self, specification: FlightIntentsSpecification):
+    def __init__(self, specification: FlightIntentsSpecification, resource_origin: str):
+        super(FlightIntentsResource, self).__init__(specification, resource_origin)
         has_file = "file" in specification and specification.file
         has_literal = (
             "intent_collection" in specification and specification.intent_collection

--- a/monitoring/uss_qualifier/resources/flight_planning/flight_planners.py
+++ b/monitoring/uss_qualifier/resources/flight_planning/flight_planners.py
@@ -27,8 +27,10 @@ class FlightPlannerResource(Resource[FlightPlannerSpecification]):
     def __init__(
         self,
         specification: FlightPlannerSpecification,
+        resource_origin: str,
         auth_adapter: AuthAdapterResource,
     ):
+        super(FlightPlannerResource, self).__init__(specification, resource_origin)
         if (
             "scd_injection_base_url" in specification.flight_planner
             and specification.flight_planner.scd_injection_base_url
@@ -69,15 +71,19 @@ class FlightPlannersResource(Resource[FlightPlannersSpecification]):
     def __init__(
         self,
         specification: FlightPlannersSpecification,
+        resource_origin: str,
         auth_adapter: AuthAdapterResource,
     ):
+        super(FlightPlannersResource, self).__init__(specification, resource_origin)
         self._specification = specification
         self._auth_adapter = auth_adapter
         self.flight_planners = [
             FlightPlannerResource(
-                FlightPlannerSpecification(flight_planner=p), auth_adapter
+                FlightPlannerSpecification(flight_planner=p),
+                f"instance {i + 1} in {resource_origin}",
+                auth_adapter,
             )
-            for p in specification.flight_planners
+            for i, p in enumerate(specification.flight_planners)
         ]
 
     def make_subset(self, select_indices: Iterable[int]) -> List[FlightPlannerResource]:
@@ -97,7 +103,14 @@ class FlightPlannerCombinationSelectorResource(
 ):
     _specification: FlightPlannerCombinationSelectorSpecification
 
-    def __init__(self, specification: FlightPlannerCombinationSelectorSpecification):
+    def __init__(
+        self,
+        specification: FlightPlannerCombinationSelectorSpecification,
+        resource_origin: str,
+    ):
+        super(FlightPlannerCombinationSelectorResource, self).__init__(
+            specification, resource_origin
+        )
         self._specification = specification
 
     def is_valid_combination(

--- a/monitoring/uss_qualifier/resources/geospatial_info/geospatial_info_providers.py
+++ b/monitoring/uss_qualifier/resources/geospatial_info/geospatial_info_providers.py
@@ -57,8 +57,12 @@ class GeospatialInfoProviderResource(Resource[GeospatialInfoProviderSpecificatio
     def __init__(
         self,
         specification: GeospatialInfoProviderSpecification,
+        resource_origin: str,
         auth_adapter: AuthAdapterResource,
     ):
+        super(GeospatialInfoProviderResource, self).__init__(
+            specification, resource_origin
+        )
         if (
             "geospatial_map_v1_base_url" in specification.geospatial_info_provider
             and specification.geospatial_info_provider.geospatial_map_v1_base_url

--- a/monitoring/uss_qualifier/resources/interuss/crdb/crdb.py
+++ b/monitoring/uss_qualifier/resources/interuss/crdb/crdb.py
@@ -28,7 +28,9 @@ class CockroachDBNodeResource(Resource[CockroachDBNodeSpecification]):
     def __init__(
         self,
         specification: CockroachDBNodeSpecification,
+        resource_origin: str,
     ):
+        super(CockroachDBNodeResource, self).__init__(specification, resource_origin)
         self._specification = specification
 
     def get_client(self) -> CockroachDBNode:
@@ -56,12 +58,14 @@ class CockroachDBClusterResource(Resource[CockroachDBClusterSpecification]):
     def __init__(
         self,
         specification: CockroachDBClusterSpecification,
+        resource_origin: str,
     ):
+        super(CockroachDBClusterResource, self).__init__(specification, resource_origin)
         self.nodes = [
             CockroachDBNodeResource(
-                specification=s,
+                specification=s, resource_origin=f"node {i + 1} in {resource_origin}"
             )
-            for s in specification.nodes
+            for i, s in enumerate(specification.nodes)
         ]
 
 

--- a/monitoring/uss_qualifier/resources/interuss/flight_authorization/flight_check_table.py
+++ b/monitoring/uss_qualifier/resources/interuss/flight_authorization/flight_check_table.py
@@ -13,5 +13,8 @@ class FlightCheckTableSpecification(ImplicitDict):
 class FlightCheckTableResource(Resource[FlightCheckTableSpecification]):
     table: FlightCheckTable
 
-    def __init__(self, specification: FlightCheckTableSpecification):
+    def __init__(
+        self, specification: FlightCheckTableSpecification, resource_origin: str
+    ):
+        super(FlightCheckTableResource, self).__init__(specification, resource_origin)
         self.table = specification.table

--- a/monitoring/uss_qualifier/resources/interuss/geospatial_map/feature_check_table.py
+++ b/monitoring/uss_qualifier/resources/interuss/geospatial_map/feature_check_table.py
@@ -13,5 +13,8 @@ class FeatureCheckTableSpecification(ImplicitDict):
 class FeatureCheckTableResource(Resource[FeatureCheckTableSpecification]):
     table: FeatureCheckTable
 
-    def __init__(self, specification: FeatureCheckTableSpecification):
+    def __init__(
+        self, specification: FeatureCheckTableSpecification, resource_origin: str
+    ):
+        super(FeatureCheckTableResource, self).__init__(specification, resource_origin)
         self.table = specification.table

--- a/monitoring/uss_qualifier/resources/interuss/id_generator.py
+++ b/monitoring/uss_qualifier/resources/interuss/id_generator.py
@@ -19,8 +19,10 @@ class IDGeneratorResource(Resource[IDGeneratorSpecification]):
     def __init__(
         self,
         specification: IDGeneratorSpecification,
+        resource_origin: str,
         client_identity: ClientIdentityResource,
     ):
+        super(IDGeneratorResource, self).__init__(specification, resource_origin)
         self._client_identity = client_identity
 
     @property

--- a/monitoring/uss_qualifier/resources/interuss/mock_uss/client.py
+++ b/monitoring/uss_qualifier/resources/interuss/mock_uss/client.py
@@ -154,8 +154,10 @@ class MockUSSResource(Resource[MockUSSSpecification]):
     def __init__(
         self,
         specification: MockUSSSpecification,
+        resource_origin: str,
         auth_adapter: AuthAdapterResource,
     ):
+        super(MockUSSResource, self).__init__(specification, resource_origin)
         self.mock_uss = MockUSSClient(
             specification.participant_id,
             specification.mock_uss_base_url,
@@ -172,8 +174,12 @@ class MockUSSsResource(Resource[MockUSSsSpecification]):
     mock_uss_instances: List[MockUSSClient]
 
     def __init__(
-        self, specification: MockUSSsSpecification, auth_adapter: AuthAdapterResource
+        self,
+        specification: MockUSSsSpecification,
+        resource_origin: str,
+        auth_adapter: AuthAdapterResource,
     ):
+        super(MockUSSsResource, self).__init__(specification, resource_origin)
         self.mock_uss_instances = [
             MockUSSClient(s.participant_id, s.mock_uss_base_url, auth_adapter.adapter)
             for s in specification.instances

--- a/monitoring/uss_qualifier/resources/interuss/mock_uss/locality.py
+++ b/monitoring/uss_qualifier/resources/interuss/mock_uss/locality.py
@@ -11,7 +11,9 @@ class LocalitySpecification(ImplicitDict):
 class LocalityResource(Resource[LocalitySpecification]):
     locality_code: LocalityCode
 
-    def __init__(self, specification: LocalitySpecification):
+    def __init__(self, specification: LocalitySpecification, resource_origin: str):
+        super(LocalityResource, self).__init__(specification, resource_origin)
+
         # Make sure provided code is valid
         Locality.from_locale(specification.locality_code)
 

--- a/monitoring/uss_qualifier/resources/netrid/evaluation.py
+++ b/monitoring/uss_qualifier/resources/netrid/evaluation.py
@@ -20,5 +20,8 @@ class EvaluationConfiguration(ImplicitDict):
 class EvaluationConfigurationResource(Resource[EvaluationConfiguration]):
     configuration: EvaluationConfiguration
 
-    def __init__(self, specification: EvaluationConfiguration):
+    def __init__(self, specification: EvaluationConfiguration, resource_origin: str):
+        super(EvaluationConfigurationResource, self).__init__(
+            specification, resource_origin
+        )
         self.configuration = specification

--- a/monitoring/uss_qualifier/resources/netrid/flight_data_resources.py
+++ b/monitoring/uss_qualifier/resources/netrid/flight_data_resources.py
@@ -31,7 +31,8 @@ class FlightDataResource(Resource[FlightDataSpecification]):
     _flight_start_delay: timedelta
     flight_collection: FlightRecordCollection
 
-    def __init__(self, specification: FlightDataSpecification):
+    def __init__(self, specification: FlightDataSpecification, resource_origin: str):
+        super(FlightDataResource, self).__init__(specification, resource_origin)
         if "record_source" in specification:
             self.flight_collection = ImplicitDict.parse(
                 load_dict(specification.record_source),
@@ -99,5 +100,8 @@ class FlightDataStorageSpecification(ImplicitDict):
 class FlightDataStorageResource(Resource[FlightDataStorageSpecification]):
     storage_configuration: FlightDataStorageSpecification
 
-    def __init__(self, specification: FlightDataStorageSpecification):
+    def __init__(
+        self, specification: FlightDataStorageSpecification, resource_origin: str
+    ):
+        super(FlightDataStorageResource, self).__init__(specification, resource_origin)
         self.storage_configuration = specification

--- a/monitoring/uss_qualifier/resources/netrid/observers.py
+++ b/monitoring/uss_qualifier/resources/netrid/observers.py
@@ -106,8 +106,10 @@ class NetRIDObserversResource(Resource[NetRIDObserversSpecification]):
     def __init__(
         self,
         specification: NetRIDObserversSpecification,
+        resource_origin: str,
         auth_adapter: AuthAdapterResource,
     ):
+        super(NetRIDObserversResource, self).__init__(specification, resource_origin)
         auth_adapter.assert_scopes_available(
             scopes_required={
                 Scope.Observe: "observe RID flights visible to user from USSs under test"

--- a/monitoring/uss_qualifier/resources/netrid/service_area.py
+++ b/monitoring/uss_qualifier/resources/netrid/service_area.py
@@ -66,5 +66,6 @@ class ServiceAreaSpecification(ImplicitDict):
 class ServiceAreaResource(Resource[ServiceAreaSpecification]):
     specification: ServiceAreaSpecification
 
-    def __init__(self, specification: ServiceAreaSpecification):
+    def __init__(self, specification: ServiceAreaSpecification, resource_origin: str):
+        super(ServiceAreaResource, self).__init__(specification, resource_origin)
         self.specification = specification

--- a/monitoring/uss_qualifier/resources/netrid/service_providers.py
+++ b/monitoring/uss_qualifier/resources/netrid/service_providers.py
@@ -80,8 +80,10 @@ class NetRIDServiceProviders(Resource[NetRIDServiceProvidersSpecification]):
     def __init__(
         self,
         specification: NetRIDServiceProvidersSpecification,
+        resource_origin: str,
         auth_adapter: AuthAdapterResource,
     ):
+        super(NetRIDServiceProviders, self).__init__(specification, resource_origin)
         auth_adapter.assert_scopes_available(
             scopes_required={
                 SCOPE_RID_QUALIFIER_INJECT: "inject RID test flight data into USSs under test"

--- a/monitoring/uss_qualifier/resources/versioning/client.py
+++ b/monitoring/uss_qualifier/resources/versioning/client.py
@@ -37,8 +37,10 @@ class VersionProvidersResource(Resource[VersionProvidersSpecification]):
     def __init__(
         self,
         specification: VersionProvidersSpecification,
+        resource_origin: str,
         auth_adapter: AuthAdapterResource,
     ):
+        super(VersionProvidersResource, self).__init__(specification, resource_origin)
         auth_adapter.assert_scopes_available(
             {
                 Scope.ReadSystemVersions: "read and record the version of each system under test",

--- a/monitoring/uss_qualifier/resources/versioning/system_identity.py
+++ b/monitoring/uss_qualifier/resources/versioning/system_identity.py
@@ -10,5 +10,8 @@ class SystemIdentitySpecification(ImplicitDict):
 class SystemIdentityResource(Resource[SystemIdentitySpecification]):
     system_identity: str
 
-    def __init__(self, specification: SystemIdentitySpecification):
+    def __init__(
+        self, specification: SystemIdentitySpecification, resource_origin: str
+    ):
+        super(SystemIdentityResource, self).__init__(specification, resource_origin)
         self.system_identity = specification.system_identity

--- a/monitoring/uss_qualifier/resources/vertices.py
+++ b/monitoring/uss_qualifier/resources/vertices.py
@@ -17,5 +17,6 @@ class VerticesSpecification(ImplicitDict):
 class VerticesResource(Resource[VerticesSpecification]):
     specification: VerticesSpecification
 
-    def __init__(self, specification: VerticesSpecification):
+    def __init__(self, specification: VerticesSpecification, resource_origin: str):
+        super(VerticesResource, self).__init__(specification, resource_origin)
         self.specification = specification

--- a/monitoring/uss_qualifier/scenarios/interuss/unit_test.py
+++ b/monitoring/uss_qualifier/scenarios/interuss/unit_test.py
@@ -12,6 +12,7 @@ class UnitTestScenario(GenericTestScenario):
             scenario_type="scenarios.interuss.unit_test.UnitTestScenario",
         )
         super().__init__()
+        self.resource_origins = {}
 
     def run(self, context: ExecutionContext):
         self.begin_test_scenario(context)

--- a/monitoring/uss_qualifier/suites/suite.py
+++ b/monitoring/uss_qualifier/suites/suite.py
@@ -241,7 +241,9 @@ class TestSuite(object):
         else:
             self.local_resources = {}
         if "local_resources" in self.definition and self.definition.local_resources:
-            local_resources = create_resources(self.definition.local_resources)
+            local_resources = create_resources(
+                self.definition.local_resources, self.declaration.type_name
+            )
             for local_resource_id, resource in local_resources.items():
                 if local_resource_id not in self.local_resources:
                     self.local_resources[local_resource_id] = resource

--- a/schemas/monitoring/uss_qualifier/reports/report/TestScenarioReport.json
+++ b/schemas/monitoring/uss_qualifier/reports/report/TestScenarioReport.json
@@ -68,6 +68,22 @@
         "null"
       ]
     },
+    "resource_origins": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "For each resource used by this test scenario, the place that resource originated.",
+      "properties": {
+        "$ref": {
+          "description": "Path to content that replaces the $ref",
+          "type": "string"
+        }
+      },
+      "type": [
+        "object",
+        "null"
+      ]
+    },
     "scenario_type": {
       "description": "Type of this test scenario",
       "type": "string"


### PR DESCRIPTION
An important piece of information when auditing or understanding what happened during a test run is which resources were used to perform a particular test scenario.  This task can be difficult when a resource passes through multiple test suite/action generator/transformation layers before being used by the test scenario, so this PR aims to simplify that task for readers of the sequence view artifact.

The largest change in this PR is mandating every resource specify its `resource_origin` (a string) upon construction.  This superclass constructor signature change mandates a change in every Resource subclass and a new call to the now-concrete (previously abstract) superclass constructor, and that is the bulk of the volume of this PR.  The `resource_origin`s of the resources used by a scenario can then be easily recorded to a new (optional) field in the TestScenarioReport.  When this origin information is present in the TestScenarioReport, each scenario page in the sequence view will display it.

![Screenshot 2024-09-26 at 4 33 45 PM](https://github.com/user-attachments/assets/c97450b4-23f4-49bf-9c52-88c8735a86db)
