### PR TITLE
[uss_qualifier] Fix requierement collection of uspace test to check for UAS ID as well

### DIFF
--- a/monitoring/uss_qualifier/configurations/dev/uspace.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/uspace.yaml
@@ -139,6 +139,7 @@ v1:
                   - astm.f3411.v22a.service_provider#Operator Position provider
                   - astm.f3411.v22a.service_provider#Operational Status provider
                   - astm.f3411.v22a.display_provider#Mandatory requirements
+                  - astm.f3411.v22a.display_provider#UAS ID transmitter
                   - astm.f3411.v22a.display_provider#UAS ID Serial Number transmitter
                   - astm.f3411.v22a.display_provider#UA Type transmitter
                   - astm.f3411.v22a.display_provider#UA Classification Type transmitter


### PR DESCRIPTION
Add `NET0470,Table1,1` to uspace tests

Partially fix #857