### PR TITLE
[uss_qualifier/docs] Clarify wording around low-severity findings

### DIFF
--- a/monitoring/uss_qualifier/scenarios/README.md
+++ b/monitoring/uss_qualifier/scenarios/README.md
@@ -111,16 +111,16 @@ If a test step fragment involves performing checks X and Y, and then check Z is 
 
 ### Test checks
 
-Each check a test step performs that may result in a finding/issue must be documented via a subsection of the parent test step, named with a " check" suffix, and a prefix according to the severity of failure of that check (example: `#### 🛑 Successful injection check`).
+Each check a test step performs that may result in a finding/issue must be documented via a subsection of the parent test step, named with a " check" suffix, and a prefix according to the severity of a finding produced by that check (example: `#### 🛑 Successful injection check`).
 
-The severity of a failure of the check should be indicated with one of the following unicode symbols (these can be copied and pasted into the Markdown documentation):
+The severity of a finding from a check (when a medium+ severity check fails) should be indicated with one of the following unicode symbols (these can be copied and pasted into the Markdown documentation):
 
 * ℹ️ Low severity: No requirement was violated, but this finding may be useful for improvement.
 * ⚠️ Medium severity: A requirement was violated, but the test scenario can continue.
 * 🛑 High severity: The test scenario should terminate after cleaning up.
 * ☢ Critical severity: Not only can the test scenario not continue, the entire test run should stop.
 
-A check should document the requirement(s) violated if the check fails.  Requirements are identified by putting a strong emphasis/bold style around the requirement ID (example: `**astm.f3411.v19.NET0420**`).  The description of a check should generally explain why the relevant requirement would fail when that information is useful, but the requirement itself should generally not be re-iterated in this description.  If the check is self-evident from the requirement, the requirement can be noted without further explanation.
+A check should document the requirement(s) violated if the check produces a finding.  Requirements are identified by putting a strong emphasis/bold style around the requirement ID (example: `**astm.f3411.v19.NET0420**`).  The description of a check should generally explain why the relevant requirement would fail when that information is useful, but the requirement itself should generally not be re-iterated in this description.  If the check is self-evident from the requirement, the requirement can be noted without further explanation.
 
 Any requirements identified (e.g., `**astm.f3411.v19.NET0420**`) must be documented as well.  See [the requirements documentation](../requirements/README.md) for more information.
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/test_steps/put_isa.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/test_steps/put_isa.md
@@ -5,7 +5,7 @@ See `DSSWrapper.put_isa` in [`dss_wrapper.py`](../../../dss_wrapper.py).
 
 ## ℹ️ ISA response code check
 
-The API for **[astm.f3411.v19.DSS0030,a](../../../../../../requirements/astm/f3411/v19.md)** specifies that the code of successful DSS responses is 200. While tolerated in some cases, if the DSS responds with an HTTP code 201 for success, this check will fail with a low severity.
+The API for **[astm.f3411.v19.DSS0030,a](../../../../../../requirements/astm/f3411/v19.md)** specifies that the code of successful DSS responses is 200. While tolerated in some cases, if the DSS responds with an HTTP code 201 for success, this check will produce a low severity finding.
 
 ## ⚠️ ISA response format check
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/sp_notification_behavior.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/sp_notification_behavior.md
@@ -59,15 +59,15 @@ at which a flight was injected.
 
 This check validates that each Service Provider at which a test flight was injected properly notified the mock_uss.
 
-ASTM F3411 V19 has no explicit requirement for this check, so failing it will raise an informational warning.
+ASTM F3411 V19 has no explicit requirement for this check, so triggering it will raise an informational warning.
 
 #### ℹ️ Service Provider notification was received within delay check
 
 This check validates that the notification from each Service Provider was received by the mock_uss within the specified delay.
 
-ASTM F3411 V19 has no explicit requirement for this check, so failing it will raise an informational warning.
+ASTM F3411 V19 has no explicit requirement for this check, so triggering it will raise an informational warning.
 
-This check will be failed if it takes longer than 3 seconds between the injection of the flight and the notification being received by the mock_uss.
+This check will be triggered if it takes longer than 3 seconds between the injection of the flight and the notification being received by the mock_uss.
 
 ## Cleanup
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/test_steps/put_isa.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/test_steps/put_isa.md
@@ -5,7 +5,7 @@ See `DSSWrapper.put_isa` in [`dss_wrapper.py`](../../../dss_wrapper.py).
 
 ## ℹ️ ISA response code check
 
