### PR TITLE
[uss_qualifier] don't document version update check when it never happens

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/netrid/dss_wrapper.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/dss_wrapper.py
@@ -377,7 +377,7 @@ class DSSWrapper(object):
         )
 
         isa_validator.validate_mutated_isa(
-            isa_id, mutated_isa.dss_query, previous_version=None
+            isa_id, mutated_isa.dss_query, previous_version=isa_version
         )
         # TODO: Validate subscriber notifications (the validator currently does not)
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dp_behavior.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dp_behavior.md
@@ -50,7 +50,7 @@ Each observer is queried for flights in the empty area.
 
 This test step has the mock_uss begin a new flight by establishing an ISA.
 
-### [Create ISA test step](./dss/test_steps/put_isa.md)
+### [Create ISA test step](./dss/test_steps/create_isa.md)
 
 uss_qualifier, acting as mock_uss, creates an ISA in the area specified by the `isa` resource, valid from the moment the scenario runs and for a duration of 5 minutes.
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/heavy_traffic_concurrent.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/heavy_traffic_concurrent.md
@@ -35,7 +35,7 @@ This test case will:
 5. Query each ISA individually, but concurrently
 6. Search for all ISAs in the area of the deleted ISAs (using a single request)
 
-### [Create ISA concurrently test step](test_steps/put_isa.md)
+### [Create ISA concurrently test step](test_steps/create_isa.md)
 
 This step attempts to concurrently create multiple ISAs, as specified in this scenario's resource, at the configured DSS.
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/isa_simple.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/isa_simple.md
@@ -32,7 +32,7 @@ part of the test.
 
 ## Create and check ISA test case
 
-### [Create ISA test step](test_steps/put_isa.md)
+### [Create ISA test step](test_steps/create_isa.md)
 
 This step attempts to query the configured DSS with the ISA provided as a resource.
 
@@ -56,7 +56,7 @@ The DSS returns the version of the ISA in the response body.  If this version do
 
 ## Update and search ISA test case
 
-### [Update ISA test step](test_steps/put_isa.md)
+### [Update ISA test step](test_steps/mutate_isa.md)
 
 This step attempts to update the configured DSS with the ISA provided as a resource, with a slightly different end time.
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/test_steps/create_isa.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/test_steps/create_isa.md
@@ -1,0 +1,8 @@
+# Create or update ISA test step fragment
+
+This page describes the content of a common test step where a creation of an ISA should be successful.
+See `DSSWrapper.put_isa` in [`dss_wrapper.py`](../../../dss_wrapper.py).
+
+## [Put ISA](put_isa.md)
+
+Checks common to creation and mutation.

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/test_steps/mutate_isa.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/test_steps/mutate_isa.md
@@ -1,0 +1,12 @@
+# Create or update ISA test step fragment
+
+This page describes the content of a common test step where a mutation of an ISA should be successful.
+See `DSSWrapper.put_isa` in [`dss_wrapper.py`](../../../dss_wrapper.py).
+
+## [Put ISA](put_isa.md)
+
+Checks common to creation and mutation.
+
+## ⚠️ ISA version changed check
+
+When the ISA is updated, the DSS returns the updated version of the ISA in the response body.  If this version remains the same as the one before the update, **[astm.f3411.v19.DSS0030,a](../../../../../../requirements/astm/f3411/v19.md)** was not implemented correctly and this check will fail.

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/token_validation.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/token_validation.md
@@ -27,7 +27,7 @@ part of the test.
 
 ## Token validation test case
 
-### [Token validation test step](test_steps/put_isa.md)
+### [Token validation test step](test_steps/create_isa.md)
 
 This step attempts to create and read ISAs by providing both the correct and incorrect scopes, omitting the token or providing an invalid one,
 and expects the DSS to properly behave in each case.

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss_interoperability.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss_interoperability.md
@@ -61,7 +61,7 @@ As such, this check will fail if the DSS is not reachable with a dummy query,
 
 ## Interoperability sequence test case
 
