### PR TITLE
[uss_qualifier] Upgrade to latest dss version; Add 'supports_ovn_request' field to dss resources; Fix DSSOVNRequest scenario

### DIFF
--- a/build/dev/docker-compose.yaml
+++ b/build/dev/docker-compose.yaml
@@ -25,8 +25,8 @@ services:
       start_interval: 5s
 
   rid_bootstrapper:
-    image: interuss/dss:v0.18.0-rc1
-    command: /usr/bin/db-manager --schemas_dir=/db-schemas/rid --db_version "latest" --cockroach_host crdb
+    image: interuss/dss:v0.19.0-rc2
+    command: /usr/bin/db-manager migrate --schemas_dir=/db-schemas/rid --db_version "latest" --cockroach_host crdb
     depends_on:
       crdb:
         condition: service_healthy
@@ -34,8 +34,8 @@ services:
       - dss_internal_network
 
   scd_bootstrapper:
-    image: interuss/dss:v0.18.0-rc1
-    command: /usr/bin/db-manager --schemas_dir=/db-schemas/scd --db_version "latest" --cockroach_host crdb
+    image: interuss/dss:v0.19.0-rc2
+    command: /usr/bin/db-manager migrate --schemas_dir=/db-schemas/scd --db_version "latest" --cockroach_host crdb
     depends_on:
       crdb:
         condition: service_healthy
@@ -44,7 +44,7 @@ services:
 
   dss:
     hostname: dss.uss1.localutm
-    image: interuss/dss:v0.18.0-rc1
+    image: interuss/dss:v0.19.0-rc2
     volumes:
       - $PWD/../test-certs:/var/test-certs:ro
       - $PWD/startup/core_service.sh:/startup/core_service.sh:ro

--- a/monitoring/uss_qualifier/configurations/dev/dss_probing.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/dss_probing.yaml
@@ -64,4 +64,4 @@ v1:
         pass_condition:
           elements:
             count:
-              equal_to: 8 # 6 CRDBAccess + 2 DSSOVNRequest scenarios are skipped
+              equal_to: 6 # 6 CRDBAccess scenarios are skipped

--- a/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml
@@ -134,6 +134,7 @@ v1:
             # A USS that hosts a DSS instance is also a participant in the test, even if they don't fulfill any other roles
             participant_id: uss1_dss
             base_url: http://dss.uss1.localutm
+            supports_ovn_request: true
 
         dss_instances:
           resource_type: resources.astm.f3548.v21.DSSInstancesResource
@@ -146,8 +147,10 @@ v1:
                   # Participants using a DSS instance they do not provide should be listed as users of that DSS (so that they can take credit for USS requirements enforced by the DSS)
                   - mock_uss  # mock_uss uses this DSS instance; it does not provide its own instance
                 base_url: http://dss.uss1.localutm
+                supports_ovn_request: true
               - participant_id: uss2_dss
                 base_url: http://dss.uss2.localutm
+                supports_ovn_request: true
 
         # Mock USS that can be used in tests for flight planning, modifying data sharing behavior and recording interactions
         mock_uss:

--- a/monitoring/uss_qualifier/configurations/dev/library/environment_containers.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/library/environment_containers.yaml
@@ -187,6 +187,7 @@ scd_dss:
   specification:
     participant_id: uss1
     base_url: http://dss.uss1.localutm
+    supports_ovn_request: true
 
 scd_dss_instances:
   $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
@@ -199,8 +200,10 @@ scd_dss_instances:
         user_participant_ids:
           - mock_uss
         base_url: http://dss.uss1.localutm
+        supports_ovn_request: true
       - participant_id: uss2
         base_url: http://dss.uss2.localutm
+        supports_ovn_request: true
 
 # ===== DSS CockroachDB nodes =====
 

--- a/monitoring/uss_qualifier/configurations/dev/library/environment_localhost.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/library/environment_localhost.yaml
@@ -186,6 +186,7 @@ scd_dss:
   specification:
     participant_id: uss1
     base_url: http://localhost:8082
+    supports_ovn_request: true
 
 scd_dss_instances:
   $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
@@ -198,8 +199,10 @@ scd_dss_instances:
         user_participant_ids:
           - mock_uss
         base_url: http://localhost:8082
+        supports_ovn_request: true
       - participant_id: uss2
         base_url: http://localhost:8082
+        supports_ovn_request: true
 
 # ===== DSS CockroachDB nodes =====
 

--- a/monitoring/uss_qualifier/configurations/dev/uspace.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/uspace.yaml
@@ -155,4 +155,4 @@ v1:
         pass_condition:
           elements:
             count:
-              equal_to: 6 # 4 CRDBAccess + 2 DSSOVNRequest scenarios are skipped
+              equal_to: 4 # 4 CRDBAccess scenarios are skipped

--- a/monitoring/uss_qualifier/configurations/dev/utm_implementation_us_lib/baseline.libsonnet
+++ b/monitoring/uss_qualifier/configurations/dev/utm_implementation_us_lib/baseline.libsonnet
@@ -417,7 +417,7 @@ function(env) {
               count: {
                 // We currently expect this amount of skipped scenarios: making it an equality
                 // to make sure this is reduced if some scenarios start to be executed
-                equal_to: 13,
+                equal_to: 11,
               },
             },
           },

