### PR TITLE
[uss_qualifier] Add flag to ensure redaction of sensitive information

### DIFF
--- a/monitoring/monitorlib/dicts.py
+++ b/monitoring/monitorlib/dicts.py
@@ -1,5 +1,5 @@
 import json
-from typing import List, Tuple, Any, Union
+from typing import List, Tuple, Any, Union, Iterator
 
 from implicitdict import ImplicitDict
 
@@ -60,6 +60,17 @@ def get_element(obj: dict, element: Union[JSONAddress, List[str]], pop=False) ->
         raise ValueError(f"{str(e)} at {element}")
     except ValueError as e:
         raise ValueError(f"{str(e)} at {element}")
+
+
+def get_element_or_default(
+    obj: dict, element: Union[JSONAddress, List[str]], default_value: Any
+) -> Any:
+    try:
+        return get_element(obj, element)
+    except KeyError:
+        return default_value
+    except TypeError:
+        return default_value
 
 
 class RemovedElement(ImplicitDict):

--- a/monitoring/uss_qualifier/make_artifacts.py
+++ b/monitoring/uss_qualifier/make_artifacts.py
@@ -88,7 +88,7 @@ def main() -> int:
                 output_path = default_output_path(report_name)
             else:
                 output_path = default_output_path(config_name)
-            generate_artifacts(report, config.artifacts, output_path)
+            generate_artifacts(report, config.artifacts, output_path, False)
         else:
             output_path = "nowhere"
             logger.warning(f"No artifacts to generate for {config_name}")

--- a/monitoring/uss_qualifier/reports/artifacts.py
+++ b/monitoring/uss_qualifier/reports/artifacts.py
@@ -34,12 +34,18 @@ def generate_artifacts(
     report: TestRunReport,
     artifacts: ArtifactsConfiguration,
     output_path: str,
+    disallow_unredacted: bool,
 ):
     logger.debug(f"Writing artifacts to {os.path.abspath(output_path)}")
     os.makedirs(output_path, exist_ok=True)
 
     def _should_redact(cfg) -> bool:
-        return "redact_access_tokens" in cfg and cfg.redact_access_tokens
+        result = "redact_access_tokens" in cfg and cfg.redact_access_tokens
+        if disallow_unredacted and not result:
+            raise RuntimeError(
+                "The option to disallow unredacted information was set, but the configuration specified unredacted information any way"
+            )
+        return result
 
     logger.info(f"Redacting access tokens from report")
     redacted_report = ImplicitDict.parse(json.loads(json.dumps(report)), TestRunReport)


### PR DESCRIPTION
If a user provided execution of uss_qualifier as a service and accepted test configuration from their users, the uss_qualifier executer would want to make sure that a provided test configuration did not cause the artifacts to reveal sensitive information.  This PR adds that capability by adding a --disallow-unredacted flag that produces an error if a test configuration is provided which doesn't redact sensitive information from artifacts.  A redundant check is also added in the artifact generation routine that double checks this redaction directive.