### PR TITLE
[uss_qualifier/utm/down_uss] Contain requirement of utm.conformance_monitoring_sa scope to DownUSSEqualPriorityNotPermitted

### DIFF
--- a/monitoring/uss_qualifier/configurations/dev/utm_implementation_us_lib/baseline.libsonnet
+++ b/monitoring/uss_qualifier/configurations/dev/utm_implementation_us_lib/baseline.libsonnet
@@ -424,7 +424,7 @@ function(env) {
               count: {
                 // We currently expect this amount of skipped scenarios: making it an equality
                 // to make sure this is reduced if some scenarios start to be executed
-                equal_to: 9,
+                equal_to: 8,
               },
             },
           },

--- a/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss.py
@@ -57,6 +57,7 @@ class DownUSS(TestScenario):
     uss_qualifier_sub: str
 
     tested_uss: FlightPlannerClient
+    dss_resource: DSSInstanceResource
     dss: DSSInstance
 
     def __init__(
@@ -67,13 +68,7 @@ class DownUSS(TestScenario):
     ):
         super().__init__()
         self.tested_uss = tested_uss.client
-        self.dss = dss.get_instance(
-            {
-                Scope.StrategicCoordination: "search for operational intent references to verify outcomes of planning activities and retrieve operational intent details",
-                Scope.AvailabilityArbitration: "declare virtual USS down in DSS",
-                Scope.ConformanceMonitoringForSituationalAwareness: "create operational intent references in an off-nominal state",
-            }
-        )
+        self.dss = dss.get_instance(self._dss_req_scopes)
 
         templates = flight_intents.get_flight_intents()
         try:
@@ -87,6 +82,13 @@ class DownUSS(TestScenario):
 
         for efi in self._expected_flight_intents:
             setattr(self, efi.intent_id, templates[efi.intent_id])
+
+    @property
+    def _dss_req_scopes(self) -> dict[str, str]:
+        return {
+            Scope.StrategicCoordination: "search for operational intent references to verify outcomes of planning activities and retrieve operational intent details",
+            Scope.AvailabilityArbitration: "declare virtual USS down in DSS",
+        }
 
     @property
     def _expected_flight_intents(self) -> List[ExpectedFlightIntent]:

--- a/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.py
@@ -5,6 +5,7 @@ from uas_standards.astm.f3548.v21.api import (
     OperationalIntentReference,
     OperationalIntentState,
 )
+from uas_standards.astm.f3548.v21.constants import Scope
 
 from monitoring.monitorlib.clients.flight_planning.flight_info import (
     AirspaceUsageState,
@@ -33,6 +34,14 @@ from monitoring.uss_qualifier.suites.suite import ExecutionContext
 
 class DownUSSEqualPriorityNotPermitted(DownUSS):
     flight2_planned: FlightInfoTemplate
+
+    @property
+    def _dss_req_scopes(self) -> dict[str, str]:
+        return {
+            Scope.StrategicCoordination: "search for operational intent references to verify outcomes of planning activities and retrieve operational intent details",
+            Scope.AvailabilityArbitration: "declare virtual USS down in DSS",
+            Scope.ConformanceMonitoringForSituationalAwareness: "create operational intent references in an off-nominal state",
+        }
 
     @property
     def _expected_flight_intents(self) -> List[ExpectedFlightIntent]:


### PR DESCRIPTION
Requirement for scope `utm.conformance_monitoring_sa` was added in `DownUSS`, however this is required only in `DownUSSEqualPriorityNotPermitted` which inherits from `DownUSS`.
This PR removes the requirement for scope `utm.conformance_monitoring_sa` in `DownUSS` but keep it in `DownUSSEqualPriorityNotPermitted`.

See https://github.com/interuss/monitoring/issues/991#issuecomment-2742983899