### PR TITLE
[mock_uss] Fix incoming tracer notifications with non-Z time zones

### DIFF
--- a/monitoring/mock_uss/tracer/template.py
+++ b/monitoring/mock_uss/tracer/template.py
@@ -1,19 +1,17 @@
 import datetime
 
+import arrow
+
 from monitoring.monitorlib import formatting
 
 
 def _print_time_range(t0: str, t1: str) -> str:
     if not t0 and not t1:
         return ""
-    now = datetime.datetime.now(datetime.UTC)
-    if t0.endswith("Z"):
-        t0 = t0[0:-1]
-    if t1.endswith("Z"):
-        t1 = t1[0:-1]
+    now = arrow.utcnow()
     try:
-        t0dt = datetime.datetime.fromisoformat(t0) - now
-        t1dt = datetime.datetime.fromisoformat(t1) - now
+        t0dt = arrow.get(t0) - now
+        t1dt = arrow.get(t1) - now
         return " {} to {}".format(
             formatting.format_timedelta(t0dt), formatting.format_timedelta(t1dt)
         )


### PR DESCRIPTION
Currently, part of mock_uss tracer's handling logic for operational intent notifications attempts to adjust timestamp strings to be timezone-naive by stripping off the trailing "Z" before converting them to datetimes in order to compare to now.  This is problematic when timestamp strings use a time offset other than "Z" (e.g., "-07:00") because those timestamps are converted to timezone-aware datetimes which then raise an exception when compared to timezone-naive now.

This PR fixes this bug by simply letting `arrow` handle timestamp parsing so that there will never be timezone-naive/aware mismatches.