### PR TITLE
[uss_qualifier] isa_validation now also checks extends validity

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/isa_validation.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/isa_validation.py
@@ -86,6 +86,7 @@ class ISAValidation(GenericTestScenario):
 
         self._isa_missing_outline(create_isa_url, json_body)
         self._isa_missing_volume(create_isa_url, json_body)
+        self._isa_missing_extents(create_isa_url, json_body)
 
         self.end_test_step()
         self.end_test_case()


### PR DESCRIPTION
A documented check was not tested, likely because an omission during the implementation of the `isa_validation` scenario.

Part of #975