### PR TITLE
[uss_qualifier/NetRID] Update U-space CI tested requirements

### DIFF
--- a/monitoring/uss_qualifier/configurations/dev/uspace.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/uspace.yaml
@@ -135,17 +135,35 @@ v1:
                   - astm.f3411.v22a.service_provider#Operational Status provider
                   - astm.f3411.v22a.display_provider#Mandatory requirements
                   - astm.f3411.v22a.display_provider#UAS ID Serial Number transmitter
+                  - astm.f3411.v22a.display_provider#UA Type transmitter
+                  - astm.f3411.v22a.display_provider#UA Classification Type transmitter
                   - astm.f3411.v22a.display_provider#Timestamp transmitter
+                  - astm.f3411.v22a.display_provider#Timestamp Accuracy transmitter
                   - astm.f3411.v22a.display_provider#Operational Status transmitter
                   - astm.f3411.v22a.display_provider#Operator ID transmitter
                   - astm.f3411.v22a.display_provider#Current Position transmitter
+                  - astm.f3411.v22a.display_provider#Geodetic Altitude transmitter
                   - astm.f3411.v22a.display_provider#Height transmitter
+                  - astm.f3411.v22a.display_provider#Geodetic Vertical Accuracy transmitter
+                  - astm.f3411.v22a.display_provider#Horizontal Accuracy transmitter
+                  - astm.f3411.v22a.display_provider#Speed Accuracy transmitter
                   - astm.f3411.v22a.display_provider#Track Direction transmitter
                   - astm.f3411.v22a.display_provider#Speed transmitter
+                  - astm.f3411.v22a.display_provider#Vertical Speed transmitter
                   - astm.f3411.v22a.display_provider#Operator Position transmitter
                   - astm.f3411.v22a.dss_provider
                   - astm.f3548.v21.scd#Automated verification
                   - astm.f3548.v21.dss_provider
+                exclude:
+                  requirements:
+                    - astm.f3411.v22a.DSS0040
+                    - astm.f3411.v22a.NET0010
+                    - astm.f3411.v22a.NET0020
+                    - astm.f3411.v22a.NET0230
+                    - astm.f3411.v22a.NET0410
+                    - astm.f3411.v22a.NET0620
+                    - astm.f3411.v22a.NET0630
+                    - astm.f3411.v22a.NET0720
               - requirements:
                   - uspace.article8.MSLAltitude
         participant_requirements:

--- a/monitoring/uss_qualifier/requirements/astm/f3411/v22a/service_provider.md
+++ b/monitoring/uss_qualifier/requirements/astm/f3411/v22a/service_provider.md
@@ -82,21 +82,25 @@ All Service Provider Role requirements can be verified by automation.
 
 #### Operator ID provider
 
-  * **astm.f3411.v22a.NET0260,Table1,9**
+* **astm.f3411.v22a.NET0260,Table1,9**
 
 #### UAS ID Serial Number provider
 
-  * **astm.f3411.v22a.NET0260,Table1,1a**
+* **astm.f3411.v22a.NET0260,Table1,1a**
 
 #### Height provider
 
-  * **astm.f3411.v22a.NET0260,Table1,14**
+* **astm.f3411.v22a.NET0260,Table1,14**
+
+#### Height Type provider
+
+* **astm.f3411.v22a.NET0260,Table1,15**
 
 #### Operator Position provider
 
-  * **astm.f3411.v22a.NET0260,Table1,23**
-  * **astm.f3411.v22a.NET0260,Table1,24**
+* **astm.f3411.v22a.NET0260,Table1,23**
+* **astm.f3411.v22a.NET0260,Table1,24**
 
 #### Operational Status provider
 
-  * **astm.f3411.v22a.NET0260,Table1,7**
+* **astm.f3411.v22a.NET0260,Table1,7**


### PR DESCRIPTION
In anticipation of completing #754, this PR updates the NetRID requirements included in the U-space CI test configuration's tested requirements to match those necessary to complete #754 and use ASTM F3411-22a for U-space compliance.

Once this update is merged, #754 should be complete when [the U-space CI tested requirements for uss1](https://interuss.github.io/monitoring/artifacts/uss_qualifier/reports/uspace/requirements/uss1.html) contain all green entries in the **Requirement** column, except DSS0020, DSS0110, DSS0120, and NET0220 (testable in real deployments, not in CI).