### PR TITLE
[security] Secure workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,7 +251,7 @@ jobs:
         run: ./monitoring/github_pages/make_site_content.sh
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847  # v3.9.3
         if: github.ref == 'refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/monitoring-test.yml
+++ b/.github/workflows/monitoring-test.yml
@@ -16,6 +16,8 @@ jobs:
   monitoring-test:
     runs-on: ubuntu-latest
     name: ${{ inputs.name }} test
+    permissions:
+      contents: read
     steps:
     - name: Job information
       run: |


### PR DESCRIPTION
This PR addresses two code scanning findings by:

1. Pinning the version of a third-party workflow dependency
2. Explicitly defining the permissions of an internally-defined workflow (even though all uses of that workflow also explicitly set permissions)