### PR TITLE
Add no-response issue manager action

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -1,0 +1,27 @@
+name: No Response
+
+# Both `issue_comment` and `scheduled` event types are required for this Action
+# to work properly.
+on:
+  issue_comment:
+    types: [created]
+  schedule:
+    # Schedule for five minutes after the hour, every hour
+    - cron: '5 * * * *'
+
+jobs:
+  noResponse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: lee-dohm/no-response@9bb0a4b5e6a45046f00353d5de7d90fb8bd773bb
+        with:
+          token: ${{ github.token }}
+          closeComment: >
+            This issue has been automatically closed because there has been no response
+            to our request for more information from the original author. With only the
+            information that is currently in the issue, we don't have enough information
+            to take action. Please reach out if you have or find the answers we need so
+            that we can investigate further.
+          daysUntilClose: 14
+          responseRequiredColor: ffffff
+          responseRequiredLabel: more-information-needed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,10 @@ Welcome to this repository and thank you for your interest in contributing to it
 
 Contributions should follow [the general InterUSS contributions process](https://github.com/interuss/tsc/blob/main/repo_contributions.md).  Additional information specific to this repository is provided below.
 
+## Issues requiring more information
+
+When more information is needed from an issue's author to continue investigation/consideration of the issue, a maintainer may apply the `more-informationed-needed` label following a comment requesting the additional information.  [no-response](https://github.com/lee-dohm/no-response?tab=readme-ov-file#action-flow) will automatically close the issue if no additional information is provided.  New information (in the form of a comment on the issue) should remove the label and reopen the issue if it was closed.
+
 ## Formatting and verification
 
 This repository has a very strict Python linter, as well as very strict expected formats for a number of other artifacts such as Markdown files.  Correct formatting can be verified with `make lint` from the repository root.  But, in most cases manual formatting is not necessary to resolve issues -- instead, `make format` from the repository root should automatically reformat Python and most other mere-formatting issues without changing functionality.  Because `make lint` is part of the integration tests, `make format` should generally be run before integration tests.


### PR DESCRIPTION
This PR is intended to help us manage Issues by automatically closing Issues abandoned by their authors.

Following the merge of this PR, I intend to inform repo maintainers of the new tool available to them: when they comment on an issue asking for something from the author needed to move the issue forward, they can also (at their discretion, but usually) add the `more-information-needed` label indicating that the Issue can't effectively move forward until an additional response is provided.  Issues with that label will be auto-closed if abandoned by their author (the author does not provide the necessary information/feedback/follow-up/etc).