### PR TITLE
[uss_qualifier/common_dict_eval] Move timestamp to generic function

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/common_dictionary_evaluator_dp_flight.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/common_dictionary_evaluator_dp_flight.md
@@ -15,6 +15,19 @@ If the UA type value exposed by the observer API is inconsistent with the inject
 **[astm.f3411.v19.NET0450](../../../../requirements/astm/f3411/v19.md)** because the DP fails to provide accurate data;
 **[astm.f3411.v19.NET0470,Table1,3](../../../../requirements/astm/f3411/v19.md)**  because the DP fails to expose data consistent with the valid injected value.
 
+## ⚠️ Timestamp is exposed correctly check
+
+If the Timestamp value exposed by the observation API is invalid this check will fail per:
+**[interuss.automated_testing.rid.observation.ObservationSuccess](../../../../requirements/interuss/automated_testing/rid/observation.md)** because the DP violates the observation API contract;
+**[astm.f3411.v19.NET0450](../../../../requirements/astm/f3411/v19.md)** because the DP fails to provide accurate data;
+**[astm.f3411.v19.NET0470,Table1,4](../../../../requirements/astm/f3411/v19.md)** because the DP fails to expose data consistent with the Common Data Dictionary.
+
+## ⚠️ Timestamp is consistent with injected value check
+
+If the Timestamp value exposed by the observer API is inconsistent with the injected value this check will fail per:
+**[astm.f3411.v19.NET0450](../../../../requirements/astm/f3411/v19.md)** because the DP fails to provide accurate data;
+**[astm.f3411.v19.NET0470,Table1,4](../../../../requirements/astm/f3411/v19.md)**  because the DP fails to expose data consistent with the valid injected value.
+
 ## ⚠️ Timestamp accuracy is exposed correctly check
 
 If the Timestamp accuracy value exposed by the observation API is invalid this check will fail per:

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/common_dictionary_evaluator_sp_flight.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/common_dictionary_evaluator_sp_flight.md
@@ -13,6 +13,17 @@ If the UA type value exposed by the SP API is missing or invalid this check will
 If the UA type value exposed by the SP API is inconsistent with the injected value this check will fail per:
 **[astm.f3411.v19.NET0260,Table1,3](../../../../requirements/astm/f3411/v19.md)** because the SP fails to expose data consistent with the valid injected value.
 
+## ⚠️ Timestamp is exposed correctly check
+
+If the Timestamp value exposed by the SP API is missing or invalid this check will fail per:
+**[astm.f3411.v19.NET0710,1](../../../../requirements/astm/f3411/v19.md)** because the SP violates the SP API contract;
+**[astm.f3411.v19.NET0260,Table1,4](../../../../requirements/astm/f3411/v19.md)** because the SP fails to expose data consistent with the Common Data Dictionary.
+
+## ⚠️ Timestamp is consistent with injected value check
+
+If the Timestamp value exposed by the SP API is inconsistent with the injected value this check will fail per:
+**[astm.f3411.v19.NET0260,Table1,4](../../../../requirements/astm/f3411/v19.md)** because the SP fails to expose data consistent with the valid injected value.
+
 ## ⚠️ Timestamp accuracy is exposed correctly check
 
 If the Timestamp accuracy value exposed by the SP API is missing or invalid this check will fail per:

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/common_dictionary_evaluator_dp_flight.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/common_dictionary_evaluator_dp_flight.md
@@ -15,6 +15,19 @@ If the UA type value exposed by the observer API is inconsistent with the inject
 **[astm.f3411.v22a.NET0450](../../../../requirements/astm/f3411/v22a.md)** because the DP fails to provide accurate data;
 **[astm.f3411.v22a.NET0470,Table1,2](../../../../requirements/astm/f3411/v22a.md)**  because the DP fails to expose data consistent with the valid injected value.
 
+## ⚠️ Timestamp is exposed correctly check
+
+If the Timestamp value exposed by the observation API is invalid this check will fail per:
+**[interuss.automated_testing.rid.observation.ObservationSuccess](../../../../requirements/interuss/automated_testing/rid/observation.md)** because the DP violates the observation API contract;
+**[astm.f3411.v22a.NET0450](../../../../requirements/astm/f3411/v22a.md)** because the DP fails to provide accurate data;
+**[astm.f3411.v22a.NET0470,Table1,5](../../../../requirements/astm/f3411/v22a.md)** because the DP fails to expose data consistent with the Common Data Dictionary.
+
+## ⚠️ Timestamp is consistent with injected value check
+
+If the Timestamp value exposed by the observer API is inconsistent with the injected value this check will fail per:
+**[astm.f3411.v22a.NET0450](../../../../requirements/astm/f3411/v22a.md)** because the DP fails to provide accurate data;
+**[astm.f3411.v22a.NET0470,Table1,5](../../../../requirements/astm/f3411/v22a.md)**  because the DP fails to expose data consistent with the valid injected value.
+
 ## ⚠️ Timestamp accuracy is exposed correctly check
 
 If the Timestamp accuracy value exposed by the observation API is invalid this check will fail per:
