### PR TITLE
[uss_qualifier] CR/OIR sync: cleanup search/get-specific checks

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/cr/sync_fields.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/cr/sync_fields.md
@@ -1,28 +1,6 @@
-# Synchronize constraint reference test step fragment
+# Synchronize constraint reference fields test step fragment
 
-This test step fragment validates that constraint references are properly synchronized across a set of DSS instances.
-
-## 🛑 Constraint reference can be found at every DSS check
-
-If the previously created or mutated constraint reference cannot be found at a DSS, either one of the instances at which the constraint reference was created or the one that was queried,
-is failing to implement one of the following requirements:
-
-**[astm.f3548.v21.DSS0210,2a](../../../../../../requirements/astm/f3548/v21.md)**, if the API is not working as described by the OpenAPI specification;
-**[astm.f3548.v21.DSS0215](../../../../../../requirements/astm/f3548/v21.md)**, if the DSS is returning API calls to the client before having updated its underlying distributed storage.
-
-As a result, the DSS pool under test is failing to meet **[astm.f3548.v21.DSS0020](../../../../../../requirements/astm/f3548/v21.md)**.
-
-## 🛑 Propagated constraint reference general area is synchronized check
-
-When querying a secondary DSS for constraints in the planning area that contains the propagated
-constraint, if the propagated constraint is not contained in the response, then the general area in which the
-propagated constraint is located is not synchronized across DSS instances.
-As such, either the primary or the secondary DSS fail to properly one of the following requirements:
-
-**[astm.f3548.v21.DSS0210,2e](../../../../../../requirements/astm/f3548/v21.md)**, if the API is not working as described by the OpenAPI specification;
-**[astm.f3548.v21.DSS0215](../../../../../../requirements/astm/f3548/v21.md)**, if the DSS is returning API calls to the client before having updated its underlying distributed storage.
-
-As a result, the DSS pool under test is failing to meet **[astm.f3548.v21.DSS0020](../../../../../../requirements/astm/f3548/v21.md)**.
+This test step fragment validates that constraint reference attributes are properly synchronized across a set of DSS instances.
 
 ## ⚠️ Propagated constraint reference contains the correct manager check
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/cr/sync_get.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/cr/sync_get.md
@@ -1,0 +1,16 @@
+# Verify constraint reference synchronization through direct access test step fragment
+
+This test step fragment validates that constraint references are properly synchronized across a set of DSS instances
+by querying a constraint reference that is known to exist at each one of the DSS instances.
+
+## 🛑 Constraint reference can be found at every DSS check
+
+If the previously created or mutated constraint reference cannot be found at a DSS, either one of the instances at which the constraint reference was created or the one that was queried,
+is failing to implement one of the following requirements:
+
+**[astm.f3548.v21.DSS0210,2a](../../../../../../requirements/astm/f3548/v21.md)**, if the API is not working as described by the OpenAPI specification;
+**[astm.f3548.v21.DSS0215](../../../../../../requirements/astm/f3548/v21.md)**, if the DSS is returning API calls to the client before having updated its underlying distributed storage.
+
+As a result, the DSS pool under test is failing to meet **[astm.f3548.v21.DSS0020](../../../../../../requirements/astm/f3548/v21.md)**.
+
+## [Constraint Reference fields are synchronized](./sync_fields.md)

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/cr/sync_search.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/cr/sync_search.md
@@ -1,0 +1,18 @@
+# Verify constraint reference synchronization through search test step fragment
+
+This test step fragment validates that constraint references are properly synchronized across a set of DSS instances by
+searching for a constraint reference that is known to exist in a specific area at each one of the DSS instances.
+
+## 🛑 Propagated constraint reference general area is synchronized check
+
+When querying a secondary DSS for constraints in the planning area that contains the propagated
+constraint, if the propagated constraint is not contained in the response, then the general area in which the
+propagated constraint is located is not synchronized across DSS instances.
+As such, either the primary or the secondary DSS fail to properly one of the following requirements:
+
+**[astm.f3548.v21.DSS0210,2e](../../../../../../requirements/astm/f3548/v21.md)**, if the API is not working as described by the OpenAPI specification;
+**[astm.f3548.v21.DSS0215](../../../../../../requirements/astm/f3548/v21.md)**, if the DSS is returning API calls to the client before having updated its underlying distributed storage.
+
+As a result, the DSS pool under test is failing to meet **[astm.f3548.v21.DSS0020](../../../../../../requirements/astm/f3548/v21.md)**.
+
+## [Constraint Reference fields are synchronized](./sync_fields.md)

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/oir/sync_fields.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/oir/sync_fields.md
@@ -1,28 +1,6 @@
-# Synchronize operational intent reference test step fragment
+# Synchronize operational intent reference fields test step fragment
 
