### PR TITLE
[mock_uss/RID] Use RID subscriptions in mock_uss

### DIFF
--- a/monitoring/mock_uss/logging.py
+++ b/monitoring/mock_uss/logging.py
@@ -42,7 +42,7 @@ class RequestLogger(object):
     def get_response(self, resp: Response) -> Response:
         if self._report_log and resp.is_json and self.messages:
             body = resp.json
-            if "log_messages" not in body:
+            if body is not None and "log_messages" not in body:
                 body["log_messages"] = self.messages
             resp.data = json.dumps(body)
         return resp

--- a/monitoring/mock_uss/riddp/database.py
+++ b/monitoring/mock_uss/riddp/database.py
@@ -1,23 +1,60 @@
 import json
-from typing import Dict
+from typing import Dict, List
 
 from .behavior import DisplayProviderBehavior
 from implicitdict import ImplicitDict
 from monitoring.monitorlib.multiprocessing import SynchronizedValue
+from monitoring.monitorlib.mutate.rid import ChangedSubscription, UpdatedISA
+from monitoring.monitorlib.geo import LatLngBoundingBox
+from monitoring.monitorlib.fetch.rid import ISA
 
 
 class FlightInfo(ImplicitDict):
     flights_url: str
 
 
+class ObservationSubscription(ImplicitDict):
+    bounds: LatLngBoundingBox
+
+    upsert_result: ChangedSubscription
+
+    updates: List[UpdatedISA]
+
+    def get_isas(self) -> List[ISA]:
+        isas = [isa for isa in self.upsert_result.isas]
+        # TODO: consider sorting updates by notification index
+        for update in self.updates:
+            current_isas = []
+            isa_already_exists = False
+            for isa in isas:
+                if update.isa_id == isa.id:
+                    isa_already_exists = True
+                    if update.isa is not None:
+                        current_isas.append(update.isa)
+                    else:
+                        pass  # Exclude this ISA since the update removed it
+                else:
+                    current_isas.append(isa)
+            if not isa_already_exists:
+                current_isas.append(update.isa)
+            isas = current_isas
+        return isas
+
+    @property
+    def flights_urls(self) -> Dict[str, str]:
+        """Returns map of flights URL to owning USS"""
+        return {isa.flights_url: isa.owner for isa in self.get_isas()}
+
+
 class Database(ImplicitDict):
     """Simple pseudo-database structure tracking the state of the mock system"""
 
-    flights: Dict[str, FlightInfo] = {}
+    flights: Dict[str, FlightInfo]
     behavior: DisplayProviderBehavior = DisplayProviderBehavior()
+    subscriptions: List[ObservationSubscription]
 
 
 db = SynchronizedValue(
-    Database(),
+    Database(flights={}, subscriptions=[]),
     decoder=lambda b: ImplicitDict.parse(json.loads(b.decode("utf-8")), Database),
 )