-The API for **[astm.f3411.v22a.DSS0030,a](../../../../../../requirements/astm/f3411/v22a.md)** specifies that the code of successful DSS responses is 200. While tolerated in some cases, if the DSS responds with an HTTP code 201 for success, this check will fail with a low severity.
+The API for **[astm.f3411.v22a.DSS0030,a](../../../../../../requirements/astm/f3411/v22a.md)** specifies that the code of successful DSS responses is 200. While tolerated in some cases, if the DSS responds with an HTTP code 201 for success, this check will produce a low severity finding.
 
 ## ⚠️ ISA response format check
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/test_steps/validate_no_notification_operational_intent.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/test_steps/validate_no_notification_operational_intent.md
@@ -4,7 +4,7 @@ This step verifies when a flight is not created, it is also not notified by chec
 
 ## [Get Mock USS interactions logs](../../../../interuss/mock_uss/get_mock_uss_interactions.md)
 
-## ℹ️ Mock USS interaction can be parsed check
+## 🛑 Mock USS interaction can be parsed check
 **[interuss.mock_uss.hosted_instance.ExposeInterface](../../../../../requirements/interuss/mock_uss/hosted_instance.md)**.
 
 ## 🛑 Expect Notification not sent check

--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md
@@ -154,11 +154,11 @@ Flight 1 should not have been shared with the interoperability ecosystem since i
 #### [Plan Flight 1c](../../../../flight_planning/plan_flight_intent.md)
 The smaller Flight 1c form (which doesn't conflict with Flight 2) should be successfully planned by the tested USS.
 
-#### ℹ️ Validate tested USS intersection algorithm check
+#### ⚠️ Validate tested USS intersection algorithm check
 Because Flight 2 is nearby Flight 1c, successful planning of Flight 1c indicates the tested USS is complying with the portion of
 **[astm.f3548.v21.GEN0500](../../../../../requirements/astm/f3548/v21.md)** that requires a USS to indicate two 4D volumes are non-intersecting when they are separated by more than 1 cm.
 
-This check does not fail if the planning is rejected.
+This check is not relevant if the planning is rejected.
 
 #### [Validate Flight 1c sharing](../../validate_shared_operational_intent.md)
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss.md
@@ -88,8 +88,7 @@ will. Refer to this check for more information.
 #### ℹ️ Rejected planning check
 All flight intent data provided is correct and the USS should have either successfully planned Flight 1 or rejected
 properly the planning if it decided to be more conservative with such conflicts.
-If the USS rejects the planning, this check will fail with a low severity per **[astm.f3548.v21.SCD0005](../../../../requirements/astm/f3548/v21.md)**.
-This won't actually fail the test but will serve as a warning.
+If the USS rejects the planning, this check will produce a low severity finding per **[astm.f3548.v21.SCD0005](../../../../requirements/astm/f3548/v21.md)**.
 
 #### 🛑 Failure check
 All flight intent data provided was complete and correct. It should have been processed successfully, allowing the USS

--- a/monitoring/uss_qualifier/scenarios/flight_planning/modify_activated_flight_intent.md
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/modify_activated_flight_intent.md
@@ -32,9 +32,8 @@ and create a new one. This may or may not be strictly speaking a failure to meet
 distinguish between an actual failure to meet the requirement and a reasonable behavior due to implementation
 limitations.
 
-As such, if the pre-existing conflict was present, and that the USS rejected the modification, this check will fail with
-a low severity per **[astm.f3548.v21.SCD0030](../../requirements/astm/f3548/v21.md)**. This won't actually fail the test
-but will serve as a warning.
+As such, if the pre-existing conflict was present, and that the USS rejected the modification, this check will produce
+a low severity finding per **[astm.f3548.v21.SCD0030](../../requirements/astm/f3548/v21.md)**.
 
 ## 🛑 Failure check
 


### PR DESCRIPTION
Low-severity findings are conceptually in a separate category from higher-severity findings since medium+ severity findings indicate some kind of compliance failure whereas low-severity findings do not indicate a failure to comply.  This PR attempts to clarify the situation by replacing mentions of "failing a low severity check" or similar with "producing a low-severity finding" since these findings are not actually failures.

The severity of the "Validate tested USS intersection algorithm check" is upgraded to medium since if the check failed (it can't actually fail as currently implemented; it can only be skipped since we can't differentiate between failure an inapplicability) it would indicate failure to comply with a requirement.

The severity of the "Mock USS interaction can be parsed check" is upgraded to high since we cannot perform the next check if this check fails.