### PR TITLE
 [tooling] Upgrade isort to latest version 

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common_dictionary_evaluator.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common_dictionary_evaluator.py
@@ -26,7 +26,9 @@ from uas_standards.astm.f3411.v22a.api import (
     UAClassificationEUClass,
     VerticalAccuracy,
 )
-from uas_standards.interuss.automated_testing.rid.v1 import injection
+from uas_standards.interuss.automated_testing.rid.v1 import (
+    injection,
+)
 from uas_standards.interuss.automated_testing.rid.v1 import (
     observation as observation_api,
 )

--- a/monitoring/uss_qualifier/scenarios/scenario_test/utils.py
+++ b/monitoring/uss_qualifier/scenarios/scenario_test/utils.py
@@ -30,7 +30,9 @@ from monitoring.uss_qualifier.scenarios.scenario import TestScenario as _TestSce
 from monitoring.uss_qualifier.scenarios.scenario import (
     TestStepReport as _TestStepReport,
 )
-from monitoring.uss_qualifier.scenarios.scenario import uss_qualifier_module
+from monitoring.uss_qualifier.scenarios.scenario import (
+    uss_qualifier_module,
+)
 
 
 def build_fake_scenarios_module():

--- a/test/isort/pyproject.toml
+++ b/test/isort/pyproject.toml
@@ -3,5 +3,5 @@ name = "isorthelper"
 version = "0.1.0"
 requires-python = "==3.13.*"
 dependencies = [
-    "isort<6",
+    "isort",
 ]

--- a/test/isort/uv.lock
+++ b/test/isort/uv.lock
@@ -4,11 +4,11 @@ requires-python = "==3.13.*"
 
 [[package]]
 name = "isort"
-version = "5.13.2"
+version = "6.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/87/f9/c1eb8635a24e87ade2efce21e3ce8cd6b8630bb685ddc9cdaca1349b2eb5/isort-5.13.2.tar.gz", hash = "sha256:48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109", size = 175303, upload-time = "2023-12-13T20:37:26.124Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/21/1e2a441f74a653a144224d7d21afe8f4169e6c7c20bb13aec3a2dc3815e0/isort-6.0.1.tar.gz", hash = "sha256:1cb5df28dfbc742e490c5e41bad6da41b805b0a8be7bc93cd0fb2a8a890ac450", size = 821955, upload-time = "2025-02-26T21:13:16.955Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/b3/8def84f539e7d2289a02f0524b944b15d7c75dab7628bedf1c4f0992029c/isort-5.13.2-py3-none-any.whl", hash = "sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6", size = 92310, upload-time = "2023-12-13T20:37:23.244Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/11/114d0a5f4dabbdcedc1125dee0888514c3c3b16d3e9facad87ed96fad97c/isort-6.0.1-py3-none-any.whl", hash = "sha256:2dc5d7f65c9678d94c88dfc29161a320eec67328bc97aad576874cb4be1e9615", size = 94186, upload-time = "2025-02-26T21:13:14.911Z" },
 ]
 
 [[package]]
@@ -20,4 +20,4 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "isort", specifier = "<6" }]
+requires-dist = [{ name = "isort" }]


### PR DESCRIPTION
* Remove constrain about isort version ([UV take care of that for us](https://docs.astral.sh/uv/concepts/projects/sync/#upgrading-locked-package-versions))
* Upgrade to latest version
* Run isort (2 import changed)