### PR TITLE
[uss_qualifier] NetRID extend polling in nominal_behavior so all post-flight checks run

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/nominal_behavior.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/nominal_behavior.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from typing import List, Optional
 
 from requests.exceptions import RequestException
@@ -86,7 +87,9 @@ class NominalBehavior(GenericTestScenario):
             repeat_query_rect_period=config.repeat_query_rect_period,
             min_query_diagonal_m=config.min_query_diagonal,
             relevant_past_data_period=self._rid_version.realtime_period
-            + config.max_propagation_latency.timedelta,
+            + config.max_propagation_latency.timedelta
+            # add two 'min_polling_interval' to make sure we poll at least once after flights are over
+            + (config.min_polling_interval.timedelta * 2),
         )
         evaluator = display_data_evaluator.RIDObservationEvaluator(
             self,


### PR DESCRIPTION
The nominal behavior scenario was ending too early, preventing the [Lingering Flight](https://github.com/interuss/monitoring/blob/51576beeb1bb536c4e2f9eb508996e0e0f302d04/monitoring/uss_qualifier/scenarios/astm/netrid/display_data_evaluator.py#L1440) check to run. 

Adding 10 seconds allows to guarantee that one of the polls (that occurs about every 5 seconds) will run after the flight is complete, and when no data should be returned anymore.