### PR TITLE
[uss_qualifier] endpoint_encryption: use requests exceptions

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/endpoint_encryption.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/endpoint_encryption.py
@@ -83,7 +83,10 @@ class EndpointEncryption(GenericTestScenario):
                         "HTTP GET request did not redirect to HTTPS",
                         details=f"Made an http GET request and obtained status code {response.status_code} with response {str(response.content)} that was not redirected to https",
                     )
-
+            except requests.exceptions.ConnectionError:
+                pass
+            except requests.exceptions.Timeout:
+                pass
             except socket.error as e:
                 if e.errno not in [
                     errno.ECONNREFUSED,


### PR DESCRIPTION
Ad recorded in #1033, it does seems that `errno` is not set on the connection error from the requests library

```
.__dict__: {''response'': None, ''request'': <PreparedRequest [GET]>}
.errno: None
```

This PR use the errors from the library in addition to the standard ones.