### PR TITLE
[uss_qualifier] scd: oir implicit sub handling scenarion - cleanup stray forgotten comment

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/oir_implicit_sub_handling.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/oir_implicit_sub_handling.py
@@ -194,12 +194,6 @@ class OIRImplicitSubHandling(TestScenario):
 
         self.end_test_scenario()
 
-        """
-
-Create OI3 in DSS from t2 to t3, confirm no subscriptions beyond pre-existing subscriptions in step 2 are among subscribers
-Clean up
-        """
-
     def _case_1_step_create_oir_1(self):
         oir, subs, impl_sub, _ = self._create_oir(
             self._oir_a_id, self._time_2, self._time_3, [], True


### PR DESCRIPTION
This comment should have been cleaned up in #720 as it is the remnant of some early development notes and not useful in any way.