### PR TITLE
[rid/dp_behavior] Fix misplaced end_test_case

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dp_behavior.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dp_behavior.py
@@ -158,7 +158,8 @@ class DisplayProviderBehavior(GenericTestScenario):
             self._step_validate_queries_to_sp(obs, test_case_start_time)
             self.end_test_step()
 
-        self.end_test_case()
+            self.end_test_case()
+
         self.end_test_scenario()
 
     def _mock_sp_base_url(self):


### PR DESCRIPTION
Running the rid/dp_behavior test scenario with multiple observers fails with the error below because of a misplaced end_test_case call. This PR fixes it.

```
2025-09-02 11:15:54.157 | ERROR    | monitoring.uss_qualifier.suites.suite:_run_test_scenario:176 - Execution error:
  Traceback (most recent call last):
    File "/app/monitoring/uss_qualifier/suites/suite.py", line 158, in _run_test_scenario
      scenario.run(context)
      ~~~~~~~~~~~~^^^^^^^^^
    File "/app/monitoring/uss_qualifier/scenarios/astm/netrid/common/dp_behavior.py", line 141, in run
      self.begin_test_case("Display Provider Behavior")
      ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/app/monitoring/uss_qualifier/scenarios/scenario.py", line 368, in begin_test_case
      self._expect_phase(ScenarioPhase.ReadyForTestCase)
      ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/app/monitoring/uss_qualifier/scenarios/scenario.py", line 320, in _expect_phase
      raise RuntimeError(
          f"Test scenario `{self.me()}` was {self._phase} when {caller} was called (expected {acceptable_phases})"
      )
  RuntimeError: Test scenario `monitoring.uss_qualifier.scenarios.astm.netrid.v22a.dp_behavior.DisplayProviderBehavior` was ScenarioPhase.ReadyForTestStep when begin_test_case was called (expected ReadyForTestCase)
```