### PR TITLE
[uss_qualifier/scenarios/utm/data_exchange_validation] Factor away fragment 'expect_uss_obtained_op_intent_details'

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md
@@ -45,16 +45,10 @@ which is of equal priority and came first.
 
 #### [Validate operational intent is shared](../validate_shared_operational_intent.md)
 
-### Check for notification to tested_uss due to subscription in flight 2 area test step
-In the following test step, we want to assert that tested_uss must have retrieved operational intent details from
-mock_uss via a GET request.  This assertion is only valid, however, if tested_uss did not obtain the  operational
-intent details in a different way -- specifically, a notification due to a pre-existing subscription.  In this test
-step, we determine if tested_uss had a pre-existing subscription by:
-
-#### [checking if mock_uss sent a notification to tested_uss](../../../interuss/mock_uss/get_mock_uss_interactions.md)
-
-### [Validate flight2 GET interaction, if no notification test step](test_steps/validate_get_operational_intent.md)
-This step is skipped if a notification to tested_uss was found in the previous step since tested_uss obtained the operational intent details of flight 2 without needing to perform a GET interaction.
+### [Validate that tested_uss obtained flight2 details test step](test_steps/validate_operational_intent_details_obtained.md)
+Validate that tested_uss obtained flight2 details from mock_uss, by means of either
+a notification pushed by mock_uss to tested_uss due to the pre-existing subscription, or
+direct retrieval by tested_uss from mock_uss.
 
 ### [Validate flight1 Notification sent to mock_uss test step](test_steps/validate_notification_operational_intent.md)
 tested_uss notifies mock_uss of flight 1, due to mock_uss's subscription covering flight 2 (which is necessarily relevant to flight 1 per test design).
@@ -93,16 +87,10 @@ The planning attempt should fail because tested_uss will be unable to obtain val
 
 Validate flight 1 is not shared with DSS, as plan failed.
 
-### Check for notification to tested_uss due to subscription in flight 2 area test step
-In the following test step, we want to assert that tested_uss must have retrieved operational intent details from
-mock_uss via a GET request.  This assertion is only valid, however, if tested_uss did not obtain the  operational
-intent details in a different way -- specifically, a notification due to a pre-existing subscription.  In this test
-step, we determine if tested_uss had a pre-existing subscription by:
-
-#### [Check if mock_uss sent a notification to tested_uss](../../../interuss/mock_uss/get_mock_uss_interactions.md)
-
-### [Validate flight2 GET interaction, if no notification test step](test_steps/validate_get_operational_intent.md)
-This step is skipped if a notification to tested_uss was found in the previous step.
+### [Validate that tested_uss obtained flight2 details test step](test_steps/validate_operational_intent_details_obtained.md)
+Validate that tested_uss obtained flight2 details from mock_uss, by means of either
+a notification pushed by mock_uss to tested_uss due to the pre-existing subscription, or
+direct retrieval by tested_uss from mock_uss.
 
 ### [Validate flight 1 Notification not sent to mock_uss test step](test_steps/validate_no_notification_operational_intent.md)
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/test_steps/validate_get_operational_intent.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/test_steps/validate_get_operational_intent.md
@@ -1,9 +1,0 @@
-# Validate GET interaction test step fragment
-
-This step verifies that a USS makes a GET request to get the intent_details of an existing operation when needed as per ASTM F3548-21 by checking the interuss interactions of mock uss
-
-## [Get Mock USS interactions logs](../../../../interuss/mock_uss/get_mock_uss_interactions.md)
-
-## 🛑 Expect GET request when no notification check
-**[astm.f3548.v21.SCD0035](../../../../../requirements/astm/f3548/v21.md)**
-SCD0035 needs a USS to verify before transitioning to Accepted that it does not conflict with a type of operational intent, and the only way to have verified this is by knowing all operational intent details, and (from previous checks of no notifications) the only way to know the operational intent details of flight is to have requested them via a GET details interaction.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/test_steps/validate_operational_intent_details_obtained.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/test_steps/validate_operational_intent_details_obtained.md
@@ -1,0 +1,11 @@
+# Validate operational intent details obtained test step fragment
+This step verifies that a USS obtained operational intent details from a Mock USS by means of either a notification from
+the Mock USS (push), or a GET request (operation *getOperationalIntentDetails*) to the Mock USS.
+
+## [Get Mock USS interactions logs](../../../../interuss/mock_uss/get_mock_uss_interactions.md)
+
+## 🛑 USS obtained operational intent details by means of either notification or GET request check
+SCD0035 requires a USS to verify before transitioning to Accepted that it does not conflict with another operational
+intent, and the only way to have verified this is by knowing all operational intent details.
+As such, if the USS was neither notified of the details by the Mock USS, nor did it retrieve them directly from the Mock
+USS, this check will fail per **[astm.f3548.v21.SCD0035](../../../../../requirements/astm/f3548/v21.md)**


### PR DESCRIPTION
Issue #797.
Stacked on top of #833, please consider only last commit.

This creates the test step fragment `expect_uss_obtained_op_intent_details` which is used in the scenario data_exchange_validation, replacing some parts of the scenario that were attempting to do the same with some conditional test steps.
With that change we do a single call to the mock USS to retrieve the interaction logs, and from there we are able to determine whether the tested USS has obtained the operational intent details, no matter how. This makes the documentation clearer.
The implementation of the check now validates as well that the status code of the notification or details retrieval is a success (previously a failed call would be considered as valid). 
   