### PR TITLE
[uss_qualifier] Fix obfuscated_clusters list

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/netrid/display_data_evaluator.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/display_data_evaluator.py
@@ -626,7 +626,7 @@ class RIDObservationEvaluator:
 
                 # evaluate clusters that are actually obfuscated flights
                 obfuscated_clusters = [
-                    c for c in observation.clusters if c.number_of_flights == 1
+                    c for c in observation.clusters if c.number_of_flights > 0
                 ]
                 self._evaluate_obfuscated_clusters_observation(
                     observer, obfuscated_clusters, expected, uncertain


### PR DESCRIPTION
In uss_qualifier, the `Individual flights obfuscation` scenario was checking only cluster with one and only one flight, when there may be more that one flight in a cluster.

This fix it by testing for cluster with at least one flight.