### PR TITLE
[uss_qualifier/scenarios/utm/data_exchange_validation] Refactor filtering of mock_uss_interactions

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/get_op_data_validation.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/get_op_data_validation.py
@@ -41,7 +41,9 @@ from monitoring.uss_qualifier.scenarios.astm.utm.data_exchange_validation.test_s
     expect_no_interuss_post_interactions,
     expect_mock_uss_receives_op_intent_notification,
     mock_uss_interactions,
-    is_op_intent_notification_with_id,
+    notif_op_intent_id_filter,
+    operation_filter,
+    direction_filter,
 )
 from monitoring.monitorlib.clients.mock_uss.mock_uss_scd_injection_api import (
     MockUssFlightBehavior,
@@ -198,26 +200,25 @@ class GetOpResponseDataValidationByUSS(TestScenario):
             "Check for notification to tested_uss due to subscription in flight 2 area"
         )
         tested_uss_notifications, _ = mock_uss_interactions(
-            scenario=self,
-            mock_uss=self.mock_uss,
-            op_id=OperationID.NotifyOperationalIntentDetailsChanged,
-            direction=QueryDirection.Outgoing,
-            since=flight_2_planning_time,
-            is_applicable=is_op_intent_notification_with_id(flight_2_oi_ref.id),
+            self,
+            self.mock_uss,
+            flight_2_planning_time,
+            operation_filter(OperationID.NotifyOperationalIntentDetailsChanged),
+            direction_filter(QueryDirection.Outgoing),
+            notif_op_intent_id_filter(flight_2_oi_ref.id),
         )
         self.end_test_step()
 
         self.begin_test_step("Validate flight2 GET interaction, if no notification")
         if not tested_uss_notifications:
             tested_uss_get_requests, query = mock_uss_interactions(
-                scenario=self,
-                mock_uss=self.mock_uss,
-                op_id=OperationID.GetOperationalIntentDetails,
-                direction=QueryDirection.Incoming,
-                since=flight_1_planning_time,
-                query_params=dict(
-                    entityid=flight_2_oi_ref.id,
+                self,
+                self.mock_uss,
+                flight_1_planning_time,
+                operation_filter(
+                    OperationID.GetOperationalIntentDetails, entityid=flight_2_oi_ref.id
                 ),
+                direction_filter(QueryDirection.Incoming),
             )
             with self.check(
                 "Expect GET request when no notification",
@@ -322,26 +323,25 @@ class GetOpResponseDataValidationByUSS(TestScenario):
             "Check for notification to tested_uss due to subscription in flight 2 area"
         )
         tested_uss_notifications, _ = mock_uss_interactions(
-            scenario=self,
-            mock_uss=self.mock_uss,
-            op_id=OperationID.NotifyOperationalIntentDetailsChanged,
-            direction=QueryDirection.Outgoing,
-            since=flight_2_planning_time,
-            is_applicable=is_op_intent_notification_with_id(flight_2_oi_ref.id),
+            self,
+            self.mock_uss,
+            flight_2_planning_time,
+            operation_filter(OperationID.NotifyOperationalIntentDetailsChanged),
+            direction_filter(QueryDirection.Outgoing),
+            notif_op_intent_id_filter(flight_2_oi_ref.id),
         )
         self.end_test_step()
 
         self.begin_test_step("Validate flight2 GET interaction, if no notification")
         if not tested_uss_notifications:
             tested_uss_get_requests, query = mock_uss_interactions(
-                scenario=self,
-                mock_uss=self.mock_uss,
-                op_id=OperationID.GetOperationalIntentDetails,
-                direction=QueryDirection.Incoming,
-                since=flight_1_planning_time,
-                query_params=dict(
-                    entityid=flight_2_oi_ref.id,
+                self,
+                self.mock_uss,
+                flight_1_planning_time,
+                operation_filter(
+                    OperationID.GetOperationalIntentDetails, entityid=flight_2_oi_ref.id
                 ),
+                direction_filter(QueryDirection.Incoming),
             )
             with self.check(
                 "Expect GET request when no notification",

--- a/monitoring/uss_qualifier/scenarios/astm/utm/subscription_notifications/test_steps/validate_notification_received.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/subscription_notifications/test_steps/validate_notification_received.py
@@ -5,6 +5,10 @@ from monitoring.uss_qualifier.resources.interuss.mock_uss.client import MockUSSC
 from datetime import datetime
 from monitoring.uss_qualifier.scenarios.astm.utm.data_exchange_validation.test_steps.expected_interactions_test_steps import (
     mock_uss_interactions,
+    operation_filter,
+    direction_filter,
+    notif_op_intent_id_filter,
+    base_url_filter,
 )
 from monitoring.uss_qualifier.scenarios.astm.utm.data_exchange_validation.test_steps.wait import (
     wait_in_intervals,
@@ -52,14 +56,13 @@ def expect_tested_uss_receives_notification_from_mock_uss(
     ) as check:
         try:
             interactions, query = wait_in_intervals(mock_uss_interactions)(
-                scenario=scenario,
-                mock_uss=mock_uss,
-                op_id=OperationID.NotifyOperationalIntentDetailsChanged,
-                direction=QueryDirection.Outgoing,
-                since=StringBasedDateTime(interactions_since_time),
-                is_applicable=_is_notification_sent_to_url_with_op_intent_id(
-                    op_intent_ref_id, tested_uss_base_url
-                ),
+                scenario,
+                mock_uss,
+                StringBasedDateTime(interactions_since_time),
+                operation_filter(OperationID.NotifyOperationalIntentDetailsChanged),
+                direction_filter(QueryDirection.Outgoing),
+                notif_op_intent_id_filter(op_intent_ref_id),
+                base_url_filter(tested_uss_base_url),
             )
         except ValueError as e:
             check.record_failed(
@@ -110,42 +113,6 @@ def expect_tested_uss_receives_notification_from_mock_uss(
                     details=f"Invalid notification containing incorrect subscription_id should be rejected by tested_uss. Tested_uss responded with response status {resp_status} instead of 400.",
                     query_timestamps=[plan_request_time, query.request.timestamp],
                 )
-
-
-def _is_notification_sent_to_url_with_op_intent_id(
-    op_intent_id: str,
-    base_url: str,
-) -> Callable[[Interaction], bool]:
-    """
-    Returns an `is_applicable` function that detects if the request in an interaction is sent to the given url and with given op_intent_id
-
-    Args:
-        op_intent_id: The operational_intent id that needs to be notified
-        base_url: The url domain to which the notification request needs to be sent
-
-    """
-
-    def is_applicable(interaction: Interaction) -> bool:
-        if "json" in interaction.query.request and interaction.query.request.json:
-            if (
-                interaction.query.query_type
-                == QueryType.F3548v21USSNotifyOperationalIntentDetailsChanged
-            ):
-                try:
-                    notification = ImplicitDict.parse(
-                        interaction.query.request.json,
-                        PutOperationalIntentDetailsParameters,
-                    )
-                except (ValueError, TypeError, KeyError) as e:
-                    raise ValueError(
-                        f"Parsing mock_uss notification to type PutOperationalIntentDetailsParameters failed - {e}"
-                    )
-            return (notification.operational_intent_id == op_intent_id) and (
-                base_url in interaction.query.request.url
-            )
-        return False
-
-    return is_applicable
 
 
 def _check_notification_sent_with_subscription_id_and_response(


### PR DESCRIPTION
Issue #797
Stack on top of #829, please consider only last commit.

This refactors the way `mock_uss_interactions` filters interactions by generalizing the filtering by functions that already existed. On top of simplifying the logic, this enables invoking that function without any filters, which we will need in an upcoming PR.

- Usage of parameters `op_id` and `query_params` is replaced by filter function `operation_filter`
- Usage of parameter `direction` is replaced by filter function `direction_filter`
- `is_op_intent_notification_with_id` is renamed into `notif_op_intent_id_filter`
- `_is_notification_sent_to_url_with_op_intent_id` is replaced by new `base_url_filter` combined with existing `notif_op_intent_id_filter`
