### PR TITLE
[uss_qualifier/NetRID] Implement NET0730 test

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dp_behavior.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dp_behavior.md
@@ -64,8 +64,6 @@ If the ISA cannot be created, the PUT DSS endpoint in **[astm.f3411.v19.DSS0030,
 
 Prior to ISA creation, the Display Providers of one or more observers may have established subscriptions for the area due to subscription priming above.  If a subscription was present but the managing Display Provider did not acknowledge a notification correctly, the Display Provider will have failed to meet **[astm.f3411.v19.NET0730](../../../../requirements/astm/f3411/v19.md)**.  If a Display Provider did not establish a subscription, this check cannot be evaluated as no notification was sent.
 
-TODO: Implement this check
-
 ## Display Provider Behavior test case
 
 ### Query acceptable diagonal area test step

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dp_behavior.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dp_behavior.md
@@ -64,8 +64,6 @@ If the ISA cannot be created, the PUT DSS endpoint in **[astm.f3411.v22a.DSS0030
 
 Prior to ISA creation, the Display Providers of one or more observers may have established subscriptions for the area due to subscription priming above.  If a subscription was present but the managing Display Provider did not acknowledge a notification correctly, the Display Provider will have failed to meet **[astm.f3411.v22a.NET0730](../../../../requirements/astm/f3411/v22a.md)**.  If a Display Provider did not establish a subscription, this check cannot be evaluated as no notification was sent.
 
-TODO: Implement this check
-
 ## Display Provider Behavior test case
 
 ### Query acceptable diagonal area test step

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_19.md
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_19.md
@@ -441,7 +441,7 @@
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3411/v19.md">NET0730</a></td>
-    <td>Implemented + TODO</td>
+    <td>Implemented</td>
     <td><a href="../../../scenarios/astm/netrid/v19/dss/heavy_traffic_concurrent.md">ASTM NetRID DSS: Concurrent Requests</a><br><a href="../../../scenarios/astm/netrid/v19/dss/isa_expiry.md">ASTM NetRID DSS: ISA Expiry</a><br><a href="../../../scenarios/astm/netrid/v19/dss/isa_subscription_interactions.md">ASTM NetRID DSS: ISA Subscription Interactions</a><br><a href="../../../scenarios/astm/netrid/v19/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../../scenarios/astm/netrid/v19/dss/isa_validation.md">ASTM NetRID DSS: Submitted ISA Validations</a><br><a href="../../../scenarios/astm/netrid/v19/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/netrid/v19/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/netrid/v19/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a><br><a href="../../../scenarios/astm/netrid/v19/dp_behavior.md">ASTM NetRID Display Provider behavior</a><br><a href="../../../scenarios/astm/netrid/v19/sp_notification_behavior.md">ASTM NetRID Service Provider notification behavior</a></td>
   </tr>
   <tr>

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a.md
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a.md
@@ -591,7 +591,7 @@
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3411/v22a.md">NET0730</a></td>
-    <td>Implemented + TODO</td>
+    <td>Implemented</td>
     <td><a href="../../../scenarios/astm/netrid/v22a/dss/heavy_traffic_concurrent.md">ASTM NetRID DSS: Concurrent Requests</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/isa_expiry.md">ASTM NetRID DSS: ISA Expiry</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/isa_subscription_interactions.md">ASTM NetRID DSS: ISA Subscription Interactions</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/isa_validation.md">ASTM NetRID DSS: Submitted ISA Validations</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a><br><a href="../../../scenarios/astm/netrid/v22a/dp_behavior.md">ASTM NetRID Display Provider behavior</a><br><a href="../../../scenarios/astm/netrid/v22a/sp_notification_behavior.md">ASTM NetRID Service Provider notification behavior</a></td>
   </tr>
   <tr>

--- a/monitoring/uss_qualifier/suites/uspace/network_identification.md
+++ b/monitoring/uss_qualifier/suites/uspace/network_identification.md
@@ -584,7 +584,7 @@
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3411/v22a.md">NET0730</a></td>
-    <td>Implemented + TODO</td>
+    <td>Implemented</td>
     <td><a href="../../scenarios/astm/netrid/v22a/dss/heavy_traffic_concurrent.md">ASTM NetRID DSS: Concurrent Requests</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_expiry.md">ASTM NetRID DSS: ISA Expiry</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_subscription_interactions.md">ASTM NetRID DSS: ISA Subscription Interactions</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_validation.md">ASTM NetRID DSS: Submitted ISA Validations</a><br><a href="../../scenarios/astm/netrid/v22a/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a><br><a href="../../scenarios/astm/netrid/v22a/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a><br><a href="../../scenarios/astm/netrid/v22a/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a><br><a href="../../scenarios/astm/netrid/v22a/dp_behavior.md">ASTM NetRID Display Provider behavior</a><br><a href="../../scenarios/astm/netrid/v22a/sp_notification_behavior.md">ASTM NetRID Service Provider notification behavior</a></td>
   </tr>
   <tr>

--- a/monitoring/uss_qualifier/suites/uspace/required_services.md
+++ b/monitoring/uss_qualifier/suites/uspace/required_services.md
@@ -585,7 +585,7 @@
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3411/v22a.md">NET0730</a></td>
-    <td>Implemented + TODO</td>
+    <td>Implemented</td>
     <td><a href="../../scenarios/astm/netrid/v22a/dss/heavy_traffic_concurrent.md">ASTM NetRID DSS: Concurrent Requests</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_expiry.md">ASTM NetRID DSS: ISA Expiry</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_subscription_interactions.md">ASTM NetRID DSS: ISA Subscription Interactions</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_simple.md">ASTM NetRID DSS: Simple ISA</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_validation.md">ASTM NetRID DSS: Submitted ISA Validations</a><br><a href="../../scenarios/astm/netrid/v22a/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a><br><a href="../../scenarios/astm/netrid/v22a/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a><br><a href="../../scenarios/astm/netrid/v22a/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a><br><a href="../../scenarios/astm/netrid/v22a/dp_behavior.md">ASTM NetRID Display Provider behavior</a><br><a href="../../scenarios/astm/netrid/v22a/sp_notification_behavior.md">ASTM NetRID Service Provider notification behavior</a></td>
   </tr>
   <tr>


### PR DESCRIPTION
This PR technically implements the new test for ASTM F3411 NET0730 documented in #914.

The test executes, but does not verify compliance to NET0730 in CI currently because mock_uss does not establish subscriptions.  However, this PR has also been tested with #927 -- with that mock_uss behavior change, NET0730 is successfully verified by this test.

Some places in the test where queries were not recorded are also fixed in this PR (issue discovered during testing).