### PR TITLE
[uss_qualifier/reports] Fix tested requirements representation of low-severity findings

### DIFF
--- a/monitoring/uss_qualifier/reports/templates/tested_requirements/participant_tested_requirements.html
+++ b/monitoring/uss_qualifier/reports/templates/tested_requirements/participant_tested_requirements.html
@@ -57,6 +57,9 @@
     .pass_result {
       background-color: rgb(192, 255, 192);
     }
+    .findings_result {
+      background-color: rgb(255, 255, 192);
+    }
     .fail_result {
       background-color: rgb(255, 192, 192);
     }
@@ -126,6 +129,8 @@
       <td class="{{ overall_status.get_class() }}">
         {% if overall_status == ParticipantVerificationStatus.Pass %}
           Pass
+        {% elif overall_status == ParticipantVerificationStatus.PassWithFindings %}
+          Pass (with findings)
         {% elif overall_status == ParticipantVerificationStatus.Fail %}
           Fail
         {% elif overall_status == ParticipantVerificationStatus.Incomplete %}

--- a/monitoring/uss_qualifier/reports/tested_requirements/breakdown.py
+++ b/monitoring/uss_qualifier/reports/tested_requirements/breakdown.py
@@ -9,6 +9,7 @@ from monitoring.uss_qualifier.action_generators.documentation.definitions import
 from monitoring.uss_qualifier.action_generators.documentation.documentation import (
     list_potential_actions_for_action_generator_definition,
 )
+from monitoring.uss_qualifier.common_data_definitions import Severity
 from monitoring.uss_qualifier.configurations.configuration import ParticipantID
 from monitoring.uss_qualifier.fileio import load_dict_with_references
 from monitoring.uss_qualifier.reports.report import (
@@ -214,7 +215,10 @@ def _populate_breakdown_with_scenario_report(
                 if isinstance(check, PassedCheck):
                     tested_check.successes += 1
                 elif isinstance(check, FailedCheck):
-                    tested_check.failures += 1
+                    if check.severity == Severity.Low:
+                        tested_check.findings += 1
+                    else:
+                        tested_check.failures += 1
                 else:
                     raise ValueError("Check is neither PassedCheck nor FailedCheck")
 

--- a/monitoring/uss_qualifier/reports/tested_requirements/summaries.py
+++ b/monitoring/uss_qualifier/reports/tested_requirements/summaries.py
@@ -6,11 +6,12 @@ from monitoring.uss_qualifier.configurations.configuration import ParticipantID
 from monitoring.uss_qualifier.reports.report import TestRunReport, TestSuiteActionReport
 from monitoring.uss_qualifier.reports.tested_requirements.data_types import (
     FAIL_CLASS,
+    FINDINGS_CLASS,
     NOT_TESTED_CLASS,
     PASS_CLASS,
     ParticipantVerificationStatus,
     TestedBreakdown,
-    TestRunInformation, FINDINGS_CLASS,
+    TestRunInformation,
 )
 from monitoring.uss_qualifier.signatures import compute_signature
 

--- a/monitoring/uss_qualifier/reports/tested_requirements/summaries.py
+++ b/monitoring/uss_qualifier/reports/tested_requirements/summaries.py
@@ -10,7 +10,7 @@ from monitoring.uss_qualifier.reports.tested_requirements.data_types import (
     PASS_CLASS,
     ParticipantVerificationStatus,
     TestedBreakdown,
-    TestRunInformation,
+    TestRunInformation, FINDINGS_CLASS,
 )
 from monitoring.uss_qualifier.signatures import compute_signature
 
@@ -40,6 +40,9 @@ def compute_overall_status(
                 return ParticipantVerificationStatus.Fail
             elif req.classname == NOT_TESTED_CLASS:
                 overall_status = ParticipantVerificationStatus.Incomplete
+            elif req.classname == FINDINGS_CLASS:
+                if overall_status == ParticipantVerificationStatus.Pass:
+                    overall_status = ParticipantVerificationStatus.PassWithFindings
             elif req.classname == PASS_CLASS:
                 pass
             else:


### PR DESCRIPTION
Currently, a low-severity finding (not a failure to comply with a requirement) will be summarized in the tested requirements artifact as Fail.  This PR fixes that situation by communicating the findings information while also correctly representing Pass as the overall status.