### PR TITLE
[local-env] improve compatibility with different local dev environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,9 @@ python-lint: image
 
 	docker run --rm -u ${USER_GROUP} -v "$(CURDIR):/app" -w /app interuss/monitoring uv run ruff format --check || (echo "Linter didn't succeed. You can use the following command to fix python linter issues: make format" && exit 1)
 	docker run --rm -u ${USER_GROUP} -v "$(CURDIR):/app" -w /app interuss/monitoring uv run ruff check || (echo "Linter didn't succeed. You can use the following command to fix python linter issues: make format" && exit 1)
-	sha256sum .basedpyright/baseline.json > /tmp/baseline-before.hash
+	shasum -b -a 256 .basedpyright/baseline.json > /tmp/baseline-before.hash
 	docker run --rm -u ${USER_GROUP} -v "$(CURDIR):/app" -w /app interuss/monitoring uv run basedpyright || (echo "Typing check didn't succeed. Please fix issue and run make format to validate changes." && exit 1)
-	sha256sum .basedpyright/baseline.json > /tmp/baseline-after.hash
+	shasum -b -a 256 .basedpyright/baseline.json > /tmp/baseline-after.hash
 	diff /tmp/baseline-before.hash /tmp/baseline-after.hash || (echo "Basedpyright baseline changed, probably dues to issues that have been cleanup. Use the following command to update baseline: make format" && exit 1)
 
 .PHONY: validate-uss-qualifier-docs


### PR DESCRIPTION
This PR improves general compatibility & usability of the interuss/monitoring repository by:

- adding `venv` to .dockerignore, for any one using a local virtualenv that might live in `venv`
- replaces `sha256sum` (absent from OS X) with `sha -a 256`, which should work on both OS X and most linux environments 
- excluding `venv` and `.venv` from the `basedpyright` configuration (otherwise they get picked up and linted, which is both useless AND hellishly slow)

@the-glu you may want to confirm I'm not breaking any of your intentions here! :) 