--- a/monitoring/uss_qualifier/configurations/dev/utm_implementation_us_lib/local/env.libsonnet
+++ b/monitoring/uss_qualifier/configurations/dev/utm_implementation_us_lib/local/env.libsonnet
@@ -88,6 +88,7 @@ function(participants) {
         // A USS that hosts a DSS instance is also a participant in the test, even if they don't fulfill any other roles
         participant_id: 'uss1_dss',
         base_url: 'http://dss.uss1.localutm',
+        supports_ovn_request: true,
       },
     },
 

--- a/monitoring/uss_qualifier/configurations/dev/utm_implementation_us_lib/uss1.libsonnet
+++ b/monitoring/uss_qualifier/configurations/dev/utm_implementation_us_lib/uss1.libsonnet
@@ -44,6 +44,7 @@
           'mock_uss',  // mock_uss uses this DSS instance; it does not provide its own instance
         ],
         base_url: 'http://dss.uss1.localutm',
+        supports_ovn_request: true
       },
     ]
   }

--- a/monitoring/uss_qualifier/configurations/dev/utm_implementation_us_lib/uss2.libsonnet
+++ b/monitoring/uss_qualifier/configurations/dev/utm_implementation_us_lib/uss2.libsonnet
@@ -40,6 +40,7 @@
       {
         participant_id: 'uss2_dss',
         base_url: 'http://dss.uss2.localutm',
+        supports_ovn_request: true,
       },
     ]
   }

--- a/monitoring/uss_qualifier/scenarios/interuss/ovn_request/dss_ovn_request.md
+++ b/monitoring/uss_qualifier/scenarios/interuss/ovn_request/dss_ovn_request.md
@@ -45,22 +45,22 @@ Check that the DSS has set the expected OVN correctly.
 This case validates the off-nominal behaviors of the OVN request.
 
 ### Attempt to create OIR with OVN suffix request not being a UUID test step
-#### [Attempt to create OIR with OVN suffix request not being a UUID rejected check](./invalid_ovn_suffix_fragment.md)
+#### [Attempt to create OIR with OVN suffix request not being a UUID rejected](./invalid_ovn_suffix_fragment.md)
 Check that the DSS rejects OVN suffix that are not UUIDs.
 If the DSS accepts the OVN suffix, or fails with an unexpected error, this check will fail.
 
 ### Attempt to create OIR with OVN suffix request empty test step
-#### [Attempt to create OIR with OVN suffix request empty rejected check](./invalid_ovn_suffix_fragment.md)
+#### [Attempt to create OIR with OVN suffix request empty rejected](./invalid_ovn_suffix_fragment.md)
 Check that the DSS rejects OVN suffix that are empty.
 If the DSS accepts the OVN suffix, or fails with an unexpected error, this check will fail.
 
 ### Attempt to create OIR with OVN suffix request being a UUID but not v7 test step
-#### [Attempt to create OIR with OVN suffix request being a UUID but not v7 rejected check](./invalid_ovn_suffix_fragment.md)
+#### [Attempt to create OIR with OVN suffix request being a UUID but not v7 rejected](./invalid_ovn_suffix_fragment.md)
 Check that the DSS rejects OVN suffix that are UUIDs but not v7.
 If the DSS accepts the OVN suffix, or fails with an unexpected error, this check will fail.
 
 ### Attempt to create OIR with OVN suffix request being an outdated UUIDv7 test step
-#### [Attempt to create OIR with OVN suffix request being an outdated UUIDv7 rejected check](./invalid_ovn_suffix_fragment.md)
+#### [Attempt to create OIR with OVN suffix request being an outdated UUIDv7 rejected](./invalid_ovn_suffix_fragment.md)
 Check that the DSS rejects OVN suffix that are outdated UUIDv7.
 If the DSS accepts the OVN suffix, or fails with an unexpected error, this check will fail.
 

--- a/monitoring/uss_qualifier/scenarios/interuss/ovn_request/dss_ovn_request.py
+++ b/monitoring/uss_qualifier/scenarios/interuss/ovn_request/dss_ovn_request.py
@@ -77,7 +77,7 @@ class DSSOVNRequest(TestScenario):
 
         self.begin_test_step("Activate OIR with OVN suffix request")
         req_ovn_suffix = str(uuid7())
-        self._activate_oir(extents, oir.ovn, req_ovn_suffix)
+        oir = self._activate_oir(extents, oir.ovn, req_ovn_suffix)
         self._check_expected_ovn(req_ovn_suffix, oir)
         self.end_test_step()
 
@@ -164,6 +164,8 @@ class DSSOVNRequest(TestScenario):
                     details=qe.msg,
                     query_timestamps=qe.query_timestamps,
                 )
+
+        return oir
 
     def _create_invalid_oir_attempt(self, extents: List[Volume4D], req_ovn_suffix: str):
         with self.check(


### PR DESCRIPTION
Stacked on top of #816 please consider only last commit.
This upgrades the DSS version used up to v0.19.0-rc2 which has the OVN request support and adapt accordingly the specification of the DSS resources in the configurations.

This also fixes two issues that went unnoticed in the `DSSOVNRequest` scenario:
- not checking for the proper OVN in a step
- removing the `check` suffix when linking a test step fragment