-This test step fragment validates that operational intent references are properly synchronized across a set of DSS instances.
-
-## 🛑 Operational intent reference can be found at every DSS check
-
-If the previously created or mutated operational intent reference cannot be found at a DSS, either one of the instances at which the operational intent reference was created or the one that was queried,
-is failing to implement one of the following requirements:
-
-**[astm.f3548.v21.DSS0210,2a](../../../../../../requirements/astm/f3548/v21.md)**, if the API is not working as described by the OpenAPI specification;
-**[astm.f3548.v21.DSS0215](../../../../../../requirements/astm/f3548/v21.md)**, if the DSS is returning API calls to the client before having updated its underlying distributed storage.
-
-As a result, the DSS pool under test is failing to meet **[astm.f3548.v21.DSS0020](../../../../../../requirements/astm/f3548/v21.md)**.
-
-## 🛑 Propagated operational intent reference general area is synchronized check
-
-When querying a secondary DSS for operational intents in the planning area that contains the propagated operational
-intent, if the propagated operational intent is not contained in the response, then the general area in which the
-propagated operational intent is located is not synchronized across DSS instances.
-As such, either the primary or the secondary DSS fails to properly implement one of the following requirements:
-
-**[astm.f3548.v21.DSS0210,2e](../../../../../../requirements/astm/f3548/v21.md)**, if the API is not working as described by the OpenAPI specification;
-**[astm.f3548.v21.DSS0215](../../../../../../requirements/astm/f3548/v21.md)**, if the DSS is returning API calls to the client before having updated its underlying distributed storage.
-
-As a result, the DSS pool under test is failing to meet **[astm.f3548.v21.DSS0020](../../../../../../requirements/astm/f3548/v21.md)**.
+This test step fragment validates that operational intent reference attributes are properly synchronized across a set of DSS instances.
 
 ## ⚠️ Propagated operational intent reference contains the correct manager check
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/oir/sync_get.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/oir/sync_get.md
@@ -1,0 +1,16 @@
+# Verify operational intent reference synchronization through direct access test step fragment
+
+This test step fragment validates that operational intent references are properly synchronized across a set of DSS instances
+by querying an operational intent reference that is known to exist at each one of the DSS instances.
+
+## 🛑 Operational intent reference can be found at every DSS check
+
+If the previously created or mutated operational intent reference cannot be found at a DSS, either one of the instances at which the operational intent reference was created or the one that was queried,
+is failing to implement one of the following requirements:
+
+**[astm.f3548.v21.DSS0210,2a](../../../../../../requirements/astm/f3548/v21.md)**, if the API is not working as described by the OpenAPI specification;
+**[astm.f3548.v21.DSS0215](../../../../../../requirements/astm/f3548/v21.md)**, if the DSS is returning API calls to the client before having updated its underlying distributed storage.
+
+As a result, the DSS pool under test is failing to meet **[astm.f3548.v21.DSS0020](../../../../../../requirements/astm/f3548/v21.md)**.
+
+## [Operational Intent Reference fields are synchronized](./sync_fields.md)

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/oir/sync_search.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/oir/sync_search.md
@@ -1,0 +1,18 @@
+# Verify operational intent reference synchronization through search test step fragment
+
+This test step fragment validates that operational intent references are properly synchronized across a set of DSS instances
+by searching for an operational intent reference that is known to exist in a specific area at each one of the DSS instances.
+
+## 🛑 Propagated operational intent reference general area is synchronized check
+
+When querying a secondary DSS for operational intents in the planning area that contains the propagated operational
+intent, if the propagated operational intent is not contained in the response, then the general area in which the
+propagated operational intent is located is not synchronized across DSS instances.
+As such, either the primary or the secondary DSS fails to properly implement one of the following requirements:
+
+**[astm.f3548.v21.DSS0210,2e](../../../../../../requirements/astm/f3548/v21.md)**, if the API is not working as described by the OpenAPI specification;
+**[astm.f3548.v21.DSS0215](../../../../../../requirements/astm/f3548/v21.md)**, if the DSS is returning API calls to the client before having updated its underlying distributed storage.
+
+As a result, the DSS pool under test is failing to meet **[astm.f3548.v21.DSS0020](../../../../../../requirements/astm/f3548/v21.md)**.
+
+## [Operational Intent Reference fields are synchronized](./sync_fields.md)

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md
@@ -63,18 +63,12 @@ If the constraint retrieved from a secondary DSS instance is not consistent with
 primary DSS instance, this check will fail per **[astm.f3548.v21.DSS0210,A2-7-2,1a](../../../../../requirements/astm/f3548/v21.md)**, **[astm.f3548.v21.DSS0210,A2-7-2,1f](../../../../../requirements/astm/f3548/v21.md)**,
 **[astm.f3548.v21.DSS0215](../../../../../requirements/astm/f3548/v21.md)** and **[astm.f3548.v21.DSS0020](../../../../../requirements/astm/f3548/v21.md)**.
 
