### PR TITLE
[CI] Sign published images with cosign

### DIFF
--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -22,7 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     # To modify to enable the job for forked repository
     if: github.repository == 'interuss/monitoring'
+    permissions:
+      id-token: write # needed for signing the images with GitHub OIDC Token
+
     steps:
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.9.1
       - name: Job information
         run: |
           echo "Job information"
@@ -31,6 +36,7 @@ jobs:
           echo "Repository: ${{ github.repository }}"
           echo "Branch: ${{ github.ref }}"
           docker images
+          cosign version
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -45,9 +51,12 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build and push image
+      - name: Build, push and sign image
         env:
           DOCKER_URL: ${{ secrets.DOCKER_URL }}
           DOCKER_UPDATE_LATEST: true
+          DOCKER_SIGN: true
+          CERT_IDENTITY: https://github.com/${{ github.workflow_ref }}
+          CERT_ISSUER: https://token.actions.githubusercontent.com
         run: |
           build/build_and_push.sh

--- a/build/build_and_push.sh
+++ b/build/build_and_push.sh
@@ -3,8 +3,18 @@
 # This script builds and pushes the InterUSS monitoring docker image and may be
 # run from any working directory.  If DOCKER_URL is present, it will both
 # build the versioned monitoring image and push it to the DOCKER_URL remote.
-# If DOCKER_URL is set, DOCKER_UPDATE_LATEST can be optionally set to `true` in order
-# to publish the latest tag along the version.
+# If DOCKER_URL is set:
+#
+# 1) DOCKER_UPDATE_LATEST can be optionally set to `true` in order to publish
+# the latest tag along the version.
+#
+# 2) DOCKER_SIGN can be optionally set to `true` in order to sign the published
+# image using sigstore. When ran within the Github Actions CI, the identity of
+# the CI workflow will be used through the ID token emitted by GitHub. When ran
+# outside of the CI, `cosign` will interactively ask for an authentication
+# against a supported identity provider (Google, GitHub or Microsoft at this time).
+# If DOCKER_SIGN is `true`, CERT_IDENTITY and CERT_ISSUER must be set in order
+# to verify the signature of the published image.
 
 set -eo pipefail
 
@@ -26,20 +36,36 @@ if [[ -z "${DOCKER_URL}" ]]; then
 
   echo "DOCKER_URL environment variable was not set; built image to interuss/monitoring"
 else
-  echo "Building image ${DOCKER_URL}/monitoring:${VERSION}"
-  ./monitoring/build.sh "${DOCKER_URL}/monitoring:${VERSION}"
+  TAG="${DOCKER_URL}/monitoring:${VERSION}"
 
-  echo "Pushing docker image ${DOCKER_URL}/monitoring:${VERSION}..."
-  docker image push "${DOCKER_URL}/monitoring:${VERSION}"
+  echo "Building image ${TAG}"
+  ./monitoring/build.sh "${TAG}"
+
+  echo "Pushing docker image ${TAG}..."
+  docker image push "${TAG}"
+
+  echo "Built and pushed docker image ${TAG}"
+
+  if [[ "${DOCKER_SIGN}" == "true" ]]; then
+    # We sign only the first digest of the image. We don't expect multiple ones as we are building for a single architecture.
+    DIGEST=$(docker image inspect --format='{{index .RepoDigests 0}}' "${TAG}")
+    echo "Signing docker image ${TAG} (digest: ${DIGEST})..."
+    cosign sign --yes "${DIGEST}"
+
+    echo "Verifying signature of docker image ${TAG} (digest: ${DIGEST})..."
+    cosign verify "${DIGEST}" --certificate-identity="${CERT_IDENTITY}" --certificate-oidc-issuer="${CERT_ISSUER}"
+
+    echo "Signed and verified signature of docker image ${TAG} (digest: ${DIGEST})..."
+
+  fi
 
   if [[ "${DOCKER_UPDATE_LATEST}" == "true" ]]; then
     echo "Tagging docker image ${DOCKER_URL}/monitoring:${LATEST_TAG}..."
-    docker tag "${DOCKER_URL}/monitoring:${VERSION}" "${DOCKER_URL}/monitoring:${LATEST_TAG}"
+    docker tag "${TAG}" "${DOCKER_URL}/monitoring:${LATEST_TAG}"
 
     echo "Pushing docker image ${DOCKER_URL}/monitoring:${LATEST_TAG}..."
     docker image push "${DOCKER_URL}/monitoring:${LATEST_TAG}"
 
     echo "Built and pushed docker image ${DOCKER_URL}/monitoring:${LATEST_TAG}"
   fi
-  echo "Built and pushed docker image ${DOCKER_URL}/monitoring:${VERSION}"
 fi

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -52,3 +52,17 @@ allow it to fulfill different roles.
 ## Settings
 
 Some tools within this repository (especially uss_qualifier's report generation) need to know where on GitHub the repository is hosted.  The interuss repository URL is used by default, but this may be overridden by setting the `MONITORING_GITHUB_ROOT` environment variable.
+
+## Verify signature of prebuilt InterUSS Docker images
+
+The prebuilt docker images are signed using [sigstore](https://www.sigstore.dev/).
+The identity of the CI workflow, attested by GitHub, is used so sign the images.
+
+The signature may be verified by using [cosign](https://github.com/sigstore/cosign):
+```shell
+docker pull "docker.io/interuss/monitoring:latest"
+cosign verify "docker.io/interuss/monitoring:latest" \
+  --certificate-identity-regexp="https://github.com/interuss/monitoring/.github/workflows/image-publish.yml@refs/*" \
+  --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
+```
+Adapt the version specified if required.


### PR DESCRIPTION
Closes #1058 

This adds to the docker image built in the CI and pushed to Docker Hub a signature using sigstore.
The identity of the GitHub Actions CI workflow is used to perform the "keyless" signing.

This follows the exact same approach as https://github.com/interuss/dss/pull/1226