### PR TITLE
[uss_qualifier] oir_simple: accepted oir can be detached from explicit subscription

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/oir_explicit_sub_handling.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/oir_explicit_sub_handling.md
@@ -128,6 +128,14 @@ it is in violation of **[astm.f3548.v21.DSS0005,1](../../../../requirements/astm
 
 ### [OIR is attached to expected subscription test step](./fragments/oir/oir_has_expected_subscription.md)
 
+## Remove explicit subscription from OIR test case
+
+Checks that an OIR in the ACCEPTED state that is attached to an explicit subscription can be mutated in order to not be attached to any subscription.
+
+### [Remove explicit subscription from OIR test step](./fragments/oir/crud/update_query.md)
+
+### [OIR is not attached to any subscription test step](./fragments/oir/oir_has_no_subscription.md)
+
 ## Cleanup
 
 ### [Cleanup OIRs test step](./clean_workspace_op_intents.md)


### PR DESCRIPTION
Extend OIRSimple to check that an OIR in the accepted state can be detached from an explicit subscription and left without subscription.

This covers scenario (5) from https://github.com/interuss/dss/issues/1088

Note: this builds on top of #804, only the last commit of this PR is relevant