### PR TITLE
[uss_qualifier] sp notifications: wait for permissible delay before requesting notifications

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/netrid/injection.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/injection.py
@@ -23,6 +23,7 @@ class InjectedFlight(ImplicitDict):
     test_id: str
     flight: TestFlight
     query_timestamp: datetime
+    query_duration_s: float
 
 
 class InjectedTest(ImplicitDict):
@@ -89,6 +90,7 @@ def inject_flights(
                     test_id=test_id,
                     flight=TestFlight(flight),
                     query_timestamp=query.request.timestamp,
+                    query_duration_s=query.response.elapsed_s,
                 )
             )
             timestamps = [

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/sp_notification_behavior.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/sp_notification_behavior.md
@@ -55,13 +55,13 @@ at which a flight was injected.
 
 #### [Get mock_uss interactions](../../../interuss/mock_uss/get_mock_uss_interactions.md)
 
-#### ℹ️ Service Provider notification was received within delay check
+#### ℹ️ Service Provider notification was received check
 
-This check validates that the notification from each Service Provider was received by the mock_uss within the specified delay.
+This check validates that the notification from each Service Provider was received by the mock_uss within a reasonable delay.
 
 ASTM F3411 V19 has no explicit requirement for this check, so triggering it will raise an informational warning.
 
-This check will be triggered if it takes longer than 3 seconds between the injection of the flight and the notification being received by the mock_uss.
+This check will be triggered if it takes longer than approximately 3 seconds between the injection of the flight and the notification being received by the mock_uss.
 
 ## Cleanup
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/sp_notification_behavior.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/sp_notification_behavior.md
@@ -55,12 +55,6 @@ at which a flight was injected.
 
 #### [Get mock_uss interactions](../../../interuss/mock_uss/get_mock_uss_interactions.md)
 
-#### ℹ️ Service Provider issued a notification check
-
-This check validates that each Service Provider at which a test flight was injected properly notified the mock_uss.
-
-ASTM F3411 V19 has no explicit requirement for this check, so triggering it will raise an informational warning.
-
 #### ℹ️ Service Provider notification was received within delay check
 
 This check validates that the notification from each Service Provider was received by the mock_uss within the specified delay.

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/sp_notification_behavior.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/sp_notification_behavior.md
@@ -55,12 +55,6 @@ at which a flight was injected.
 
 #### [Get mock_uss interactions](../../../interuss/mock_uss/get_mock_uss_interactions.md)
 
-#### ⚠️ Service Provider issued a notification check
-
-This check validates that each Service Provider at which a test flight was injected properly notified the mock_uss.
-
-If this is not the case, the respective Service Provider fails to meet **[astm.f3411.v22a.NET0740](../../../../requirements/astm/f3411/v22a.md)**.
-
 #### ⚠️ Service Provider notification was received within delay check
 
 This check validates that the notification from each Service Provider was received by the mock_uss within the specified delay.

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/sp_notification_behavior.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/sp_notification_behavior.md
@@ -55,13 +55,13 @@ at which a flight was injected.
 
 #### [Get mock_uss interactions](../../../interuss/mock_uss/get_mock_uss_interactions.md)
 
-#### ⚠️ Service Provider notification was received within delay check
+#### ⚠️ Service Provider notification was received check
 
-This check validates that the notification from each Service Provider was received by the mock_uss within the specified delay.
+This check validates that the notification from each Service Provider was received by the mock_uss within a reasonable delay.
 
 **[astm.f3411.v22a.NET0740](../../../../requirements/astm/f3411/v22a.md)** states that a Service Provider must notify the owner of a subscription within `NetDpDataResponse95thPercentile` (1 second) second 95% of the time and `NetDpDataResponse99thPercentile` (3 seconds) 99% of the time as soon as the SP becomes aware of the subscription.
 
-This check will be failed if it takes longer than 3 seconds between the injection of the flight and the notification being received by the mock_uss.
+This check will be failed if it takes longer than approximately 3 seconds between the injection of the flight and the notification being received by the mock_uss.
 
 ## Cleanup
 


### PR DESCRIPTION
Remove redundant check, and wait for the acceptable notification delivery time before declaring that notifications have not been delivered.

The PR adds some retry logic, so we don't need to wait for the full 3 seconds in situations where notifications arrive earlier.

The PR also adds a duration field to the `InjectedFlight` class.

Should fix #1043 