### PR TITLE
[uss_qualifier] scd: add missing query registration in test_step_fragments

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/test_step_fragments.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/test_step_fragments.py
@@ -166,6 +166,7 @@ def cleanup_active_oirs(
     ) as check:
         try:
             oirs, query = dss.find_op_intent(volume)
+            scenario.record_query(query)
         except QueryError as qe:
             scenario.record_queries(qe.queries)
             check.record_failed(
@@ -190,6 +191,7 @@ def cleanup_op_intent(
     ) as check:
         try:
             oir, q = dss.get_op_intent_reference(oi_id)
+            scenario.record_query(q)
         except fetch.QueryError as e:
             scenario.record_queries(e.queries)
             if e.cause_status_code != 404:


### PR DESCRIPTION
`cleanup_active_oirs`and `cleanup_constraint_ref` were not registering successful requests to the DSS. The missing registration in `cleanup_active_oirs` likely caused #809.

This PR properly registers the queries in the two aforementioned functions.

(All other fragments in the modified file are properly registering both successful and failed queries)

Resolves #809 