### PR TITLE
[uss_qualifier] oir_simple: check oir can be created without sub and attached to explicit sub

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/oir/crud/__init__.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/oir/crud/__init__.py
@@ -38,6 +38,7 @@ def create_oir_query(
                 base_url=oir_params.uss_base_url,
                 oi_id=oir_id,
                 subscription_id=sub_id,
+                force_no_implicit_subscription="new_subscription" not in oir_params,
             )
             scenario.record_query(query)
             return new_oir, subs, query

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/oir/oir_has_no_subscription.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/oir/oir_has_no_subscription.md
@@ -1,0 +1,18 @@
+# OIR is attached to expected subscription test step fragment
+
+## [Verify query succeeds](./crud/read_query.md)
+
+## 🛑 OIR is attached to the NULL subscription check
+
+If the OIR returned by the DSS under test is not attached to the expected subscription,
+it is in violation of **[astm.f3548.v21.DSS0005,1](../../../../../../requirements/astm/f3548/v21.md)**
+
+## 🛑 Subscription referenced by the OIR does not exist check
+
+Attempt to fetch the subscription referenced by the OIR in order to confirm that it does not exist.
+
+This check will fail if the DSS under test does not return a 400 or 404 error when the subscription
+that it reported in the OIR is queried.
+
+This is only used in circumstances where the subscription is expected to not exist and the DSS implementation
+is not using the _null_ subscription ID with value `00000000-0000-4000-8000-000000000000`.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/oir/oir_has_no_subscription.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/oir/oir_has_no_subscription.md
@@ -1,10 +1,10 @@
-# OIR is attached to expected subscription test step fragment
+# OIR is attached to no subscription test step fragment
 
 ## [Verify query succeeds](./crud/read_query.md)
 
-## 🛑 OIR is attached to the NULL subscription check
+## 🛑 OIR is not attached to a subscription check
 
-If the OIR returned by the DSS under test is not attached to the expected subscription,
+If the OIR returned by the DSS under test is not attached to a subscription,
 it is in violation of **[astm.f3548.v21.DSS0005,1](../../../../../../requirements/astm/f3548/v21.md)**
 
 ## 🛑 Subscription referenced by the OIR does not exist check
