### PR TITLE
[uss_qualifier/scenarios/netrid/misbehavior] Add checks for invalid credentials (NET0210)

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/misbehavior.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/misbehavior.md
@@ -44,12 +44,20 @@ This particular test requires each flight to be uniquely identifiable by its 2D 
 In order to properly test whether the SP handles authentication correctly, this step will first attempt to do a request with the proper credentials
 to confirm that the requested data is indeed available to any authorized query.
 
-It then repeats the exact same request with incorrect credentials, and expects this to fail.
+It then repeats the exact same request without credentials, and expects this to fail.
 
 #### Missing credentials check
 
 This check ensures that all requests are properly authenticated, as required by **[astm.f3411.v19.NET0210](../../../../requirements/astm/f3411/v19.md)**,
-and that requests for existing flights that are executed with missing or incorrect credentials fail.
+and that requests for existing flights that are executed with missing credentials fail.
+
+### Incorrectly authenticated requests test step
+
+This step is similar to unauthenticated requests, but uses incorrectly-authenticated requests instead.
+
+#### ⚠️ Invalid credentials check
+This check ensures that all requests are properly authenticated, as required by **[astm.f3411.v19.NET0210](../../../../requirements/astm/f3411/v19.md)**,
+and that requests for existing flights that are executed with incorrect credentials fail.
 
 ## Cleanup
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/misbehavior.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/misbehavior.md
@@ -44,12 +44,21 @@ This particular test requires each flight to be uniquely identifiable by its 2D 
 In order to properly test whether the SP handles authentication correctly, this step will first attempt to do a request with the proper credentials
 to confirm that the requested data is indeed available to any authorized query.
 
-It then repeats the exact same request with incorrect credentials, and expects this to fail.
+It then repeats the exact same request without credentials, and expects this to fail.
 
 #### Missing credentials check
 
 This check ensures that all requests are properly authenticated, as required by **[astm.f3411.v22a.NET0210](../../../../requirements/astm/f3411/v22a.md)**,
-and that requests for existing flights that are executed with missing or incorrect credentials fail.
+and that requests for existing flights that are executed with missing credentials fail.
+
+### Incorrectly authenticated requests test step
+
+This step is similar to unauthenticated requests, but uses incorrectly-authenticated requests instead.
+
+#### ⚠️ Invalid credentials check
+
+This check ensures that all requests are properly authenticated, as required by **[astm.f3411.v22a.NET0210](../../../../requirements/astm/f3411/v22a.md)**,
+and that requests for existing flights that are executed with incorrect credentials fail.
 
 ## Cleanup
 


### PR DESCRIPTION
This PR adds two steps in misbehavior scenario to ensure invalid credentials (and not only missing credentials) return authentication failures, as stated in #874