@@ -118,18 +131,6 @@ If the Vertical Speed value exposed by the observation API is invalid this check
 If the Vertical Speed value exposed by the observer API is inconsistent with the injected value this check will fail per:
 **[astm.f3411.v22a.NET0450](../../../../requirements/astm/f3411/v22a.md)** because the DP fails to provide accurate data;
 **[astm.f3411.v22a.NET0470,Table1,21](../../../../requirements/astm/f3411/v22a.md)**  because the DP fails to expose data consistent with the valid injected value.
-
-## ⚠️ Timestamp field is present check
-
-**[astm.f3411.v22a.NET0470](../../../../requirements/astm/f3411/v22a.md)** requires that Net-RID Display Provider shall provide access to required and optional fields to Remote ID Display Applications according to the Common Dictionary. This check validates that the timestamp field is actually provided. (**[astm.f3411.v22a.NET0470,Table1,5](../../../../requirements/astm/f3411/v22a.md)**)
-
-## ⚠️ Timestamp consistency with Common Dictionary check
-
-**[astm.f3411.v22a.NET0470](../../../../requirements/astm/f3411/v22a.md)** requires that Net-RID Display Provider shall provide access to required and optional fields to Remote ID Display Applications according to the Common Dictionary. This check validates that timestamps are relative to UTC. (**[astm.f3411.v22a.NET0470,Table1,5](../../../../requirements/astm/f3411/v22a.md)**)
-
-## ⚠️ Observed timestamp is consistent with injected one check
-
-If the timestamp reported for an observation does not correspond to the injected one, the DP is not providing timely and accurate data and is thus in breach of **[astm.f3411.v22a.NET0450](../../../../requirements/astm/f3411/v22a.md)**
 
 ## ⚠️ Operational Status consistency with Common Dictionary check
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/common_dictionary_evaluator_sp_flight.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/common_dictionary_evaluator_sp_flight.md
@@ -13,6 +13,17 @@ If the UA type value exposed by the SP API is missing or invalid this check will
 If the UA type value exposed by the SP API is inconsistent with the injected value this check will fail per:
 **[astm.f3411.v22a.NET0260,Table1,2](../../../../requirements/astm/f3411/v22a.md)** because the SP fails to expose data consistent with the valid injected value.
 
+## ⚠️ Timestamp is exposed correctly check
+
+If the Timestamp value exposed by the SP API is missing or invalid this check will fail per:
+**[astm.f3411.v22a.NET0710,1](../../../../requirements/astm/f3411/v22a.md)** because the SP violates the SP API contract;
+**[astm.f3411.v22a.NET0260,Table1,5](../../../../requirements/astm/f3411/v22a.md)** because the SP fails to expose data consistent with the Common Data Dictionary.
+
+## ⚠️ Timestamp is consistent with injected value check
+
+If the Timestamp value exposed by the SP API is inconsistent with the injected value this check will fail per:
+**[astm.f3411.v22a.NET0260,Table1,5](../../../../requirements/astm/f3411/v22a.md)** because the SP fails to expose data consistent with the valid injected value.
+
 ## ⚠️ Timestamp accuracy is exposed correctly check
 
 If the Timestamp accuracy value exposed by the SP API is missing or invalid this check will fail per:

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_19.md
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_19.md
@@ -26,7 +26,7 @@
     <th><a href="../../README.md#checked-in">Checked in</a></th>
   </tr>
   <tr>
-    <td rowspan="86" style="vertical-align:top;"><a href="../../../requirements/astm/f3411/v19.md">astm<br>.f3411<br>.v19</a></td>
+    <td rowspan="88" style="vertical-align:top;"><a href="../../../requirements/astm/f3411/v19.md">astm<br>.f3411<br>.v19</a></td>
     <td><a href="../../../requirements/astm/f3411/v19.md">DSS0010</a></td>
     <td>Implemented</td>
     <td><a href="../../../scenarios/astm/netrid/v19/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a></td>
@@ -322,6 +322,11 @@
     <td><a href="../../../scenarios/astm/netrid/v19/sp_operator_notify_slow_update.md">ASTM NetRID Service Provider operator notification under slow update rate</a><br><a href="../../../scenarios/astm/netrid/v19/networked_uas_disconnect.md">ASTM NetRID networked UAS disconnection</a><br><a href="../../../scenarios/astm/netrid/v19/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
   </tr>
   <tr>
+    <td><a href="../../../requirements/astm/f3411/v19.md">NET0260,Table1,4</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/netrid/v19/sp_operator_notify_slow_update.md">ASTM NetRID Service Provider operator notification under slow update rate</a><br><a href="../../../scenarios/astm/netrid/v19/networked_uas_disconnect.md">ASTM NetRID networked UAS disconnection</a><br><a href="../../../scenarios/astm/netrid/v19/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
+  </tr>
+  <tr>
     <td><a href="../../../requirements/astm/f3411/v19.md">NET0260,Table1,5</a></td>
     <td>Implemented</td>
     <td><a href="../../../scenarios/astm/netrid/v19/sp_operator_notify_slow_update.md">ASTM NetRID Service Provider operator notification under slow update rate</a><br><a href="../../../scenarios/astm/netrid/v19/networked_uas_disconnect.md">ASTM NetRID networked UAS disconnection</a><br><a href="../../../scenarios/astm/netrid/v19/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
