### PR TITLE
[deps] update uas_standards dependency to 3.3.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -46,5 +46,5 @@ scipy==1.13.0
 shapely==1.7.1
 structlog==21.5.0  # deployment_manager
 termcolor==1.1.0
-uas_standards==3.2.2
+uas_standards==3.3.0
 uuid6==2024.7.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1621,9 +1621,9 @@ tzdata==2024.1 \
     --hash=sha256:2674120f8d891909751c38abcdfd386ac0a5a1127954fbc332af6b5ceae07efd \
     --hash=sha256:9068bc196136463f5245e51efda838afa15aaeca9903f49050dfa2679db4d252
     # via pandas
-uas-standards==3.2.2 \
-    --hash=sha256:c9cee8f30e6f238570ad4aa83029d4c48d4e8ea38651907d0a51ceaea0ab3b38 \
-    --hash=sha256:de710dec3a8f6e7ee66ae3cc386416dce52e862efba519ba9de64fea76f9e048
+uas-standards==3.3.0 \
+    --hash=sha256:38f3010d3a946349ad12652190c54d6c190f676ec6d3a31555e59321b7b20b13 \
+    --hash=sha256:8ff8e3befa0230374a8e3d7362a7d5bbe6e5f17028c2bdc484603f696f963e52
     # via -r requirements.in
 urllib3==2.2.1 \
     --hash=sha256:450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d \


### PR DESCRIPTION
This will give us access to the new optional fields in the observation APIs