--- a/monitoring/mock_uss/riddp/routes_riddp_v19.py
+++ b/monitoring/mock_uss/riddp/routes_riddp_v19.py
@@ -1,5 +1,6 @@
-import flask
-from implicitdict import ImplicitDict
+from monitoring.mock_uss.riddp.database import db
+from monitoring.monitorlib.fetch import describe_flask_query
+from monitoring.monitorlib.mutate.rid import UpdatedISA
 from uas_standards.astm.f3411.v19.api import (
     OperationID,
     OPERATIONS,
@@ -11,6 +12,10 @@ from uas_standards.astm.f3411.v19.constants import (
 
 from monitoring.mock_uss import webapp
 from monitoring.mock_uss.auth import requires_scope
+
+import flask
+from implicitdict import ImplicitDict
+from loguru import logger
 
 
 def rid_v19_operation(op_id: OperationID):
@@ -26,12 +31,32 @@ def ridsp_notify_isa_v19(id: str):
         json = flask.request.json
         if json is None:
             raise ValueError("Request did not contain a JSON payload")
-        ImplicitDict.parse(json, PutIdentificationServiceAreaNotificationParameters)
+        put_params: PutIdentificationServiceAreaNotificationParameters = (
+            ImplicitDict.parse(json, PutIdentificationServiceAreaNotificationParameters)
+        )
     except ValueError as e:
         msg = "Unable to parse PutIdentificationServiceAreaNotificationParameters JSON request: {}".format(
             e
         )
         return msg, 400
+
+    subscription_ids = [s.subscription_id for s in put_params.subscriptions]
+    if subscription_ids:
+        with db as tx:
+            updated = False
+
+            for subscription in tx.subscriptions:
+                if subscription.upsert_result.subscription.id in subscription_ids:
+                    query = describe_flask_query(flask.request, flask.jsonify(None), 0)
+                    subscription.updates.append(UpdatedISA(v22a_query=query))
+                    logger.debug(
+                        f"Updated subscription {subscription.upsert_result.subscription.id} with ISA {id}"
+                    )
+                    updated = True
+            if not updated:
+                logger.warning(
+                    f"Update for ISA {id} specified non-existent subscriptions {','.join(subscription_ids)}"
+                )
 
     return (
         flask.jsonify(None),

--- a/monitoring/mock_uss/riddp/routes_riddp_v19.py
+++ b/monitoring/mock_uss/riddp/routes_riddp_v19.py
@@ -48,7 +48,7 @@ def ridsp_notify_isa_v19(id: str):
             for subscription in tx.subscriptions:
                 if subscription.upsert_result.subscription.id in subscription_ids:
                     query = describe_flask_query(flask.request, flask.jsonify(None), 0)
-                    subscription.updates.append(UpdatedISA(v22a_query=query))
+                    subscription.updates.append(UpdatedISA(v19_query=query))
                     logger.debug(
                         f"Updated subscription {subscription.upsert_result.subscription.id} with ISA {id}"
                     )

--- a/monitoring/monitorlib/mutate/rid.py
+++ b/monitoring/monitorlib/mutate/rid.py
@@ -663,6 +663,59 @@ def delete_isa(
     return ISAChange(dss_query=dss_response, notifications=notifications)
 
 
+class UpdatedISA(RIDQuery):
+    """Version-independent representation of an updated (via notification) F3411 identification service area."""
+
+    @property
+    def _v19_request(
+        self,
+    ) -> v19.api.PutIdentificationServiceAreaNotificationParameters:
+        return ImplicitDict.parse(
+            self.v19_query.request.json,
+            v19.api.PutIdentificationServiceAreaNotificationParameters,
+        )
+
+    @property
+    def _v22a_request(
+        self,
+    ) -> v22a.api.PutIdentificationServiceAreaNotificationParameters:
+        return ImplicitDict.parse(
+            self.v22a_query.request.json,
+            v22a.api.PutIdentificationServiceAreaNotificationParameters,
+        )
+
+    @property
+    def isa(self) -> Optional[ISA]:
+        if self.rid_version == RIDVersion.f3411_19:
+            return ISA(
+                v19_value=self._v19_request.service_area
+                if "service_area" in self._v19_request
+                else None
+            )
+        elif self.rid_version == RIDVersion.f3411_22a:
+            return ISA(
+                v22a_value=self._v22a_request.service_area
+                if "service_area" in self._v22a_request
+                else None
+            )
+        else:
+            raise NotImplementedError(
+                f"Cannot retrieve ISA using RID version {self.rid_version}"
+            )
+
+    @property
+    def isa_id(self) -> str:
+        if self.rid_version == RIDVersion.f3411_19:
+            url = self.v19_query.request.url
+        elif self.rid_version == RIDVersion.f3411_22a:
+            url = self.v22a_query.request.url
+        else:
+            raise NotImplementedError(
+                f"Cannot retrieve ISA ID using RID version {self.rid_version}"
+            )
+        return url.split("?")[0].split("/")[-1]
+
+
 yaml.add_representer(ChangedSubscription, Representer.represent_dict)
 yaml.add_representer(ChangedISA, Representer.represent_dict)
 yaml.add_representer(ISAChange, Representer.represent_dict)


### PR DESCRIPTION
Currently, mock_uss polls the DSS for current ISAs every time an individual observation for flights is made.  This is generally unrealistic and wasteful as most USSs will keep track of ISAs via subscriptions.  This PR updates mock_uss behavior to emplace a subscription to identify ISAs necessary to fulfill an observation query, and then use existing subscriptions to identify ISAs (with no query to the DSS) when possible.

This behavior change is necessary to validate a new test that verifies compliance to NET0730.