### PR TITLE
[uss_qualifier/common_dict_eval] Move height and height type to generic function

### DIFF
--- a/monitoring/monitorlib/fetch/rid.py
+++ b/monitoring/monitorlib/fetch/rid.py
@@ -169,14 +169,16 @@ class Position(ImplicitDict):
 
     @staticmethod
     def from_v19_rid_aircraft_position(
-        p: v19.api.RIDAircraftPosition, t: v19.api.StringBasedDateTime
+        p: v19.api.RIDAircraftPosition,
+        t: v19.api.StringBasedDateTime,
+        h: Optional[v19.api.RIDHeight],
     ) -> Position:
         return Position(
             lat=p.lat,
             lng=p.lng,
             alt=p.alt,
             time=t.datetime,
-            height=None,
+            height=h,
             accuracy_v=p.accuracy_v if "accuracy_v" in p else None,
             accuracy_h=p.accuracy_h if "accuracy_h" in p else None,
         )
@@ -237,6 +239,7 @@ class Flight(ImplicitDict):
                 return Position.from_v19_rid_aircraft_position(
                     self.v19_value.current_state.position,
                     self.v19_value.current_state.timestamp,
+                    self.height,
                 )
             elif self.rid_version == RIDVersion.f3411_22a:
                 return Position.from_v22a_rid_aircraft_position(
@@ -254,7 +257,7 @@ class Flight(ImplicitDict):
     def recent_positions(self) -> List[Position]:
         if self.rid_version == RIDVersion.f3411_19:
             return [
-                Position.from_v19_rid_aircraft_position(p.position, p.time)
+                Position.from_v19_rid_aircraft_position(p.position, p.time, self.height)
                 for p in self.v19_value.recent_positions
             ]
         elif self.rid_version == RIDVersion.f3411_22a:

--- a/monitoring/monitorlib/fetch/rid.py
+++ b/monitoring/monitorlib/fetch/rid.py
@@ -407,6 +407,28 @@ class Flight(ImplicitDict):
                 f"Cannot retrieve aircraft_type using RID version {self.rid_version}"
             )
 
+    @property
+    def height(
+        self,
+    ) -> Optional[Union[v19.api.RIDHeight, v22a.api.RIDHeight]]:
+        if self.rid_version == RIDVersion.f3411_19:
+            if not self.v19_value.has_field_with_value(
+                "current_state"
+            ) or not self.v19_value.current_state.has_field_with_value("height"):
+                return None
+            return self.v19_value.current_state.height
+        elif self.rid_version == RIDVersion.f3411_22a:
+            if (
+                not self.most_recent_position
+                or not self.most_recent_position.has_field_with_value("height")
+            ):
+                return None
+            return self.most_recent_position.height
+        else:
+            raise NotImplementedError(
+                f"Cannot retrieve aircraft_type using RID version {self.rid_version}"
+            )
+
     def errors(self) -> List[str]:
         try:
             rid_version = self.rid_version

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common_dictionary_evaluator.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common_dictionary_evaluator.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import math
 from collections.abc import Callable
@@ -14,6 +16,7 @@ from uas_standards.astm.f3411.v22a import constants
 from uas_standards.astm.f3411.v22a.api import (
     UASID,
     HorizontalAccuracy,
+    RIDHeightReference,
     RIDOperationalStatus,
     SpeedAccuracy,
     Time,
@@ -64,6 +67,8 @@ class RIDCommonDictionaryEvaluator(object):
         "_evaluate_vertical_speed",
         "_evaluate_speed",
         "_evaluate_track",
+        "_evaluate_height",
+        "_evaluate_height_type",
     ]
     details_evaluators = [
         "_evaluate_ua_classification",
@@ -142,11 +147,6 @@ class RIDCommonDictionaryEvaluator(object):
         self._evaluate_position(
             injected_telemetry.position,
             observed_flight.most_recent_position,
-            participants,
-        )
-        self._evaluate_height(
-            injected_telemetry.get("height"),
-            observed_flight.most_recent_position.get("height"),
             participants,
         )
 
@@ -536,66 +536,69 @@ class RIDCommonDictionaryEvaluator(object):
                 message=f"Unsupported version {self._rid_version}: skipping position evaluation",
             )
 