@@ -408,6 +413,11 @@
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3411/v19.md">NET0470,Table1,3</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/netrid/v19/networked_uas_disconnect.md">ASTM NetRID networked UAS disconnection</a><br><a href="../../../scenarios/astm/netrid/v19/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3411/v19.md">NET0470,Table1,4</a></td>
     <td>Implemented</td>
     <td><a href="../../../scenarios/astm/netrid/v19/networked_uas_disconnect.md">ASTM NetRID networked UAS disconnection</a><br><a href="../../../scenarios/astm/netrid/v19/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
   </tr>

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a.md
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a.md
@@ -26,7 +26,7 @@
     <th><a href="../../README.md#checked-in">Checked in</a></th>
   </tr>
   <tr>
-    <td rowspan="115" style="vertical-align:top;"><a href="../../../requirements/astm/f3411/v22a.md">astm<br>.f3411<br>.v22a</a></td>
+    <td rowspan="116" style="vertical-align:top;"><a href="../../../requirements/astm/f3411/v22a.md">astm<br>.f3411<br>.v22a</a></td>
     <td><a href="../../../requirements/astm/f3411/v22a.md">DSS0010</a></td>
     <td>Implemented</td>
     <td><a href="../../../scenarios/astm/netrid/v22a/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a></td>
@@ -368,6 +368,11 @@
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3411/v22a.md">NET0260,Table1,4</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/netrid/v22a/sp_operator_notify_slow_update.md">ASTM NetRID Service Provider operator notification under slow update rate</a><br><a href="../../../scenarios/astm/netrid/v22a/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3411/v22a.md">NET0260,Table1,5</a></td>
     <td>Implemented</td>
     <td><a href="../../../scenarios/astm/netrid/v22a/sp_operator_notify_slow_update.md">ASTM NetRID Service Provider operator notification under slow update rate</a><br><a href="../../../scenarios/astm/netrid/v22a/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
   </tr>

--- a/monitoring/uss_qualifier/suites/uspace/network_identification.md
+++ b/monitoring/uss_qualifier/suites/uspace/network_identification.md
@@ -17,7 +17,7 @@
     <th><a href="../README.md#checked-in">Checked in</a></th>
   </tr>
   <tr>
-    <td rowspan="115" style="vertical-align:top;"><a href="../../requirements/astm/f3411/v22a.md">astm<br>.f3411<br>.v22a</a></td>
+    <td rowspan="116" style="vertical-align:top;"><a href="../../requirements/astm/f3411/v22a.md">astm<br>.f3411<br>.v22a</a></td>
     <td><a href="../../requirements/astm/f3411/v22a.md">DSS0010</a></td>
     <td>Implemented</td>
     <td><a href="../../scenarios/astm/netrid/v22a/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a></td>
@@ -359,6 +359,11 @@
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3411/v22a.md">NET0260,Table1,4</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/netrid/v22a/sp_operator_notify_slow_update.md">ASTM NetRID Service Provider operator notification under slow update rate</a><br><a href="../../scenarios/astm/netrid/v22a/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3411/v22a.md">NET0260,Table1,5</a></td>
     <td>Implemented</td>
     <td><a href="../../scenarios/astm/netrid/v22a/sp_operator_notify_slow_update.md">ASTM NetRID Service Provider operator notification under slow update rate</a><br><a href="../../scenarios/astm/netrid/v22a/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
   </tr>

--- a/monitoring/uss_qualifier/suites/uspace/required_services.md
+++ b/monitoring/uss_qualifier/suites/uspace/required_services.md
@@ -18,7 +18,7 @@
     <th><a href="../README.md#checked-in">Checked in</a></th>
   </tr>
   <tr>
-    <td rowspan="115" style="vertical-align:top;"><a href="../../requirements/astm/f3411/v22a.md">astm<br>.f3411<br>.v22a</a></td>
+    <td rowspan="116" style="vertical-align:top;"><a href="../../requirements/astm/f3411/v22a.md">astm<br>.f3411<br>.v22a</a></td>
     <td><a href="../../requirements/astm/f3411/v22a.md">DSS0010</a></td>
     <td>Implemented</td>
     <td><a href="../../scenarios/astm/netrid/v22a/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a></td>
@@ -360,6 +360,11 @@
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3411/v22a.md">NET0260,Table1,4</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/netrid/v22a/sp_operator_notify_slow_update.md">ASTM NetRID Service Provider operator notification under slow update rate</a><br><a href="../../scenarios/astm/netrid/v22a/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3411/v22a.md">NET0260,Table1,5</a></td>
     <td>Implemented</td>
     <td><a href="../../scenarios/astm/netrid/v22a/sp_operator_notify_slow_update.md">ASTM NetRID Service Provider operator notification under slow update rate</a><br><a href="../../scenarios/astm/netrid/v22a/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
   </tr>


### PR DESCRIPTION
Follow #952 

Like #952, moving of timestamp to the generic function, with tests.

Fix an issue with the _generic_function as well, who was not using the `value_validator` for the `observed_val`