### PR TITLE
[prober] fix scope conversion

### DIFF
--- a/monitoring/prober/scd/actions.py
+++ b/monitoring/prober/scd/actions.py
@@ -5,7 +5,7 @@ from monitoring.monitorlib.scd import SCOPE_CM, SCOPE_SC, SCOPE_CP
 
 def _read_both_scope(scd_api: str) -> str:
     if scd_api == scd.API_0_3_17:
-        return "{} {}".format(SCOPE_SC, SCOPE_CP)
+        return f"{str(SCOPE_SC)} {str(SCOPE_CP)}"
     else:
         raise NotImplementedError("Unsupported API version {}".format(scd_api))
 


### PR DESCRIPTION
This PR fixes a missing casting of an enum value in _read_both_scope.

