### PR TITLE
[uss_qualifier] Cleanup flights during missing fields test

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/sp_operator_notify_missing_fields.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/sp_operator_notify_missing_fields.py
@@ -91,6 +91,10 @@ class SpOperatorNotifyMissingFields(GenericTestScenario):
 
             self._poll_during_flights()
 
+            self.begin_test_step("Intermediate cleanup")
+            self._cleanup()
+            self.end_test_step()
+
         self.end_test_case()
         self.end_test_scenario()
 
@@ -169,8 +173,7 @@ class SpOperatorNotifyMissingFields(GenericTestScenario):
                     )
         self.end_test_step()
 
-    def cleanup(self):
-        self.begin_cleanup()
+    def _cleanup(self):
         while self._injected_tests:
             injected_test = self._injected_tests.pop()
             matching_sps = [
@@ -199,4 +202,8 @@ class SpOperatorNotifyMissingFields(GenericTestScenario):
                     summary="Error while trying to delete test flight",
                     details=f"While trying to delete a test flight from {sp.participant_id}, encountered error:\n{stacktrace}",
                 )
+
+    def cleanup(self):
+        self.begin_cleanup()
+        self._cleanup()
         self.end_cleanup()

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/sp_operator_notify_missing_fields.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/sp_operator_notify_missing_fields.md
@@ -44,6 +44,14 @@ Compare after polling the notification of each service providers retrieved durin
 
 The "after" set of operator notifications should contain at least one more entry than the "before" set of operator notifications. If there was no new operator notification, the Service Provider will not have met **[astm.f3411.v19.NET0030](../../../../requirements/astm/f3411/v19.md)**.
 
+### Intermediate cleanup test step
+
+This step attempts to remove injected data from all SPs, avoiding multiple flights with the same data at the same time.
+
+#### ⚠️ Successful test deletion check
+
+**[interuss.automated_testing.rid.injection.DeleteTestSuccess](../../../../requirements/interuss/automated_testing/rid/injection.md)**
+
 ## Cleanup
 
 The cleanup phase of this test scenario attempts to remove injected data from all SPs.

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/sp_operator_notify_missing_fields.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/sp_operator_notify_missing_fields.md
@@ -44,6 +44,14 @@ Compare after polling the notification of each service providers retrieved durin
 
 The "after" set of operator notifications should contain at least one more entry than the "before" set of operator notifications. If there was no new operator notification, the Service Provider will not have met **[astm.f3411.v22a.NET0030](../../../../requirements/astm/f3411/v22a.md)**.
 
+### Intermediate cleanup test step
+
+This step attempts to remove injected data from all SPs, avoiding multiple flights with the same data at the same time.
+
+#### ⚠️ Successful test deletion check
+
+**[interuss.automated_testing.rid.injection.DeleteTestSuccess](../../../../requirements/interuss/automated_testing/rid/injection.md)**
+
 ## Cleanup
 
 The cleanup phase of this test scenario attempts to remove injected data from all SPs.


### PR DESCRIPTION
As discussed on slack, some USS generate conflicts dues to the test flight injected multiple time with the same data.

This PR (try to) improve the situation by deleting flight after each check, starting from a fresh base on each iteration of the loop on each field.

<img width="2068" height="1089" alt="image" src="https://github.com/user-attachments/assets/0c47608a-4214-47ef-bac2-ec224f00cbaf" />
