### PR TITLE
[CI/Makefiles] Run unit tests in 'hygiene-tests' instead of 'monitoring-test' and consolidate commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,14 +24,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
-    - name: Python lint
-      run: make python-lint
     - name: Automated hygiene verification
       run: make check-hygiene
-    - name: uss_qualifier documentation validation
-      run: make validate-uss-qualifier-docs
-    - name: Shell lint
-      run: make shell-lint
+    - name: Unit tests
+      run: make unit-test
 
   mock_uss-test:
     name: mock_uss tests

--- a/monitoring/Makefile
+++ b/monitoring/Makefile
@@ -6,6 +6,10 @@ lint:
 format:
 	cd uss_qualifier && make format
 
+.PHONY: unit-test
+unit-test:
+	cd uss_qualifier && make unit_test
+
 image: ../requirements.txt $(shell find . -type f ! -path "*/output/*" ! -name image ! -name *.pyc) $(shell find ../interfaces -type f)
 	# Building image due to changes in the following files: $?
 	./build.sh

--- a/monitoring/uss_qualifier/Makefile
+++ b/monitoring/uss_qualifier/Makefile
@@ -23,5 +23,5 @@ unit_test:
 	./scripts/run_unit_tests.sh
 
 .PHONY: test
-test: lint unit_test
+test:
 	./scripts/test_docker_fully_mocked.sh


### PR DESCRIPTION
The unit tests were tied to the `make test` command which run the full USS qualifier test suite. It makes more sense for those unit tests to be ran within the repository hygiene tests.
This PR also consolidates some make commands and CI targets to reduce noise.

cc @the-glu 