### PR TITLE
[uss_qualifier] doc: split out some fragments for nominal behavior

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/fragments/flight_check.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/fragments/flight_check.md
@@ -1,0 +1,19 @@
+# Flight check test step fragment
+
+This test step fragment documents the validation of an injected test flight
+
+## ⚠️ Flights data format check
+
+**[astm.f3411.v19.NET0710,1](../../../../../requirements/astm/f3411/v19.md)** and **[astm.f3411.v19.NET0340](../../../../../requirements/astm/f3411/v19.md)** requires a Service Provider to implement the P2P portion of the OpenAPI specification. This check will fail if the response to the /flights endpoint does not validate against the OpenAPI-specified schema.
+
+
+## ⚠️ Recent positions for aircraft crossing the requested area boundary show only one position before or after crossing check
+
+**[astm.f3411.v19.NET0270](../../../../../requirements/astm/f3411/v19.md)** requires that when an aircraft enters or leaves the queried area, the last or first reported position outside the area is provided in the recent positions, as long as it is not older than NetMaxNearRealTimeDataPeriod.
+
+This implies that any recent position outside the area must be either preceded or followed by a position inside the area.
+
+(This check validates NET0270 b and c).
+
+## [Flight consistency with Common Data Dictionary checks](../common_dictionary_evaluator_sp_flight.md)
+

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/fragments/flight_details_check.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/fragments/flight_details_check.md
@@ -1,0 +1,11 @@
+# Flight details check test step fragment
+
+This test step fragment documents the validation of an injected test flight's details
+
+## ⚠️ Flight details data format check
+
+**[astm.f3411.v19.NET0710,2](../../../../../requirements/astm/f3411/v19.md)** and **[astm.f3411.v19.NET0340](../../../../../requirements/astm/f3411/v19.md) require a Service Provider to implement the P2P portion of the OpenAPI specification.  This check will fail if the response to the flight details endpoint does not validate against the OpenAPI-specified schema.
+
+## ⚠️ Recent positions timestamps check
+
+**[astm.f3411.v19.NET0270](../../../../../requirements/astm/f3411/v19.md)** requires all recent positions to be within the NetMaxNearRealTimeDataPeriod. This check will fail if any of the reported positions are older than the maximally allowed period plus NetSpDataResponseTime99thPercentile.

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/nominal_behavior.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/nominal_behavior.md
@@ -36,31 +36,13 @@ In this step, uss_qualifier injects a single nominal flight into each SP under t
 
 If a DSS was provided to this test scenario, uss_qualifier acts as a Display Provider to query Service Providers under test in this step.
 
+#### [Validate injected flight](./fragments/flight_check.md)
+
+#### [Validate injected flight details](./fragments/flight_details_check.md)
+
 #### ⚠️ Area too large check
 
 **[astm.f3411.v19.NET0250](../../../../requirements/astm/f3411/v19.md)** requires that a NetRID Service Provider rejects a request for a very large view area with a diagonal greater than *NetMaxDisplayAreaDiagonal*.  If such a large view is requested and a 413 error code is not received, then this check will fail.
