### PR TITLE
[tooling] Configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "uv"
+    directory: "/test/repo_hygiene/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "docker"
+    directory: "/monitoring/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "/test/repo_hygiene/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Seeing PRs like #1097, dependabot didn't use uv mode.

This add a config file to do so, and add docker + github action updates as well.

It not tested and it doesn't target the isort part that will be removed when #1096 is merged.