### PR TITLE
[uss_qualifier] Record unexpected responses when cleanuping flights

### DIFF
--- a/monitoring/uss_qualifier/scenarios/flight_planning/test_steps.py
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/test_steps.py
@@ -423,6 +423,16 @@ def cleanup_flights(
 
                 # A non-existing flight is considered successfully deleted
                 if query.status_code in [200, 404]:
+
+                    if (
+                        resp.flight_plan_status != FlightPlanStatus.Closed
+                        or query.status_code == 404
+                    ):
+                        scenario.record_note(
+                            f"Deletion of {flight_id}",
+                            f"Deletion of flight {flight_id} returned a status of '{resp.flight_plan_status}' ({FlightPlanStatus.Closed} wanted), with a {query.status_code} status code (200 wanted)",
+                        )
+
                     removed.append(flight_id)
                 else:
                     check.record_failed(


### PR DESCRIPTION
Contrib to #1100 , point 4

This make the uss_qualifier to record notes about unexpected states when doing flight cleanup.

Until #1105 is merged, this will probably add some log, but none are to be expected after the other PR is merged.

<img width="2152" height="596" alt="image" src="https://github.com/user-attachments/assets/4467481b-0c6f-4abf-81e7-950ae6b48fc0" />

This doesn't make a failing cleanup an error, should we want that (I would think that too 'strict'), #1105 will be needed first :)