### PR TITLE
[uss_qualifier/resources/netrid/simulation/kml_flights] Add support for 'eu_classification' field

### DIFF
--- a/monitoring/uss_qualifier/resources/netrid/simulation/kml_flights.py
+++ b/monitoring/uss_qualifier/resources/netrid/simulation/kml_flights.py
@@ -217,6 +217,17 @@ def generate_flight_record(
         )
         flight_telemetry.append(rid_aircraft_state)
     flight_id_bytes = bytes(r.randint(0, 255) for _ in range(16))
+    eu_classification = None
+    if (
+        flight_description.get("eu_classification_category") is not None
+        and flight_description.get("eu_classification_class") is not None
+    ):
+        eu_classification = injection.UAClassificationEU(
+            {
+                "category": flight_description.get("eu_classification_category"),
+                "class": flight_description.get("eu_classification_class"),
+            }
+        )
     rid_details = injection.RIDFlightDetails(
         id=flight_description.get(
             "id", str(uuid.UUID(bytes=flight_id_bytes, version=4))
@@ -229,6 +240,7 @@ def generate_flight_record(
         ),
         operator_id=flight_description.get("operator_id"),
         registration_number=flight_description.get("registration_number"),
+        eu_classification=eu_classification,
     )
 
     return FullFlightRecord(

--- a/monitoring/uss_qualifier/test_data/che/rid/foca.kml
+++ b/monitoring/uss_qualifier/test_data/che/rid/foca.kml
@@ -322,7 +322,9 @@ timestamp_accuracy: 1.0
 speed_accuracy: SA3mps
 sample_rate: 1.0
 accuracy_h: HAUnknown
-accuracy_v: VAUnknown</description>
+accuracy_v: VAUnknown
+eu_classification_category: EUCategoryUndefined
+eu_classification_class: EUClassUndefined</description>
 			<Placemark>
 				<name>operator_location</name>
 				<LookAt>
@@ -424,7 +426,9 @@ timestamp_accuracy: 1.0
 speed_accuracy: SA3mps
 sample_rate: 1.0
 accuracy_h: HAUnknown
-accuracy_v: VAUnknown</description>
+accuracy_v: VAUnknown
+eu_classification_category: EUCategoryUndefined
+eu_classification_class: EUClassUndefined</description>
 			<Placemark>
 				<name>Head west</name>
 				<styleUrl>#msn_ylw-pushpin10</styleUrl>


### PR DESCRIPTION
Stacked on top of #868, please review only last commit.

This adds the support for 'eu_classification' field in the KML flight resource generator by specifying directly both elements 'eu_classification_category' and 'eu_classification_class'.
This also adds to the KML file used in the CI those fields so that they are injected by the USS qualifier.