### PR TITLE
[uss_qualifier/configurations/utm_implementation_us_lib] Fix number of skipped actions

### DIFF
--- a/monitoring/uss_qualifier/configurations/dev/utm_implementation_us_lib/baseline.libsonnet
+++ b/monitoring/uss_qualifier/configurations/dev/utm_implementation_us_lib/baseline.libsonnet
@@ -419,7 +419,7 @@ function(env) {
               count: {
                 // We currently expect this amount of skipped scenarios: making it an equality
                 // to make sure this is reduced if some scenarios start to be executed
-                equal_to: 11,
+                equal_to: 9,
               },
             },
           },


### PR DESCRIPTION
I merged #844 without updating the branch first, and the automatic merge with the concurrent changes from #848 ended up setting a wrong number of skipped actions, making the CI on the main branch failing.