### PR TITLE
[uss_qualifier] Record failure for user notifications parsing errors

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/netrid/injection.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/injection.py
@@ -174,7 +174,14 @@ def get_user_notifications(
                     details=f"Expected response code 200 from {target.participant_id} but received {query.status_code} while trying to retrieve user notifications",
                     query_timestamps=[query.request.timestamp],
                 )
-
-            notifications[target.participant_id] = response.user_notifications
+            if response is None:
+                check.record_failed(
+                    summary="Error while trying to retrieve user notifications",
+                    details=f"Response from {target.participant_id} was not valid",
+                    query_timestamps=[query.request.timestamp],
+                )
+                notifications[target.participant_id] = []
+            else:
+                notifications[target.participant_id] = response.user_notifications
 
     return notifications


### PR DESCRIPTION
This PR fixes a uss_qualifier bug when invalid responses are received from a USS's user notifications endpoint -- prior to this PR, uss_qualifier would raise an uncaught exception (always indicating a uss_qualifier bug) if the USS response could not be parsed.  This PR records a failed check and proceeds gracefully instead of raising an uncaught exception.