@@ -12,7 +12,8 @@ it is in violation of **[astm.f3548.v21.DSS0005,1](../../../../../../requirement
 Attempt to fetch the subscription referenced by the OIR in order to confirm that it does not exist.
 
 This check will fail if the DSS under test does not return a 400 or 404 error when the subscription
-that it reported in the OIR is queried.
+that it reported in the OIR is queried, as the DSS is in violation of **[astm.f3548.v21.DSS0005,1](../../../../../../requirements/astm/f3548/v21.md)**.
 
 This is only used in circumstances where the subscription is expected to not exist and the DSS implementation
 is not using the _null_ subscription ID with value `00000000-0000-4000-8000-000000000000`.
+

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/oir_explicit_sub_handling.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/oir_explicit_sub_handling.md
@@ -85,9 +85,54 @@ to another explicit subscription that properly covers the extent of the OIR.
 
 #### [Updated OIR is attached to newly specified subscription](./fragments/oir/oir_has_expected_subscription.md)
 
-### [Cleanup OIR test step](./fragments/oir/crud/delete_query.md)
+### Cleanup After Test Case test step
 
-### [Cleanup subscription test step](./fragments/sub/crud/delete_query.md)
+The test case that follows requires the creation of a fresh OIR and subscription. Therefore, this test case will clean up after itself.
+
+#### [Delete OIRs](./fragments/oir/crud/delete_query.md)
+
+#### [Delete Subscriptions](./fragments/sub/crud/delete_query.md)
+
+## OIR in ACCEPTED state can be created without subscription test case
+
+Checks that a DSS allows an OIR to be created in the accepted state without any subscription.
+
+### Create an operational intent reference test step
+
+This step verifies that an OIR can be created in the ACCEPTED state without providing any subscription information (implicit or explicit) in the request.
+
+#### [Create OIR in ACCEPTED state without subscription](./fragments/oir/crud/create_query.md)
+
+### [OIR is not attached to any subscription test step](./fragments/oir/oir_has_no_subscription.md)
+
+#### 🛑 Referenced subscription does not exist check
+
+If the placeholder subscription contained in the OIR returned to the qualifier by the DSS references an existing subscription,
+then the DSS under test is in violation of **[astm.f3548.v21.DSS0005,1](../../../../requirements/astm/f3548/v21.md)**, as the creation request
+did not specify any subscription.
+
+## Validate explicit subscription being attached to OIR without subscription test case
+
+Ensures that an explicit subscription can be attached to an OIR without subscription attached, and that the subscription is required to properly cover the OIR.
+
+### [Create a subscription test step](./fragments/sub/crud/create_query.md)
+
+### Attempt to attach insufficient subscription to OIR test step
+
+This step verifies that the DSS refuses the request to attach an insufficient subscription to an OIR that currently has no subscription.
+
+#### 🛑 Request to attach insufficient subscription to OIR fails check
+
+If the DSS under test allows the qualifier to attach an insufficient explicit subscription to a subscription-free OIR,
+it is in violation of **[astm.f3548.v21.DSS0005,1](../../../../requirements/astm/f3548/v21.md)**
+
+### [OIR is not attached to any subscription test step](./fragments/oir/oir_has_no_subscription.md)
+
+### Attach explicit subscription to OIR test step
+
+#### [Attach OIR to sufficient explicit subscription](./fragments/oir/crud/update_query.md)
+
+### [OIR is attached to expected subscription test step](./fragments/oir/oir_has_expected_subscription.md)
 
 ## Cleanup
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/oir_explicit_sub_handling.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/oir_explicit_sub_handling.md
@@ -105,12 +105,6 @@ This step verifies that an OIR can be created in the ACCEPTED state without prov
 
 ### [OIR is not attached to any subscription test step](./fragments/oir/oir_has_no_subscription.md)
 
-#### 🛑 Referenced subscription does not exist check
-
-If the placeholder subscription contained in the OIR returned to the qualifier by the DSS references an existing subscription,
-then the DSS under test is in violation of **[astm.f3548.v21.DSS0005,1](../../../../requirements/astm/f3548/v21.md)**, as the creation request
-did not specify any subscription.
-
 ## Validate explicit subscription being attached to OIR without subscription test case
 
 Ensures that an explicit subscription can be attached to an OIR without subscription attached, and that the subscription is required to properly cover the OIR.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/oir_explicit_sub_handling.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/oir_explicit_sub_handling.py
@@ -118,7 +118,7 @@ class OIRExplicitSubHandling(TestScenario):
         self.begin_test_case(
             "Validate explicit subscription upon subscription replacement"
         )
-        self._step_update_oir_with_insufficient_explicit_sub(is_replacement=True)
+        self._steps_update_oir_with_insufficient_explicit_sub(is_replacement=True)
         self._step_update_oir_with_sufficient_explicit_sub(is_replacement=True)
         self._clean_test_case()
         self.end_test_case()
@@ -148,7 +148,7 @@ class OIRExplicitSubHandling(TestScenario):
         self.begin_test_case(
             "Validate explicit subscription being attached to OIR without subscription"
         )
-        self._step_update_oir_with_insufficient_explicit_sub(is_replacement=False)
+        self._steps_update_oir_with_insufficient_explicit_sub(is_replacement=False)
         self._step_oir_has_correct_subscription(expected_sub_id=None)
         self._step_update_oir_with_sufficient_explicit_sub(is_replacement=False)
         self._step_oir_has_correct_subscription(expected_sub_id=self._extra_sub_id)
@@ -236,7 +236,7 @@ class OIRExplicitSubHandling(TestScenario):
 
         self._step_oir_has_correct_subscription(expected_sub_id=self._sub_id)
 
-    def _step_update_oir_with_insufficient_explicit_sub(self, is_replacement: bool):
+    def _steps_update_oir_with_insufficient_explicit_sub(self, is_replacement: bool):
         # Create another subscription that is a few seconds short of covering the OIR:
         oir_duration = (
             self._current_oir.time_end.value.datetime
@@ -385,7 +385,7 @@ class OIRExplicitSubHandling(TestScenario):
             sub_is_as_expected = oir.subscription_id == expected_sub_id
 
         attached_check_name = (
-            "OIR is attached to the NULL subscription"
+            "OIR is not attached to a subscription"
             if expected_sub_id is None
             else f"OIR is attached to expected subscription"
         )

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/oir_explicit_sub_handling.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/oir_explicit_sub_handling.py
@@ -120,8 +120,39 @@ class OIRExplicitSubHandling(TestScenario):
         )
         self._step_update_oir_with_insufficient_explicit_sub(is_replacement=True)
         self._step_update_oir_with_sufficient_explicit_sub(is_replacement=True)
+        self._clean_test_case()
         self.end_test_case()
 
+        self.begin_test_case(
+            "OIR in ACCEPTED state can be created without subscription"
+        )
+        self.begin_test_step("Create an operational intent reference")
+        self._current_oir, _, _ = oir_fragments.create_oir_query(
+            scenario=self,
+            dss=self._dss,
+            oir_id=self._oir_id,
+            oir_params=self._planning_area.get_new_operational_intent_ref_params(
+                key=[],
+                state=OperationalIntentState.Accepted,
+                uss_base_url=self._planning_area.get_base_url(),
+                time_start=datetime.now() - timedelta(seconds=10),
+                time_end=datetime.now() + timedelta(minutes=20),
+                subscription_id=None,
+                implicit_sub_base_url=None,
+            ),
+        )
+        self.end_test_step()
+        self._step_oir_has_correct_subscription(expected_sub_id=None)
+        self.end_test_case()
+
+        self.begin_test_case(
+            "Validate explicit subscription being attached to OIR without subscription"
+        )
+        self._step_update_oir_with_insufficient_explicit_sub(is_replacement=False)
+        self._step_oir_has_correct_subscription(expected_sub_id=None)
+        self._step_update_oir_with_sufficient_explicit_sub(is_replacement=False)
+        self._step_oir_has_correct_subscription(expected_sub_id=self._extra_sub_id)
+        self.end_test_case()
         self.end_test_scenario()
 
     def _step_create_explicit_sub(self):
@@ -416,6 +447,16 @@ class OIRExplicitSubHandling(TestScenario):
         # Make sure the subscription IDs we are going to use are available
         test_step_fragments.cleanup_sub(self, self._dss, self._sub_id)
         test_step_fragments.cleanup_sub(self, self._dss, self._extra_sub_id)
+
+    def _clean_test_case(self):
+        self.begin_test_step("Cleanup After Test Case")
+        oir_fragments.delete_oir_query(
+            scenario=self, dss=self._dss, oir_id=self._oir_id, ovn=self._current_oir.ovn
+        )
+        self._current_oir = None
+        self._delete_subscription(self._extra_sub_id, self._current_extra_sub.version)
+        self._current_sub = None
+        self.end_test_step()
 
     def cleanup(self):
         self.begin_cleanup()


### PR DESCRIPTION
Extend `OIRSimple` with a test case that:
 - checks we can create a subscription-free OIR
 - then checks an explicit subscription can be attached, and that the subscription needs to cover the OIR.

This covers point (4) on https://github.com/interuss/dss/issues/1088

Note: this builds on top of #1012, only the last commit of this PR is relevant.