-    def _evaluate_height(
-        self,
-        height_inj: Optional[injection.RIDHeight],
-        height_obs: Optional[observation_api.RIDHeight],
-        participants: List[str],
-    ):
-        if self._rid_version == RIDVersion.f3411_22a:
-            if height_obs is not None:
-                with self._test_scenario.check(
-                    "Height consistency with Common Dictionary", participants
-                ) as check:
-                    if (
-                        height_obs.reference
-                        != observation_api.RIDHeightReference.TakeoffLocation
-                        and height_obs.reference
-                        != observation_api.RIDHeightReference.GroundLevel
-                    ):
-                        check.record_failed(
-                            f"Invalid height type: {height_obs.reference}",
-                            details=f"The height type reference shall be either {observation_api.RIDHeightReference.TakeoffLocation} or {observation_api.RIDHeightReference.GroundLevel}",
-                        )
+    def _evaluate_height(self, **generic_kwargs):
+        """
+        Evaluates Height. Exactly one of sp_observed or dp_observed must be provided.
+        See as well `common_dictionary_evaluator.md`.
 
-                with self._test_scenario.check(
-                    "Height is consistent with injected one", participants
-                ) as check:
-                    if not math.isclose(
-                        height_obs.distance, height_inj.distance, abs_tol=1.0
-                    ):
-                        check.record_failed(
-                            "Observed Height is inconsistent with injected one",
-                            details=f"Observed height: {height_obs} - injected: {height_inj}",
-                        )
+        Raises:
+            ValueError: if a test operation wasn't performed correctly by uss_qualifier.
+        """
 
-                with self._test_scenario.check(
-                    "Height Type consistency with Common Dictionary", participants
-                ) as check:
-                    if (
-                        height_obs.reference
-                        != observation_api.RIDHeightReference.TakeoffLocation
-                        and height_obs.reference
-                        != observation_api.RIDHeightReference.GroundLevel
-                    ):
-                        check.record_failed(
-                            f"Invalid height type: {height_obs.reference}",
-                            details=f"The height type reference shall be either {observation_api.RIDHeightReference.TakeoffLocation} or {observation_api.RIDHeightReference.GroundLevel}",
-                        )
+        def value_comparator(v1: Optional[float], v2: Optional[float]) -> bool:
 
