### PR TITLE
[uss_qualifier/scenarios/netrid/nominal_behavior] Add checks for UA classification in SP (NET0260)

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/netrid/display_data_evaluator.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/display_data_evaluator.py
@@ -1198,8 +1198,18 @@ class RIDObservationEvaluator(object):
                         query_timestamps=[details_query.query.request.timestamp],
                     )
 
+            # Get details that are expected to be valid for the present telemetry:
+            telemetry_inj = mapping.injected_flight.flight.telemetry[
+                mapping.telemetry_index
+            ]
+            details_inj = mapping.injected_flight.flight.get_details(
+                telemetry_inj.timestamp.datetime
+            )
             self._common_dictionary_evaluator.evaluate_sp_details(
-                details_query.details, [mapping.injected_flight.uss_participant_id]
+                details_inj,
+                details_query.details,
+                mapping.injected_flight.uss_participant_id,
+                details_query.query.request.timestamp,
             )
 
     def _evaluate_area_too_large_sp_observation(

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/common_dictionary_evaluator_sp_flight_details.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/common_dictionary_evaluator_sp_flight_details.md
@@ -10,6 +10,27 @@ NET0260 requires that relevant Remote ID data, consistent with the common data d
 
 NET0260 requires that relevant Remote ID data, consistent with the common data dictionary, be reported by the Service Provider. This check validates that the UAS ID is in serial number format. (**[astm.f3411.v22a.NET0260,Table1,1a](../../../../requirements/astm/f3411/v22a.md)**)
 
+## ⚠️ UA classification type is consistent with injected one check
+
+**[astm.f3411.v22a.NET0260,Table1,4](../../../../requirements/astm/f3411/v22a.md)** requires that relevant Remote ID data, consistent with the common data dictionary, be reported by the Service Provider.
+This check will fail if the UA classification type is inconsistent with the injected value.
+
+## ⚠️ UA classification type is consistent with Common Data Dictionary check
+
+**[astm.f3411.v22a.NET0260,Table1,4](../../../../requirements/astm/f3411/v22a.md)** requires that relevant Remote ID data, consistent with the common data dictionary, be reported by the Service Provider.
+The UA classification type is implicitly defined by the presence of an UA classification field, or left undefined by the absence of all of them.
+This check will fail if more than one UA classification types are defined.
+
+## ⚠️ UA classification for 'European Union' type is consistent with injected one check
+
+**[astm.f3411.v22a.NET0260,Table1,3](../../../../requirements/astm/f3411/v22a.md)** requires that relevant Remote ID data, consistent with the common data dictionary, be reported by the Service Provider.
+The UA classification being an optional field, this check will fail only if it is inconsistent with the injected value.
+
+## ⚠️ UA classification for 'European Union' type is consistent with Common Data Dictionary check
+
+**[astm.f3411.v22a.NET0260,Table1,3](../../../../requirements/astm/f3411/v22a.md)** requires that relevant Remote ID data, consistent with the common data dictionary, be reported by the Service Provider.
+This check will fail if the UA classification has an invalid value.
+
 ## Operator ID consistency with Common Dictionary check
 
 NET0260 requires that relevant Remote ID data, consistent with the common data dictionary, be reported by the Service Provider. This check validates that the Operator ID, if present, is expressed as ASCII text. (**[astm.f3411.v22a.NET0260,Table1,9](../../../../requirements/astm/f3411/v22a.md)**)

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a.md
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a.md
@@ -21,7 +21,7 @@
     <th><a href="../../README.md#checked-in">Checked in</a></th>
   </tr>
   <tr>
-    <td rowspan="100" style="vertical-align:top;"><a href="../../../requirements/astm/f3411/v22a.md">astm<br>.f3411<br>.v22a</a></td>
+    <td rowspan="102" style="vertical-align:top;"><a href="../../../requirements/astm/f3411/v22a.md">astm<br>.f3411<br>.v22a</a></td>
     <td><a href="../../../requirements/astm/f3411/v22a.md">DSS0010</a></td>
     <td>Implemented</td>
     <td><a href="../../../scenarios/astm/netrid/v22a/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a></td>
@@ -348,6 +348,16 @@
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3411/v22a.md">NET0260,Table1,26</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/netrid/v22a/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3411/v22a.md">NET0260,Table1,3</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/netrid/v22a/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3411/v22a.md">NET0260,Table1,4</a></td>
     <td>Implemented</td>
     <td><a href="../../../scenarios/astm/netrid/v22a/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
   </tr>

--- a/monitoring/uss_qualifier/suites/uspace/network_identification.md
+++ b/monitoring/uss_qualifier/suites/uspace/network_identification.md
@@ -17,7 +17,7 @@
     <th><a href="../README.md#checked-in">Checked in</a></th>
   </tr>
   <tr>
-    <td rowspan="100" style="vertical-align:top;"><a href="../../requirements/astm/f3411/v22a.md">astm<br>.f3411<br>.v22a</a></td>
+    <td rowspan="102" style="vertical-align:top;"><a href="../../requirements/astm/f3411/v22a.md">astm<br>.f3411<br>.v22a</a></td>
     <td><a href="../../requirements/astm/f3411/v22a.md">DSS0010</a></td>
     <td>Implemented</td>
     <td><a href="../../scenarios/astm/netrid/v22a/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a></td>
@@ -344,6 +344,16 @@
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3411/v22a.md">NET0260,Table1,26</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/netrid/v22a/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3411/v22a.md">NET0260,Table1,3</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/netrid/v22a/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3411/v22a.md">NET0260,Table1,4</a></td>
     <td>Implemented</td>
     <td><a href="../../scenarios/astm/netrid/v22a/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
   </tr>

--- a/monitoring/uss_qualifier/suites/uspace/required_services.md
+++ b/monitoring/uss_qualifier/suites/uspace/required_services.md
@@ -18,7 +18,7 @@
     <th><a href="../README.md#checked-in">Checked in</a></th>
   </tr>
   <tr>
-    <td rowspan="100" style="vertical-align:top;"><a href="../../requirements/astm/f3411/v22a.md">astm<br>.f3411<br>.v22a</a></td>
+    <td rowspan="102" style="vertical-align:top;"><a href="../../requirements/astm/f3411/v22a.md">astm<br>.f3411<br>.v22a</a></td>
     <td><a href="../../requirements/astm/f3411/v22a.md">DSS0010</a></td>
     <td>Implemented</td>
     <td><a href="../../scenarios/astm/netrid/v22a/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a></td>
@@ -345,6 +345,16 @@
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3411/v22a.md">NET0260,Table1,26</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/netrid/v22a/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3411/v22a.md">NET0260,Table1,3</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/netrid/v22a/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3411/v22a.md">NET0260,Table1,4</a></td>
     <td>Implemented</td>
     <td><a href="../../scenarios/astm/netrid/v22a/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
   </tr>


### PR DESCRIPTION
This adds the checks for UA classification and UA classification type exposed by SP (requirements NET0260,Table1,3 and  NET0260,Table1,4).