### PR TITLE
[ci] don't keep gh-pages history

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,3 +269,4 @@ jobs:
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'
           commit_message: ${{ github.event.head_commit.message }}
+          force_orphan: true


### PR DESCRIPTION
Adds the `force_orphan` option, which should cause the `gh-pages` branch to only have a single commit with the current published site, according to the [documentation](https://github.com/peaceiris/actions-gh-pages?tab=readme-ov-file#%EF%B8%8F-force-orphan-force_orphan) of the plugin.

This is a first attempt to solve #1002 