### PR TITLE
[mock_uss/riddp] Expose aircraft_type through observation interface

### DIFF
--- a/monitoring/mock_uss/riddp/routes_observation.py
+++ b/monitoring/mock_uss/riddp/routes_observation.py
@@ -22,6 +22,7 @@ from monitoring.mock_uss.auth import requires_scope
 from uas_standards.interuss.automated_testing.rid.v1.observation import (
     AltitudeReference,
     MSLAltitude,
+    UAType,
 )
 from . import clustering, database, utm_client
 from .behavior import DisplayProviderBehavior
@@ -79,6 +80,9 @@ def _make_flight_observation(
         h.distance = limit_resolution(h.distance, MinHeightResolution)
     return observation_api.Flight(
         id=flight.id,
+        aircraft_type=flight.aircraft_type
+        if flight.aircraft_type
+        else UAType.NotDeclared,
         most_recent_position=observation_api.Position(
             lat=p.lat,
             lng=p.lng,

--- a/monitoring/monitorlib/fetch/rid.py
+++ b/monitoring/monitorlib/fetch/rid.py
@@ -358,6 +358,23 @@ class Flight(ImplicitDict):
                 f"Cannot retrieve speed using RID version {self.rid_version}"
             )
 
+    @property
+    def aircraft_type(
+        self,
+    ) -> Optional[Union[v19.api.RIDAircraftType, v22a.api.UAType]]:
+        if self.rid_version == RIDVersion.f3411_19:
+            if not self.v19_value.has_field_with_value("aircraft_type"):
+                return None
+            return self.v19_value.aircraft_type
+        elif self.rid_version == RIDVersion.f3411_22a:
+            if not self.v22a_value.has_field_with_value("aircraft_type"):
+                return None
+            return self.v22a_value.aircraft_type
+        else:
+            raise NotImplementedError(
+                f"Cannot retrieve aircraft_type using RID version {self.rid_version}"
+            )
+
     def errors(self) -> List[str]:
         try:
             rid_version = self.rid_version


### PR DESCRIPTION
Follow-up to #859: the DP interface also required an update. In addition this adds in the fetch package the necessary functions to extract the aircraft type from the fetched flight.