### PR TITLE
[mock_uss] save a notification when telemetry is too sparse

### DIFF
--- a/monitoring/mock_uss/ridsp/routes_injection.py
+++ b/monitoring/mock_uss/ridsp/routes_injection.py
@@ -1,33 +1,31 @@
 import datetime
-from typing import Tuple
 import uuid
+from typing import Tuple
 
+import arrow
 import flask
 from implicitdict import ImplicitDict
 from loguru import logger
-from uas_standards.interuss.automated_testing.rid.v1.injection import ChangeTestResponse
-import datetime
-import arrow
-
 from uas_standards.astm.f3411.v19.api import ErrorResponse
+from uas_standards.interuss.automated_testing.rid.v1.injection import ChangeTestResponse
 from uas_standards.interuss.automated_testing.rid.v1.injection import (
     OPERATIONS,
     OperationID,
     QueryUserNotificationsResponse,
 )
 
-from monitoring.monitorlib.mutate import rid as mutate
-from monitoring.monitorlib.rid import RIDVersion
-from monitoring.monitorlib.rid_automated_testing import injection_api
 from monitoring.mock_uss import webapp, require_config_value
 from monitoring.mock_uss.auth import requires_scope
 from monitoring.mock_uss.config import KEY_BASE_URL
 from monitoring.mock_uss.riddp.config import KEY_RID_VERSION
 from monitoring.mock_uss.ridsp import utm_client
-from . import database
-from .database import db
 from monitoring.monitorlib import geo
 from monitoring.monitorlib.idempotency import idempotent_request
+from monitoring.monitorlib.mutate import rid as mutate
+from monitoring.monitorlib.rid import RIDVersion
+from monitoring.monitorlib.rid_automated_testing import injection_api
+from . import database
+from .database import db
 
 require_config_value(KEY_BASE_URL)
 require_config_value(KEY_RID_VERSION)
@@ -115,6 +113,7 @@ def ridsp_create_test(test_id: str) -> Tuple[str, int]:
     with db as tx:
         tx.tests[test_id] = record
         tx.notifications.create_notifications_if_needed(record)
+
     return flask.jsonify(
         ChangeTestResponse(version=record.version, injected_flights=record.flights)
     )

--- a/monitoring/monitorlib/rid_automated_testing/injection_api.py
+++ b/monitoring/monitorlib/rid_automated_testing/injection_api.py
@@ -166,6 +166,18 @@ class TestFlight(injection.TestFlight):
             [(t.position.lat, t.position.lng) for t in self.telemetry]
         )
 
+    def get_mean_update_rate_hz(self) -> Optional[float]:
+        """
+        Calculate the mean update rate of the telemetry in Hz
+        """
+        if not self.telemetry or len(self.telemetry) == 1:
+            return None
+        # TODO check if required or not (may have been called earlier?)
+        self.order_telemetry()
+        start = self.telemetry[0].timestamp.datetime
+        end = self.telemetry[-1].timestamp.datetime
+        return (len(self.telemetry) - 1) / (end - start).seconds
+
 
 class CreateTestParameters(injection.CreateTestParameters):
     def get_span(


### PR DESCRIPTION
This is a building block for the scenario that will cover Net0040, for which notifications must be sent to the operator when the telemetry update rate is insufficient.

(This will allow us to implement the scenario for which documentation was added in https://github.com/interuss/monitoring/pull/907)