### PR TITLE
[dev] Lower docker image healthcheck interval

### DIFF
--- a/monitoring/Dockerfile
+++ b/monitoring/Dockerfile
@@ -50,7 +50,7 @@ WORKDIR /app/monitoring
 RUN mkdir -p /app/uss-host-files
 
 # This script indicates the status of the container
-HEALTHCHECK CMD sh /app/health_check.sh
+HEALTHCHECK --interval=3s CMD sh /app/health_check.sh
 
 # Discover `monitoring` module in Python
 ENV PYTHONPATH=/app


### PR DESCRIPTION
The health checks have a interval of 30s by default, who can be quite long when restarting mocks for testing multiple time.

This PR lower the interval to 3s, making restarts / starts faster.

Since the heath checks are only simple curl call or a simple `exit 0`, this shouldn't probably hurt CPU usage.