-                with self._test_scenario.check(
-                    "Height Type is consistent with injected one", participants
-                ) as check:
-                    if height_obs.reference != height_inj.reference:
-                        check.record_failed(
-                            "Observed Height type is inconsistent with injected one",
-                            details=f"Observed height: {height_obs} - injected: {height_inj}",
-                        )
-        else:
-            self._test_scenario.record_note(
-                key="skip_reason",
-                message=f"Unsupported version {self._rid_version}: skipping Height and Height Type evaluation",
-            )
+            if v1 is None or v2 is None:
+                return False
+
+            return abs(v1 - v2) < constants.MinHeightResolution
+
+        self._generic_evaluator(
+            "position.height.distance",
+            "height.distance",
+            "most_recent_position.height.distance",
+            "Height",
+            None,
+            None,
+            False,
+            [None, -1000],
+            value_comparator,
+            **generic_kwargs,
+        )
+
+    def _evaluate_height_type(self, **generic_kwargs):
+        """
+        Evaluates Height type. Exactly one of sp_observed or dp_observed must be provided.
+        See as well `common_dictionary_evaluator.md`.
+
+        Raises:
+            ValueError: if a test operation wasn't performed correctly by uss_qualifier.
+        """
+
+        def value_validator(val: str) -> RIDHeightReference:
+            return RIDHeightReference(val)
+
+        def value_comparator(
+            v1: Optional[RIDHeightReference], v2: Optional[RIDHeightReference]
+        ) -> bool:
+
+            return v1 == v2
+
+        self._generic_evaluator(
+            "position.height.reference",
+            "height.reference",
+            "most_recent_position.height.reference",
+            "Height type",
+            value_validator,
+            None,
+            False,
+            [
+                None,
+                RIDHeightReference.TakeoffLocation,
+                RIDHeightReference.GroundLevel,
+            ],
+            value_comparator,
+            **generic_kwargs,
+        )
 
     def _evaluate_operator_location(
         self,
@@ -1188,7 +1191,7 @@ class RIDCommonDictionaryEvaluator(object):
         value_validator: Optional[Callable[[T], T2]],
         observed_value_validator: Optional[Callable[[PendingCheck, T2], None]],
         injection_required_field: bool,
-        unknown_value: Optional[T2],
+        unknown_value: Optional[T2 | List[T2]],
         value_comparator: Callable[[Optional[T2], Optional[T2]], bool],
         injected: Union[
             injection.TestFlight,
@@ -1217,7 +1220,7 @@ class RIDCommonDictionaryEvaluator(object):
             value_validator: If not None, pass values through this function. You may raise ValueError to indicate errors.
             observed_value_validator: If not None, will be called with check and observed value, for additional verifications
             injection_required_field: Boolean to indicate we need to check the case where nothing has been injected (C6)
-            unknown_value: The default value that needs to be returned when nothing has been injected
+            unknown_value: The default value that needs to be returned when nothing has been injected. Should multiple ones be accepted, use a list there.
             value_comparator: Function that need to return True if both parameters are equal
             injected: injected data (flight, telemetry or details).
             sp_observed: flight (or details) observed through the SP API.
@@ -1237,7 +1240,7 @@ class RIDCommonDictionaryEvaluator(object):
                 if isinstance(val, dict) and k in val:
                     val = val[k]
                 else:
-                    val = getattr(val, k)
+                    val = getattr(val, k, None)
             return val
 
         injected_val: Optional[T] = dotted_get(injected, injected_field_name)
@@ -1307,7 +1310,10 @@ class RIDCommonDictionaryEvaluator(object):
                         f"Invalid {field_human_name} value injected. Injection is marked as required, but we injected a None value. This should have been caught by the injection api."
                     )
 
-                if observed_val != unknown_value:  # C6 / C10
+                if not isinstance(unknown_value, list):
+                    unknown_value = [unknown_value]
+
+                if observed_val not in unknown_value:  # C6 / C10
                     check.record_failed(
                         f"{field_human_name} is inconsistent, expected '{unknown_value}' since no value was injected",
                         details=f"USS returned the UA type {observed_val} yet no value was injected. Since '{field_human_name}' is a required field of SP API, the SP should map this to '{unknown_value}' and the DP should expose the same value.",

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/common_dictionary_evaluator_dp_flight.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/common_dictionary_evaluator_dp_flight.md
@@ -67,6 +67,32 @@ If the Geodetic Altitude value exposed by the observer API is inconsistent with 
 **[astm.f3411.v19.NET0450](../../../../requirements/astm/f3411/v19.md)** because the DP fails to provide accurate data;
 **[astm.f3411.v19.NET0470,Table1,11](../../../../requirements/astm/f3411/v19.md)**  because the DP fails to expose data consistent with the valid injected value.
 
+## ⚠️ Height is exposed correctly check
+
+If the Height value exposed by the observation API is invalid this check will fail per:
+**[interuss.automated_testing.rid.observation.ObservationSuccess](../../../../requirements/interuss/automated_testing/rid/observation.md)** because the DP violates the observation API contract;
+**[astm.f3411.v19.NET0450](../../../../requirements/astm/f3411/v19.md)** because the DP fails to provide accurate data;
+**[astm.f3411.v19.NET0470,Table1,13](../../../../requirements/astm/f3411/v19.md)** because the DP fails to expose data consistent with the Common Data Dictionary.
+
+## ⚠️ Height is consistent with injected value check
+
+If the Height value exposed by the observer API is inconsistent with the injected value this check will fail per:
+**[astm.f3411.v19.NET0450](../../../../requirements/astm/f3411/v19.md)** because the DP fails to provide accurate data;
+**[astm.f3411.v19.NET0470,Table1,13](../../../../requirements/astm/f3411/v19.md)**  because the DP fails to expose data consistent with the valid injected value.
+
+## ⚠️ Height type is exposed correctly check
+
+If the Height type value exposed by the observation API is invalid this check will fail per:
+**[interuss.automated_testing.rid.observation.ObservationSuccess](../../../../requirements/interuss/automated_testing/rid/observation.md)** because the DP violates the observation API contract;
+**[astm.f3411.v19.NET0450](../../../../requirements/astm/f3411/v19.md)** because the DP fails to provide accurate data;
+**[astm.f3411.v19.NET0470,Table1,14](../../../../requirements/astm/f3411/v19.md)** because the DP fails to expose data consistent with the Common Data Dictionary.
+
+## ⚠️ Height type is consistent with injected value check
+
+If the Height type value exposed by the observer API is inconsistent with the injected value this check will fail per:
+**[astm.f3411.v19.NET0450](../../../../requirements/astm/f3411/v19.md)** because the DP fails to provide accurate data;
+**[astm.f3411.v19.NET0470,Table1,14](../../../../requirements/astm/f3411/v19.md)**  because the DP fails to expose data consistent with the valid injected value.
+
 ## ⚠️ Geodetic Vertical Accuracy is exposed correctly check
 
 If the Geodetic Vertical Accuracy value exposed by the observation API is invalid this check will fail per:

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/common_dictionary_evaluator_sp_flight.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/common_dictionary_evaluator_sp_flight.md
@@ -57,6 +57,28 @@ If the Geodetic Altitude value exposed by the SP API is missing or invalid this 
 If the Geodetic Altitude value exposed by the SP API is inconsistent with the injected value this check will fail per:
 **[astm.f3411.v19.NET0260,Table1,11](../../../../requirements/astm/f3411/v19.md)** because the SP fails to expose data consistent with the valid injected value.
 
+## ⚠️ Height is exposed correctly check
+
+If the Height value exposed by the SP API is missing or invalid this check will fail per:
+**[astm.f3411.v19.NET0710,1](../../../../requirements/astm/f3411/v19.md)** because the SP violates the SP API contract;
+**[astm.f3411.v19.NET0260,Table1,13](../../../../requirements/astm/f3411/v19.md)** because the SP fails to expose data consistent with the Common Data Dictionary.
+
+## ⚠️ Height is consistent with injected value check
+
+If the Height value exposed by the SP API is inconsistent with the injected value this check will fail per:
+**[astm.f3411.v19.NET0260,Table1,13](../../../../requirements/astm/f3411/v19.md)** because the SP fails to expose data consistent with the valid injected value.
+
+## ⚠️ Height type is exposed correctly check
+
+If the Height type value exposed by the SP API is missing or invalid this check will fail per:
+**[astm.f3411.v19.NET0710,1](../../../../requirements/astm/f3411/v19.md)** because the SP violates the SP API contract;
+**[astm.f3411.v19.NET0260,Table1,14](../../../../requirements/astm/f3411/v19.md)** because the SP fails to expose data consistent with the Common Data Dictionary.
+
+## ⚠️ Height type is consistent with injected value check
+
+If the Height type value exposed by the SP API is inconsistent with the injected value this check will fail per:
+**[astm.f3411.v19.NET0260,Table1,14](../../../../requirements/astm/f3411/v19.md)** because the SP fails to expose data consistent with the valid injected value.
+
 ## ⚠️ Geodetic Vertical Accuracy is exposed correctly check
 
 If the Geodetic Vertical Accuracy value exposed by the SP API is missing or invalid this check will fail per:
@@ -126,7 +148,3 @@ If the Vertical Speed value exposed by the SP API is inconsistent with the injec
 ## ⚠️ Service Provider timestamp accuracy is present check
 
 If the timestamp accuracy is not present, the USS under test is not properly implementing the REST interface specified by the OpenAPI definition contained in Annex A4, and is therefore in violation of **[astm.f3411.v19.NET0710,1](../../../../requirements/astm/f3411/v19.md)**.
-
-## ⚠️ Service Provider height check
-
-**[astm.f3411.v19.NET0260,Table1,13](../../../../requirements/astm/f3411/v19.md)** requires that relevant Remote ID data, consistent with the common data dictionary, be reported by the Service Provider.  The reported height of the flight is unrealistic or otherwise not consistent with the injected data.

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/common_dictionary_evaluator_dp_flight.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/common_dictionary_evaluator_dp_flight.md
@@ -67,6 +67,32 @@ If the Geodetic Altitude value exposed by the observer API is inconsistent with 
 **[astm.f3411.v22a.NET0450](../../../../requirements/astm/f3411/v22a.md)** because the DP fails to provide accurate data;
 **[astm.f3411.v22a.NET0470,Table1,12](../../../../requirements/astm/f3411/v22a.md)**  because the DP fails to expose data consistent with the valid injected value.
 
+## ⚠️ Height is exposed correctly check
+
+If the Height value exposed by the observation API is invalid this check will fail per:
+**[interuss.automated_testing.rid.observation.ObservationSuccess](../../../../requirements/interuss/automated_testing/rid/observation.md)** because the DP violates the observation API contract;
+**[astm.f3411.v22a.NET0450](../../../../requirements/astm/f3411/v22a.md)** because the DP fails to provide accurate data;
+**[astm.f3411.v22a.NET0470,Table1,14](../../../../requirements/astm/f3411/v22a.md)** because the DP fails to expose data consistent with the Common Data Dictionary.
+
+## ⚠️ Height is consistent with injected value check
+
+If the Height value exposed by the observer API is inconsistent with the injected value this check will fail per:
+**[astm.f3411.v22a.NET0450](../../../../requirements/astm/f3411/v22a.md)** because the DP fails to provide accurate data;
+**[astm.f3411.v22a.NET0470,Table1,14](../../../../requirements/astm/f3411/v22a.md)**  because the DP fails to expose data consistent with the valid injected value.
+
+## ⚠️ Height type is exposed correctly check
+
+If the Height type value exposed by the observation API is invalid this check will fail per:
+**[interuss.automated_testing.rid.observation.ObservationSuccess](../../../../requirements/interuss/automated_testing/rid/observation.md)** because the DP violates the observation API contract;
+**[astm.f3411.v22a.NET0450](../../../../requirements/astm/f3411/v22a.md)** because the DP fails to provide accurate data;
+**[astm.f3411.v22a.NET0470,Table1,15](../../../../requirements/astm/f3411/v22a.md)** because the DP fails to expose data consistent with the Common Data Dictionary.
+
+## ⚠️ Height type is consistent with injected value check
+
+If the Height type value exposed by the observer API is inconsistent with the injected value this check will fail per:
+**[astm.f3411.v22a.NET0450](../../../../requirements/astm/f3411/v22a.md)** because the DP fails to provide accurate data;
+**[astm.f3411.v22a.NET0470,Table1,15](../../../../requirements/astm/f3411/v22a.md)**  because the DP fails to expose data consistent with the valid injected value.
+
 ## ⚠️ Geodetic Vertical Accuracy is exposed correctly check
 
 If the Geodetic Vertical Accuracy value exposed by the observation API is invalid this check will fail per:
@@ -153,19 +179,3 @@ TODO: If the resolution is greater than 7 number digits, this check will fail.
 ## ⚠️ Observed Position is consistent with injected one check
 
 If the Position reported for an observation does not correspond to the injected one, the DP is not providing timely and accurate data and is thus in breach of **[astm.f3411.v22a.NET0450](../../../../requirements/astm/f3411/v22a.md)**
-
-## ⚠️ Height consistency with Common Dictionary check
-
-**[astm.f3411.v22a.NET0470](../../../../requirements/astm/f3411/v22a.md)** requires that Net-RID Display Provider shall provide access to required and optional fields to Remote ID Display Applications according to the Common Dictionary. This check validates that the Height (**[astm.f3411.v22a.NET0470,Table1,14](../../../../requirements/astm/f3411/v22a.md)**), if present, is valid.
-
-## ⚠️ Height is consistent with injected one check
-
-If the Height reported for an observation does not correspond to the injected one, the DP is not providing timely and accurate data and is thus in breach of **[astm.f3411.v22a.NET0450](../../../../requirements/astm/f3411/v22a.md)**
-
-## ⚠️ Height Type consistency with Common Dictionary check
-
-**[astm.f3411.v22a.NET0470](../../../../requirements/astm/f3411/v22a.md)** requires that Net-RID Display Provider shall provide access to required and optional fields to Remote ID Display Applications according to the Common Dictionary. This check validates that the Height Type (**[astm.f3411.v22a.NET0470,Table1,15](../../../../requirements/astm/f3411/v22a.md)**), if present, is valid. If the observed Height Type indicates a value different than Takeoff Location or Ground Level, this check will fail.
-
-## ⚠️ Height Type is consistent with injected one check
-
-If the Height Type reported for an observation does not correspond to the injected one, the DP is not providing timely and accurate data and is thus in breach of **[astm.f3411.v22a.NET0450](../../../../requirements/astm/f3411/v22a.md)**

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/common_dictionary_evaluator_sp_flight.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/common_dictionary_evaluator_sp_flight.md
@@ -57,6 +57,28 @@ If the Geodetic Altitude value exposed by the SP API is missing or invalid this 
 If the Geodetic Altitude value exposed by the SP API is inconsistent with the injected value this check will fail per:
 **[astm.f3411.v22a.NET0260,Table1,12](../../../../requirements/astm/f3411/v22a.md)** because the SP fails to expose data consistent with the valid injected value.
 
+## ⚠️ Height is exposed correctly check
+
+If the Height value exposed by the SP API is missing or invalid this check will fail per:
+**[astm.f3411.v22a.NET0710,1](../../../../requirements/astm/f3411/v22a.md)** because the SP violates the SP API contract;
+**[astm.f3411.v22a.NET0260,Table1,14](../../../../requirements/astm/f3411/v22a.md)** because the SP fails to expose data consistent with the Common Data Dictionary.
+
+## ⚠️ Height is consistent with injected value check
+
+If the Height value exposed by the SP API is inconsistent with the injected value this check will fail per:
+**[astm.f3411.v22a.NET0260,Table1,14](../../../../requirements/astm/f3411/v22a.md)** because the SP fails to expose data consistent with the valid injected value.
+
+## ⚠️ Height type is exposed correctly check
+
+If the Height type value exposed by the SP API is missing or invalid this check will fail per:
+**[astm.f3411.v22a.NET0710,1](../../../../requirements/astm/f3411/v22a.md)** because the SP violates the SP API contract;
+**[astm.f3411.v22a.NET0260,Table1,15](../../../../requirements/astm/f3411/v22a.md)** because the SP fails to expose data consistent with the Common Data Dictionary.
+
+## ⚠️ Height type is consistent with injected value check
+
+If the Height type value exposed by the SP API is inconsistent with the injected value this check will fail per:
+**[astm.f3411.v22a.NET0260,Table1,15](../../../../requirements/astm/f3411/v22a.md)** because the SP fails to expose data consistent with the valid injected value.
+
 ## ⚠️ Geodetic Vertical Accuracy is exposed correctly check
 
 If the Geodetic Vertical Accuracy value exposed by the SP API is missing or invalid this check will fail per:
@@ -122,7 +144,3 @@ If the Vertical Speed value exposed by the SP API is missing or invalid this che
 
 If the Vertical Speed value exposed by the SP API is inconsistent with the injected value this check will fail per:
 **[astm.f3411.v22a.NET0260,Table1,21](../../../../requirements/astm/f3411/v22a.md)** because the SP fails to expose data consistent with the valid injected value.
-
-## ⚠️ Service Provider height check
-
-**[astm.f3411.v22a.NET0260,Table1,14](../../../../requirements/astm/f3411/v22a.md)** requires that relevant Remote ID data, consistent with the common data dictionary, be reported by the Service Provider.  The reported height of the flight is unrealistic or otherwise not consistent with the injected data.

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_19.md
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_19.md
@@ -26,7 +26,7 @@
     <th><a href="../../README.md#checked-in">Checked in</a></th>
   </tr>
   <tr>
-    <td rowspan="90" style="vertical-align:top;"><a href="../../../requirements/astm/f3411/v19.md">astm<br>.f3411<br>.v19</a></td>
+    <td rowspan="93" style="vertical-align:top;"><a href="../../../requirements/astm/f3411/v19.md">astm<br>.f3411<br>.v19</a></td>
     <td><a href="../../../requirements/astm/f3411/v19.md">DSS0010</a></td>
     <td>Implemented</td>
     <td><a href="../../../scenarios/astm/netrid/v19/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a></td>
@@ -287,6 +287,11 @@
     <td><a href="../../../scenarios/astm/netrid/v19/sp_operator_notify_slow_update.md">ASTM NetRID Service Provider operator notification under slow update rate</a><br><a href="../../../scenarios/astm/netrid/v19/networked_uas_disconnect.md">ASTM NetRID networked UAS disconnection</a><br><a href="../../../scenarios/astm/netrid/v19/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
   </tr>
   <tr>
+    <td><a href="../../../requirements/astm/f3411/v19.md">NET0260,Table1,14</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/netrid/v19/sp_operator_notify_slow_update.md">ASTM NetRID Service Provider operator notification under slow update rate</a><br><a href="../../../scenarios/astm/netrid/v19/networked_uas_disconnect.md">ASTM NetRID networked UAS disconnection</a><br><a href="../../../scenarios/astm/netrid/v19/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
+  </tr>
+  <tr>
     <td><a href="../../../requirements/astm/f3411/v19.md">NET0260,Table1,15</a></td>
     <td>Implemented</td>
     <td><a href="../../../scenarios/astm/netrid/v19/sp_operator_notify_slow_update.md">ASTM NetRID Service Provider operator notification under slow update rate</a><br><a href="../../../scenarios/astm/netrid/v19/networked_uas_disconnect.md">ASTM NetRID networked UAS disconnection</a><br><a href="../../../scenarios/astm/netrid/v19/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
@@ -383,6 +388,16 @@
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3411/v19.md">NET0470,Table1,11</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/netrid/v19/networked_uas_disconnect.md">ASTM NetRID networked UAS disconnection</a><br><a href="../../../scenarios/astm/netrid/v19/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3411/v19.md">NET0470,Table1,13</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/netrid/v19/networked_uas_disconnect.md">ASTM NetRID networked UAS disconnection</a><br><a href="../../../scenarios/astm/netrid/v19/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3411/v19.md">NET0470,Table1,14</a></td>
     <td>Implemented</td>
     <td><a href="../../../scenarios/astm/netrid/v19/networked_uas_disconnect.md">ASTM NetRID networked UAS disconnection</a><br><a href="../../../scenarios/astm/netrid/v19/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
   </tr>

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a.md
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a.md
@@ -26,7 +26,7 @@
     <th><a href="../../README.md#checked-in">Checked in</a></th>
   </tr>
   <tr>
-    <td rowspan="116" style="vertical-align:top;"><a href="../../../requirements/astm/f3411/v22a.md">astm<br>.f3411<br>.v22a</a></td>
+    <td rowspan="117" style="vertical-align:top;"><a href="../../../requirements/astm/f3411/v22a.md">astm<br>.f3411<br>.v22a</a></td>
     <td><a href="../../../requirements/astm/f3411/v22a.md">DSS0010</a></td>
     <td>Implemented</td>
     <td><a href="../../../scenarios/astm/netrid/v22a/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a></td>
@@ -298,6 +298,11 @@
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3411/v22a.md">NET0260,Table1,14</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/netrid/v22a/sp_operator_notify_slow_update.md">ASTM NetRID Service Provider operator notification under slow update rate</a><br><a href="../../../scenarios/astm/netrid/v22a/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3411/v22a.md">NET0260,Table1,15</a></td>
     <td>Implemented</td>
     <td><a href="../../../scenarios/astm/netrid/v22a/sp_operator_notify_slow_update.md">ASTM NetRID Service Provider operator notification under slow update rate</a><br><a href="../../../scenarios/astm/netrid/v22a/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
   </tr>

--- a/monitoring/uss_qualifier/suites/uspace/network_identification.md
+++ b/monitoring/uss_qualifier/suites/uspace/network_identification.md
@@ -17,7 +17,7 @@
     <th><a href="../README.md#checked-in">Checked in</a></th>
   </tr>
   <tr>
-    <td rowspan="116" style="vertical-align:top;"><a href="../../requirements/astm/f3411/v22a.md">astm<br>.f3411<br>.v22a</a></td>
+    <td rowspan="117" style="vertical-align:top;"><a href="../../requirements/astm/f3411/v22a.md">astm<br>.f3411<br>.v22a</a></td>
     <td><a href="../../requirements/astm/f3411/v22a.md">DSS0010</a></td>
     <td>Implemented</td>
     <td><a href="../../scenarios/astm/netrid/v22a/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a></td>
@@ -289,6 +289,11 @@
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3411/v22a.md">NET0260,Table1,14</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/netrid/v22a/sp_operator_notify_slow_update.md">ASTM NetRID Service Provider operator notification under slow update rate</a><br><a href="../../scenarios/astm/netrid/v22a/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3411/v22a.md">NET0260,Table1,15</a></td>
     <td>Implemented</td>
     <td><a href="../../scenarios/astm/netrid/v22a/sp_operator_notify_slow_update.md">ASTM NetRID Service Provider operator notification under slow update rate</a><br><a href="../../scenarios/astm/netrid/v22a/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
   </tr>

--- a/monitoring/uss_qualifier/suites/uspace/required_services.md
+++ b/monitoring/uss_qualifier/suites/uspace/required_services.md
@@ -18,7 +18,7 @@
     <th><a href="../README.md#checked-in">Checked in</a></th>
   </tr>
   <tr>
-    <td rowspan="116" style="vertical-align:top;"><a href="../../requirements/astm/f3411/v22a.md">astm<br>.f3411<br>.v22a</a></td>
+    <td rowspan="117" style="vertical-align:top;"><a href="../../requirements/astm/f3411/v22a.md">astm<br>.f3411<br>.v22a</a></td>
     <td><a href="../../requirements/astm/f3411/v22a.md">DSS0010</a></td>
     <td>Implemented</td>
     <td><a href="../../scenarios/astm/netrid/v22a/dss/token_validation.md">ASTM NetRID DSS: Token Validation</a></td>
@@ -290,6 +290,11 @@
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3411/v22a.md">NET0260,Table1,14</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/netrid/v22a/sp_operator_notify_slow_update.md">ASTM NetRID Service Provider operator notification under slow update rate</a><br><a href="../../scenarios/astm/netrid/v22a/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3411/v22a.md">NET0260,Table1,15</a></td>
     <td>Implemented</td>
     <td><a href="../../scenarios/astm/netrid/v22a/sp_operator_notify_slow_update.md">ASTM NetRID Service Provider operator notification under slow update rate</a><br><a href="../../scenarios/astm/netrid/v22a/nominal_behavior.md">ASTM NetRID nominal behavior</a></td>
   </tr>


### PR DESCRIPTION
This implements properly the check for height and height type in the common dictionary evaluator.
Note that most of the work has been done by @the-glu in 4f47ede11386f572bfdd0014a88cb4f0a68d1896.
 
In addition:
- cleanup legacy height and height types checks
- adapt generic evaluator to support multiple unknown values
- for mock USS DP v19: expose height correctly

With this PR the RID coverage should now be complete, modulo some still pending issues. 