### PR TITLE
[uss_qualifier] Fix private repos locally

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
         echo "Repository: ${{ github.repository }}"
         echo "Branch: ${{ github.ref }}"
         docker images
+        docker version
+        docker compose version
     - name: Checkout
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/monitoring-test.yml
+++ b/.github/workflows/monitoring-test.yml
@@ -27,6 +27,8 @@ jobs:
         echo "Repository: ${{ github.repository }}"
         echo "Branch: ${{ github.ref }}"
         docker images
+        docker version
+        docker compose version
     - name: Checkout
       uses: actions/checkout@v4
       with:

--- a/monitoring/uss_qualifier/fileio.py
+++ b/monitoring/uss_qualifier/fileio.py
@@ -80,7 +80,9 @@ def _get_web_content(url: str) -> str:
 
     # Check if this is a request to a private GitHub repo
     github_private_repos_key = "GITHUB_PRIVATE_REPOS"
-    if github_private_repos_key in os.environ:
+    if github_private_repos_key in os.environ and os.environ.get(
+        github_private_repos_key
+    ):
         github_match = re.match(
             r"^https://(?P<hostname>github\.com|raw\.githubusercontent\.com|api\.github\.com)/(?P<org>[^/]*)/(?P<repo>[^/?#]*)(?P<predicate>.*)$",
             url,

--- a/monitoring/uss_qualifier/fileio.py
+++ b/monitoring/uss_qualifier/fileio.py
@@ -80,9 +80,7 @@ def _get_web_content(url: str) -> str:
 
     # Check if this is a request to a private GitHub repo
     github_private_repos_key = "GITHUB_PRIVATE_REPOS"
-    if github_private_repos_key in os.environ and os.environ.get(
-        github_private_repos_key
-    ):
+    if os.environ.get(github_private_repos_key):
         github_match = re.match(
             r"^https://(?P<hostname>github\.com|raw\.githubusercontent\.com|api\.github\.com)/(?P<org>[^/]*)/(?P<repo>[^/?#]*)(?P<predicate>.*)$",
             url,

--- a/monitoring/uss_qualifier/run_locally.sh
+++ b/monitoring/uss_qualifier/run_locally.sh
@@ -60,6 +60,14 @@ else
   docker_args="-it"
 fi
 
+# Initialize an empty string for additional Docker options
+PRIVATE_REPOS_ENV_FLAG=""
+
+# Check if GITHUB_PRIVATE_REPOS is set and not empty
+if [ -n "${GITHUB_PRIVATE_REPOS}" ]; then
+  PRIVATE_REPOS_ENV_FLAG="-e GITHUB_PRIVATE_REPOS=${GITHUB_PRIVATE_REPOS}"
+fi
+
 # shellcheck disable=SC2086
 docker run ${docker_args} --name uss_qualifier \
   --rm \
@@ -69,7 +77,7 @@ docker run ${docker_args} --name uss_qualifier \
   -e PYTHONBUFFERED=1 \
   -e AUTH_SPEC=${AUTH_SPEC} \
   -e AUTH_SPEC_2=${AUTH_SPEC_2} \
-  -e GITHUB_PRIVATE_REPOS=${GITHUB_PRIVATE_REPOS:-} \
+  ${PRIVATE_REPOS_ENV_FLAG} \
   -e MONITORING_GITHUB_ROOT=${MONITORING_GITHUB_ROOT:-} \
   -v "$(pwd)/$OUTPUT_DIR:/app/$OUTPUT_DIR" \
   -v "$(pwd)/$CACHE_DIR:/app/$CACHE_DIR" \


### PR DESCRIPTION
uss_qualifier has the capability to access private GitHub repos when provided with one or more access tokens to do so via the GITHUB_PRIVATE_REPOS environment variable.  However, currently run_locally.sh produces an error when GITHUB_PRIVATE_REPOS is not provided because it is set to an empty value rather than being left unset.  This PR addresses that problem in two ways: first, it doesn't set the environment variable in the docker container when it isn't provided/present, and second, empty GITHUB_PRIVATE_REPOS values are ignored.