### PR TITLE
Update the way key value parameters on auth adapter are parsed

### DIFF
--- a/monitoring/monitorlib/auth.py
+++ b/monitoring/monitorlib/auth.py
@@ -613,11 +613,7 @@ def make_auth_adapter(spec: AuthSpec) -> AuthAdapter:
     kwargs = {}
     for param_string in param_strings:
         if "=" in param_string:
-            kv = param_string.split("=")
-            if len(kv) != 2:
-                raise ValueError(
-                    "Auth adapter specification contained a parameter with more than one `=` character"
-                )
+            kv = param_string.split("=", 1)
             kwargs[kv[0].strip()] = kv[1].strip()
         else:
             args.append(param_string)


### PR DESCRIPTION
This is to support values that contain `=` as part of their string. We ran into an issue where a client_secret value contained an `=` sign and it was not possible to get the test runner working with that secret. This change will make it so that the split occurs only on the first `=` and will ignore the ones in the value. It'll force a user to enter the params using key args but at least that path will work.