### PR TITLE
[uss_qualifier/resources/query_behavior] Add parameter fake_netlocs

### DIFF
--- a/monitoring/uss_qualifier/resources/interuss/query_behavior.py
+++ b/monitoring/uss_qualifier/resources/interuss/query_behavior.py
@@ -20,6 +20,9 @@ class QueryBehaviorSpecification(ImplicitDict):
     add_request_id: Optional[bool]
     """Whether to automatically add a `request_id` field to any request with a JSON body and no pre-existing `request_id` field"""
 
+    fake_netlocs: Optional[list[str]]
+    """Network locations well-known to be fake and for which a request should fail immediately without being attempted."""
+
 
 class QueryBehaviorResource(Resource[QueryBehaviorSpecification]):
     """When declared, this resource adjusts the settings for all queries made by uss_qualifier.
@@ -80,4 +83,10 @@ class QueryBehaviorResource(Resource[QueryBehaviorSpecification]):
             settings.add_request_id = specification.add_request_id
             logger.info(
                 f"QueryBehaviorResource: Fetch query set to {'' if settings.add_request_id else 'not '} add `request_id`"
+            )
+
+        if "fake_netlocs" in specification and specification.fake_netlocs is not None:
+            settings.fake_netlocs = tuple(specification.fake_netlocs)
+            logger.info(
+                f"QueryBehaviorResource: Fake network locations set to {settings.fake_netlocs}"
             )

--- a/schemas/monitoring/uss_qualifier/resources/interuss/query_behavior/QueryBehaviorSpecification.json
+++ b/schemas/monitoring/uss_qualifier/resources/interuss/query_behavior/QueryBehaviorSpecification.json
@@ -28,6 +28,16 @@
         "null"
       ]
     },
+    "fake_netlocs": {
+      "description": "Network locations well-known to be fake and for which a request should fail immediately without being attempted.",
+      "items": {
+        "type": "string"
+      },
+      "type": [
+        "array",
+        "null"
+      ]
+    },
     "read_timeout_seconds": {
       "description": "Number of seconds to allow for a request to complete after establishing a connection.  Use 0 for no timeout.",
       "type": [


### PR DESCRIPTION
Follow-up to https://github.com/interuss/monitoring/pull/1001#pullrequestreview-2717954216

Tested to work by adding: 
```yaml
        query_behavior:
          $content_schema: monitoring/uss_qualifier/resources/definitions/QueryBehaviorSpecification.json
          resource_type: resources.interuss.QueryBehaviorResource
          specification:
            fake_netlocs:
              - testdummy.interuss.org
              - testdummy-2.interuss.org
```
to a test run resources configuration and confirming the following logging:
```
2025-05-13 13:49:00.084 | INFO     | monitoring.uss_qualifier.resources.interuss.query_behavior:__init__:90 - QueryBehaviorResource: Fake network locations set to ('testdummy.interuss.org', 'testdummy-2.interuss.org')
```