### PR TITLE
[uss_qualifier/utm/sub_notif] Rework validate_notification_received test step fragment

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/utm/subscription_notifications/test_steps/validate_notification_received.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/subscription_notifications/test_steps/validate_notification_received.md
@@ -8,29 +8,19 @@ Mock USS provides a GET endpoint to retrieve all the interactions that took plac
 and other USSes after a particular time.
 These interactions also include the notifications sent and received by Mock USS.
 
-## ⚠️ Mock USS sends valid notification check
+## 🛑 Mock USS sends valid notification check
 There is an assumption here that DSS shared the correct subscriber information with Mock USS in response to planning or modifying its operational intent.
 
 As per **[astm.f3548.v21.USS0005](../../../../../requirements/astm/f3548/v21.md)**,
 Mock USS should send valid notification to USSes subscribed in the area.
 The validation of notification involves checking that Mock USS included the correct subscription_id in the notification.
-The check will fail if the notification to tested USS does not include the expected subscription_id.
+The check will fail if no or more than one notification is sent to the tested USS, or if the notification does not include the expected subscription_id.
 
 ## ⚠️ Tested USS receives valid notification check
-As per **[astm.f3548.v21.SCD0080](../../../../../requirements/astm/f3548/v21.md)**, USSes shall maintain awareness of
-operational intents relevant to their own ones when they are in the Activated, NonConforming or Contingent states.
+USSes shall maintain awareness of operational intents relevant to their own ones when they are in the Activated, NonConforming or Contingent states.
 In DSS, there is a subscription associated with an operational intent managed by a USS. A tested USS should successfully
 receive a notification of relevant intent from Mock USS based on this subscription.