-### [S1 test step](dss/test_steps/put_isa.md)
+### [S1 test step](dss/test_steps/create_isa.md)
 
 Action: USS1@DSS*P*: PUT ISA with no start time and end time 10 minutes from now
 
@@ -156,7 +156,7 @@ Qualitatively proves: All Subscription[i] 1≤i≤n are returned in subscription
 
 **[astm.f3411.v19.DSS0070](../../../../requirements/astm/f3411/v19.md)** requires that all DSS instances in a pool return the same result. This check fails if the DSS instance does not return the same result as the other DSS instances.
 
-### [S5 test step](dss/test_steps/put_isa.md)
+### [S5 test step](dss/test_steps/mutate_isa.md)
 
 Action: USS1@DSS*P*: PUT ISA[*P*] setting end time to now + D seconds
 
@@ -236,7 +236,7 @@ Qualitatively proves: Expired ISA automatically removed, ISA modifications acces
 
 **[astm.f3411.v19.DSS0070](../../../../requirements/astm/f3411/v19.md)** requires that all DSS instances in a pool return the same result. This check fails if the DSS instance does not return the same result as the other DSS instances.
 
-### [S10 test step](dss/test_steps/put_isa.md)
+### [S10 test step](dss/test_steps/create_isa.md)
 
 Action: USS1@DSS*P*: PUT ISA with no start time and end time 10 minutes from now
 
@@ -264,7 +264,7 @@ Qualitatively proves: ISA deletion triggers subscription notification requests
 
 **[astm.f3411.v19.DSS0130,A2-6-1,3c](../../../../requirements/astm/f3411/v19.md)**
 
-### [S12 test step](dss/test_steps/put_isa.md)
+### [S12 test step](dss/test_steps/create_isa.md)
 
 Action: Wait >D seconds from S9 then USS1@DSS*P*: PUT ISA with no start time and end time 10 minutes from now
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dp_behavior.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dp_behavior.md
@@ -50,7 +50,7 @@ Each observer is queried for flights in the empty area.
 
 This test step has the mock_uss begin a new flight by establishing an ISA.
 
-### [Create ISA test step](./dss/test_steps/put_isa.md)
+### [Create ISA test step](./dss/test_steps/create_isa.md)
 
 uss_qualifier, acting as mock_uss, creates an ISA in the area specified by the `isa` resource, valid from the moment the scenario runs and for a duration of 5 minutes.
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/heavy_traffic_concurrent.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/heavy_traffic_concurrent.md
@@ -35,7 +35,7 @@ This test case will:
 5. Query each ISA individually, but concurrently
 6. Search for all ISAs in the area of the deleted ISAs (using a single request)
 
-### [Create ISA concurrently test step](test_steps/put_isa.md)
+### [Create ISA concurrently test step](test_steps/create_isa.md)
 
 This step attempts to concurrently create multiple ISAs, as specified in this scenario's resource, at the configured DSS.
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/isa_simple.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/isa_simple.md
@@ -32,7 +32,7 @@ part of the test.
 
 ## Create and check ISA test case
 
-### [Create ISA test step](test_steps/put_isa.md)
+### [Create ISA test step](test_steps/create_isa.md)
 
 This step attempts to query the configured DSS with the ISA provided as a resource.
 
@@ -56,7 +56,7 @@ The DSS returns the version of the ISA in the response body.  If this version do
 
 ## Update and search ISA test case
 
