### PR TITLE
[mock_uss/obervation-api] add newly exposed API fields to the current_state

### DIFF
--- a/monitoring/mock_uss/riddp/routes_observation.py
+++ b/monitoring/mock_uss/riddp/routes_observation.py
@@ -71,9 +71,12 @@ def _make_flight_observation(
     msl_alt = MSLAltitude(meters=msl_alt_m, reference_datum=AltitudeReference.EGM96)
     current_state = observation_api.CurrentState(
         timestamp=p.time.isoformat(),
+        timestamp_accuracy=flight.timestamp_accuracy,
         operational_status=flight.operational_status,
         track=limit_resolution(flight.track, MinTrackDirectionResolution),
         speed=limit_resolution(flight.speed, MinSpeedResolution),
+        speed_accuracy=flight.speed_accuracy,
+        vertical_speed=flight.vertical_speed,
     )
     h = p.get("height")
     if h:

--- a/monitoring/monitorlib/fetch/rid.py
+++ b/monitoring/monitorlib/fetch/rid.py
@@ -359,6 +359,38 @@ class Flight(ImplicitDict):
             )
 
     @property
+    def speed_accuracy(
+        self,
+    ) -> Optional[Union[v19.api.SpeedAccuracy, v22a.api.SpeedAccuracy]]:
+        if self.rid_version == RIDVersion.f3411_19:
+            if not self.v19_value.has_field_with_value("current_state"):
+                return None
+            return self.v19_value.current_state.speed_accuracy
+        elif self.rid_version == RIDVersion.f3411_22a:
+            if not self.v22a_value.has_field_with_value("current_state"):
+                return None
+            return self.v22a_value.current_state.speed_accuracy
+        else:
+            raise NotImplementedError(
+                f"Cannot retrieve speed accuracy using RID version {self.rid_version}"
+            )
+
+    @property
+    def vertical_speed(self) -> Optional[float]:
+        if self.rid_version == RIDVersion.f3411_19:
+            if not self.v19_value.has_field_with_value("current_state"):
+                return None
+            return self.v19_value.current_state.vertical_speed
+        elif self.rid_version == RIDVersion.f3411_22a:
+            if not self.v22a_value.has_field_with_value("current_state"):
+                return None
+            return self.v22a_value.current_state.vertical_speed
+        else:
+            raise NotImplementedError(
+                f"Cannot retrieve vertical speed using RID version {self.rid_version}"
+            )
+
+    @property
     def aircraft_type(
         self,
     ) -> Optional[Union[v19.api.RIDAircraftType, v22a.api.UAType]]:


### PR DESCRIPTION
When the mock_uss acts like a Display Provider, we want it to expose the relevant fields of `current_state` that were defined in the injected data. 

We now populates the following additional fields:
* timestamp_accuracy=flight.timestamp_accuracy,
* speed_accuracy=flight.speed_accuracy,
* vertical_speed=flight.vertical_speed,