### PR TITLE
[uss_qualifier/resources/netrid/service_providers:get_user_notifications] ISO-format 'after' and 'before' dates

### DIFF
--- a/monitoring/uss_qualifier/resources/netrid/service_providers.py
+++ b/monitoring/uss_qualifier/resources/netrid/service_providers.py
@@ -89,8 +89,8 @@ class NetRIDServiceProvider(object):
             participant_id=self.participant_id,
             query_type=fetch.QueryType.InterussRIDAutomatedTestingV1UserNotifications,
             params={
-                "after": after,
-                "before": before,
+                "after": after.isoformat(),
+                "before": before.isoformat(),
             },
         )
 


### PR DESCRIPTION
This should fix #1063 