### PR TITLE
[uss_qualifier] netrid: DSSInteroperability scenario gets configurable area

### DIFF
--- a/monitoring/uss_qualifier/configurations/dev/netrid_v19.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/netrid_v19.yaml
@@ -8,6 +8,7 @@ v1:
         utm_client_identity: {$ref: 'library/resources.yaml#/utm_client_identity'}
         id_generator: {$ref: 'library/resources.yaml#/id_generator'}
         kentland_service_area: {$ref: 'library/resources.yaml#/kentland_service_area'}
+        kentland_planning_area: {$ref: 'library/resources.yaml#/kentland_planning_area'}
         au_problematically_big_area: {$ref: 'library/resources.yaml#/au_problematically_big_area'}
 
         utm_auth: {$ref: 'library/environment.yaml#/utm_auth'}
@@ -40,6 +41,7 @@ v1:
           id_generator: id_generator
           service_area: kentland_service_area
           problematically_big_area: au_problematically_big_area
+          planning_area: kentland_planning_area
           test_exclusions: test_exclusions
           uss_identification: uss_identification
     execution:

--- a/monitoring/uss_qualifier/configurations/dev/netrid_v22a.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/netrid_v22a.yaml
@@ -8,6 +8,7 @@ v1:
         utm_client_identity: {$ref: 'library/resources.yaml#/utm_client_identity'}
         id_generator: {$ref: 'library/resources.yaml#/id_generator'}
         kentland_service_area: {$ref: 'library/resources.yaml#/kentland_service_area'}
+        kentland_planning_area: {$ref: 'library/resources.yaml#/kentland_planning_area'}
         au_problematically_big_area: {$ref: 'library/resources.yaml#/au_problematically_big_area'}
 
         utm_auth: {$ref: 'library/environment.yaml#/utm_auth'}
@@ -40,6 +41,7 @@ v1:
           id_generator: id_generator
           service_area: kentland_service_area
           problematically_big_area: au_problematically_big_area
+          planning_area: kentland_planning_area
           test_exclusions: test_exclusions
           uss_identification: uss_identification
     execution:

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss_interoperability.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss_interoperability.md
@@ -21,7 +21,9 @@ A resources.astm.f3411.DSSInstancesResource containing at least two DSS instance
 
 ### planning_area
 
-A [resources.astm.f3411.PlanningAreaResource](../../../../resources/planning_area.py) containing a planning area that covers the area of interest for this
+A [resources.PlanningAreaResource](../../../../resources/planning_area.py) containing a planning area to be used when creating relevant resources on the DSS instances.
+
+Note that the bounding box of the area will be used, not the area itself.
 
 ### test_exclusions
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss_interoperability.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss_interoperability.md
@@ -19,6 +19,10 @@ A resources.astm.f3411.DSSInstanceResource containing the "primary" DSS instance
 
 A resources.astm.f3411.DSSInstancesResource containing at least two DSS instances complying with ASTM F3411-19.
 
+### planning_area
+
+A [resources.astm.f3411.PlanningAreaResource](../../../../resources/planning_area.py) containing a planning area that covers the area of interest for this
+
 ### test_exclusions
 
 A [resources.dev.TestExclusionsResource](../../../../resources/dev/test_exclusions.py) containing test exclusions parameters like whether private addresses are allowed.

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss_interoperability.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss_interoperability.md
@@ -21,7 +21,9 @@ A resources.astm.f3411.DSSInstancesResource containing at least two DSS instance
 
 ### planning_area
 
-A [resources.astm.f3411.PlanningAreaResource](../../../../resources/planning_area.py) containing a planning area that covers the area of interest for this
+A [resources.PlanningAreaResource](../../../../resources/planning_area.py) containing a planning area to be used when creating relevant resources on the DSS instances.
+
+Note that the bounding box of the area will be used, not the area itself.
 
 ### test_exclusions
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss_interoperability.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss_interoperability.md
@@ -19,6 +19,10 @@ A resources.astm.f3411.DSSInstanceResource containing the "primary" DSS instance
 
 A resources.astm.f3411.DSSInstancesResource containing at least two DSS instances complying with ASTM F3411-22a.
 
+### planning_area
+
+A [resources.astm.f3411.PlanningAreaResource](../../../../resources/planning_area.py) containing a planning area that covers the area of interest for this
+
 ### test_exclusions
 
 A [resources.dev.TestExclusionsResource](../../../../resources/dev/test_exclusions.py) containing test exclusions parameters like whether private addresses are allowed.

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_19.yaml
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_19.yaml
@@ -12,6 +12,7 @@ resources:
   id_generator: resources.interuss.IDGeneratorResource
   service_area: resources.netrid.ServiceAreaResource
   problematically_big_area: resources.VerticesResource
+  planning_area: resources.PlanningAreaResource
   test_exclusions: resources.dev.TestExclusionsResource?
   uss_identification: resources.interuss.uss_identification.USSIdentificationResource?
 actions:
@@ -56,6 +57,7 @@ actions:
         id_generator: id_generator
         service_area: service_area
         problematically_big_area: problematically_big_area
+        planning_area: planning_area
         test_exclusions: test_exclusions?
       specification:
         action_to_repeat:
@@ -69,6 +71,7 @@ actions:
               id_generator: id_generator
               isa: service_area
               problematically_big_area: problematically_big_area
