### PR TITLE
[uss_qualifier/scenarios/netrid/common_dictionary_evaluator] Test alt, accuracy_v, accuracy_h, speed_accuracy, vertical_speed

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common_dictionary_evaluator.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common_dictionary_evaluator.py
@@ -997,10 +997,8 @@ class RIDCommonDictionaryEvaluator(object):
         VERTICAL_SPEED_PRECISION = 0.1
 
         def value_validator(val: float) -> float:
-            if val < -63:
-                raise ValueError("Vertical speed is less than -63")
-            if -63 > val > -62:
-                raise ValueError("Vertical speed is between -63 and -62, exclusive")
+            if val < -62:
+                raise ValueError("Vertical speed is less than -62")
             if val > 63:
                 raise ValueError("Vertical speed is greather than 63")
             if 62 < val < 63:


### PR DESCRIPTION
This PR add all missing tests on common_dictionary_evaluator's _evaluate function.

It's mostly basic application of existing function, but also include a fix for the vertical speed who shouldn't be valid between -62 and -63