### PR TITLE
[uss_qualifier/resources/netrid] Use models from injection interface rather than RID v19

### DIFF
--- a/monitoring/uss_qualifier/resources/netrid/flight_data.py
+++ b/monitoring/uss_qualifier/resources/netrid/flight_data.py
@@ -3,17 +3,17 @@ from typing import List, Optional
 from implicitdict import ImplicitDict, StringBasedDateTime, StringBasedTimeDelta
 
 from monitoring.uss_qualifier.resources.files import ExternalFile
-from uas_standards.astm.f3411.v19.api import RIDAircraftState, RIDFlightDetails
+from uas_standards.interuss.automated_testing.rid.v1 import injection
 
 
 class FullFlightRecord(ImplicitDict):
     reference_time: StringBasedDateTime
     """The reference time of this flight (usually the time of first telemetry)"""
 
-    states: List[RIDAircraftState]
+    states: List[injection.RIDAircraftState]
     """All telemetry that will be/was received for this flight"""
 
-    flight_details: RIDFlightDetails
+    flight_details: injection.RIDFlightDetails
     """Details of this flight, as would be reported at the ASTM /details endpoint"""
 
     aircraft_type: str

--- a/monitoring/uss_qualifier/resources/netrid/simulation/adjacent_circular_flights_simulator.py
+++ b/monitoring/uss_qualifier/resources/netrid/simulation/adjacent_circular_flights_simulator.py
@@ -16,14 +16,8 @@ from monitoring.uss_qualifier.resources.netrid.flight_data import (
 from monitoring.uss_qualifier.resources.netrid.simulation import (
     operator_flight_details,
 )
-from uas_standards.astm.f3411.v19.api import (
-    HorizontalAccuracy,
-    VerticalAccuracy,
-    RIDAircraftPosition,
-    RIDAircraftState,
-    RIDHeight,
-    RIDFlightDetails,
-)
+from uas_standards.interuss.automated_testing.rid.v1 import injection
+
 from .utils import (
     QueryBoundingBox,
     FlightPoint,
@@ -254,7 +248,7 @@ class AdjacentCircularFlightsSimulator:
 
         self.grid_cells_flight_tracks = all_grid_cell_tracks
 
-    def generate_flight_details(self, id: str) -> RIDFlightDetails:
+    def generate_flight_details(self, id: str) -> injection.RIDFlightDetails:
         """This class generates details of flights and operator details for a flight, this data is required for identifying flight, operator and operation"""
 
         my_flight_details_generator = (
@@ -262,7 +256,7 @@ class AdjacentCircularFlightsSimulator:
         )
 
         # TODO: Put operator_location in center of circle rather than stacking operators of all flights on top of each other
-        return RIDFlightDetails(
+        return injection.RIDFlightDetails(
             id=id,
             serial_number=my_flight_details_generator.generate_serial_number(),
             operation_description=my_flight_details_generator.generate_operation_description(),
@@ -280,7 +274,7 @@ class AdjacentCircularFlightsSimulator:
 
 
         """
-        all_flight_telemetry: List[List[RIDAircraftState]] = []
+        all_flight_telemetry: List[List[injection.RIDAircraftState]] = []
         flight_track_details = {}  # Develop a index of flight length and their index
         # Store where on the track the current index is, since the tracks are circular, once the end of the track is reached, the index is reset to 0 to indicate beginning of the track again.
         flight_current_index = {}
@@ -320,19 +314,19 @@ class AdjacentCircularFlightsSimulator:
                     flight_point = self.grid_cells_flight_tracks[k].track[
                         flight_current_index[k]
                     ]
-                    aircraft_position = RIDAircraftPosition(
+                    aircraft_position = injection.RIDAircraftPosition(
                         lat=flight_point.lat,
                         lng=flight_point.lng,
                         alt=flight_point.alt,
-                        accuracy_h=HorizontalAccuracy.HAUnknown,
-                        accuracy_v=VerticalAccuracy.VAUnknown,
+                        accuracy_h=injection.HorizontalAccuracy.HAUnknown,
+                        accuracy_v=injection.VerticalAccuracy.VAUnknown,
                         extrapolated=False,
                     )
-                    aircraft_height = RIDHeight(
+                    aircraft_height = injection.RIDHeight(
                         distance=self.altitude_agl, reference="TakeoffLocation"
                     )
 
-                    rid_aircraft_state = RIDAircraftState(
+                    rid_aircraft_state = injection.RIDAircraftState(
                         timestamp=timestamp_isoformat,
                         operational_status="Airborne",
                         position=aircraft_position,

--- a/monitoring/uss_qualifier/resources/netrid/simulation/kml_flights.py
+++ b/monitoring/uss_qualifier/resources/netrid/simulation/kml_flights.py
@@ -18,12 +18,8 @@ from monitoring.uss_qualifier.resources.netrid.flight_data import (
 )
 from typing import List
 
-from uas_standards.astm.f3411.v19.api import (
-    LatLngPoint,
-    RIDFlightDetails,
-    RIDAircraftPosition,
-    RIDAircraftState,
-)
+from uas_standards.interuss.automated_testing.rid.v1 import injection
+
 
 STATE_INCREMENT_SECONDS = 1
 
@@ -191,13 +187,13 @@ def generate_flight_record(
         r = random.Random(x=random_seed)
     now_isoformat = timestamp.isoformat()
 
-    flight_telemetry: List[RIDAircraftState] = []
+    flight_telemetry: List[injection.RIDAircraftState] = []
     for coordinates, speed, angle in zip(
         state_coordinates, flight_state_speeds, flight_track_angles
     ):
         timestamp = timestamp + timedelta(0, STATE_INCREMENT_SECONDS)
         timestamp_isoformat = timestamp.isoformat()
-        aircraft_position = RIDAircraftPosition(
+        aircraft_position = injection.RIDAircraftPosition(
             lng=coordinates[0],
             lat=coordinates[1],
             alt=coordinates[2],
@@ -206,7 +202,7 @@ def generate_flight_record(
             extrapolated=False,
         )
         aircraft_height = None
-        rid_aircraft_state = RIDAircraftState(
+        rid_aircraft_state = injection.RIDAircraftState(
             timestamp=StringBasedDateTime(timestamp_isoformat),
             operational_status="Airborne",
             position=aircraft_position,
@@ -221,13 +217,13 @@ def generate_flight_record(
         )
         flight_telemetry.append(rid_aircraft_state)
     flight_id_bytes = bytes(r.randint(0, 255) for _ in range(16))
-    rid_details = RIDFlightDetails(
+    rid_details = injection.RIDFlightDetails(
         id=flight_description.get(
             "id", str(uuid.UUID(bytes=flight_id_bytes, version=4))
         ),
         serial_number=flight_description.get("serial_number"),
         operation_description=flight_description.get("operation_description"),
-        operator_location=LatLngPoint(
+        operator_location=injection.LatLngPoint(
             lat=float(operator_location.get("lat")),
             lng=float(operator_location.get("lng")),
         ),

--- a/monitoring/uss_qualifier/resources/netrid/simulation/operator_flight_details.py
+++ b/monitoring/uss_qualifier/resources/netrid/simulation/operator_flight_details.py
@@ -1,10 +1,9 @@
 from faker import Faker
 import string
 import random
-import uuid
 from uas_standards.ansi_cta_2063_a import SerialNumber
 
-from uas_standards.astm.f3411.v19.api import LatLngPoint
+from uas_standards.interuss.automated_testing.rid.v1 import injection
 
 
 class OperatorFlightDataGenerator:
@@ -38,7 +37,7 @@ class OperatorFlightDataGenerator:
 
     def generate_operator_location(self, centroid):
         # TODO: Inject operator location altitude
-        operator_location = LatLngPoint(lat=centroid.y, lng=centroid.x)
+        operator_location = injection.LatLngPoint(lat=centroid.y, lng=centroid.x)
         return operator_location
 
     def generate_operator_id(self, prefix="OP-"):


### PR DESCRIPTION
The models from the injection/observation interface are compatible with both versions of RID.
Before the changes in that PR, some RID models from v19 were used for injection, making impossible to test v22a-specific features like 'UA classification'.