+              planning_area: planning_area
               test_exclusions: test_exclusions?
           on_failure: Continue
         dss_instances_source: dss_instances

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_19/dss_probing.yaml
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_19/dss_probing.yaml
@@ -7,6 +7,7 @@ resources:
   utm_client_identity: resources.communications.ClientIdentityResource
   isa: resources.netrid.ServiceAreaResource
   problematically_big_area: resources.VerticesResource
+  planning_area: resources.PlanningAreaResource
   test_exclusions: resources.dev.TestExclusionsResource?
 actions:
   - test_scenario:
@@ -58,6 +59,7 @@ actions:
       resources:
         primary_dss_instance: dss
         all_dss_instances: all_dss_instances
+        planning_area: planning_area
         test_exclusions: test_exclusions?
   - test_scenario:
       scenario_type: scenarios.astm.netrid.v19.dss.TokenValidation

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a.yaml
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a.yaml
@@ -12,6 +12,7 @@ resources:
   id_generator: resources.interuss.IDGeneratorResource
   service_area: resources.netrid.ServiceAreaResource
   problematically_big_area: resources.VerticesResource
+  planning_area: resources.PlanningAreaResource
   test_exclusions: resources.dev.TestExclusionsResource?
   uss_identification: resources.interuss.uss_identification.USSIdentificationResource?
 actions:
@@ -56,6 +57,7 @@ actions:
         id_generator: id_generator
         service_area: service_area
         problematically_big_area: problematically_big_area
+        planning_area: planning_area
         test_exclusions: test_exclusions?
       specification:
         action_to_repeat:
@@ -70,6 +72,7 @@ actions:
               isa: service_area
               client_identity: utm_client_identity
               problematically_big_area: problematically_big_area
+              planning_area: planning_area
               test_exclusions: test_exclusions?
           on_failure: Continue
         dss_instances_source: dss_instances

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a/dss_probing.yaml
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a/dss_probing.yaml
@@ -7,6 +7,7 @@ resources:
   utm_client_identity: resources.communications.ClientIdentityResource
   isa: resources.netrid.ServiceAreaResource
   problematically_big_area: resources.VerticesResource
+  planning_area: resources.PlanningAreaResource
   test_exclusions: resources.dev.TestExclusionsResource?
 actions:
   - test_scenario:
@@ -58,6 +59,7 @@ actions:
       resources:
         primary_dss_instance: dss
         all_dss_instances: all_dss_instances
+        planning_area: planning_area
         test_exclusions: test_exclusions?
   - test_scenario:
       scenario_type: scenarios.astm.netrid.v22a.dss.TokenValidation

--- a/monitoring/uss_qualifier/suites/interuss/dss/all_tests.yaml
+++ b/monitoring/uss_qualifier/suites/interuss/dss/all_tests.yaml
@@ -57,6 +57,7 @@ actions:
         id_generator: id_generator
         service_area: service_area
         problematically_big_area: problematically_big_area
+        planning_area: planning_area
         test_exclusions: test_exclusions?
       specification:
         action_to_repeat:
@@ -70,6 +71,7 @@ actions:
               id_generator: id_generator
               isa: service_area
               problematically_big_area: problematically_big_area
+              planning_area: planning_area
               test_exclusions: test_exclusions?
           on_failure: Continue
         dss_instances_source: dss_instances
@@ -84,6 +86,7 @@ actions:
         id_generator: id_generator
         service_area: service_area
         problematically_big_area: problematically_big_area
+        planning_area: planning_area
         test_exclusions: test_exclusions?
       specification:
         action_to_repeat:
@@ -97,6 +100,7 @@ actions:
               id_generator: id_generator
               isa: service_area
               problematically_big_area: problematically_big_area
+              planning_area: planning_area
               test_exclusions: test_exclusions?
           on_failure: Continue
         dss_instances_source: dss_instances

--- a/monitoring/uss_qualifier/suites/uspace/network_identification.yaml
+++ b/monitoring/uss_qualifier/suites/uspace/network_identification.yaml
@@ -10,6 +10,7 @@ resources:
   id_generator: resources.interuss.IDGeneratorResource
   service_area: resources.netrid.ServiceAreaResource
   problematically_big_area: resources.VerticesResource
+  planning_area: resources.PlanningAreaResource
   test_exclusions: resources.dev.TestExclusionsResource?
   mock_uss_dp: resources.interuss.mock_uss.client.MockUSSResource?
   mock_uss_sp: resources.interuss.mock_uss.client.MockUSSResource?
@@ -28,6 +29,7 @@ actions:
       id_generator: id_generator
       service_area: service_area
       problematically_big_area: problematically_big_area
+      planning_area: planning_area
       test_exclusions: test_exclusions?
       mock_uss_dp: mock_uss_dp?
       mock_uss_sp: mock_uss_sp?

--- a/monitoring/uss_qualifier/suites/uspace/required_services.yaml
+++ b/monitoring/uss_qualifier/suites/uspace/required_services.yaml
@@ -80,6 +80,7 @@ actions:
       id_generator: id_generator
       service_area: service_area
       problematically_big_area: problematically_big_area
+      planning_area: planning_area
       test_exclusions: test_exclusions?
       mock_uss_dp: mock_uss_dp?
       mock_uss_sp: mock_uss_sp?


### PR DESCRIPTION
Replace the hardcoded vertices with a PlanningAreaResource in `DSSInteroperability`, so the area used for testing can be configured.

Fixes #843

## Breaking Configuration Change

all configurations that specify a `DSSInteroperability` scenario now need to provide a `PlanningAreaResource`. This resource is newly available as a general `resource`, and any existing `PlanningAreaResource` defined in the context of SCD/F3548 scenarios should be directly reusable in most situations.