### PR TITLE
[tooling] remove docker-compose version

### DIFF
--- a/build/dev/docker-compose.yaml
+++ b/build/dev/docker-compose.yaml
@@ -2,8 +2,6 @@
 
 # To bring up this system, run ./run_locally.sh up -d and wait for all containers to succeed or become healthy.
 
-version: '3.8'
-
 services:
 
   crdb:

--- a/monitoring/mock_uss/docker-compose.yaml
+++ b/monitoring/mock_uss/docker-compose.yaml
@@ -3,8 +3,6 @@
 
 # To bring up this system, see README.md
 
-version: '3.8'
-
 services:
 
   mock_uss_scdsc_a:


### PR DESCRIPTION
Version in docker-compose file is deprecated and generate a warning since docker compose v2, that has been released in 2022.

docker compose v1 is deprecated since[ two years ago](https://github.com/docker/roadmap/issues/257#issuecomment-2075758099), I think we can safely remove the version and such disable the warning.