### PR TITLE
[uss_qualifier/scenarios/data_exchange_validation] Fix wrong check failure for lack of notification

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/test_steps/expected_interactions_test_steps.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/test_steps/expected_interactions_test_steps.py
@@ -2,12 +2,17 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 import re
-from typing import Callable, Dict, List, Tuple, Optional
+from typing import Callable, Dict, List, Tuple, Optional, Set
 
 import arrow
-from implicitdict import StringBasedDateTime
+from implicitdict import StringBasedDateTime, ImplicitDict
 from uas_standards.astm.f3548.v21 import api
-from uas_standards.astm.f3548.v21.api import OperationID, EntityID
+from uas_standards.astm.f3548.v21.api import (
+    OperationID,
+    EntityID,
+    PutOperationalIntentDetailsParameters,
+    OperationalIntentReference,
+)
 
 from monitoring.monitorlib.clients.mock_uss.interactions import Interaction
 from monitoring.monitorlib.clients.mock_uss.interactions import QueryDirection
@@ -58,32 +63,55 @@ def expect_no_interuss_post_interactions(
     scenario: TestScenarioType,
     mock_uss: MockUSSClient,
     st: StringBasedDateTime,
+    shared_op_intent_ids: Set[EntityID],
     participant_id: str,
 ):
-    """This step checks no notification is sent to any USS within the required time window (as no DSS entity was created).
+    """This step checks no notification about an unexpected operational intent is sent to any USS within the required time window (as no DSS entity was created).
 
     Args:
         st: the earliest time a notification may have been sent
+        shared_op_intent_ids: the set of IDs of previously shared operational intents for which it is expected that notifications are present regardless of their timings
         participant_id: id of the participant responsible to send the notification
     """
     sleep(
         max_wait_time,
         "we have to wait the longest it may take a USS to send a notification before we can establish that they didn't send a notification",
     )
-    found, query = mock_uss_interactions(
+    interactions, query = mock_uss_interactions(
         scenario=scenario,
         mock_uss=mock_uss,
         op_id=OperationID.NotifyOperationalIntentDetailsChanged,
         direction=QueryDirection.Incoming,
         since=st,
     )
-    with scenario.check("Expect Notification not sent", [participant_id]) as check:
-        if found:
-            check.record_failed(
-                summary=f"Notification was wrongly sent for an entity not created.",
-                details=f"Notification was wrongly sent for an entity not created.",
-                query_timestamps=[query.request.timestamp],
-            )
+
+    for interaction in interactions:
+        with scenario.check(
+            "Mock USS interaction can be parsed", [mock_uss.participant_id]
+        ) as check:
+            try:
+                req = PutOperationalIntentDetailsParameters(
+                    ImplicitDict.parse(
+                        interaction.query.request.json,
+                        PutOperationalIntentDetailsParameters,
+                    )
+                )
+            except (ValueError, TypeError, KeyError) as e:
+                check.record_failed(
+                    summary=f"Failed to parse request of a 'NotifyOperationalIntentDetailsChanged' interaction with mock_uss as a PutOperationalIntentDetailsParameters",
+                    details=f"{str(e)}\nRequest: {interaction.query.request.json}\n\nStack trace:\n{e.stacktrace}",
+                    query_timestamps=[query.request.timestamp],
+                )
+                continue  # low priority failure: continue checking interactions if one cannot be parsed
+
+        with scenario.check("Expect Notification not sent", [participant_id]) as check:
+            op_intent_id = EntityID(req.operational_intent_id)
+            if op_intent_id not in shared_op_intent_ids:
+                check.record_failed(
+                    summary=f"Observed unexpected notification for operational intent ID {req.operational_intent_id}.",
+                    details=f"Notification for operational intent ID {req.operational_intent_id} triggered by subscriptions {', '.join([sub.subscription_id for sub in req.subscriptions])} with timestamp {interaction.query.request.timestamp}.",
+                    query_timestamps=[query.request.timestamp],
+                )
 
 
 def mock_uss_interactions(

--- a/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/test_steps/validate_no_notification_operational_intent.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/test_steps/validate_no_notification_operational_intent.md
@@ -5,6 +5,9 @@ This step verifies when a flight is not created, it is also not notified by chec
 ## 🛑 Mock USS interactions logs retrievable check
 **[interuss.mock_uss.hosted_instance.ExposeInterface](../../../../../requirements/interuss/mock_uss/hosted_instance.md)**.
 
+## ℹ️ Mock USS interaction can be parsed check
+**[interuss.mock_uss.hosted_instance.ExposeInterface](../../../../../requirements/interuss/mock_uss/hosted_instance.md)**.
+
 ## 🛑 Expect Notification not sent check
 
 **[interuss.f3548.notification_requirements.NoDssEntityNoNotification](../../../../../requirements/interuss/f3548/notification_requirements.md)**


### PR DESCRIPTION
This addresses #797.
We keep track of the operational intent IDs that were created during the scenario run in order to ignore notifications about them that might have been sent asynchronously after the rejected planning attempt. 
This also enhances the failure message of the check and add a low severity check for parsing the interaction query request.