### PR TITLE
[uss_qualifier] make PlanningAreaResource a non-standard-specific resource

### DIFF
--- a/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml
@@ -195,7 +195,7 @@ v1:
         # Area that will be used for queries and resource creation that are geo-located
         planning_area:
           $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
-          resource_type: resources.astm.f3548.v21.PlanningAreaResource
+          resource_type: resources.PlanningAreaResource
           specification:
             base_url: https://testdummy.interuss.org/interuss/monitoring/uss_qualifier/configurations/dev/f3548_self_contained/planning_area
             volume:

--- a/monitoring/uss_qualifier/configurations/dev/library/resources.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/library/resources.yaml
@@ -43,7 +43,7 @@ kentland_service_area:
 
 kentland_planning_area:
   $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
-  resource_type: resources.astm.f3548.v21.PlanningAreaResource
+  resource_type: resources.PlanningAreaResource
   specification:
     base_url: https://testdummy.interuss.org/interuss/monitoring/uss_qualifier/configurations/dev/library/resources/kentland_planning_area
     volume:
@@ -145,7 +145,7 @@ kml_storage_config:
 
 che_planning_area:
   $content_schema: monitoring/uss_qualifier/resources/definitions/ResourceDeclaration.json
-  resource_type: resources.astm.f3548.v21.PlanningAreaResource
+  resource_type: resources.PlanningAreaResource
   specification:
     base_url: https://testdummy.interuss.org/interuss/monitoring/uss_qualifier/configurations/dev/library/resources/che_planning_area
     volume:

--- a/monitoring/uss_qualifier/configurations/dev/netrid_v19.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/netrid_v19.yaml
@@ -8,6 +8,7 @@ v1:
         utm_client_identity: {$ref: 'library/resources.yaml#/utm_client_identity'}
         id_generator: {$ref: 'library/resources.yaml#/id_generator'}
         kentland_service_area: {$ref: 'library/resources.yaml#/kentland_service_area'}
+        kentland_planning_area: {$ref: 'library/resources.yaml#/kentland_planning_area'}
         au_problematically_big_area: {$ref: 'library/resources.yaml#/au_problematically_big_area'}
 
         utm_auth: {$ref: 'library/environment.yaml#/utm_auth'}
@@ -40,6 +41,7 @@ v1:
           id_generator: id_generator
           service_area: kentland_service_area
           problematically_big_area: au_problematically_big_area
+          planning_area: kentland_planning_area
           test_exclusions: test_exclusions
           uss_identification: uss_identification
     execution:

--- a/monitoring/uss_qualifier/configurations/dev/netrid_v19.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/netrid_v19.yaml
@@ -8,7 +8,6 @@ v1:
         utm_client_identity: {$ref: 'library/resources.yaml#/utm_client_identity'}
         id_generator: {$ref: 'library/resources.yaml#/id_generator'}
         kentland_service_area: {$ref: 'library/resources.yaml#/kentland_service_area'}
-        kentland_planning_area: {$ref: 'library/resources.yaml#/kentland_planning_area'}
         au_problematically_big_area: {$ref: 'library/resources.yaml#/au_problematically_big_area'}
 
         utm_auth: {$ref: 'library/environment.yaml#/utm_auth'}
@@ -41,7 +40,6 @@ v1:
           id_generator: id_generator
           service_area: kentland_service_area
           problematically_big_area: au_problematically_big_area
-          planning_area: kentland_planning_area
           test_exclusions: test_exclusions
           uss_identification: uss_identification
     execution:

--- a/monitoring/uss_qualifier/configurations/dev/netrid_v22a.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/netrid_v22a.yaml
@@ -8,6 +8,7 @@ v1:
         utm_client_identity: {$ref: 'library/resources.yaml#/utm_client_identity'}
         id_generator: {$ref: 'library/resources.yaml#/id_generator'}
         kentland_service_area: {$ref: 'library/resources.yaml#/kentland_service_area'}
+        kentland_planning_area: {$ref: 'library/resources.yaml#/kentland_planning_area'}
         au_problematically_big_area: {$ref: 'library/resources.yaml#/au_problematically_big_area'}
 
         utm_auth: {$ref: 'library/environment.yaml#/utm_auth'}
@@ -40,6 +41,7 @@ v1:
           id_generator: id_generator
           service_area: kentland_service_area
           problematically_big_area: au_problematically_big_area
+          planning_area: kentland_planning_area
           test_exclusions: test_exclusions
           uss_identification: uss_identification
     execution:

--- a/monitoring/uss_qualifier/configurations/dev/netrid_v22a.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/netrid_v22a.yaml
@@ -8,7 +8,6 @@ v1:
         utm_client_identity: {$ref: 'library/resources.yaml#/utm_client_identity'}
         id_generator: {$ref: 'library/resources.yaml#/id_generator'}
         kentland_service_area: {$ref: 'library/resources.yaml#/kentland_service_area'}
