### PR TITLE
[monitorlib/flight_planning] Ignore wrong body on non-200 responses when a flight is deleted

### DIFF
--- a/monitoring/monitorlib/clients/flight_planning/client_v1.py
+++ b/monitoring/monitorlib/clients/flight_planning/client_v1.py
@@ -146,8 +146,8 @@ class V1FlightPlannerClient(FlightPlannerClient):
             participant_id=self.participant_id,
             query_type=QueryType.InterUSSFlightPlanningV1DeleteFlightPlan,
         )
-        # 404 is acceptable, as the end state we are interested in is already effective.
-        if query.status_code not in [200, 404]:
+
+        if query.status_code != 200:
             raise PlanningActivityError(
                 f"Attempt to delete flight plan returned status {query.status_code} rather than 200 as expected",
                 query,
@@ -157,9 +157,12 @@ class V1FlightPlannerClient(FlightPlannerClient):
                 query.response.json, api.DeleteFlightPlanResponse
             )
         except ValueError as e:
+
             raise PlanningActivityError(
-                f"Response to delete flight plan could not be parsed: {str(e)}", query
+                f"Response to delete flight plan could not be parsed: {str(e)}",
+                query,
             )
+
         self.created_flight_ids.discard(flight_id)
         response = PlanningActivityResponse(
             flight_id=flight_id,

--- a/monitoring/uss_qualifier/scenarios/flight_planning/test_steps.py
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/test_steps.py
@@ -412,35 +412,30 @@ def cleanup_flights(
                     resp, query = cleanup_flight(flight_planner, flight_id)
                     scenario.record_query(query)
                 except QueryError as e:
+
                     for q in e.queries:
                         scenario.record_query(q)
-                    check.record_failed(
-                        summary=f"Failed to clean up flight {flight_id} from {flight_planner.participant_id}",
-                        details=f"{str(e)}\n\nStack trace:\n{e.stacktrace}",
-                        query_timestamps=[q.request.timestamp for q in e.queries],
-                    )
-                    continue
-
-                # A non-existing flight is considered successfully deleted
-                if query.status_code in [200, 404]:
 
                     if (
-                        resp.flight_plan_status != FlightPlanStatus.Closed
-                        or query.status_code == 404
-                    ):
+                        e.queries and e.queries[0].status_code == 404
+                    ):  # We allow 404 during cleanup
                         scenario.record_note(
                             f"Deletion of {flight_id}",
-                            f"Deletion of flight {flight_id} returned a status of '{resp.flight_plan_status}' ({FlightPlanStatus.Closed} wanted), with a {query.status_code} status code (200 wanted)",
+                            f"Deletion of flight {flight_id} returned a status code of 404 (instead of a 200)",
                         )
 
-                    removed.append(flight_id)
-                else:
-                    check.record_failed(
-                        summary="Failed to delete flight",
-                        details=(
-                            f"USS indicated {resp.activity_result} with flight plan status {resp.flight_plan_status} rather than the expected Completed with flight plan status Closed.  Its notes were: {resp.notes}"
-                            if "notes" in resp
-                            else "See query"
-                        ),
-                        query_timestamps=[query.request.timestamp],
+                    else:
+                        check.record_failed(
+                            summary=f"Failed to clean up flight {flight_id} from {flight_planner.participant_id}",
+                            details=f"{str(e)}\n\nStack trace:\n{e.stacktrace}",
+                            query_timestamps=[q.request.timestamp for q in e.queries],
+                        )
+                    continue
+
+                if resp.flight_plan_status != FlightPlanStatus.Closed:
+                    scenario.record_note(
+                        f"Deletion of {flight_id}",
+                        f"Deletion of flight {flight_id} returned a status of '{resp.flight_plan_status}' ({FlightPlanStatus.Closed} wanted)",
                     )
+
+                removed.append(flight_id)


### PR DESCRIPTION
This PR contrib to #1100 , point 1

It change try_end_flight behavior by ignoring wrong responses when the status code of the query is not 200.

In such cases, the response will have a limited field available. It's up to the caller to handle such cases.

The code base already handle this situation correctly, by ignoring 404 errors when doing wild cleanup: https://github.com/interuss/monitoring/blob/main/monitoring/uss_qualifier/scenarios/flight_planning/test_steps.py#L424

We don't have a rogue-dss implementation / tests, so I tested locally the new behavior with a special mock uss:

- When returning empty 404 on unknown flights, the test suite pass
- When always returning 404 on any flight delete, the test suite fail (as wanted, since we want to ensure deletion in such case).

Another test for the new behavior:

<img width="1737" height="982" alt="image" src="https://github.com/user-attachments/assets/a49c380e-05bf-451e-b022-a97e409af49b" />

We can see that the remove valid flight complained about the wrong response and the cleanup part happily ignored the 404 :)