### PR TITLE
[configurations/uspace] Pass uss_identification to required_services suite for NET0730 validation

### DIFF
--- a/monitoring/uss_qualifier/configurations/dev/uspace.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/uspace.yaml
@@ -32,6 +32,7 @@ v1:
         netrid_dss_instances_v22a: {$ref: 'library/environment.yaml#/netrid_dss_instances_v22a'}
 
         test_exclusions: { $ref: 'library/resources.yaml#/test_exclusions' }
+        uss_identification: { $ref: 'library/environment.yaml#/uss_identification' }
     non_baseline_inputs:
       - v1.test_run.resources.resource_declarations.utm_auth
       - v1.test_run.resources.resource_declarations.mock_uss_instances_scdsc
@@ -79,6 +80,7 @@ v1:
           problematically_big_area: au_problematically_big_area
 
           test_exclusions: test_exclusions
+          uss_identification: uss_identification
         specification:
           mock_uss_instances_source: mock_uss_instances
           locality_source: locality
@@ -114,6 +116,7 @@ v1:
                 problematically_big_area: problematically_big_area
 
                 test_exclusions: test_exclusions
+                uss_identification: uss_identification
     execution:
       stop_fast: true
   artifacts:


### PR DESCRIPTION
In `uspace` configuration the requirement NET0730 is not validated while it is validated in `netrid_v22a`.
That's due to the fact that it is required for the `uss_identification` to be passed to the scenario to validate that requirement.
This was setup for configuration `netrid_v22a` but not `uspace`. This PR sets it up for `uspace`.