### PR TITLE
[uss_qualifier] subscription scenarios: remove redundant documented checks

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/sub/crud/update_correct.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/sub/crud/update_correct.md
@@ -4,18 +4,4 @@ This test step fragment validates that subscriptions can be updated.
 
 ## [Update query succeeds](./update_query.md)
 
-## 🛑 Mutate subscription response format conforms to spec check
-
-The response to a successful subscription mutation query is expected to conform to the format defined by the OpenAPI specification under the `A3.1` Annex of ASTM F3548−21.
-
-If it does not, the DSS is failing to implement **[astm.f3548.v21.DSS0005,5](../../../../../../../requirements/astm/f3548/v21.md)**.
-
-## 🛑 Mutate subscription response content is correct check
-
-A successful subscription mutation query is expected to return a well-defined body, the content of which reflects the mutated subscription.
-
-If the content of the response does correspond to the requested mutation, the DSS is failing to implement **[astm.f3548.v21.DSS0005,5](../../../../../../../requirements/astm/f3548/v21.md)**.
-
-## [Validate subscription fields](../validate/correctness.md)
-
-## [Validate version fields](../validate/mutated.md)
+## [Update response validation](./update_validation.md)

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/sub/crud/update_validation.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/sub/crud/update_validation.md
@@ -1,0 +1,21 @@
+# Update subscription without query-related check test step fragment
+
+This test step fragment validates that subscriptions can be updated but does not contain a check related to the query itself.
+
+This fragment is intended to be used in scenarios that define their own query verification check, usually when more specific requirements are being tested.
+
+## 🛑 Mutate subscription response format conforms to spec check
+
+The response to a successful subscription mutation query is expected to conform to the format defined by the OpenAPI specification under the `A3.1` Annex of ASTM F3548−21.
+
+If it does not, the DSS is failing to implement **[astm.f3548.v21.DSS0005,5](../../../../../../../requirements/astm/f3548/v21.md)**.
+
+## 🛑 Mutate subscription response content is correct check
+
+A successful subscription mutation query is expected to return a well-defined body, the content of which reflects the mutated subscription.
+
+If the content of the response does correspond to the requested mutation, the DSS is failing to implement **[astm.f3548.v21.DSS0005,5](../../../../../../../requirements/astm/f3548/v21.md)**.
+
+## [Validate subscription fields](../validate/correctness.md)
+
+## [Validate version fields](../validate/mutated.md)

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_simple.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_simple.md
@@ -159,10 +159,6 @@ The response to a successful delete subscription query is expected to conform to
 
 If it does not, the DSS is failing to implement **[astm.f3548.v21.DSS0005,5](../../../../requirements/astm/f3548/v21.md)**.
 
-#### 🛑 Subscription can be deleted check
-
-An attempt to delete a subscription when the correct version is provided should succeed, otherwise the DSS is in violation of **[astm.f3548.v21.DSS0005,5](../../../../requirements/astm/f3548/v21.md)**.
-
 #### [Validate subscription](fragments/sub/validate/correctness.md)
 
 Verify that the subscription returned by the DSS via the deletion is properly formatted and contains the correct content.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/subscription_synchronization.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/subscription_synchronization.md
@@ -112,13 +112,7 @@ If the secondary DSS does not allow the subscription to be mutated, either the s
 **[astm.f3548.v21.DSS0210,1b](../../../../../requirements/astm/f3548/v21.md)**, if the `manager` of the subscription fails to be taken into account (either because the primary DSS did not propagated it, or because the secondary failed to consider it);
 **[astm.f3548.v21.DSS0005,5](../../../../../requirements/astm/f3548/v21.md)**, if the secondary DSS fails to properly implement the API to mutate subscriptions.
 
-#### 🛑 Subscription returned by a secondary DSS is valid and correct check
-
-When queried for a subscription that was created via another DSS, a DSS instance is expected to provide a valid subscription.
-
-If it does not, it might be in violation of **[astm.f3548.v21.DSS0005,5](../../../../../requirements/astm/f3548/v21.md)**.
-
-#### [Update subscription](../fragments/sub/crud/update_correct.md)
+#### [Update subscription](../fragments/sub/crud/update_validation.md)
 
 ### Verify mutation on all secondaries test step
 


### PR DESCRIPTION
Remove redundant checks from UTM subscription related scenarios. 

1) For `subscription_synchronization` this involves adding a fragment and reorganizing things so that a fragment that does not import the `update_query` fragment (that defines the `Subscription can be mutated` check, which is redundant in the context of the `Mutate subscription on secondaries` test step, because we already have an equivalent check under a different name).

2) `Subscription returned by a secondary DSS is valid and correct` is removed because it is redundant with `Mutate subscription response content is correct` that is already documented and checked via the `update_validation.md` fragment

Progress on #975