### PR TITLE
[uss_qualifier] Add missing end_test_case in MSLAltitude scenario

### DIFF
--- a/monitoring/uss_qualifier/scenarios/uspace/netrid/msl.py
+++ b/monitoring/uss_qualifier/scenarios/uspace/netrid/msl.py
@@ -39,6 +39,7 @@ class MSLAltitude(TestScenario):
                 "Skip reason",
                 "Nominal behavior test scenario report could not be found for any of the scenario types",
             )
+            self.end_test_case()
             self.end_test_scenario()
             return
 


### PR DESCRIPTION
A `end_test_case`was missing in the `MSLAltitude` scenario, this fixes it :)