### PR TITLE
[uss_qualifier] subscription sync scenario: run content validation checks and remove not-runned ones

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/sub/crud/read_correct.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/sub/crud/read_correct.md
@@ -12,6 +12,13 @@ The response to a successful get subscription query is expected to conform to th
 
 If it does not, the DSS is failing to implement **[astm.f3548.v21.DSS0005,5](../../../../../../../requirements/astm/f3548/v21.md)**.
 
+## 🛑 Get subscription response content is correct check
+
+A successful query for a subscription is expected to return a body, the content of which reflects the created subscription.
+If the content of the response does not correspond to what was requested, the DSS is failing to implement **[astm.f3548.v21.DSS0005,5](../../../../../../../requirements/astm/f3548/v21.md)**.
+
+This check will usually be performing a series of sub-checks from the [validate](../validate) fragments.
+
 ## [Validate subscription fields](../validate/correctness.md)
 
 ## [Validate version fields](../validate/non_mutated.md)

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/subscription_synchronization.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/subscription_synchronization.md
@@ -76,12 +76,11 @@ All subscriptions are left on the DSS when this step ends, as they are expected 
 
 Query the created subscription at every DSS provided in `dss_instances` to confirm that it is properly synchronized across all DSS instances,
 and that it can be accessed directly by ID or searched for by area.
-
 #### [Subscription is synchronized](../fragments/sub/sync.md)
 
 #### [Get subscription](../fragments/sub/crud/read_correct.md)
 
-#### [Search subscription](../fragments/sub/crud/search_correct.md)
+#### [Search subscription](../fragments/sub/crud/search_query.md)
 
 ### Mutate subscription broadcast test step
 
@@ -98,7 +97,7 @@ Query the updated subscription at every DSS provided in `dss_instances` to confi
 
 #### [Get subscription](../fragments/sub/crud/read_correct.md)
 
-#### [Search subscription](../fragments/sub/crud/search_correct.md)
+#### [Search subscription](../fragments/sub/crud/search_query.md)
 
 ### Mutate subscription on secondaries test step
 
@@ -131,7 +130,7 @@ Note that this step is repeated for every secondary DSS instance.
 
 #### [Get subscription](../fragments/sub/crud/read_correct.md)
 
-#### [Search subscription](../fragments/sub/crud/search_correct.md)
+#### [Search subscription](../fragments/sub/crud/search_query.md)
 
 ### Create subscription with different credentials test step
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/validators/subscription_validator.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/validators/subscription_validator.py
@@ -376,6 +376,7 @@ class SubscriptionValidator:
         fetched_sub: FetchedSubscription,
         expected_version: str,
         is_implicit: bool,
+        validate_schema: bool = True,
     ) -> None:
         """Validate a subscription that was directly queried by its ID.
         Callers must specify if this is an implicit subscription or not."""
@@ -383,16 +384,17 @@ class SubscriptionValidator:
         (t_dss, sub) = (fetched_sub.request.timestamp, fetched_sub.subscription)
 
         # Validate the response schema
-        with self._scenario.check(
-            "Get subscription response format conforms to spec", self._pid
-        ) as check:
-            errors = schema_validation.validate(
-                F3548_21.OpenAPIPath,
-                F3548_21.GetSubscriptionResponse,
-                fetched_sub.response.json,
-            )
-            if errors:
-                fail_with_schema_errors(check, errors, t_dss)
+        if validate_schema:
+            with self._scenario.check(
+                "Get subscription response format conforms to spec", self._pid
+            ) as check:
+                errors = schema_validation.validate(
+                    F3548_21.OpenAPIPath,
+                    F3548_21.GetSubscriptionResponse,
+                    fetched_sub.response.json,
+                )
+                if errors:
+                    fail_with_schema_errors(check, errors, t_dss)
 
         # Validate the subscription itself
         self._validate_sub(


### PR DESCRIPTION
Some documented checks in subscription sync scenarios were documented but not verified.

For two of them the check is now conducted:
 - _Get Subscription by ID_ has been added to confirm that the DSS instance can fulfill that kind of request. 
 - _Get subscription response content is correct_ and all relevant subchecks are now run
 
The documentation for _Created Subscription is in search results_ is removed, it was included because the incorrect fragment was imported in the documentation. The intent of the scenario was to check for search query success, and to run synchronization-specific checks afterwards.
 

Progress on #975 