-
-#### ⚠️ Flights data format check
-
-**[astm.f3411.v19.NET0710,1](../../../../requirements/astm/f3411/v19.md)** and **[astm.f3411.v19.NET0340](../../../../requirements/astm/f3411/v19.md)** require a Service Provider to implement the P2P portion of the OpenAPI specification.  This check will fail if the response to the /flights endpoint does not validate against the OpenAPI-specified schema.
-
-#### [Flight consistency with Common Data Dictionary checks](./common_dictionary_evaluator_sp_flight.md)
-
-#### ⚠️ Recent positions timestamps check
-
-**[astm.f3411.v19.NET0270](../../../../requirements/astm/f3411/v19.md)** requires all recent positions to be within the NetMaxNearRealTimeDataPeriod. This check will fail if any of the reported positions are older than the maximally allowed period plus NetSpDataResponseTime99thPercentile.
-
-#### ⚠️ Recent positions for aircraft crossing the requested area boundary show only one position before or after crossing check
-
-**[astm.f3411.v19.NET0270](../../../../requirements/astm/f3411/v19.md)** requires that when an aircraft enters or leaves the queried area, the last or first reported position outside the area is provided in the recent positions, as long as it is not older than NetMaxNearRealTimeDataPeriod.
-
-This implies that any recent position outside the area must be either preceded or followed by a position inside the area.
-
-(This check validates NET0270 b and c).
-
-#### ⚠️ Flight details data format check
-
-**[astm.f3411.v19.NET0710,2](../../../../requirements/astm/f3411/v19.md)** and **[astm.f3411.v19.NET0340](../../../../requirements/astm/f3411/v19.md)** require a Service Provider to implement the P2P portion of the OpenAPI specification.  This check will fail if the response to the flight details endpoint does not validate against the OpenAPI-specified schema.
 
 ### Observer polling test step
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/fragments/flight_check.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/fragments/flight_check.md
@@ -1,0 +1,19 @@
+# Flight check test step fragment
+
+This test step fragment documents the validation of an injected test flight
+
+## ⚠️ Flights data format check
+
+**[astm.f3411.v22a.NET0710,1](../../../../../requirements/astm/f3411/v22a.md)** and **[astm.f3411.v22a.NET0340](../../../../../requirements/astm/f3411/v22a.md)** requires a Service Provider to implement the P2P portion of the OpenAPI specification. This check will fail if the response to the /flights endpoint does not validate against the OpenAPI-specified schema.
+
+
+## ⚠️ Recent positions for aircraft crossing the requested area boundary show only one position before or after crossing check
+
+**[astm.f3411.v22a.NET0270](../../../../../requirements/astm/f3411/v22a.md)** requires that when an aircraft enters or leaves the queried area, the last or first reported position outside the area is provided in the recent positions, as long as it is not older than NetMaxNearRealTimeDataPeriod.
+
+This implies that any recent position outside the area must be either preceded or followed by a position inside the area.
+
+(This check validates NET0270 b and c).
+
+## [Flight consistency with Common Data Dictionary checks](../common_dictionary_evaluator_sp_flight.md)
+

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/fragments/flight_details_check.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/fragments/flight_details_check.md
@@ -1,0 +1,13 @@
+# Flight details check test step fragment
+
+This test step fragment documents the validation of an injected test flight's details
+
+## ⚠️ Flight details data format check
+
+**[astm.f3411.v22a.NET0710,2](../../../../../requirements/astm/f3411/v22a.md)** and **[astm.f3411.v22a.NET0340](../../../../../requirements/astm/f3411/v22a.md) require a Service Provider to implement the P2P portion of the OpenAPI specification.  This check will fail if the response to the flight details endpoint does not validate against the OpenAPI-specified schema.
+
+## ⚠️ Recent positions timestamps check
+
+**[astm.f3411.v22a.NET0270](../../../../../requirements/astm/f3411/v22a.md)** requires all recent positions to be within the NetMaxNearRealTimeDataPeriod. This check will fail if any of the reported positions are older than the maximally allowed period plus NetSpDataResponseTime99thPercentile.
+
+## [Flight details consistency with Common Data Dictionary checks](../common_dictionary_evaluator_sp_flight_details.md)

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/nominal_behavior.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/nominal_behavior.md
@@ -34,33 +34,13 @@ If specified, uss_qualifier will act as a Display Provider and check a DSS insta
 
 If a DSS was provided to this test scenario, uss_qualifier acts as a Display Provider to query Service Providers under test in this step.
 
+#### [Validate injected flight](./fragments/flight_check.md)
+
+#### [Validate injected flight details](./fragments/flight_details_check.md)
+
 #### ⚠️ Area too large check
 
 **[astm.f3411.v22a.NET0250](../../../../requirements/astm/f3411/v22a.md)** requires that a NetRID Service Provider rejects a request for a very large view area with a diagonal greater than *NetMaxDisplayAreaDiagonal*.  If such a large view is requested and a 413 error code is not received, then this check will fail.
-
-#### ⚠️ Flights data format check
-
-**[astm.f3411.v22a.NET0710,1](../../../../requirements/astm/f3411/v22a.md)** and **[astm.f3411.v22a.NET0340](../../../../requirements/astm/f3411/v22a.md)** requires a Service Provider to implement the P2P portion of the OpenAPI specification. This check will fail if the response to the /flights endpoint does not validate against the OpenAPI-specified schema.
-
-#### [Flight consistency with Common Data Dictionary checks](./common_dictionary_evaluator_sp_flight.md)
-
-#### ⚠️ Recent positions timestamps check
-
-**[astm.f3411.v22a.NET0270](../../../../requirements/astm/f3411/v22a.md)** requires all recent positions to be within the NetMaxNearRealTimeDataPeriod. This check will fail if any of the reported positions are older than the maximally allowed period plus NetSpDataResponseTime99thPercentile.
-
-#### ⚠️ Recent positions for aircraft crossing the requested area boundary show only one position before or after crossing check
-
-**[astm.f3411.v22a.NET0270](../../../../requirements/astm/f3411/v22a.md)** requires that when an aircraft enters or leaves the queried area, the last or first reported position outside the area is provided in the recent positions, as long as it is not older than NetMaxNearRealTimeDataPeriod.
-
-This implies that any recent position outside the area must be either preceded or followed by a position inside the area.
-
-(This check validates NET0270 b and c).
-
-#### ⚠️ Flight details data format check
-
-**[astm.f3411.v22a.NET0710,2](../../../../requirements/astm/f3411/v22a.md)** and **[astm.f3411.v22a.NET0340](../../../../requirements/astm/f3411/v22a.md) require a Service Provider to implement the P2P portion of the OpenAPI specification.  This check will fail if the response to the flight details endpoint does not validate against the OpenAPI-specified schema.
-
-#### [Flight details consistency with Common Data Dictionary checks](./common_dictionary_evaluator_sp_flight_details.md)
 
 ### Observer polling test step
 


### PR DESCRIPTION
Other scenarios injecting flights are being added: this should help reduce the amount of copy-pasted checks.