-#### [CR is synchronized](../fragments/cr/sync.md)
-
-Confirm that each DSS provides direct access to the created constraint reference.
-Confirm that the constraint reference that was just created is properly synchronized across all DSS instances.
+#### [CR is synchronized](../fragments/cr/sync_get.md)
 
 #### [CR Content is correct](../fragments/cr/validate/correctness.md)
 
-Sanity check on the rest of the content and format of the response.
-
 #### [CR version is correct](../fragments/cr/validate/non_mutated.md)
 
-Confirm that version and OIR are as expected.
 
 ### Search for newly created CR test step
 
@@ -90,7 +84,7 @@ If the constraint searched from a secondary DSS instance is not consistent with 
 primary DSS instance, this check will fail per **[astm.f3548.v21.DSS0210,A2-7-2,1a](../../../../../requirements/astm/f3548/v21.md)**, **[astm.f3548.v21.DSS0210,A2-7-2,1e](../../../../../requirements/astm/f3548/v21.md)**,
 , **[astm.f3548.v21.DSS0215](../../../../../requirements/astm/f3548/v21.md)** and **[astm.f3548.v21.DSS0020](../../../../../requirements/astm/f3548/v21.md)**.
 
-#### [CR is synchronized](../fragments/cr/sync.md)
+#### [CR is synchronized](../fragments/cr/sync_search.md)
 
 Confirm that each DSS returns the constraint in relevant search results.
 Confirm that the constraint reference that was just created is properly synchronized across all DSS instances.
@@ -130,7 +124,7 @@ If the constraint retrieved from a secondary DSS instance is not consistent with
 primary DSS instance, this check will fail per **[astm.f3548.v21.DSS0210,A2-7-2,1b](../../../../../requirements/astm/f3548/v21.md)**, **[astm.f3548.v21.DSS0210,A2-7-2,1d](../../../../../requirements/astm/f3548/v21.md)**,
 **[astm.f3548.v21.DSS0215](../../../../../requirements/astm/f3548/v21.md)** and **[astm.f3548.v21.DSS0020](../../../../../requirements/astm/f3548/v21.md)**.
 
-#### [CR is synchronized](../fragments/cr/sync.md)
+#### [CR is synchronized](../fragments/cr/sync_get.md)
 
 Confirm that each DSS provides direct access to the updated constraint reference.
 Confirm that the constraint reference that was just updated is properly synchronized across all DSS instances.
@@ -153,7 +147,7 @@ If the constraint searched from a secondary DSS instance is not consistent with 
 primary DSS instance, this check will fail per **[astm.f3548.v21.DSS0210,A2-7-2,1b](../../../../../requirements/astm/f3548/v21.md)**, **[astm.f3548.v21.DSS0210,A2-7-2,1e](../../../../../requirements/astm/f3548/v21.md)**,
 **[astm.f3548.v21.DSS0215](../../../../../requirements/astm/f3548/v21.md)** and **[astm.f3548.v21.DSS0020](../../../../../requirements/astm/f3548/v21.md)**.
 
-#### [CR is synchronized](../fragments/cr/sync.md)
+#### [CR is synchronized](../fragments/cr/sync_search.md)
 
 Confirm that each DSS returns the constraint in relevant search results.
 Confirm that the constraint reference that was just updated is properly synchronized across all DSS instances.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md
@@ -47,18 +47,13 @@ Retrieve and validate synchronization of the created operational intent at every
 
 #### [Get OIR query](../fragments/oir/crud/read_query.md)
 
