### PR TITLE
[uss_qualifier/common_dict_eval] generate height for kml flights to test height fields

### DIFF
--- a/monitoring/monitorlib/fetch/rid.py
+++ b/monitoring/monitorlib/fetch/rid.py
@@ -1156,7 +1156,7 @@ def uss_flights(
             flights_url,
             params=params,
             scope=v22a.constants.Scope.DisplayProvider,
-            query_type=QueryType.F3411v19USSSearchFlights,
+            query_type=QueryType.F3411v22aUSSSearchFlights,
             participant_id=participant_id,
         )
         return FetchedUSSFlights(v22a_query=query)

--- a/monitoring/uss_qualifier/resources/netrid/simulation/kml_flights.py
+++ b/monitoring/uss_qualifier/resources/netrid/simulation/kml_flights.py
@@ -187,12 +187,19 @@ def generate_flight_record(
         r = random.Random(x=random_seed)
     now_isoformat = timestamp.isoformat()
 
+    # We get the minimum altitude to simulate height
+    minimum_altitude = min(c[2] for c in state_coordinates)
+
     flight_telemetry: List[injection.RIDAircraftState] = []
     for coordinates, speed, angle in zip(
         state_coordinates, flight_state_speeds, flight_track_angles
     ):
         timestamp = timestamp + timedelta(0, STATE_INCREMENT_SECONDS)
         timestamp_isoformat = timestamp.isoformat()
+
+        aircraft_height = injection.RIDHeight(
+            distance=coordinates[2] - minimum_altitude, reference="TakeoffLocation"
+        )
         aircraft_position = injection.RIDAircraftPosition(
             lng=coordinates[0],
             lat=coordinates[1],
@@ -200,8 +207,8 @@ def generate_flight_record(
             accuracy_h=flight_description.get("accuracy_h"),
             accuracy_v=flight_description.get("accuracy_v"),
             extrapolated=False,
+            height=aircraft_height,
         )
-        aircraft_height = None
         rid_aircraft_state = injection.RIDAircraftState(
             timestamp=StringBasedDateTime(timestamp_isoformat),
             operational_status="Airborne",


### PR DESCRIPTION
This PR compute height of the flight during kml flight generation, to test height and height accuracy in common_dict_eval.

A few remarks:

- The method of computing the height is a guess based on current altitude. Should we have the information somehow directly in the kml file?
- After a discussion with Mike related to KML, the vertical speed, currently set to zero, may be computed in a similar way. I created #943  to track it.
- I fixed a 19 -> 22 typo I found during debugging
- It seems the height is injected in two locations: the position and the state (v22/v19a ?) and the code is using various version of the field. To ensure it's working for this PR, I just used the same value in two locations and I created #942 to normalize it
- Like the test in the common_dict, I set the height to v22 only for the test in display_data evaluator who was failing. I all cases the display_data test should be moved to the common_ tests, there is already a TODO in the code.