### PR TITLE
[monitorlib/reports] Render newlines in string values

### DIFF
--- a/monitoring/monitorlib/html/templates/explorer.html
+++ b/monitoring/monitorlib/html/templates/explorer.html
@@ -5,11 +5,15 @@
 
 {% macro collapseable(v) %}{% if v is mapping or (v is iterable and v is not string) %}collapseable{% else %}not_collapseable{% endif %}{% endmacro %}
 
+{% macro render_string_value(s) %}
+  {{ s | replace('\n', '<br>') | safe }}
+{% endmacro %}
+
 {% macro draw_value(v) %}
   {% if v is mapping %}
     {{ draw_node(v) }}
   {% elif v is string %}
-    {{ v }}
+    {{ render_string_value(v) }}
   {% elif v is iterable %}
     {{ draw_list(v) }}
   {% else %}


### PR DESCRIPTION
monitorlib houses a Jinja2 macro to render complex dicts as interactive expandable/collapseable elements.  This is used in many places, but one important place is representing queries in uss_qualifier reports.  When troubleshooting, these queries will often have a stack trace value.  But, because Jinja2 renders the string as HTML, newlines are ignored as plain whitespace.  This PR addresses that narrow issue by replacing newlines with explicit HTML br elements so stack traces are easier to read.