### PR TITLE
[tooling] Exclude output dirs from automatic tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,8 +59,22 @@ target-version = "py313"
 lint.select = [
     "E4", "E7", "E9", "F", "I",
 ]
-extend-exclude = ["interfaces/*"]
+extend-exclude = [
+  "interfaces/*",
+  "monitoring/prober/output/*",
+  "monitoring/mock_uss/output/*",
+  "monitoring/uss_qualifier/output/*",
+]
 line-length = 88
 
 [tool.basedpyright]
 typeCheckingMode = "standard"
+
+exclude = [
+  "**/__pycache__",
+  "**/.*",
+  "interfaces/*",
+  "monitoring/prober/output/*",
+  "monitoring/mock_uss/output/*",
+  "monitoring/uss_qualifier/output/*",
+]


### PR DESCRIPTION
This PR exclude output dirs from automatic tools.

I didn't find a way to automatically use `.gitignore` files (for basedpyright, ruff does), so that has been done manually by looking at gitignore files ^^' 