### PR TITLE
[mock_uss] interaction logging for the mock RID DP and SP

### DIFF
--- a/monitoring/mock_uss/__init__.py
+++ b/monitoring/mock_uss/__init__.py
@@ -108,6 +108,10 @@ if SERVICE_INTERACTION_LOGGING in webapp.config[config.KEY_SERVICES]:
     from monitoring.mock_uss.interaction_logging import logger as interactions_logger
     from monitoring.mock_uss.interaction_logging import routes_interactions_log
 
+    logger.info("Interaction logging enabled")
+else:
+    logger.info("Interaction logging disabled")
+
 if SERVICE_TRACER in webapp.config[config.KEY_SERVICES]:
     enabled_services.add(SERVICE_TRACER)
     from monitoring.mock_uss import tracer

--- a/monitoring/mock_uss/docker-compose.yaml
+++ b/monitoring/mock_uss/docker-compose.yaml
@@ -106,7 +106,8 @@ services:
       - MOCK_USS_PUBLIC_KEY=/var/test-certs/auth2.pem
       - MOCK_USS_TOKEN_AUDIENCE=v22a.ridsp.uss1.localutm,localhost,host.docker.internal
       - MOCK_USS_BASE_URL=http://v22a.ridsp.uss1.localutm
-      - MOCK_USS_SERVICES=ridsp
+      - MOCK_USS_SERVICES=ridsp,interaction_logging
+      - MOCK_USS_INTERACTIONS_LOG_DIR=output/ridsp_interaction_logs
       - MOCK_USS_RID_VERSION=F3411-22a
       - MOCK_USS_PORT=80
       - MOCK_USS_PROXY_VALUES=x_for=1,x_proto=1,x_host=1,x_prefix=1,x_port=1
@@ -116,6 +117,7 @@ services:
       - 8081:80
     volumes:
       - ../../build/test-certs:/var/test-certs:ro
+      - ./output/ridsp_interaction_logs:/app/monitoring/mock_uss/output/ridsp_interaction_logs
     restart: always
     networks:
       - interop_ecosystem_network
@@ -136,7 +138,8 @@ services:
       - MOCK_USS_PUBLIC_KEY=/var/test-certs/auth2.pem
       - MOCK_USS_TOKEN_AUDIENCE=v22a.riddp.uss1.localutm,localhost,host.docker.internal
       - MOCK_USS_BASE_URL=http://v22a.riddp.uss1.localutm
-      - MOCK_USS_SERVICES=riddp
+      - MOCK_USS_SERVICES=riddp,interaction_logging
+      - MOCK_USS_INTERACTIONS_LOG_DIR=output/riddp_interaction_logs
       - MOCK_USS_RID_VERSION=F3411-22a
       - MOCK_USS_PORT=80
       - MOCK_USS_PROXY_VALUES=x_for=1,x_proto=1,x_host=1,x_prefix=1,x_port=1
@@ -146,6 +149,7 @@ services:
       - 8083:80
     volumes:
       - ../../build/test-certs:/var/test-certs:ro
+      - ./output/riddp_interaction_logs:/app/monitoring/mock_uss/output/riddp_interaction_logs
     restart: always
     networks:
       - interop_ecosystem_network
@@ -166,7 +170,8 @@ services:
       - MOCK_USS_PUBLIC_KEY=/var/test-certs/auth2.pem
       - MOCK_USS_TOKEN_AUDIENCE=v19.ridsp.uss2.localutm,localhost,host.docker.internal
       - MOCK_USS_BASE_URL=http://v19.ridsp.uss2.localutm
-      - MOCK_USS_SERVICES=ridsp
+      - MOCK_USS_SERVICES=ridsp,interaction_logging
+      - MOCK_USS_INTERACTIONS_LOG_DIR=output/ridsp_v19_interaction_logs
       - MOCK_USS_RID_VERSION=F3411-19
       - MOCK_USS_PORT=80
       - MOCK_USS_PROXY_VALUES=x_for=1,x_proto=1,x_host=1,x_prefix=1,x_port=1
@@ -176,6 +181,7 @@ services:
       - 8071:80
     volumes:
       - ../../build/test-certs:/var/test-certs:ro
+      - ./output/ridsp_v19_interaction_logs:/app/monitoring/mock_uss/output/ridsp_v19_interaction_logs
     restart: always
     networks:
       - interop_ecosystem_network
@@ -196,7 +202,8 @@ services:
       - MOCK_USS_PUBLIC_KEY=/var/test-certs/auth2.pem
       - MOCK_USS_TOKEN_AUDIENCE=v19.riddp.uss3.localutm,localhost,host.docker.internal
       - MOCK_USS_BASE_URL=http://v19.riddp.uss3.localutm
-      - MOCK_USS_SERVICES=riddp
+      - MOCK_USS_SERVICES=riddp,interaction_logging
+      - MOCK_USS_INTERACTIONS_LOG_DIR=output/riddp_v19_interaction_logs
       - MOCK_USS_RID_VERSION=F3411-19
       - MOCK_USS_PORT=80
       - MOCK_USS_PROXY_VALUES=x_for=1,x_proto=1,x_host=1,x_prefix=1,x_port=1
@@ -206,6 +213,7 @@ services:
       - 8073:80
     volumes:
       - ../../build/test-certs:/var/test-certs:ro
+      - ./output/riddp_v19_interaction_logs:/app/monitoring/mock_uss/output/riddp_v19_interaction_logs
     restart: always
     networks:
       - interop_ecosystem_network

--- a/monitoring/mock_uss/interaction_logging/logger.py
+++ b/monitoring/mock_uss/interaction_logging/logger.py
@@ -3,7 +3,6 @@ import json
 import os
 
 import flask
-import arrow
 
 from monitoring.mock_uss import webapp, require_config_value
 from monitoring.mock_uss.interaction_logging.config import KEY_INTERACTIONS_LOG_DIR
@@ -53,6 +52,12 @@ class InteractionLoggingHook(QueryHook):
         if "query_type" in query and query.query_type in {
             QueryType.F3548v21USSGetOperationalIntentDetails,
             QueryType.F3548v21USSNotifyOperationalIntentDetailsChanged,
+            QueryType.F3411v19USSGetFlightDetails,
+            QueryType.F3411v19USSPostIdentificationServiceArea,
+            QueryType.F3411v19USSSearchFlights,
+            QueryType.F3411v22aUSSSearchFlights,
+            QueryType.F3411v22aUSSGetFlightDetails,
+            QueryType.F3411v22aUSSPostIdentificationServiceArea,
         }:
             log_interaction(QueryDirection.Outgoing, query)
 
@@ -72,7 +77,11 @@ def interaction_log_after_request(response):
         datetime.datetime.now(datetime.UTC) - flask.current_app.custom_profiler["start"]
     ).total_seconds()
     # TODO: Make this configurable instead of hardcoding exactly these query types
-    if "/uss/v1/" in flask.request.url:
+    if (
+        "/uss/v1/" in flask.request.url
+        or "/uss/identification_service_areas/" in flask.request.url
+        or "/uss/flights/" in flask.request.url
+    ):
         query = describe_flask_query(flask.request, response, elapsed_s)
         log_interaction(QueryDirection.Incoming, query)
     return response


### PR DESCRIPTION
In preparation for RID Net0740 (DP with a subscription is notified of newly created ISAs), we wish to determine if the mock_uss has received the relevant requests when it is deployed as a Remote ID Display Provider.

For the sake of completeness this also enables interaction logging for flight search and flight details endpoint, and does so on the mock SP as well.

This also logs at startup whether or not interaction logging is enabled.