-Check that read query succeeds.
-
 #### 🛑 Newly created OIR can be consistently retrieved from all DSS instances check
 
 If the operational intent retrieved from a secondary DSS instance is not consistent with the newly created one on the
 primary DSS instance, this check will fail per **[astm.f3548.v21.DSS0210,A2-7-2,1a](../../../../../requirements/astm/f3548/v21.md)**, **[astm.f3548.v21.DSS0210,A2-7-2,1d](../../../../../requirements/astm/f3548/v21.md)**,
 , **[astm.f3548.v21.DSS0215](../../../../../requirements/astm/f3548/v21.md)** and **[astm.f3548.v21.DSS0020](../../../../../requirements/astm/f3548/v21.md)**.
 
-#### [OIR is synchronized](../fragments/oir/sync.md)
-
-Confirm that each DSS provides direct access to the created operational intent reference.
-Confirm that the operational intent reference that was just created is properly synchronized across all DSS instances.
+#### [OIR is synchronized](../fragments/oir/sync_get.md)
 
 ### Search for newly created OIR test step
 
@@ -66,18 +61,13 @@ Search for and validate synchronization of the created operational intent at eve
 
 #### [Search OIR](../fragments/oir/crud/search_query.md)
 
-Check that search query succeeds.
-
 #### 🛑 Newly created OIR can be consistently searched for from all DSS instances check
 
 If the operational intent searched from a secondary DSS instance is not consistent with the newly created one on the
 primary DSS instance, this check will fail per **[astm.f3548.v21.DSS0210,A2-7-2,1a](../../../../../requirements/astm/f3548/v21.md)**, **[astm.f3548.v21.DSS0210,A2-7-2,1c](../../../../../requirements/astm/f3548/v21.md)**,
 , **[astm.f3548.v21.DSS0215](../../../../../requirements/astm/f3548/v21.md)** and **[astm.f3548.v21.DSS0020](../../../../../requirements/astm/f3548/v21.md)**.
 
-#### [OIR is synchronized](../fragments/oir/sync.md)
-
-Confirm that each DSS returns the operational intent in relevant search results.
-Confirm that the operational intent reference that was just created is properly synchronized across all DSS instances.
+#### [OIR is synchronized](../fragments/oir/sync_search.md)
 
 ### Mutate OIR test step
 
@@ -92,18 +82,13 @@ Retrieve and validate synchronization of the updated operational intent at every
 
 #### [Get OIR query](../fragments/oir/crud/read_query.md)
 
-Check that read query succeeds.
-
 #### 🛑 Updated OIR can be consistently retrieved from all DSS instances check
 
 If the operational intent retrieved from a secondary DSS instance is not consistent with the updated one on the
 primary DSS instance, this check will fail per **[astm.f3548.v21.DSS0210,A2-7-2,1b](../../../../../requirements/astm/f3548/v21.md)**
 and **[astm.f3548.v21.DSS0210,A2-7-2,1d](../../../../../requirements/astm/f3548/v21.md)**.
 
-#### [OIR is synchronized](../fragments/oir/sync.md)
-
-Confirm that each DSS provides direct access to the updated operational intent reference.
-Confirm that the operational intent reference that was just updated is properly synchronized across all DSS instances.
+#### [OIR is synchronized](../fragments/oir/sync_get.md)
 
 ### Search for updated OIR test step
 
@@ -111,18 +96,13 @@ Search for and validate synchronization of the updated operational intent at eve
 
 #### [Search OIR](../fragments/oir/crud/search_query.md)
 
-Check that search query succeeds.
-
 #### 🛑 Updated OIR can be consistently searched for from all DSS instances check
 
 If the operational intent searched from a secondary DSS instance is not consistent with the updated one on the
 primary DSS instance, this check will fail per **[astm.f3548.v21.DSS0210,A2-7-2,1b](../../../../../requirements/astm/f3548/v21.md)**
 and **[astm.f3548.v21.DSS0210,A2-7-2,1c](../../../../../requirements/astm/f3548/v21.md)**.
 
-#### [OIR is synchronized](../fragments/oir/sync.md)
-
-Confirm that each DSS returns the operational intent in relevant search results.
-Confirm that the operational intent reference that was just updated is properly synchronized across all DSS instances.
+#### [OIR is synchronized](../fragments/oir/sync_search.md)
 
 ### [Delete OIR test step](../fragments/oir/crud/delete_known.md)
 


### PR DESCRIPTION
OIR and CR synchronization scenarios check that entities are properly synchronized via direct access as well as via search (which additionally allows to check if the area of an entity is synchronized).

These checks happen in distinct steps which currently still reference the same documentation fragment, which leads to the situation we'd like to avoid that is described in #975.

This PR splits the `sync.md` fragment into fragments that respectively handle the direct query and the search, so no "documented but not tested" check is present in the reports for the relevant checks.

Progress on #975