### PR TITLE
[Makefile] Remove 'monitoring-tests' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,13 +100,9 @@ down-locally:
 check-monitoring:
 	cd monitoring && make test
 
-# This mirrors the monitoring-tests continuous integration workflow job (.github/workflows/ci.yml)
-.PHONY: monitoring-tests
-monitoring-tests: check-monitoring
-
 # This reproduces the entire continuous integration workflow (.github/workflows/ci.yml)
 .PHONY: presubmit
-presubmit: check-hygiene monitoring-tests
+presubmit: check-hygiene check-monitoring
 
 # For local development when restarts are frequently required (such as when testing changes on the DSS)
 .PHONY: restart-all


### PR DESCRIPTION
Follow-up to https://github.com/interuss/monitoring/pull/957/files#r1953440811
The comment on the target was indeed wrong and actually for a while: since then the different configurations were separated into separate jobs, and the job 'monitoring-tests' does not exist anymore.
This PR removes the target 'monitoring-tests' and add 'check-monitoring' as dependency of 'presubmit' to preserve its behavior.