### PR TITLE
[uss_qualifier] Annotate severity of checks in networked_uas_disconnect

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/networked_uas_disconnect.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/networked_uas_disconnect.md
@@ -39,7 +39,7 @@ Per **[interuss.automated_testing.rid.injection.UpsertTestSuccess](../../../../r
 **[astm.f3411.v19.NET0500](../../../../requirements/astm/f3411/v19.md)** requires a Service Provider to provide a persistently supported test instance of their implementation.
 This check will fail if the flight was not successfully injected.
 
-#### Valid flight check
+#### 🛑 Valid flight check
 
 TODO: Validate injected flights, especially to make sure they contain the specified injection IDs
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/networked_uas_disconnect.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/networked_uas_disconnect.md
@@ -32,14 +32,14 @@ uss_qualifier acts as a Display Provider querying the Service Provider(s) under 
 
 In this step, uss_qualifier injects a single nominal flight into each SP under test, usually with a start time in the future.  Each SP is expected to queue the provided telemetry and later simulate that telemetry coming from an aircraft at the designated timestamps.
 
-#### Successful injection check
+#### 🛑 Successful injection check
 
 Per **[interuss.automated_testing.rid.injection.UpsertTestSuccess](../../../../requirements/interuss/automated_testing/rid/injection.md)**, the injection attempt of the valid flight should succeed for every NetRID Service Provider under test.
 
 **[astm.f3411.v22a.NET0500](../../../../requirements/astm/f3411/v22a.md)** requires a Service Provider to provide a persistently supported test instance of their implementation.
 This check will fail if the flight was not successfully injected.
 
-#### Identifiable flights check
+#### 🛑 Identifiable flights check
 
 This particular test requires each flight to be uniquely identifiable by its 2D telemetry position; the same (lat, lng) pair may not appear in two different telemetry points, even if the two points are in different injected flights.  This should generally be achieved by injecting appropriate data.
 


### PR DESCRIPTION
This PR fixes [a bug](https://interuss.slack.com/archives/C05UVBHKQ0G/p1739987447769379?thread_ts=1739975246.437539&cid=C05UVBHKQ0G) where the severity of checks is not annotated in documentation nor specified in code.