### PR TITLE
[uss_qualifier] scd sub-interactions: also search for any active subs at cleanup

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_interactions.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_interactions.py
@@ -459,6 +459,8 @@ class SubscriptionInteractions(TestScenario):
         for sub_id in self._sub_ids:
             test_step_fragments.cleanup_sub(self, self._dss, sub_id)
 
+        test_step_fragments.cleanup_active_subs(self, self._dss, extents)
+
     def cleanup(self):
         self.begin_cleanup()
         self._clean_workspace()


### PR DESCRIPTION
Adds a missing search and deletion of possible active subscriptions in the setup and cleanup of `SubscriptionInteractions`.

This corresponds to both the original intent of how the scenario should be set and cleaned up, and to how the scenario was originally documented.

Resolve #809 