-        kentland_planning_area: {$ref: 'library/resources.yaml#/kentland_planning_area'}
         au_problematically_big_area: {$ref: 'library/resources.yaml#/au_problematically_big_area'}
 
         utm_auth: {$ref: 'library/environment.yaml#/utm_auth'}
@@ -41,7 +40,6 @@ v1:
           id_generator: id_generator
           service_area: kentland_service_area
           problematically_big_area: au_problematically_big_area
-          planning_area: kentland_planning_area
           test_exclusions: test_exclusions
           uss_identification: uss_identification
     execution:

--- a/monitoring/uss_qualifier/configurations/dev/utm_implementation_us_lib/baseline.libsonnet
+++ b/monitoring/uss_qualifier/configurations/dev/utm_implementation_us_lib/baseline.libsonnet
@@ -104,7 +104,7 @@ function(env) {
 
           // Area that will be used for queries and resource creation that are geo-located
           planning_area: {
-            resource_type: 'resources.astm.f3548.v21.PlanningAreaResource',
+            resource_type: 'resources.PlanningAreaResource',
             specification: {
               volume: {
                 outline_polygon: {

--- a/monitoring/uss_qualifier/resources/__init__.py
+++ b/monitoring/uss_qualifier/resources/__init__.py
@@ -1,1 +1,2 @@
+from .planning_area import PlanningAreaResource
 from .vertices import VerticesResource

--- a/monitoring/uss_qualifier/resources/astm/f3548/v21/__init__.py
+++ b/monitoring/uss_qualifier/resources/astm/f3548/v21/__init__.py
@@ -1,2 +1,1 @@
 from .dss import DSSInstanceResource, DSSInstancesResource
-from .planning_area import PlanningAreaResource

--- a/monitoring/uss_qualifier/resources/planning_area.py
+++ b/monitoring/uss_qualifier/resources/planning_area.py
@@ -23,7 +23,7 @@ from monitoring.uss_qualifier.resources.resource import Resource
 
 
 class PlanningAreaSpecification(ImplicitDict):
-    """Specifies an area and USS related information to create test resources that require them."""
+    """Specifies a 2D or 3D volume along with USS related information to create test resources that require them."""
 
     base_url: Optional[str]
     """Base URL for the USS

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/authentication/authentication_validation.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/authentication/authentication_validation.md
@@ -36,7 +36,7 @@ Optional scopes that will allow the scenario to provide additional coverage:
 
 ### planning_area
 
-[`PlanningAreaResource`](../../../../../resources/astm/f3548/v21/planning_area.py) describes the 3D volume in which entities will be created.
+[`PlanningAreaResource`](../../../../../resources/planning_area.py) describes the 3D volume in which entities will be created.
 
 ## Setup test case
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/authentication/authentication_validation.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/authentication/authentication_validation.py
@@ -13,10 +13,8 @@ from monitoring.uss_qualifier.resources.astm.f3548.v21.dss import (
     DSSInstance,
     DSSInstanceResource,
 )
-from monitoring.uss_qualifier.resources.astm.f3548.v21.planning_area import (
-    PlanningAreaResource,
-)
 from monitoring.uss_qualifier.resources.interuss.id_generator import IDGeneratorResource
+from monitoring.uss_qualifier.resources.planning_area import PlanningAreaResource
 from monitoring.uss_qualifier.resources.resource import MissingResourceError
 from monitoring.uss_qualifier.scenarios.astm.utm.dss import test_step_fragments
 from monitoring.uss_qualifier.scenarios.astm.utm.dss.authentication.availability_api_validator import (

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/authentication/cr_api_validator.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/authentication/cr_api_validator.py
@@ -5,14 +5,10 @@ from implicitdict import ImplicitDict, StringBasedDateTime
 from uas_standards.astm.f3548.v21.api import (
     OPERATIONS,
     ChangeConstraintReferenceResponse,
-    ChangeOperationalIntentReferenceResponse,
-    OperationalIntentState,
     OperationID,
     PutConstraintReferenceParameters,
-    PutOperationalIntentReferenceParameters,
     QueryConstraintReferenceParameters,
     QueryConstraintReferencesResponse,
-    QueryOperationalIntentReferenceParameters,
     Time,
 )
 
@@ -21,9 +17,7 @@ from monitoring.monitorlib.fetch import QueryError, QueryType
 from monitoring.monitorlib.geotemporal import Volume4D
 from monitoring.monitorlib.infrastructure import UTMClientSession
 from monitoring.uss_qualifier.resources.astm.f3548.v21.dss import DSSInstance
-from monitoring.uss_qualifier.resources.astm.f3548.v21.planning_area import (
-    PlanningAreaSpecification,
-)
+from monitoring.uss_qualifier.resources.planning_area import PlanningAreaSpecification
 from monitoring.uss_qualifier.scenarios.astm.utm.dss.authentication.generic import (
     GenericAuthValidator,
 )

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/authentication/oir_api_validator.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/authentication/oir_api_validator.py
@@ -17,9 +17,7 @@ from monitoring.monitorlib.fetch import QueryError, QueryType
 from monitoring.monitorlib.geotemporal import Volume4D
 from monitoring.monitorlib.infrastructure import UTMClientSession
 from monitoring.uss_qualifier.resources.astm.f3548.v21.dss import DSSInstance
-from monitoring.uss_qualifier.resources.astm.f3548.v21.planning_area import (
-    PlanningAreaSpecification,
-)
+from monitoring.uss_qualifier.resources.planning_area import PlanningAreaSpecification
 from monitoring.uss_qualifier.scenarios.astm.utm.dss.authentication.generic import (
     GenericAuthValidator,
 )

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/authentication/sub_api_validator.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/authentication/sub_api_validator.py
@@ -14,9 +14,7 @@ from monitoring.monitorlib.infrastructure import UTMClientSession
 from monitoring.monitorlib.mutate import scd as mutate
 from monitoring.monitorlib.mutate.scd import MutatedSubscription
 from monitoring.uss_qualifier.resources.astm.f3548.v21.dss import DSSInstance
-from monitoring.uss_qualifier.resources.astm.f3548.v21.planning_area import (
-    PlanningAreaSpecification,
-)
+from monitoring.uss_qualifier.resources.planning_area import PlanningAreaSpecification
 from monitoring.uss_qualifier.scenarios.astm.utm.dss.authentication.generic import (
     GenericAuthValidator,
 )

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/constraint_ref_simple.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/constraint_ref_simple.md
@@ -20,7 +20,7 @@ Verifies the behavior of a DSS for simple interactions pertaining to constraint 
 
 ### planning_area
 
-[`PlanningAreaResource`](../../../../resources/astm/f3548/v21/planning_area.py) describes the 3D volume in which constraint references will be created.
+[`PlanningAreaResource`](../../../../resources/planning_area.py) describes the 3D volume in which constraint references will be created.
 
 ## Setup test case
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/constraint_ref_simple.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/constraint_ref_simple.py
@@ -6,16 +6,14 @@ from uas_standards.astm.f3548.v21.constants import Scope
 from monitoring.monitorlib.fetch import QueryError
 from monitoring.monitorlib.geotemporal import Volume4D
 from monitoring.prober.infrastructure import register_resource_type
-from monitoring.uss_qualifier.resources.astm.f3548.v21 import PlanningAreaResource
+from monitoring.uss_qualifier.resources import PlanningAreaResource
 from monitoring.uss_qualifier.resources.astm.f3548.v21.dss import (
     DSSInstance,
     DSSInstanceResource,
 )
-from monitoring.uss_qualifier.resources.astm.f3548.v21.planning_area import (
-    PlanningAreaSpecification,
-)
 from monitoring.uss_qualifier.resources.communications import ClientIdentityResource
 from monitoring.uss_qualifier.resources.interuss.id_generator import IDGeneratorResource
+from monitoring.uss_qualifier.resources.planning_area import PlanningAreaSpecification
 from monitoring.uss_qualifier.scenarios.astm.utm.dss import test_step_fragments
 from monitoring.uss_qualifier.scenarios.scenario import TestScenario
 from monitoring.uss_qualifier.suites.suite import ExecutionContext

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/dss_interoperability.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/dss_interoperability.md
@@ -18,7 +18,7 @@ A [resources.astm.f3548.v21.DSSInstancesResource](../../../../resources/astm/f35
 
 ### planning_area
 
-A [resources.astm.f3548.v21.PlanningAreaResource](../../../../resources/astm/f3548/v21/planning_area.py) containing a planning area that covers the area of interest for this
+A [resources.PlanningAreaResource](../../../../resources/planning_area.py) containing a planning area that covers the area of interest for this
 
 ### test_exclusions
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/dss_interoperability.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/dss_interoperability.py
@@ -7,7 +7,7 @@ from uas_standards.astm.f3548.v21.api import Volume4D
 from uas_standards.astm.f3548.v21.constants import Scope
 
 from monitoring.monitorlib.fetch import QueryError
-from monitoring.uss_qualifier.resources.astm.f3548.v21 import PlanningAreaResource
+from monitoring.uss_qualifier.resources import PlanningAreaResource
 from monitoring.uss_qualifier.resources.astm.f3548.v21.dss import (
     DSSInstance,
     DSSInstanceResource,

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/oir_explicit_sub_handling.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/oir_explicit_sub_handling.md
@@ -20,7 +20,7 @@ Verifies the behavior of a DSS for interactions pertaining to operational intent
 
 ### planning_area
 
-[`PlanningAreaResource`](../../../../resources/astm/f3548/v21/planning_area.py) describes the 3D volume in which operational intent references will be created.
+[`PlanningAreaResource`](../../../../resources/planning_area.py) describes the 3D volume in which operational intent references will be created.
 
 ## Setup test case
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/oir_explicit_sub_handling.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/oir_explicit_sub_handling.py
@@ -14,19 +14,17 @@ from uas_standards.astm.f3548.v21.constants import Scope
 from monitoring.monitorlib.fetch import QueryError
 from monitoring.monitorlib.geotemporal import Volume4D
 from monitoring.prober.infrastructure import register_resource_type
-from monitoring.uss_qualifier.resources.astm.f3548.v21 import PlanningAreaResource
+from monitoring.uss_qualifier.resources import PlanningAreaResource
 from monitoring.uss_qualifier.resources.astm.f3548.v21.dss import (
     DSSInstance,
     DSSInstanceResource,
-)
-from monitoring.uss_qualifier.resources.astm.f3548.v21.planning_area import (
-    PlanningAreaSpecification,
 )
 from monitoring.uss_qualifier.resources.astm.f3548.v21.subscription_params import (
     SubscriptionParams,
 )
 from monitoring.uss_qualifier.resources.communications import ClientIdentityResource
 from monitoring.uss_qualifier.resources.interuss.id_generator import IDGeneratorResource
+from monitoring.uss_qualifier.resources.planning_area import PlanningAreaSpecification
 from monitoring.uss_qualifier.scenarios.astm.utm.dss import test_step_fragments
 from monitoring.uss_qualifier.scenarios.astm.utm.dss.fragments.oir import (
     crud as oir_fragments,

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/oir_implicit_sub_handling.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/oir_implicit_sub_handling.md
@@ -16,7 +16,7 @@ Checks that implicit subscriptions are properly created, mutated and cleaned up.
 
 ### planning_area
 
-[`PlanningAreaResource`](../../../../resources/astm/f3548/v21/planning_area.py) describes the 3D volume in which subscriptions will be created.
+[`PlanningAreaResource`](../../../../resources/planning_area.py) describes the 3D volume in which subscriptions will be created.
 
 ### utm_client_identity
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/oir_implicit_sub_handling.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/oir_implicit_sub_handling.py
@@ -16,7 +16,7 @@ from monitoring.monitorlib.fetch import Query, QueryError
 from monitoring.monitorlib.geotemporal import Volume4D
 from monitoring.monitorlib.testing import make_fake_url
 from monitoring.prober.infrastructure import register_resource_type
-from monitoring.uss_qualifier.resources.astm.f3548.v21 import PlanningAreaResource
+from monitoring.uss_qualifier.resources import PlanningAreaResource
 from monitoring.uss_qualifier.resources.astm.f3548.v21.dss import DSSInstanceResource
 from monitoring.uss_qualifier.resources.communications import ClientIdentityResource
 from monitoring.uss_qualifier.resources.interuss.id_generator import IDGeneratorResource

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/op_intent_ref_key_validation.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/op_intent_ref_key_validation.md
@@ -21,7 +21,7 @@ provide all OVNs for all currently relevant entities.
 
 ### planning_area
 
-[`PlanningAreaResource`](../../../../resources/astm/f3548/v21/planning_area.py) describes the 3D volume in which operational intent references will be created.
+[`PlanningAreaResource`](../../../../resources/planning_area.py) describes the 3D volume in which operational intent references will be created.
 
 ## Setup test case
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/op_intent_ref_key_validation.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/op_intent_ref_key_validation.py
@@ -14,7 +14,7 @@ from monitoring.monitorlib.fetch import QueryError
 from monitoring.monitorlib.geotemporal import Volume4D
 from monitoring.monitorlib.schema_validation import F3548_21
 from monitoring.prober.infrastructure import register_resource_type
-from monitoring.uss_qualifier.resources.astm.f3548.v21 import PlanningAreaResource
+from monitoring.uss_qualifier.resources import PlanningAreaResource
 from monitoring.uss_qualifier.resources.astm.f3548.v21.dss import (
     DSSInstance,
     DSSInstanceResource,

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/op_intent_ref_simple.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/op_intent_ref_simple.md
@@ -20,7 +20,7 @@ Verifies the behavior of a DSS for simple interactions pertaining to operational
 
 ### planning_area
 
-[`PlanningAreaResource`](../../../../resources/astm/f3548/v21/planning_area.py) describes the 3D volume in which operational intent references will be created.
+[`PlanningAreaResource`](../../../../resources/planning_area.py) describes the 3D volume in which operational intent references will be created.
 
 ## Setup test case
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/op_intent_ref_simple.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/op_intent_ref_simple.py
@@ -13,16 +13,14 @@ from uas_standards.astm.f3548.v21.constants import Scope
 from monitoring.monitorlib.fetch import QueryError
 from monitoring.monitorlib.geotemporal import Volume4D
 from monitoring.prober.infrastructure import register_resource_type
-from monitoring.uss_qualifier.resources.astm.f3548.v21 import PlanningAreaResource
+from monitoring.uss_qualifier.resources import PlanningAreaResource
 from monitoring.uss_qualifier.resources.astm.f3548.v21.dss import (
     DSSInstance,
     DSSInstanceResource,
 )
-from monitoring.uss_qualifier.resources.astm.f3548.v21.planning_area import (
-    PlanningAreaSpecification,
-)
 from monitoring.uss_qualifier.resources.communications import ClientIdentityResource
 from monitoring.uss_qualifier.resources.interuss.id_generator import IDGeneratorResource
+from monitoring.uss_qualifier.resources.planning_area import PlanningAreaSpecification
 from monitoring.uss_qualifier.scenarios.astm.utm.dss import test_step_fragments
 from monitoring.uss_qualifier.scenarios.astm.utm.dss.fragments.oir import (
     crud as oir_fragments,

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_interactions.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_interactions.md
@@ -20,7 +20,7 @@ Create and mutate subscriptions as well as entities, and verify that the DSS han
 
 ### planning_area
 
-[`PlanningAreaResource`](../../../../resources/astm/f3548/v21/planning_area.py) describes the 3D volume in which subscriptions will be created.
+[`PlanningAreaResource`](../../../../resources/planning_area.py) describes the 3D volume in which subscriptions will be created.
 
 ### utm_client_identity
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_interactions.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_interactions.py
@@ -18,7 +18,7 @@ from monitoring.monitorlib.temporal import Time
 from monitoring.monitorlib.testing import make_fake_url
 from monitoring.prober.infrastructure import register_resource_type
 from monitoring.uss_qualifier.configurations.configuration import ParticipantID
-from monitoring.uss_qualifier.resources.astm.f3548.v21 import PlanningAreaResource
+from monitoring.uss_qualifier.resources import PlanningAreaResource
 from monitoring.uss_qualifier.resources.astm.f3548.v21.dss import (
     DSSInstanceResource,
     DSSInstancesResource,

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_interactions_deletion.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_interactions_deletion.md
@@ -20,7 +20,7 @@ Create and mutate subscriptions as well as entities, and verify that the DSS han
 
 ### planning_area
 
-[`PlanningAreaResource`](../../../../resources/astm/f3548/v21/planning_area.py) describes the 3D volume in which subscriptions will be created.
+[`PlanningAreaResource`](../../../../resources/planning_area.py) describes the 3D volume in which subscriptions will be created.
 
 ### utm_client_identity
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_interactions_deletion.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_interactions_deletion.py
@@ -13,7 +13,7 @@ from uas_standards.astm.f3548.v21.constants import Scope
 from monitoring.monitorlib.fetch import QueryError
 from monitoring.monitorlib.geotemporal import Volume4D
 from monitoring.monitorlib.testing import make_fake_url
-from monitoring.uss_qualifier.resources.astm.f3548.v21 import PlanningAreaResource
+from monitoring.uss_qualifier.resources import PlanningAreaResource
 from monitoring.uss_qualifier.resources.astm.f3548.v21.dss import (
     DSSInstanceResource,
     DSSInstancesResource,

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_simple.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_simple.md
@@ -16,7 +16,7 @@ Perform basic operations on a single DSS instance to create, update and delete s
 
 ### planning_area
 
-[`PlanningAreaResource`](../../../../resources/astm/f3548/v21/planning_area.py) describes the 3D volume in which subscriptions will be created.
+[`PlanningAreaResource`](../../../../resources/planning_area.py) describes the 3D volume in which subscriptions will be created.
 
 ### problematically_big_area
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_simple.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_simple.py
@@ -9,13 +9,10 @@ from monitoring.monitorlib.geo import Polygon, Volume3D
 from monitoring.monitorlib.geotemporal import Volume4D
 from monitoring.monitorlib.mutate.scd import MutatedSubscription
 from monitoring.prober.infrastructure import register_resource_type
-from monitoring.uss_qualifier.resources import VerticesResource
-from monitoring.uss_qualifier.resources.astm.f3548.v21 import PlanningAreaResource
+from monitoring.uss_qualifier.resources import PlanningAreaResource, VerticesResource
 from monitoring.uss_qualifier.resources.astm.f3548.v21.dss import DSSInstanceResource
-from monitoring.uss_qualifier.resources.astm.f3548.v21.planning_area import (
-    SubscriptionParams,
-)
 from monitoring.uss_qualifier.resources.interuss.id_generator import IDGeneratorResource
+from monitoring.uss_qualifier.resources.planning_area import SubscriptionParams
 from monitoring.uss_qualifier.scenarios.astm.utm.dss import test_step_fragments
 from monitoring.uss_qualifier.scenarios.astm.utm.dss.fragments.sub.crud import (
     sub_create_query,

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_validation.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_validation.md
@@ -16,7 +16,7 @@ Ensures that a DSS properly enforces limitations on created subscriptions
 
 ### planning_area
 
-[`PlanningAreaResource`](../../../../resources/astm/f3548/v21/planning_area.py) describes the 3D volume in which subscriptions will be created.
+[`PlanningAreaResource`](../../../../resources/planning_area.py) describes the 3D volume in which subscriptions will be created.
 
 ## Setup test case
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_validation.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_validation.py
@@ -10,11 +10,11 @@ from monitoring.monitorlib.geotemporal import Volume4D
 from monitoring.monitorlib.mutate.scd import MutatedSubscription
 from monitoring.prober.infrastructure import register_resource_type
 from monitoring.uss_qualifier.resources.astm.f3548.v21.dss import DSSInstanceResource
-from monitoring.uss_qualifier.resources.astm.f3548.v21.planning_area import (
+from monitoring.uss_qualifier.resources.interuss.id_generator import IDGeneratorResource
+from monitoring.uss_qualifier.resources.planning_area import (
     PlanningAreaResource,
     PlanningAreaSpecification,
 )
-from monitoring.uss_qualifier.resources.interuss.id_generator import IDGeneratorResource
 from monitoring.uss_qualifier.scenarios.astm.utm.dss import test_step_fragments
 from monitoring.uss_qualifier.scenarios.scenario import PendingCheck, TestScenario
 from monitoring.uss_qualifier.suites.suite import ExecutionContext

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md
@@ -21,7 +21,7 @@ are properly propagated to every other DSS instance participating in the deploym
 
 ### planning_area
 
-[`PlanningAreaResource`](../../../../../resources/astm/f3548/v21/planning_area.py) describes the 3D volume in which constraint reference will be created.
+[`PlanningAreaResource`](../../../../../resources/planning_area.py) describes the 3D volume in which constraint reference will be created.
 
 ### client_identity
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.py
@@ -11,7 +11,7 @@ from uas_standards.astm.f3548.v21.constants import Scope
 from monitoring.monitorlib.fetch import Query, QueryError
 from monitoring.monitorlib.geotemporal import Volume4D, Volume4DCollection
 from monitoring.prober.infrastructure import register_resource_type
-from monitoring.uss_qualifier.resources.astm.f3548.v21 import PlanningAreaResource
+from monitoring.uss_qualifier.resources import PlanningAreaResource
 from monitoring.uss_qualifier.resources.astm.f3548.v21.dss import (
     DSSInstance,
     DSSInstanceResource,

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md
@@ -21,7 +21,7 @@ are properly propagated to every other DSS instance participating in the deploym
 
 ### planning_area
 
-[`PlanningAreaResource`](../../../../../resources/astm/f3548/v21/planning_area.py) describes the 3D volume in which operational intent reference will be created.
+[`PlanningAreaResource`](../../../../../resources/planning_area.py) describes the 3D volume in which operational intent reference will be created.
 
 ### client_identity
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.py
@@ -12,7 +12,7 @@ from uas_standards.astm.f3548.v21.constants import Scope
 from monitoring.monitorlib.fetch import Query, QueryError
 from monitoring.monitorlib.geotemporal import Volume4D, Volume4DCollection
 from monitoring.prober.infrastructure import register_resource_type
-from monitoring.uss_qualifier.resources.astm.f3548.v21 import PlanningAreaResource
+from monitoring.uss_qualifier.resources import PlanningAreaResource
 from monitoring.uss_qualifier.resources.astm.f3548.v21.dss import (
     DSSInstance,
     DSSInstanceResource,

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/subscription_synchronization.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/subscription_synchronization.md
@@ -20,7 +20,7 @@ Verifies that all subscription CRUD operations performed on a single DSS instanc
 
 ### planning_area
 
-[`PlanningAreaResource`](../../../../../resources/astm/f3548/v21/planning_area.py) describes the 3D volume in which subscriptions will be created.
+[`PlanningAreaResource`](../../../../../resources/planning_area.py) describes the 3D volume in which subscriptions will be created.
 
 ### second_utm_auth
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/subscription_synchronization.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/subscription_synchronization.py
@@ -11,17 +11,15 @@ from monitoring.monitorlib.geotemporal import Volume4D
 from monitoring.monitorlib.mutate.scd import MutatedSubscription
 from monitoring.monitorlib.schema_validation import F3548_21
 from monitoring.prober.infrastructure import register_resource_type
-from monitoring.uss_qualifier.resources.astm.f3548.v21 import PlanningAreaResource
+from monitoring.uss_qualifier.resources import PlanningAreaResource
 from monitoring.uss_qualifier.resources.astm.f3548.v21.dss import (
     DSSInstance,
     DSSInstanceResource,
     DSSInstancesResource,
 )
-from monitoring.uss_qualifier.resources.astm.f3548.v21.planning_area import (
-    SubscriptionParams,
-)
 from monitoring.uss_qualifier.resources.communications import AuthAdapterResource
 from monitoring.uss_qualifier.resources.interuss.id_generator import IDGeneratorResource
+from monitoring.uss_qualifier.resources.planning_area import SubscriptionParams
 from monitoring.uss_qualifier.scenarios.astm.utm.dss import test_step_fragments
 from monitoring.uss_qualifier.scenarios.astm.utm.dss.fragments.sub.crud import (
     sub_create_query,

--- a/monitoring/uss_qualifier/scenarios/interuss/ovn_request/dss_ovn_request.md
+++ b/monitoring/uss_qualifier/scenarios/interuss/ovn_request/dss_ovn_request.md
@@ -15,7 +15,7 @@ This test validates that a DSS correctly implements the [OVN Request Optional Ex
 [`ClientIdentityResource`](../../../resources/communications/client_identity.py) the client identity that will be used to create and update operational intent references.
 
 ### planning_area
-[`PlanningAreaResource`](../../../resources/astm/f3548/v21/planning_area.py) describes the 3D volume in which operational intent references will be created.
+[`PlanningAreaResource`](../../../resources/planning_area.py) describes the 3D volume in which operational intent references will be created.
 
 ## Setup test case
 

--- a/monitoring/uss_qualifier/scenarios/interuss/ovn_request/dss_ovn_request.py
+++ b/monitoring/uss_qualifier/scenarios/interuss/ovn_request/dss_ovn_request.py
@@ -12,7 +12,7 @@ from uuid6 import uuid6, uuid7
 from monitoring.monitorlib import geotemporal
 from monitoring.monitorlib.fetch import QueryError
 from monitoring.prober.infrastructure import register_resource_type
-from monitoring.uss_qualifier.resources.astm.f3548.v21 import PlanningAreaResource
+from monitoring.uss_qualifier.resources import PlanningAreaResource
 from monitoring.uss_qualifier.resources.astm.f3548.v21.dss import DSSInstanceResource
 from monitoring.uss_qualifier.resources.communications import ClientIdentityResource
 from monitoring.uss_qualifier.resources.interuss import IDGeneratorResource

--- a/monitoring/uss_qualifier/suites/astm/utm/dss_probing.yaml
+++ b/monitoring/uss_qualifier/suites/astm/utm/dss_probing.yaml
@@ -7,7 +7,7 @@ resources:
   dss_datastore_cluster: resources.interuss.datastore.DatastoreDBClusterResource?
   flight_intents: resources.flight_planning.FlightIntentsResource
   id_generator: resources.interuss.IDGeneratorResource
-  planning_area: resources.astm.f3548.v21.PlanningAreaResource
+  planning_area: resources.PlanningAreaResource
   problematically_big_area: resources.VerticesResource
   test_exclusions: resources.dev.TestExclusionsResource?
 actions:

--- a/monitoring/uss_qualifier/suites/astm/utm/f3548_21.yaml
+++ b/monitoring/uss_qualifier/suites/astm/utm/f3548_21.yaml
@@ -18,7 +18,7 @@ resources:
   utm_client_identity: resources.communications.ClientIdentityResource
   mock_uss: resources.interuss.mock_uss.client.MockUSSResource?
   id_generator: resources.interuss.IDGeneratorResource
-  planning_area: resources.astm.f3548.v21.PlanningAreaResource
+  planning_area: resources.PlanningAreaResource
   problematically_big_area: resources.VerticesResource
   system_identity: resources.versioning.SystemIdentityResource?
   test_exclusions: resources.dev.TestExclusionsResource?

--- a/monitoring/uss_qualifier/suites/astm/utm/prod_probe.yaml
+++ b/monitoring/uss_qualifier/suites/astm/utm/prod_probe.yaml
@@ -4,7 +4,7 @@ resources:
   dss_instances: resources.astm.f3548.v21.DSSInstancesResource?
   dss_datastore_cluster: resources.interuss.datastore.DatastoreDBClusterResource?
   id_generator: resources.interuss.IDGeneratorResource
-  planning_area: resources.astm.f3548.v21.PlanningAreaResource
+  planning_area: resources.PlanningAreaResource
   test_exclusions: resources.dev.TestExclusionsResource?
   utm_client_identity: resources.communications.ClientIdentityResource
 actions:
@@ -41,7 +41,7 @@ actions:
                 all_dss_instances: resources.astm.f3548.v21.DSSInstancesResource?
                 dss_datastore_cluster: resources.interuss.datastore.DatastoreDBClusterResource?
                 id_generator: resources.interuss.IDGeneratorResource
-                planning_area: resources.astm.f3548.v21.PlanningAreaResource
+                planning_area: resources.PlanningAreaResource
                 test_exclusions: resources.dev.TestExclusionsResource?
               actions:
                 - test_scenario:

--- a/monitoring/uss_qualifier/suites/faa/uft/message_signing.yaml
+++ b/monitoring/uss_qualifier/suites/faa/uft/message_signing.yaml
@@ -13,7 +13,7 @@ resources:
   id_generator: resources.interuss.IDGeneratorResource
   utm_client_identity: resources.communications.ClientIdentityResource
   second_utm_auth: resources.communications.AuthAdapterResource?
-  planning_area: resources.astm.f3548.v21.PlanningAreaResource
+  planning_area: resources.PlanningAreaResource
   problematically_big_area: resources.VerticesResource
   test_exclusions: resources.dev.TestExclusionsResource?
 actions:

--- a/monitoring/uss_qualifier/suites/interuss/dss/all_tests.yaml
+++ b/monitoring/uss_qualifier/suites/interuss/dss/all_tests.yaml
@@ -9,7 +9,7 @@ resources:
   id_generator: resources.interuss.IDGeneratorResource
 
   service_area: resources.netrid.ServiceAreaResource?
-  planning_area: resources.astm.f3548.v21.PlanningAreaResource?
+  planning_area: resources.PlanningAreaResource?
   problematically_big_area: resources.VerticesResource?
 
   second_utm_auth: resources.communications.AuthAdapterResource?

--- a/monitoring/uss_qualifier/suites/uspace/flight_auth.yaml
+++ b/monitoring/uss_qualifier/suites/uspace/flight_auth.yaml
@@ -16,7 +16,7 @@ resources:
   utm_client_identity: resources.communications.ClientIdentityResource
   utm_auth: resources.communications.AuthAdapterResource?
   second_utm_auth: resources.communications.AuthAdapterResource?
-  planning_area: resources.astm.f3548.v21.PlanningAreaResource
+  planning_area: resources.PlanningAreaResource
   problematically_big_area: resources.VerticesResource
   system_identity: resources.versioning.SystemIdentityResource?
   test_exclusions: resources.dev.TestExclusionsResource?

--- a/monitoring/uss_qualifier/suites/uspace/required_services.yaml
+++ b/monitoring/uss_qualifier/suites/uspace/required_services.yaml
@@ -26,7 +26,7 @@ resources:
   second_utm_auth: resources.communications.AuthAdapterResource?
   id_generator: resources.interuss.IDGeneratorResource
   service_area: resources.netrid.ServiceAreaResource
-  planning_area: resources.astm.f3548.v21.PlanningAreaResource
+  planning_area: resources.PlanningAreaResource
   problematically_big_area: resources.VerticesResource
 
   test_exclusions: resources.dev.TestExclusionsResource?

--- a/schemas/monitoring/uss_qualifier/resources/planning_area/PlanningAreaSpecification.json
+++ b/schemas/monitoring/uss_qualifier/resources/planning_area/PlanningAreaSpecification.json
@@ -1,7 +1,7 @@
 {
-  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/uss_qualifier/resources/astm/f3548/v21/planning_area/PlanningAreaSpecification.json",
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/uss_qualifier/resources/planning_area/PlanningAreaSpecification.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "description": "Specifies an area and USS related information to create test resources that require them.\n\nmonitoring.uss_qualifier.resources.astm.f3548.v21.planning_area.PlanningAreaSpecification, as defined in monitoring/uss_qualifier/resources/astm/f3548/v21/planning_area.py",
+  "description": "Specifies a 2D or 3D volume along with USS related information to create test resources that require them.\n\nmonitoring.uss_qualifier.resources.planning_area.PlanningAreaSpecification, as defined in monitoring/uss_qualifier/resources/planning_area.py",
   "properties": {
     "$ref": {
       "description": "Path to content that replaces the $ref",
@@ -15,7 +15,7 @@
       ]
     },
     "volume": {
-      "$ref": "../../../../../../monitorlib/geo/Volume3D.json",
+      "$ref": "../../../monitorlib/geo/Volume3D.json",
       "description": "3D volume of service area"
     }
   },


### PR DESCRIPTION
This is a preparatory step towards re-using the PlanningAreaResource for f3411 scenarios (eg in #1041).

It is moved from to `monitoring/uss_qualifier/resources/astm/f3548/v21/planning_area.py` to `monitoring/uss_qualifier/resources/planning_area.py`.

All other changes are adaptations of import paths.