### PR TITLE
[uss_qualifier] Fix unchecked `message` field access

### DIFF
--- a/monitoring/monitorlib/clients/flight_planning/client_v1.py
+++ b/monitoring/monitorlib/clients/flight_planning/client_v1.py
@@ -223,7 +223,10 @@ class V1FlightPlannerClient(FlightPlannerClient):
         if resp.outcome.success:
             errors = None
         else:
-            errors = [resp.outcome.message]
+            if "message" in resp.outcome:
+                errors = [resp.outcome.message]
+            else:
+                errors = ["No message specified for failure to clear area"]
 
         return TestPreparationActivityResponse(errors=errors, queries=[query])
 


### PR DESCRIPTION
In an off-nominal condition where a USS fails to clear an area via the flight planning interface, and also does not specify the optional `message` field, uss_qualifier will attempt to access the non-existent `message` field and raise an exception.  This problem was observed in the US UTM Implementation.  This PR fixes that issue by checking for the existence of the `message` field before accessing it.