-### [Update ISA test step](test_steps/put_isa.md)
+### [Update ISA test step](test_steps/mutate_isa.md)
 
 This step attempts to update the configured DSS with the ISA provided as a resource, with a slightly different end time.
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/test_steps/create_isa.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/test_steps/create_isa.md
@@ -1,0 +1,8 @@
+# Create ISA test step fragment
+
+This page describes the content of a common test step where a creation of an ISA should be successful.
+See `DSSWrapper.put_isa` in [`dss_wrapper.py`](../../../dss_wrapper.py).
+
+## [Put ISA](put_isa.md)
+
+Checks common to creation and mutation.

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/test_steps/mutate_isa.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/test_steps/mutate_isa.md
@@ -1,0 +1,12 @@
+# Create ISA test step fragment
+
+This page describes the content of a common test step where a mutation of an ISA should be successful.
+See `DSSWrapper.put_isa` in [`dss_wrapper.py`](../../../dss_wrapper.py).
+
+## [Put ISA](put_isa.md)
+
+Checks common to creation and mutation.
+
+## ⚠️ ISA version changed check
+
+When the ISA is updated, the DSS returns the updated version of the ISA in the response body.  If this version remains the same as the one before the update, **[astm.f3411.v22a.DSS0030,a](../../../../../../requirements/astm/f3411/v22a.md)** was not implemented correctly and this check will fail.

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/token_validation.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/token_validation.md
@@ -27,7 +27,7 @@ part of the test.
 
 ## Token validation test case
 
-### [Token validation test step](test_steps/put_isa.md)
+### [Token validation test step](test_steps/create_isa.md)
 
 This step attempts to create and read ISAs by providing both the correct and incorrect scopes, omitting the token or providing an invalid one,
 and expects the DSS to properly behave in each case.

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss_interoperability.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss_interoperability.md
@@ -60,7 +60,7 @@ As such, this check will fail if the DSS is not reachable with a dummy query,
 
 ## Interoperability sequence test case
 
-### [S1 test step](dss/test_steps/put_isa.md)
+### [S1 test step](dss/test_steps/create_isa.md)
 
 Action: USS1@DSS*P*: PUT ISA with no start time and end time 10 minutes from now
 
@@ -155,7 +155,7 @@ Qualitatively proves: All Subscription[i] 1≤i≤n are returned in subscription
 
 **[astm.f3411.v22a.DSS0070](../../../../requirements/astm/f3411/v22a.md)** requires that all DSS instances in a pool return the same result. This check fails if the DSS instance does not return the same result as the other DSS instances.
 
-### [S5 test step](dss/test_steps/put_isa.md)
+### [S5 test step](dss/test_steps/mutate_isa.md)
 
 Action: USS1@DSS*P*: PUT ISA[*P*] setting end time to now + D seconds
 
@@ -235,7 +235,7 @@ Qualitatively proves: Expired ISA automatically removed, ISA modifications acces
 
 **[astm.f3411.v22a.DSS0070](../../../../requirements/astm/f3411/v22a.md)** requires that all DSS instances in a pool return the same result. This check fails if the DSS instance does not return the same result as the other DSS instances.
 
-### [S10 test step](dss/test_steps/put_isa.md)
+### [S10 test step](dss/test_steps/create_isa.md)
 
 Action: USS1@DSS*P*: PUT ISA with no start time and end time 10 minutes from now
 
@@ -263,7 +263,7 @@ Qualitatively proves: ISA deletion triggers subscription notification requests
 
 **[astm.f3411.v22a.DSS0130,A2-6-1,3c](../../../../requirements/astm/f3411/v22a.md)**
 
-### [S12 test step](dss/test_steps/put_isa.md)
+### [S12 test step](dss/test_steps/create_isa.md)
 
 Action: Wait >D seconds from S9 then USS1@DSS*P*: PUT ISA with no start time and end time 10 minutes from now
 


### PR DESCRIPTION
The scenario checking for Display Provider behavior had two minor issues:
 - documented version update check in situations where that check cannot be done
 - missed opportunity for checking that versions are updated upon ISA mutation
 
 This PR fixes the two points above by rearranging test fragments to have a finer granularity around the question of creation vs mutation, and by providing the previous ISA version where possible so we can check it changed.
 
 This is part of the effort on #975 