### PR TITLE
[uss_qualifier/scenarios/netrid/common_dictionary_evaluator] Simplify check for UA type

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common_dictionary_evaluator.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common_dictionary_evaluator.py
@@ -783,21 +783,14 @@ class RIDCommonDictionaryEvaluator(object):
         ) as check:
             equivalent = {injection.UAType.HybridLift, injection.UAType.VTOL}
 
-            if injected_val is None:
-                if (
-                    sp_observed_flight is not None
-                    and observed_val != injection.UAType.NotDeclared
-                ):  # C6
+            if dp_observed_flight is not None and observed_val is None:
+                pass  # C8
+
+            elif injected_val is None:
+                if observed_val != injection.UAType.NotDeclared:  # C6 / C10
                     check.record_failed(
                         "UA type is inconsistent, expected 'NotDeclared' since no value was injected",
-                        details=f"SP returned the UA type {observed_val}, yet no value was injected, which should have been mapped to 'NotDeclared'.",
-                        query_timestamps=[query_timestamp],
-                    )
-
-                if dp_observed_flight is not None and observed_val is not None:  # C10
-                    check.record_failed(
-                        "UA type is inconsistent, expected no value since none was injected",
-                        details=f"DP returned the UA type {observed_val}, yet no value was injected.",
+                        details=f"USS returned the UA type {observed_val} yet no value was injected. Since 'aircraft_type' is a required field of SP API, the SP should map this to 'NotDeclared' and the DP should expose the same value.",
                         query_timestamps=[query_timestamp],
                     )
 


### PR DESCRIPTION
Changes:
- If the result checked is from the DP and that it is None, don't perform any additional checks since the DP (through observation API) will never be required to expose any field (case C8).
- When the injected value is None, expect both SP and DP to expose `NotDeclared`
  - SP: because it is a required field that must be exposed, so None is not a valid value
  - DP: because the DP must expose what it received from the SP (even though in the observation API the field is nullable)

Those changes simplify the control flow of the check and should also facilitate implementation of generic function in #894.
Notably because there should now only be two cases: whether or not the field is required in SP API. Which is equivalent to whether or not this is a required field by the standard. 

Note for #894 (cc @the-glu): the corresponding check for when the field is not required in SP API would look like this:
```python
                if injected_eu_category is None:
                    if observed_eu_category is not None and observed_eu_category != injection.UAClassificationEUCategory.EUCategoryUndefined:  # C6 / C10
                        check.record_failed(
                            "UA classification for 'European Union' type has an invalid category, expected none or 'EUCategoryUndefined' since no value was injected.",
                            details=f"USS returned the category of UA classification for 'European Union' type {observed_eu_category} yet no value was injected. Since 'category' is not a required field of SP API, the SP should omit the value or map this to 'EUCategoryUndefined' and the DP should expose the same value.",
                            query_timestamps=[query_timestamp],
                        )
```