### PR TITLE
[uss_qualifier] Fix query timestamp property reference

### DIFF
--- a/monitoring/monitorlib/fetch/__init__.py
+++ b/monitoring/monitorlib/fetch/__init__.py
@@ -435,6 +435,12 @@ class Query(ImplicitDict):
     """If specified, the recognized type of this query."""
 
     @property
+    def timestamp(self) -> datetime.datetime:
+        """Safety property to prevent crashes when Query.timestamp is accessed.
+        For intentional access, request.timestamp should be used instead."""
+        return self.request.timestamp
+
+    @property
     def status_code(self) -> int:
         return self.response.status_code
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/versioning/evaluate_system_versions.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/versioning/evaluate_system_versions.py
@@ -131,8 +131,8 @@ class EvaluateSystemVersions(TestScenario):
         mismatch_timestamps = []
         for participant_id in mismatched_participants:
             timestamps = [
-                test_env_versions[participant_id].query.timestamp,
-                prod_env_versions[participant_id].query.timestamp,
+                test_env_versions[participant_id].query.request.timestamp,
+                prod_env_versions[participant_id].query.request.timestamp,
             ]
             with self.check(
                 "Test software version matches production", participants=participant_id


### PR DESCRIPTION
Although a similar fix had previously been made, the F3548-21 evaluate_system_versions test scenario still [attempted to access the non-existent `timestamp` property on `Query` objects](https://github.com/interuss/monitoring/blob/8f2dc5322229c42e72ad07078f5068f0b8cb0c2b/monitoring/uss_qualifier/scenarios/astm/utm/versioning/evaluate_system_versions.py#L134) when logging certain kinds of failures.  This PR attempts to solve this problem again by:

* Accessing `timestamp` of the Query `request` rather than the Query itself
* Adding a `timestamp` property to the Query in case there are other hidden references
* Searching for instances of `q.timestamp` (there don't appear to be any)
* Searching for instances of `query.timestamp` (there don't appear to be any)
* Manually scanning all instances of `.timestamp` to verify they are all referencing a Query's `request` rather than the Query itself (they appear to be).