### PR TITLE
[monitorlib/rid injection] Move serialized class constants to module

### DIFF
--- a/monitoring/mock_uss/ridsp/user_notifications.py
+++ b/monitoring/mock_uss/ridsp/user_notifications.py
@@ -9,7 +9,11 @@ from uas_standards.interuss.automated_testing.rid.v1.injection import (
 )
 
 from monitoring.monitorlib.rid_automated_testing import injection_api
-from monitoring.monitorlib.rid_automated_testing.injection_api import TestFlight
+from monitoring.monitorlib.rid_automated_testing.injection_api import (
+    MANDATORY_POSITION_FIELDS,
+    MANDATORY_TELEMETRY_FIELDS,
+    TestFlight,
+)
 
 from . import database
 
@@ -70,7 +74,7 @@ def check_and_generate_missing_fields_notifications(
             # one
             default_timestamp = best_timestamp
 
-            for mandatory_field in flight.MANDATORY_TELEMETRY_FIELDS:
+            for mandatory_field in MANDATORY_TELEMETRY_FIELDS:
                 if telemetry.get(mandatory_field, None) is None:
                     missing_fields_notifications.append(
                         (
@@ -80,7 +84,7 @@ def check_and_generate_missing_fields_notifications(
                     )
 
             if telemetry.get("position", None):
-                for mandatory_field in flight.MANDATORY_POSITION_FIELDS:
+                for mandatory_field in MANDATORY_POSITION_FIELDS:
                     if telemetry["position"].get(mandatory_field, None) is None:
                         missing_fields_notifications.append(
                             (

--- a/monitoring/monitorlib/rid_automated_testing/injection_api.py
+++ b/monitoring/monitorlib/rid_automated_testing/injection_api.py
@@ -15,21 +15,21 @@ from monitoring.monitorlib.rid import RIDVersion
 
 SCOPE_RID_QUALIFIER_INJECT = "rid.inject_test_data"
 
+MANDATORY_TELEMETRY_FIELDS = [
+    "timestamp",
+    "timestamp_accuracy",
+    "position",
+    "track",
+    "speed",
+    "speed_accuracy",
+    "vertical_speed",
+]
+
+# TODO: Handle accuracy_h and accuracy_v
+MANDATORY_POSITION_FIELDS = ["lat", "lng", "alt"]
+
 
 class TestFlight(injection.TestFlight):
-
-    MANDATORY_TELEMETRY_FIELDS = [
-        "timestamp",
-        "timestamp_accuracy",
-        "position",
-        "track",
-        "speed",
-        "speed_accuracy",
-        "vertical_speed",
-    ]
-
-    # TODO: Handle accuracy_h and accuracy_v
-    MANDATORY_POSITION_FIELDS = ["lat", "lng", "alt"]
 
     raw_telemetry: Optional[List[RIDAircraftState]]
     """Copy of original telemetry with potential invalid data"""
@@ -56,7 +56,7 @@ class TestFlight(injection.TestFlight):
 
                 is_ok = True
 
-                for mandatory_field in self.MANDATORY_TELEMETRY_FIELDS:
+                for mandatory_field in MANDATORY_TELEMETRY_FIELDS:
                     if telemetry.get(mandatory_field, None) is None:
                         is_ok = False
                         break
@@ -64,7 +64,7 @@ class TestFlight(injection.TestFlight):
                 if not is_ok:
                     continue
 
-                for mandatory_field in self.MANDATORY_POSITION_FIELDS:
+                for mandatory_field in MANDATORY_POSITION_FIELDS:
                     if telemetry.position.get(mandatory_field, None) is None:
                         is_ok = False
                         break

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/sp_operator_notify_missing_fields.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/sp_operator_notify_missing_fields.py
@@ -7,7 +7,11 @@ from s2sphere import LatLngRect
 
 from monitoring.monitorlib.errors import stacktrace_string
 from monitoring.monitorlib.rid import RIDVersion
-from monitoring.monitorlib.rid_automated_testing.injection_api import TestFlight
+from monitoring.monitorlib.rid_automated_testing.injection_api import (
+    MANDATORY_POSITION_FIELDS,
+    MANDATORY_TELEMETRY_FIELDS,
+    TestFlight,
+)
 from monitoring.uss_qualifier.resources.astm.f3411.dss import DSSInstancesResource
 from monitoring.uss_qualifier.resources.netrid import (
     EvaluationConfigurationResource,
@@ -64,8 +68,8 @@ class SpOperatorNotifyMissingFields(GenericTestScenario):
 
         self.begin_test_case("Missing fields flight")
 
-        for field in TestFlight.MANDATORY_TELEMETRY_FIELDS + [
-            f"position.{f}" for f in TestFlight.MANDATORY_POSITION_FIELDS
+        for field in MANDATORY_TELEMETRY_FIELDS + [
+            f"position.{f}" for f in MANDATORY_POSITION_FIELDS
         ]:
             self._frozen_flights_data = self._flights_data.truncate_flights_field(
                 field


### PR DESCRIPTION
Currently, we have two constants as members of a class that is automatically serialized.  This causes the contents of these constants to be included in the serialization of instances of that class, and this is undesirable.  This PR moves those constants out of the serialized class into the containing module to avoid unwanted serialization.