### PR TITLE
[uss_qualifier] expunge assumption of scenario re-use

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/subscription_simple.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/subscription_simple.py
@@ -84,6 +84,9 @@ class SubscriptionSimple(GenericTestScenario):
 
         self._client_identity = client_identity
 
+        self._current_subscriptions = {}
+        self._sub_params_by_sub_id = {}
+
     def run(self, context: ExecutionContext):
         self._initialize_creation_params()
 
@@ -131,11 +134,6 @@ class SubscriptionSimple(GenericTestScenario):
 
     def _setup_case(self):
         self.begin_test_case("Setup")
-
-        # Multiple runs of the scenario seem to rely on the same instance of it:
-        # thus we need to reset the state of the scenario before running it.
-        self._current_subscriptions = {}
-        self._sub_params_by_sub_id = {}
 
         self._ensure_clean_workspace_step()
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/op_intent_ref_key_validation.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/op_intent_ref_key_validation.py
@@ -86,6 +86,8 @@ class OIRKeyValidation(TestScenario):
             volume=self._planning_area.volume,
         )
 
+        self._current_oirs = {}
+
     def run(self, context: ExecutionContext):
         self.begin_test_scenario(context)
         self._setup_case()
@@ -405,9 +407,6 @@ class OIRKeyValidation(TestScenario):
 
     def _setup_case(self):
         self.begin_test_case("Setup")
-        # Multiple runs of the scenario seem to rely on the same instance of it:
-        # thus we need to reset the state of the scenario before running it.
-        self._current_oirs = {}
         self.begin_test_step("Ensure clean workspace")
         self._ensure_clean_workspace_step()
         self.end_test_step()

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_simple.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_simple.py
@@ -101,6 +101,9 @@ class SubscriptionSimple(TestScenario):
             vertices=problematically_big_area.specification.vertices
         )
 
+        self._current_subscriptions = {}
+        self._sub_params_by_sub_id = {}
+
     def _build_current_time_sub_params(self):
         return self._planning_area.get_new_subscription_params(
             subscription_id="",  # subscription ID will need to be overwritten
@@ -153,12 +156,6 @@ class SubscriptionSimple(TestScenario):
     def _setup_case(self):
         self.begin_test_case("Setup")
 
-        # Multiple runs of the scenario seem to rely on the same instance of it:
-        # thus we need to reset the state of the scenario before running it.
-        self._current_subscriptions = {}
-        self._sub_params_by_sub_id = {}
-        # The subscription needs to be reasonably close to 'now':
-        # We reset it at the beginning of each run.
         self._sub_generation_params = self._build_current_time_sub_params()
 
         self._ensure_clean_workspace_step()

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.py
@@ -108,6 +108,8 @@ class CRSynchronization(TestScenario):
             volume=self._planning_area.volume,
         )
 
+        self._current_cr = None
+
     def run(self, context: ExecutionContext):
 
         # Check that we actually have at least one other DSS to test against:
@@ -169,9 +171,6 @@ class CRSynchronization(TestScenario):
 
     def _setup_case(self):
         self.begin_test_case("Setup")
-        # Multiple runs of the scenario seem to rely on the same instance of it:
-        # thus we need to reset the state of the scenario before running it.
-        self._current_cr = None
         # We need times that are close to 'now': the params are set
         # at the beginning of each scenario run.
         self._cr_params = self._planning_area.get_new_constraint_ref_params(

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.py
@@ -105,6 +105,8 @@ class OIRSynchronization(TestScenario):
             volume=self._planning_area.volume,
         )
 
+        self._current_oir = None
+
     def run(self, context: ExecutionContext):
         self._oir_params = self._planning_area.get_new_operational_intent_ref_params(
             key=[],
@@ -176,9 +178,6 @@ class OIRSynchronization(TestScenario):
 
     def _setup_case(self):
         self.begin_test_case("Setup")
-        # Multiple runs of the scenario seem to rely on the same instance of it:
-        # thus we need to reset the state of the scenario before running it.
-        self._current_oir = None
         self.begin_test_step("Ensure clean workspace")
         self._ensure_clean_workspace_step()
         self.end_test_step()

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/subscription_synchronization.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/subscription_synchronization.py
@@ -156,6 +156,10 @@ class SubscriptionSynchronization(TestScenario):
         else:
             self._dss_separate_creds = None
 
+        self._current_subscription = None
+        self._subs_for_deletion = {}
+        self._subs_for_deletion_params = {}
+
     def run(self, context: ExecutionContext):
         self._sub_params = self._planning_area.get_new_subscription_params(
             subscription_id=self._sub_id,
@@ -227,11 +231,6 @@ class SubscriptionSynchronization(TestScenario):
 
     def _step_setup_case(self):
         self.begin_test_case("Setup")
-        # Multiple runs of the scenario seem to rely on the same instance of it:
-        # thus we need to reset the state of the scenario before running it.
-        self._current_subscription = None
-        self._subs_for_deletion = {}
-        self._subs_for_deletion_params = {}
         self._ensure_clean_workspace_step()
         self.end_test_case()
 


### PR DESCRIPTION
For some reason the assumption that scenario instances are reused has crept into multiples places.

Such reuse would in fact be a bug, so we can drop the assumption (and fix the bug if it ever appears)

Fixes #1022 