### PR TITLE
[local-env] Update shebang to use bash from env

### DIFF
--- a/monitoring/mock_uss/stop_all_local_mocks.sh
+++ b/monitoring/mock_uss/stop_all_local_mocks.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Find and change to repo root directory
 OS=$(uname)


### PR DESCRIPTION
`bash` is not necessry located in `/bin/bash`.

Update `stop_all_local_mocks.sh` shebang to be consistent with other scripts and load `bash` from `env`