### PR TITLE
[uss_qualifier/netrid] Add test for NET0730

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dp_behavior.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dp_behavior.py
@@ -110,7 +110,11 @@ class DisplayProviderBehavior(GenericTestScenario):
         self.begin_test_step("Clean workspace")
         self._clean_isa()
         self.end_test_step()
+        self.end_test_case()
 
+        # TODO: Implement Subscription priming test case
+
+        self.begin_test_case("Create flight")
         self.begin_test_step("Create ISA")
         # Create an ISA that points to the mock_uss playing the role of an SP
         self._step_create_isa()

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dp_behavior.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dp_behavior.md
@@ -58,7 +58,7 @@ If the ISA cannot be created, the PUT DSS endpoint in **[astm.f3411.v19.DSS0030,
 
 #### ⚠️ DP accepted ISA notification check
 
-Prior to ISA creation, the Display Providers of one or more observers may have established subscriptions for the area due to subscription priming above.  If a subscription was present but the managing Display Provider did not acknowledge a notification correctly, the Display Provider will have failed to meet **[astm.f3411.v22a.NET0730](../../../../requirements/astm/f3411/v22a.md)**.  If a Display Provider did not establish a subscription, this check cannot be evaluated as no notification was sent.
+Prior to ISA creation, the Display Providers of one or more observers may have established subscriptions for the area due to subscription priming above.  If a subscription was present but the managing Display Provider did not acknowledge a notification correctly, the Display Provider will have failed to meet **[astm.f3411.v19.NET0730](../../../../requirements/astm/f3411/v19.md)**.  If a Display Provider did not establish a subscription, this check cannot be evaluated as no notification was sent.
 
 TODO: Implement this check
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dp_behavior.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dp_behavior.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This scenario attempts to cause a Display Provider to issue queries to a Service Provider for a too large area.
+This scenario observes Display Provider behavior when interacting with a Service Provider.  It attempts to observe the Display Provider correctly acknowledging an ISA notification from the Service Provider, and it also attempts to cause a Display Provider to issue invalid queries to the Service Provider.
 
 ## Resources
 
@@ -30,15 +30,37 @@ The set of [`NetRIDObserversResource`](../../../../resources/netrid/observers.py
 
 ### [Clean workspace test step](./dss/test_steps/clean_workspace.md)
 
+## Subscription priming test case
+
+Observers are queried for flights in an attempt to cause the Display Providers to establish subscriptions so that mock_uss will send ISA notifications when it creates its ISA.
+
+### Query observers test step
+
+Each observer is queried for flights in the empty area.
+
+#### 🛑 Observation query succeeds check
+
+**[interuss.automated_testing.rid.observation.ObservationSuccess](../../../../requirements/interuss/automated_testing/rid/observation.md)** requires that the Display Provider provides observation data for valid queries.
+
+## Create flight test case
+
+This test step has the mock_uss begin a new flight by establishing an ISA.
+
 ### [Create ISA test step](./dss/test_steps/put_isa.md)
 
-Create an ISA in the area specified by the `isa` resource, valid from the moment the scenario runs and for a duration of 5 minutes.
+uss_qualifier, acting as mock_uss, creates an ISA in the area specified by the `isa` resource, valid from the moment the scenario runs and for a duration of 5 minutes.
 
 The USS base URL will be the one specified by the passed `mock_uss` resource.
 
 #### 🛑 Create an ISA check
 
 If the ISA cannot be created, the PUT DSS endpoint in **[astm.f3411.v19.DSS0030,a](../../../../requirements/astm/f3411/v19.md)** is likely not implemented correctly.
+
+#### ⚠️ DP accepted ISA notification check
+
+Prior to ISA creation, the Display Providers of one or more observers may have established subscriptions for the area due to subscription priming above.  If a subscription was present but the managing Display Provider did not acknowledge a notification correctly, the Display Provider will have failed to meet **[astm.f3411.v22a.NET0730](../../../../requirements/astm/f3411/v22a.md)**.  If a Display Provider did not establish a subscription, this check cannot be evaluated as no notification was sent.
+
+TODO: Implement this check
 
 ## Display Provider Behavior test case
 
@@ -52,7 +74,7 @@ This test step queries the Display Provider for the exact area of the ISA.
 
 ### Query maximum diagonal area test step
 
-#### 🛑 Maximum diagonal area query succeeds check
+#### ⚠️ Maximum diagonal area query succeeds check
 
 **[interuss.automated_testing.rid.observation.ObservationSuccess](../../../../requirements/interuss/automated_testing/rid/observation.md)** requires that the Display Provider provides data for queries for an area with a diagonal no greater than `NetMaxDisplayAreaDiagonal` (3,6).
 
@@ -60,15 +82,17 @@ If the Display Provider does not respond to a request for data in an area with a
 
 ### Query too long diagonal test step
 
-#### 🛑 Too long diagonal query fails check
+#### ⚠️ Too long diagonal query fails check
 
 **[astm.f3411.v19.NET0430](../../../../requirements/astm/f3411/v19.md)** requires that the Display Provider provides data for queries for an area with a diagonal no greater than `NetMaxDisplayAreaDiagonal` (3,6).
 
 If the Display Provider responds with anything else than an error, it is in violation of this requirement.
 
-### [Verify query to SP test step](../../../interuss/mock_uss/get_mock_uss_interactions.md)
+### Verify query to SP test step
 
 Validate that the Display Provider queried the SP and behaved correctly while doing so.
+
+#### [Get mock_uss interactions](../../../interuss/mock_uss/get_mock_uss_interactions.md)
 
 #### 🛑 DP queried SP check
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dp_behavior.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dp_behavior.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This scenario attempts to cause a Display Provider to issue queries to a Service Provider for a too large area.
+This scenario observes Display Provider behavior when interacting with a Service Provider.  It attempts to observe the Display Provider correctly acknowledging an ISA notification from the Service Provider, and it also attempts to cause a Display Provider to issue invalid queries to the Service Provider.
 
 ## Resources
 
@@ -30,15 +30,37 @@ The set of [`NetRIDObserversResource`](../../../../resources/netrid/observers.py
 
 ### [Clean workspace test step](./dss/test_steps/clean_workspace.md)
 
+## Subscription priming test case
+
+Observers are queried for flights in an attempt to cause the Display Providers to establish subscriptions so that mock_uss will send ISA notifications when it creates its ISA.
+
+### Query observers test step
+
+Each observer is queried for flights in the empty area.
+
+#### 🛑 Observation query succeeds check
+
+**[interuss.automated_testing.rid.observation.ObservationSuccess](../../../../requirements/interuss/automated_testing/rid/observation.md)** requires that the Display Provider provides observation data for valid queries.
+
+## Create flight test case
+
+This test step has the mock_uss begin a new flight by establishing an ISA.
+
 ### [Create ISA test step](./dss/test_steps/put_isa.md)
 
-Create an ISA in the area specified by the `isa` resource, valid from the moment the scenario runs and for a duration of 5 minutes.
+uss_qualifier, acting as mock_uss, creates an ISA in the area specified by the `isa` resource, valid from the moment the scenario runs and for a duration of 5 minutes.
 
 The USS base URL will be the one specified by the passed `mock_uss` resource.
 
 #### 🛑 Create an ISA check
 
 If the ISA cannot be created, the PUT DSS endpoint in **[astm.f3411.v22a.DSS0030,a](../../../../requirements/astm/f3411/v22a.md)** is likely not implemented correctly.
+
+#### ⚠️ DP accepted ISA notification check
+
+Prior to ISA creation, the Display Providers of one or more observers may have established subscriptions for the area due to subscription priming above.  If a subscription was present but the managing Display Provider did not acknowledge a notification correctly, the Display Provider will have failed to meet **[astm.f3411.v22a.NET0730](../../../../requirements/astm/f3411/v22a.md)**.  If a Display Provider did not establish a subscription, this check cannot be evaluated as no notification was sent.
+
+TODO: Implement this check
 
 ## Display Provider Behavior test case
 
@@ -52,7 +74,7 @@ This test step queries the Display Provider for the exact area of the ISA.
 
 ### Query maximum diagonal area test step
 
-#### 🛑 Maximum diagonal area query succeeds check
+#### ⚠️ Maximum diagonal area query succeeds check
 
 **[interuss.automated_testing.rid.observation.ObservationSuccess](../../../../requirements/interuss/automated_testing/rid/observation.md)** requires that the Display Provider provides data for queries for an area with a diagonal no greater than `NetMaxDisplayAreaDiagonal` (7km).
 
@@ -60,15 +82,17 @@ If the Display Provider does not respond to a request for data in an area with a
 
 ### Query too long diagonal test step
 
-#### 🛑 Too long diagonal query fails check
+#### ⚠️ Too long diagonal query fails check
 
 **[astm.f3411.v22a.NET0430](../../../../requirements/astm/f3411/v22a.md)** requires that the Display Provider provides data for queries for an area with a diagonal no greater than `NetMaxDisplayAreaDiagonal` (7km).
 
 If the Display Provider responds with anything else than an error, it is in violation of this requirement.
 
-### [Verify query to SP test step](../../../interuss/mock_uss/get_mock_uss_interactions.md)
+### Verify query to SP test step
 
 Validate that the Display Provider queried the SP and behaved correctly while doing so.
+
+#### [Get mock_uss interactions](../../../interuss/mock_uss/get_mock_uss_interactions.md)
 
 #### 🛑 DP queried SP check
 

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_19.md
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_19.md
@@ -441,14 +441,8 @@
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3411/v19.md">NET0730</a></td>
-    <td>Implemented</td>
+    <td>Implemented + TODO</td>
     <td><a href="../../../scenarios/astm/netrid/v19/dss/heavy_traffic_concurrent.md">ASTM NetRID DSS: Concurrent Requests</a><br><a href="../../../scenarios/astm/netrid/v19/dss/isa_expiry.md">ASTM NetRID DSS: ISA Expiry</a><br><a href="../../../scenarios/astm/netrid/v19/dss/isa_subscription_interactions.md">ASTM NetRID DSS: ISA Subscription Interactions</a><br><a href="../../../scenarios/astm/netrid/v19/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../../scenarios/astm/netrid/v19/dss/isa_validation.md">ASTM NetRID DSS: Submitted ISA Validations</a><br><a href="../../../scenarios/astm/netrid/v19/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/netrid/v19/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/netrid/v19/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a><br><a href="../../../scenarios/astm/netrid/v19/dp_behavior.md">ASTM NetRID Display Provider behavior</a><br><a href="../../../scenarios/astm/netrid/v19/sp_notification_behavior.md">ASTM NetRID Service Provider notification behavior</a></td>
-  </tr>
-  <tr>
-    <td rowspan="1" style="vertical-align:top;"><a href="../../../requirements/astm/f3411/v22a.md">astm<br>.f3411<br>.v22a</a></td>
-    <td><a href="../../../requirements/astm/f3411/v22a.md">NET0730</a></td>
-    <td>TODO</td>
-    <td><a href="../../../scenarios/astm/netrid/v19/dp_behavior.md">ASTM NetRID Display Provider behavior</a></td>
   </tr>
   <tr>
     <td rowspan="4" style="vertical-align:top;"><a href="../../../requirements/interuss/automated_testing/rid/injection.md">interuss<br>.automated_testing<br>.rid<br>.injection</a></td>

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_19.md
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_19.md
@@ -445,6 +445,12 @@
     <td><a href="../../../scenarios/astm/netrid/v19/dss/heavy_traffic_concurrent.md">ASTM NetRID DSS: Concurrent Requests</a><br><a href="../../../scenarios/astm/netrid/v19/dss/isa_expiry.md">ASTM NetRID DSS: ISA Expiry</a><br><a href="../../../scenarios/astm/netrid/v19/dss/isa_subscription_interactions.md">ASTM NetRID DSS: ISA Subscription Interactions</a><br><a href="../../../scenarios/astm/netrid/v19/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../../scenarios/astm/netrid/v19/dss/isa_validation.md">ASTM NetRID DSS: Submitted ISA Validations</a><br><a href="../../../scenarios/astm/netrid/v19/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/netrid/v19/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/netrid/v19/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a><br><a href="../../../scenarios/astm/netrid/v19/dp_behavior.md">ASTM NetRID Display Provider behavior</a><br><a href="../../../scenarios/astm/netrid/v19/sp_notification_behavior.md">ASTM NetRID Service Provider notification behavior</a></td>
   </tr>
   <tr>
+    <td rowspan="1" style="vertical-align:top;"><a href="../../../requirements/astm/f3411/v22a.md">astm<br>.f3411<br>.v22a</a></td>
+    <td><a href="../../../requirements/astm/f3411/v22a.md">NET0730</a></td>
+    <td>TODO</td>
+    <td><a href="../../../scenarios/astm/netrid/v19/dp_behavior.md">ASTM NetRID Display Provider behavior</a></td>
+  </tr>
+  <tr>
     <td rowspan="4" style="vertical-align:top;"><a href="../../../requirements/interuss/automated_testing/rid/injection.md">interuss<br>.automated_testing<br>.rid<br>.injection</a></td>
     <td><a href="../../../requirements/interuss/automated_testing/rid/injection.md">DeleteTestSuccess</a></td>
     <td>Implemented</td>

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a.md
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a.md
@@ -571,7 +571,7 @@
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3411/v22a.md">NET0730</a></td>
-    <td>Implemented</td>
+    <td>Implemented + TODO</td>
     <td><a href="../../../scenarios/astm/netrid/v22a/dss/heavy_traffic_concurrent.md">ASTM NetRID DSS: Concurrent Requests</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/isa_expiry.md">ASTM NetRID DSS: ISA Expiry</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/isa_subscription_interactions.md">ASTM NetRID DSS: ISA Subscription Interactions</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/isa_validation.md">ASTM NetRID DSS: Submitted ISA Validations</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a><br><a href="../../../scenarios/astm/netrid/v22a/dp_behavior.md">ASTM NetRID Display Provider behavior</a><br><a href="../../../scenarios/astm/netrid/v22a/sp_notification_behavior.md">ASTM NetRID Service Provider notification behavior</a></td>
   </tr>
   <tr>

--- a/monitoring/uss_qualifier/suites/uspace/network_identification.md
+++ b/monitoring/uss_qualifier/suites/uspace/network_identification.md
@@ -564,7 +564,7 @@
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3411/v22a.md">NET0730</a></td>
-    <td>Implemented</td>
+    <td>Implemented + TODO</td>
     <td><a href="../../scenarios/astm/netrid/v22a/dss/heavy_traffic_concurrent.md">ASTM NetRID DSS: Concurrent Requests</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_expiry.md">ASTM NetRID DSS: ISA Expiry</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_subscription_interactions.md">ASTM NetRID DSS: ISA Subscription Interactions</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_validation.md">ASTM NetRID DSS: Submitted ISA Validations</a><br><a href="../../scenarios/astm/netrid/v22a/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a><br><a href="../../scenarios/astm/netrid/v22a/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a><br><a href="../../scenarios/astm/netrid/v22a/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a><br><a href="../../scenarios/astm/netrid/v22a/dp_behavior.md">ASTM NetRID Display Provider behavior</a><br><a href="../../scenarios/astm/netrid/v22a/sp_notification_behavior.md">ASTM NetRID Service Provider notification behavior</a></td>
   </tr>
   <tr>

--- a/monitoring/uss_qualifier/suites/uspace/required_services.md
+++ b/monitoring/uss_qualifier/suites/uspace/required_services.md
@@ -565,7 +565,7 @@
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3411/v22a.md">NET0730</a></td>
-    <td>Implemented</td>
+    <td>Implemented + TODO</td>
     <td><a href="../../scenarios/astm/netrid/v22a/dss/heavy_traffic_concurrent.md">ASTM NetRID DSS: Concurrent Requests</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_expiry.md">ASTM NetRID DSS: ISA Expiry</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_subscription_interactions.md">ASTM NetRID DSS: ISA Subscription Interactions</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_validation.md">ASTM NetRID DSS: Submitted ISA Validations</a><br><a href="../../scenarios/astm/netrid/v22a/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a><br><a href="../../scenarios/astm/netrid/v22a/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a><br><a href="../../scenarios/astm/netrid/v22a/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a><br><a href="../../scenarios/astm/netrid/v22a/dp_behavior.md">ASTM NetRID Display Provider behavior</a><br><a href="../../scenarios/astm/netrid/v22a/sp_notification_behavior.md">ASTM NetRID Service Provider notification behavior</a></td>
   </tr>
   <tr>


### PR DESCRIPTION
Although we currently have checks for NET0730, I do not believe we have a test that is likely to verify compliance to NET0730 under nominal circumstances.  This PR addresses that issue by adding documentation for a test intended to verify NET0730 compliance under many (but not all) circumstances.

NET0730 essentially requires that a Display Provider accept and properly acknowledge incoming notifications due to a subscription the Display Provider has established in the DSS.  There is currently no way to ensure a Display Provider necessarily has a subscription in the DSS, but many Display Providers will create a subscription when an observer starts looking at a particular area.  Therefore, the DP Behavior test is adjusted in this PR to first query observers before establishing an ISA in an attempt to elicit this subscription-creation behavior, and then check for successful notifications to Display Providers in order to verify compliance to NET0730.  The key new check is "DP accepted ISA notification".

An implementation challenge will be determining which participant to credit with NET0730 compliance due to correct notification behavior, since the only identifying information for a notification (SubscriberToNotify) is the `subscription_id` and `url` to which the notification is to be sent.  The implementation plan is to determine the participant ID from the `url` by creating and optionally using a new resource type that provides ASTM F3411 identifying information per participant.  For this test, this will include an array of regexes identifying URLs that belong to each participant, so the `url` of the SubscriberToNotify can be used to determine the participant ID of the responsible participant.  For other tests, USS ID (`sub` in access tokens) could also be added to this resource to potentially address other issues we currently have regarding attribution of behaviors observed using F3411 USS IDs.

The next PR will add the new resource described above and optionally provide it to this test scenario.  The same PR or a second follow-up will implement the new steps and checks to complete this new test for NET0730.