-The check will be done if valid notification is sent by Mock USS, which is determined in
-[Mock USS sends valid notification check](#⚠️-mock-uss-sends-valid-notification-check) above.
-This check will fail if tested USS does not respond with http status 204 to a valid notification attempt by Mock USS.
 
-## ⚠️ Tested USS rejects invalid notification check
-
-As per **[astm.f3548.v21.USS0105,3](../../../../../requirements/astm/f3548/v21.md)**, Tested USS should validate that the notification
-received includes the subscription_id associated with its managed operation.
-The check will be done if invalid notification is sent by Mock USS, which is determined in
-[Mock USS sends valid notification check](#⚠️-mock-uss-sends-valid-notification-check) above.
-This check will fail if tested USS does not respond with http status 400 for an invalid notification attempt by Mock USS.
-
-
+If the tested USS does not respond with an HTTP status 204 to a valid notification sent by the mock USS, then the tested USS
+does not maintain awareness of operational intents relevant to their own ones (**[astm.f3548.v21.SCD0080](../../../../../requirements/astm/f3548/v21.md)**), and
+does not implement correctly the `notifyOperationalIntentDetailsChanged` operation (**[astm.f3548.v21.USS0105,3](../../../../../requirements/astm/f3548/v21.md)**).

--- a/monitoring/uss_qualifier/scenarios/astm/utm/subscription_notifications/test_steps/validate_notification_received.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/subscription_notifications/test_steps/validate_notification_received.py
@@ -1,16 +1,9 @@
 from datetime import datetime
-from typing import List, Tuple
 
-from implicitdict import ImplicitDict, StringBasedDateTime
-from uas_standards.astm.f3548.v21.api import (
-    OperationID,
-    PutOperationalIntentDetailsParameters,
-)
+from implicitdict import StringBasedDateTime
+from uas_standards.astm.f3548.v21.api import OperationID
 
-from monitoring.monitorlib.clients.mock_uss.interactions import (
-    Interaction,
-    QueryDirection,
-)
+from monitoring.monitorlib.clients.mock_uss.interactions import QueryDirection
 from monitoring.uss_qualifier.resources.interuss.mock_uss.client import MockUSSClient
 from monitoring.uss_qualifier.scenarios.astm.utm.data_exchange_validation.test_steps.wait import (
     wait_in_intervals,
@@ -20,6 +13,7 @@ from monitoring.uss_qualifier.scenarios.interuss.mock_uss.test_steps import (
     direction_filter,
     get_mock_uss_interactions,
     notif_op_intent_id_filter,
+    notif_sub_id_filter,
     operation_filter,
 )
 from monitoring.uss_qualifier.scenarios.scenario import TestScenarioType
@@ -53,93 +47,38 @@ def expect_tested_uss_receives_notification_from_mock_uss(
     with scenario.check(
         "Mock USS sends valid notification", mock_uss.participant_id
     ) as check:
-        try:
-            interactions, query = wait_in_intervals(get_mock_uss_interactions)(
-                scenario,
-                mock_uss,
-                StringBasedDateTime(interactions_since_time),
-                operation_filter(OperationID.NotifyOperationalIntentDetailsChanged),
-                direction_filter(QueryDirection.Outgoing),
-                notif_op_intent_id_filter(op_intent_ref_id),
-                base_url_filter(tested_uss_base_url),
-            )
-        except ValueError as e:
-            check.record_failed(
-                summary=f"Invalid notification sent by mock_uss to tested_uss",
-                details=f"Notification to tested_uss sent in invalid format. {str(e)}\n\nStack trace:\n{e.stacktrace}",
-                query_timestamps=[plan_request_time, query.request.timestamp],
-            )
+        interactions, query = wait_in_intervals(get_mock_uss_interactions)(
+            scenario,
+            mock_uss,
+            StringBasedDateTime(interactions_since_time),
+            operation_filter(OperationID.NotifyOperationalIntentDetailsChanged),
+            direction_filter(QueryDirection.Outgoing),
+            notif_op_intent_id_filter(op_intent_ref_id),
+            notif_sub_id_filter(subscription_id),
+            base_url_filter(tested_uss_base_url),
+        )
         if not interactions:
             check.record_failed(
-                summary=f"No notification sent by mock_uss to tested_uss",
-                details=f"Notification not sent for intent id {op_intent_ref_id} to tested_uss url {tested_uss_base_url}, even though DSS instructed mock_uss to notify tested_uss based on subscription associated with its relevant operational intent.",
+                summary=f"No valid notification sent by mock_uss to tested_uss",
+                details=f"Notification not sent for intent id {op_intent_ref_id} to tested_uss url {tested_uss_base_url} with subscription id {subscription_id}, even though DSS instructed mock_uss to notify tested_uss based on subscription associated with its relevant operational intent.",
                 query_timestamps=[plan_request_time, query.request.timestamp],
             )
-
-        #  Check if a notification with expected subscription_id exists in the interactions
-        (
-            is_subscr_id_in_notification,
-            resp_status,
-        ) = _check_notification_sent_with_subscription_id_and_response(
-            interactions, subscription_id
-        )
-
-        if interactions and not is_subscr_id_in_notification:
+            return  # no use in continuing if the mock USS does not behave as expected
+        elif len(interactions) > 1:
             check.record_failed(
-                summary=f"Invalid notification sent by mock_uss",
-                details=f"Notification to tested_uss missing the subscription_id ({subscription_id}), of the operational intent owned by tested_uss .",
+                summary=f"Too many notifications sent by mock_uss to tested_uss",
+                details=f"Too many notifications were sent for intent id {op_intent_ref_id} to tested_uss url {tested_uss_base_url} with subscription id {subscription_id}.",
                 query_timestamps=[plan_request_time, query.request.timestamp],
             )
+            return  # no use in continuing if the mock USS does not behave as expected
 
-    if is_subscr_id_in_notification:
-        with scenario.check(
-            "Tested USS receives valid notification", [tested_uss_participant_id]
-        ) as check:
-            if resp_status != 204:
-                check.record_failed(
-                    summary=f"Valid notification not accepted by tested_uss.",
-                    details=f"Valid notification by mock_uss not accepted by tested_uss. Tested_uss responded with response status {resp_status} instead of 204.",
-                    query_timestamps=[plan_request_time, query.request.timestamp],
-                )
-
-    if interactions and not is_subscr_id_in_notification:
-        with scenario.check(
-            "Tested USS rejects invalid notification", [tested_uss_participant_id]
-        ) as check:
-            if resp_status != 400:
-                check.record_failed(
-                    summary=f"Invalid notification should be rejected",
-                    details=f"Invalid notification containing incorrect subscription_id should be rejected by tested_uss. Tested_uss responded with response status {resp_status} instead of 400.",
-                    query_timestamps=[plan_request_time, query.request.timestamp],
-                )
-
-
-def _check_notification_sent_with_subscription_id_and_response(
-    interactions: List[Interaction], subscription_id: str
-) -> Tuple[bool, int]:
-    """
-    This function checks if a notification with subscription_id is found in the given interactions,
-
-    interactions: It is assumed that the interactions passed are notifications in valid format
-    subscription_id: The subscription_id that should trigger the notification
-
-    Returns:
-        notification_with_subscr_id_found: True if a notification with subscription_id is found, else False
-        status: Response status code for a notification
-
-    """
-    status: int = 999
-    for interaction in interactions:
-        notification = ImplicitDict.parse(
-            interaction.query.request.json,
-            PutOperationalIntentDetailsParameters,
-        )
-
-        subscriptions = notification.subscriptions
-        for subscription in subscriptions:
-            if subscription.subscription_id == subscription_id:
-                return True, interaction.query.response.status_code
-            else:
-                status = interaction.query.response.status_code
-
-    return False, status
+    with scenario.check(
+        "Tested USS receives valid notification", [tested_uss_participant_id]
+    ) as check:
+        resp_status = interactions[0].query.response.status_code
+        if resp_status != 204:
+            check.record_failed(
+                summary=f"Valid notification not accepted by tested_uss.",
+                details=f"Valid notification by mock_uss not accepted by tested_uss. Tested_uss responded with response status {resp_status} instead of 204.",
+                query_timestamps=[plan_request_time, query.request.timestamp],
+            )

--- a/monitoring/uss_qualifier/scenarios/interuss/mock_uss/test_steps.py
+++ b/monitoring/uss_qualifier/scenarios/interuss/mock_uss/test_steps.py
@@ -62,6 +62,22 @@ def notif_op_intent_id_filter(
     return is_applicable
 
 
+def notif_sub_id_filter(
+    sub_id: EntityID,
+) -> Callable[[Interaction], bool]:
+    """Returns an `is_applicable` function that detects whether an op intent notification refers to the specified subscription."""
+
+    def is_applicable(interaction: Interaction) -> bool:
+        if "json" in interaction.query.request and interaction.query.request.json:
+            subs = interaction.query.request.json.get("subscriptions")
+            return isinstance(subs, list) and any(
+                sub_id == sub.get("subscription_id") for sub in subs
+            )
+        return False
+
+    return is_applicable
+
+
 def base_url_filter(
     base_url: str,
 ) -> Callable[[Interaction], bool]:


### PR DESCRIPTION
This PR reworks the test step fragment validate_notification_received and should address #994.

We don't consider anymore cases where the mock USS sends an invalid notification. This appears unnecessary since the mock USS is a piece of code instrumented by the USS qualifier: if it does not behave as we expect it is a bug that we must fix and we cannot anymore assume state of the USS. This also reduces complexity significantly.
- Pass check *Mock USS sends valid notification* to critical and return from code when an invalid mock USS behavior is detected (no notif, too many notif, invalid notif)
- Remove unneeded try/catch of `ValueError` and corresponding failure 
- Replace `_check_notification_sent_with_subscription_id_and_response` by a new interaction filter `notif_sub_id_filter`
- Additionally detect invalid case where there is more than one notification returned
- Remove check *Tested USS rejects invalid notification* since this will never happen as long as the mock USS behave as expected

Then we update check *Tested USS receives valid notification* to cover both requirements SCD0080 and USS0105,3 which are (IMO) both failing if the tested USS does not process correctly the valid notification.
