### PR TITLE
[tooling] Add venv to docker image path

### DIFF
--- a/monitoring/Dockerfile
+++ b/monitoring/Dockerfile
@@ -68,6 +68,9 @@ HEALTHCHECK --interval=3s CMD sh /app/health_check.sh
 # Discover `monitoring` module in Python
 ENV PYTHONPATH=/app
 
+# Add venv to path
+ENV PATH="/venv/bin/:$PATH"
+
 # This image should be built by passing in `version` and `commit_hash` based on information from git (see `make image`)
 # This version information becomes available in the environment variables specified below
 ARG version


### PR DESCRIPTION
This PR add the venv path in the docker image, improving backward compatibility with external scripts that would need adaptation otherwise.