### PR TITLE
[uss_qualifier/netrid] Fix injection of aircraft_type

### DIFF
--- a/monitoring/uss_qualifier/resources/netrid/flight_data_resources.py
+++ b/monitoring/uss_qualifier/resources/netrid/flight_data_resources.py
@@ -75,7 +75,6 @@ class FlightDataResource(Resource[FlightDataSpecification]):
             details = TestFlightDetails(
                 effective_after=StringBasedDateTime(t0),
                 details=flight.flight_details,
-                aircraft_type=flight.aircraft_type,
             )
 
             test_flights.append(
@@ -83,6 +82,7 @@ class FlightDataResource(Resource[FlightDataSpecification]):
                     injection_id=str(uuid.uuid4()),
                     telemetry=telemetry,
                     details_responses=[details],
+                    aircraft_type=flight.aircraft_type,
                 )
             )
 


### PR DESCRIPTION
`aircraft_type` is actually attached to `TestFlight`:
https://github.com/BenjaminPelletier/automated_testing_interfaces/blob/bd9971a43d8a708187567f3da4ce06ea214575ec/rid/v1/injection.yaml#L402-L405

And not `TestFlightDetails`: 
https://github.com/BenjaminPelletier/automated_testing_interfaces/blob/bd9971a43d8a708187567f3da4ce06ea214575ec/rid/v1/injection.yaml#L418-L434
