### PR TITLE
[dev] Remove .git from docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 build/workspace
 *.pyc
+.git


### PR DESCRIPTION
This remove the .git folder, who seems to be unused, from the docker context build.

It does speed up building/running local images, especially with a big .git folder (5s -> 2.5s to run uss_qualifiers units tests on my machine).

