### PR TITLE
[uss_qualifier] NetRID heavy traffic concurrent: handle concurrent query exceptions 

### DIFF
--- a/monitoring/monitorlib/fetch/__init__.py
+++ b/monitoring/monitorlib/fetch/__init__.py
@@ -196,6 +196,18 @@ def describe_aiohttp_response(
     return ResponseDescription(**kwargs)
 
 
+def describe_failed_aiohttp_response(
+    exception: Exception, duration: datetime.timedelta
+) -> ResponseDescription:
+    kwargs = {
+        "failure": str(exception),
+        "elapsed_s": duration.total_seconds(),
+        "reported": StringBasedDateTime(datetime.datetime.now(datetime.UTC)),
+    }
+
+    return ResponseDescription(**kwargs)
+
+
 def describe_flask_response(resp: flask.Response, elapsed_s: float):
     headers = {k: v for k, v in resp.headers.items()}
     kwargs = {

--- a/monitoring/monitorlib/infrastructure.py
+++ b/monitoring/monitorlib/infrastructure.py
@@ -5,7 +5,6 @@ import urllib.parse
 from enum import Enum
 from typing import Dict, List, Optional
 
-import aiohttp
 import jwt
 import requests
 from aiohttp import ClientResponse, ClientSession
@@ -199,7 +198,11 @@ class AsyncUTMTestSession:
         if "auth" not in kwargs:
             kwargs = self.adjust_request_kwargs(url, "PUT", kwargs)
         async with self._client.put(url, **kwargs) as response:
-            return await _get_response_content_with_text_fallback(response)
+            return (
+                response.status,
+                {k: v for k, v in response.headers.items()},
+                await response.json(),
+            )
 
     async def get(self, url, **kwargs):
         """Returns (status, headers, json)"""
@@ -207,7 +210,11 @@ class AsyncUTMTestSession:
         if "auth" not in kwargs:
             kwargs = self.adjust_request_kwargs(url, "GET", kwargs)
         async with self._client.get(url, **kwargs) as response:
-            return await _get_response_content_with_text_fallback(response)
+            return (
+                response.status,
+                {k: v for k, v in response.headers.items()},
+                await response.json(),
+            )
 
     async def post(self, url, **kwargs):
         """Returns (status, headers, json)"""
@@ -215,7 +222,11 @@ class AsyncUTMTestSession:
         if "auth" not in kwargs:
             kwargs = self.adjust_request_kwargs(url, "POST", kwargs)
         async with self._client.post(url, **kwargs) as response:
-            return await _get_response_content_with_text_fallback(response)
+            return (
+                response.status,
+                {k: v for k, v in response.headers.items()},
+                await response.json(),
+            )
 
     async def delete(self, url, **kwargs):
         """Returns (status, headers, json)"""
@@ -223,24 +234,11 @@ class AsyncUTMTestSession:
         if "auth" not in kwargs:
             kwargs = self.adjust_request_kwargs(url, "DELETE", kwargs)
         async with self._client.delete(url, **kwargs) as response:
-            return await _get_response_content_with_text_fallback(response)
-
-
-async def _get_response_content_with_text_fallback(response: ClientResponse):
-    # TODO: we'll want to handle this more elegantly than failing hard if the response is not JSON,
-    #  such as falling back to reading the response as text and returning that.
-    #  We cannot immediately follow this option as callers need to be adapted, and we'd rather have an obvious
-    #  cause for failures (a ContentTypeError) than obscure errors caused by returning a string instead of a dict.
-    #  Tracked in #1078
-    # try:
-    resp_content = await response.json()
-    # except aiohttp.ContentTypeError:
-    #    resp_content = await response.text()
-    return (
-        response.status,
-        {k: v for k, v in response.headers.items()},
-        resp_content,
-    )
+            return (
+                response.status,
+                {k: v for k, v in response.headers.items()},
+                await response.json(),
+            )
 
 
 def default_scopes(scopes: List[str]):

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/heavy_traffic_concurrent.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/heavy_traffic_concurrent.py
@@ -146,18 +146,24 @@ class HeavyTrafficConcurrent(GenericTestScenario):
 
     def _get_isas_by_id_concurrent_step(self):
         loop = asyncio.get_event_loop()
-        results = loop.run_until_complete(
-            asyncio.gather(*[self._get_isa(isa_id) for isa_id in self._isa_ids])
-        )
-
-        results = typing.cast(Dict[str, FetchedISA], results)
-
-        for _, fetched_isa in results:
-            self.record_query(fetched_isa.query)
 
         with self.check(
             "Successful Concurrent ISA query", [self._dss_wrapper.participant_id]
         ) as main_check:
+            try:
+                results = loop.run_until_complete(
+                    asyncio.gather(*[self._get_isa(isa_id) for isa_id in self._isa_ids])
+                )
+            except Exception as e:
+                main_check.record_failed(
+                    "Concurrent ISA retrieval failed",
+                    details=f"Concurrent ISA retrieval failed with exception: {e}\n{e.__traceback__}",
+                )
+
+            results = typing.cast(Dict[str, FetchedISA], results)
+
+            for _, fetched_isa in results:
+                self.record_query(fetched_isa.query)
             for isa_id, fetched_isa in results:
                 if fetched_isa.status_code != 200:
                     main_check.record_failed(
@@ -294,18 +300,26 @@ class HeavyTrafficConcurrent(GenericTestScenario):
 
     def _create_isas_concurrent_step(self):
         loop = asyncio.get_event_loop()
-        results = loop.run_until_complete(
-            asyncio.gather(*[self._create_isa(isa_id) for isa_id in self._isa_ids])
-        )
-
-        results = typing.cast(Dict[str, ChangedISA], results)
-
-        for _, fetched_isa in results:
-            self.record_query(fetched_isa.query)
 
         with self.check(
             "Concurrent ISAs creation", [self._dss_wrapper.participant_id]
         ) as main_check:
+            try:
+                results = loop.run_until_complete(
+                    asyncio.gather(
+                        *[self._create_isa(isa_id) for isa_id in self._isa_ids]
+                    )
+                )
+            except Exception as e:
+                main_check.record_failed(
+                    "Concurrent ISA creation failed",
+                    details=f"Concurrent ISA creation failed with exception: {e}\n{e.__traceback__}",
+                )
+
+            results = typing.cast(Dict[str, ChangedISA], results)
+
+            for _, fetched_isa in results:
+                self.record_query(fetched_isa.query)
             for isa_id, changed_isa in results:
                 with self.check(
                     "ISA response code", [self._dss_wrapper.participant_id]
@@ -371,23 +385,29 @@ class HeavyTrafficConcurrent(GenericTestScenario):
 
     def _delete_isas(self):
         loop = asyncio.get_event_loop()
-        results = loop.run_until_complete(
-            asyncio.gather(
-                *[
-                    self._delete_isa(isa_id, self._isa_versions[isa_id])
-                    for isa_id in self._isa_ids
-                ]
-            )
-        )
-
-        results = typing.cast(Dict[str, ChangedISA], results)
-
-        for _, fetched_isa in results:
-            self.record_query(fetched_isa.query)
 
         with self.check(
             "ISAs deletion query success", [self._dss_wrapper.participant_id]
         ) as main_check:
+            try:
+                results = loop.run_until_complete(
+                    asyncio.gather(
+                        *[
+                            self._delete_isa(isa_id, self._isa_versions[isa_id])
+                            for isa_id in self._isa_ids
+                        ]
+                    )
+                )
+            except Exception as e:
+                main_check.record_failed(
+                    "Concurrent ISA deletion failed",
+                    details=f"Concurrent ISA deletion failed with exception: {e}\n{e.__traceback__}",
+                )
+
+            results = typing.cast(Dict[str, ChangedISA], results)
+
+            for _, fetched_isa in results:
+                self.record_query(fetched_isa.query)
             for isa_id, deleted_isa in results:
                 if deleted_isa.query.response.code != 200:
                     main_check.record_failed(
@@ -409,18 +429,23 @@ class HeavyTrafficConcurrent(GenericTestScenario):
                 )
 
     def _get_deleted_isas(self):
-
         loop = asyncio.get_event_loop()
-        results = loop.run_until_complete(
-            asyncio.gather(*[self._get_isa(isa_id) for isa_id in self._isa_ids])
-        )
-
-        results = typing.cast(Dict[str, ChangedISA], results)
-
-        for _, fetched_isa in results:
-            self.record_query(fetched_isa.query)
 
         with self.check("ISAs not found", [self._dss_wrapper.participant_id]) as check:
+            try:
+                results = loop.run_until_complete(
+                    asyncio.gather(*[self._get_isa(isa_id) for isa_id in self._isa_ids])
+                )
+            except Exception as e:
+                check.record_failed(
+                    "Concurrent ISA retrieval failed",
+                    details=f"Concurrent ISA retrieval failed with exception: {e}\n{e.__traceback__}",
+                )
+
+            results = typing.cast(Dict[str, ChangedISA], results)
+
+            for _, fetched_isa in results:
+                self.record_query(fetched_isa.query)
             for isa_id, fetched_isa in results:
                 if fetched_isa.status_code != 404:
                     check.record_failed(


### PR DESCRIPTION
This is a fix for #1078, which should allow uss_qualifier to proceed without crashing out when mime-type errors occur, while keeping around request details for possible troubleshooting.