### PR TITLE
[mock_uss] add isa notification endpoint to mock RID display provider

### DIFF
--- a/monitoring/mock_uss/riddp/routes.py
+++ b/monitoring/mock_uss/riddp/routes.py
@@ -1,10 +1,23 @@
 from monitoring.mock_uss import webapp
+from monitoring.mock_uss.riddp.config import KEY_RID_VERSION
+from ...monitorlib.rid import RIDVersion
+
+rid_version: RIDVersion = webapp.config[KEY_RID_VERSION]
 
 
 @webapp.route("/riddp/status")
 def riddp_status():
     return "Mock RID Display Provider ok"
 
+
+if rid_version == RIDVersion.f3411_19:
+    from . import routes_riddp_v19
+elif rid_version == RIDVersion.f3411_22a:
+    from . import routes_riddp_v22a
+else:
+    raise NotImplementedError(
+        f"Mock USS does not yet support RID version {rid_version}"
+    )
 
 from . import routes_observation
 from . import routes_behavior

--- a/monitoring/mock_uss/riddp/routes_riddp_v19.py
+++ b/monitoring/mock_uss/riddp/routes_riddp_v19.py
@@ -1,0 +1,39 @@
+import flask
+from implicitdict import ImplicitDict
+from uas_standards.astm.f3411.v19.api import (
+    OperationID,
+    OPERATIONS,
+    PutIdentificationServiceAreaNotificationParameters,
+)
+from uas_standards.astm.f3411.v19.constants import (
+    Scope,
+)
+
+from monitoring.mock_uss import webapp
+from monitoring.mock_uss.auth import requires_scope
+
+
+def rid_v19_operation(op_id: OperationID):
+    op = OPERATIONS[op_id]
+    path = op.path.replace("{", "<").replace("}", ">")
+    return webapp.route("/mock/riddp" + path, methods=[op.verb])
+
+
+@rid_v19_operation(OperationID.PostIdentificationServiceArea)
+@requires_scope(Scope.Write)
+def ridsp_notify_isa_v19(id: str):
+    try:
+        json = flask.request.json
+        if json is None:
+            raise ValueError("Request did not contain a JSON payload")
+        ImplicitDict.parse(json, PutIdentificationServiceAreaNotificationParameters)
+    except ValueError as e:
+        msg = "Unable to parse PutIdentificationServiceAreaNotificationParameters JSON request: {}".format(
+            e
+        )
+        return msg, 400
+
+    return (
+        flask.jsonify(None),
+        204,
+    )

--- a/monitoring/mock_uss/riddp/routes_riddp_v22a.py
+++ b/monitoring/mock_uss/riddp/routes_riddp_v22a.py
@@ -1,0 +1,39 @@
+import flask
+from implicitdict import ImplicitDict
+from uas_standards.astm.f3411.v22a.api import (
+    OperationID,
+    OPERATIONS,
+    PutIdentificationServiceAreaNotificationParameters,
+)
+from uas_standards.astm.f3411.v22a.constants import (
+    Scope,
+)
+
+from monitoring.mock_uss import webapp
+from monitoring.mock_uss.auth import requires_scope
+
+
+def rid_v22a_operation(op_id: OperationID):
+    op = OPERATIONS[op_id]
+    path = op.path.replace("{", "<").replace("}", ">")
+    return webapp.route("/mock/riddp" + path, methods=[op.verb])
+
+
+@rid_v22a_operation(OperationID.PostIdentificationServiceArea)
+@requires_scope(Scope.ServiceProvider)
+def ridsp_notify_isa_v22a(id: str):
+    try:
+        json = flask.request.json
+        if json is None:
+            raise ValueError("Request did not contain a JSON payload")
+        ImplicitDict.parse(json, PutIdentificationServiceAreaNotificationParameters)
+    except ValueError as e:
+        msg = "Unable to parse PutIdentificationServiceAreaNotificationParameters JSON request: {}".format(
+            e
+        )
+        return msg, 400
+
+    return (
+        flask.jsonify(None),
+        204,
+    )


### PR DESCRIPTION
This complements #881 by implementing one of the endpoints for which we will want to log interactions. (Part of the effort to cover Net0740)