### PR TITLE
[uss_qualifier/F3548] Make flight planner preparation best-effort

### DIFF
--- a/monitoring/uss_qualifier/suites/astm/utm/f3548_21.yaml
+++ b/monitoring/uss_qualifier/suites/astm/utm/f3548_21.yaml
@@ -44,7 +44,7 @@ actions:
       flight_intents2: priority_preemption_flights?
       flight_intents3: conflicting_flights?
       flight_intents4: non_conflicting_flights?
-  on_failure: Abort
+  on_failure: Continue
 - action_generator:
     generator_type: action_generators.astm.f3548.ForEachDSS
     resources:


### PR DESCRIPTION
This PR should resolve #903.  Unfortunately, it will also be too tolerant of a failure to clear the airspace (continuing with the suite even when the airspace couldn't be cleared) -- ideally, in that case, we should actually abort the test suite.  So, with our current feature set, I believe we will be wrong one of two ways: either we don't abort when the airspace was not cleared successfully, or we abort when the airspace was actually clear even though a particular USS failed to execute the clear instruction.  Given that the latter is causing our customers more trouble right now (#903), I think it's better to err in the former way rather than the latter.  This PR makes that change.

In the future, we could add a feature that avoids being wrong both ways by making the abort criteria more granular.  For example, the area-clearing scenario here currently specifies:

```yaml
- test_scenario:
    scenario_type: scenarios.astm.utm.PrepareFlightPlanners
    ...
  on_failure: Continue
```

What we would really like to do is something like this:

```yaml
- test_scenario:
    scenario_type: scenarios.astm.utm.PrepareFlightPlanners
    ...
  abort_if:
    check_failed:
      test_check: Area is clear of op intents
      in_test_step: Clear area validation
      in_test_case: Flight planners preparation
```

or

```yaml
- test_scenario:
    scenario_type: scenarios.astm.utm.PrepareFlightPlanners
    ...
  abort_if:
    check_failed:
      with_minimum_severity: High
```

Basically, deprecate `on_failure` in favor of the reverse: abort under specified conditions (which may or may not involve failure directly).

As a side note, many `on_failure:` specifications in test suites are indented at the wrong level and therefore aren't doing anything.  Also, `on_failure: Continue` is the default, so any explicit declaration of this value is unnecessary.  Probably these elements should be cleaned up.