### PR TITLE
[uss_qualifier] use UssAvailabilityState in dss api

### DIFF
--- a/monitoring/uss_qualifier/resources/astm/f3548/v21/dss.py
+++ b/monitoring/uss_qualifier/resources/astm/f3548/v21/dss.py
@@ -416,14 +416,11 @@ class DSSInstance:
     def set_uss_availability(
         self,
         uss_id: str,
-        available: bool | None,
+        availability: UssAvailabilityState,
         version: str = "",
     ) -> tuple[str, Query]:
         """
         Set the availability for the USS identified by 'uss_id'.
-
-        If 'available' is None, the availability will be set to 'Unknown'.
-        True will set it to 'Normal', and False to 'Down'.
 
         Returns:
             A tuple composed of
@@ -433,13 +430,6 @@ class DSSInstance:
             * QueryError: if request failed, if HTTP status code is different than 200, or if the parsing of the response failed.
         """
         self._uses_scope(Scope.AvailabilityArbitration)
-        if available is None:
-            availability = UssAvailabilityState.Unknown
-        elif available:
-            availability = UssAvailabilityState.Normal
-        else:
-            availability = UssAvailabilityState.Down
-
         req = SetUssAvailabilityStatusParameters(
             old_version=version,
             availability=availability,

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/authentication/authentication_validation.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/authentication/authentication_validation.py
@@ -387,11 +387,13 @@ class AuthenticationValidation(TestScenario):
                     query_timestamps=[q.request.timestamp for q in e.queries],
                 )
 
-        if availability.status != UssAvailabilityState.Unknown:
+        if availability and availability.status != UssAvailabilityState.Unknown:
             with self.check("USS Availability can be updated", self._pid) as check:
                 try:
                     availability, q = self._availability_dss.set_uss_availability(
-                        self._test_id, UssAvailabilityState.Unknown, availability.version
+                        self._test_id,
+                        UssAvailabilityState.Unknown,
+                        availability.version,
                     )
                     self.record_query(q)
                 except QueryError as e:

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/authentication/authentication_validation.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/authentication/authentication_validation.py
@@ -391,7 +391,7 @@ class AuthenticationValidation(TestScenario):
             with self.check("USS Availability can be updated", self._pid) as check:
                 try:
                     availability, q = self._availability_dss.set_uss_availability(
-                        self._test_id, available=None, version=availability.version
+                        self._test_id, UssAvailabilityState.Unknown, availability.version
                     )
                     self.record_query(q)
                 except QueryError as e:

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/uss_availability_synchronization.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/uss_availability_synchronization.py
@@ -30,7 +30,7 @@ class USSAvailabilitySynchronization(TestScenario):
 
     _uss_id: str
 
-    _current_version: str | None = None
+    _current_version: str = ""
 
     def __init__(
         self,
@@ -61,7 +61,7 @@ class USSAvailabilitySynchronization(TestScenario):
         self._uss_id = client_identity.subject()
 
     def run(self, context: ExecutionContext):
-        self._current_version = None
+        self._current_version = ""
 
         self.begin_test_scenario(context)
 
@@ -226,7 +226,9 @@ class USSAvailabilitySynchronization(TestScenario):
             with self.check("USS Availability can be set to Unknown") as check:
                 try:
                     self._current_version, q = self._dss.set_uss_availability(
-                        self._uss_id, UssAvailabilityState.Unknown, self._current_version
+                        self._uss_id,
+                        UssAvailabilityState.Unknown,
+                        self._current_version,
                     )
                     self.record_query(q)
                 except QueryError as qe:

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/uss_availability_synchronization.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/uss_availability_synchronization.py
@@ -150,7 +150,7 @@ class USSAvailabilitySynchronization(TestScenario):
         ) as check:
             try:
                 self._current_version, q = self._dss.set_uss_availability(
-                    self._uss_id, None, self._current_version
+                    self._uss_id, UssAvailabilityState.Unknown, self._current_version
                 )
                 self.record_query(q)
             except QueryError as qe:
@@ -167,7 +167,7 @@ class USSAvailabilitySynchronization(TestScenario):
         ) as check:
             try:
                 self._current_version, q = self._dss.set_uss_availability(
-                    self._uss_id, False, self._current_version
+                    self._uss_id, UssAvailabilityState.Down, self._current_version
                 )
                 self.record_query(q)
             except QueryError as qe:
@@ -184,7 +184,7 @@ class USSAvailabilitySynchronization(TestScenario):
         ) as check:
             try:
                 self._current_version, q = self._dss.set_uss_availability(
-                    self._uss_id, True, self._current_version
+                    self._uss_id, UssAvailabilityState.Normal, self._current_version
                 )
                 self.record_query(q)
             except QueryError as qe:
@@ -226,7 +226,7 @@ class USSAvailabilitySynchronization(TestScenario):
             with self.check("USS Availability can be set to Unknown") as check:
                 try:
                     self._current_version, q = self._dss.set_uss_availability(
-                        self._uss_id, None, self._current_version
+                        self._uss_id, UssAvailabilityState.Unknown, self._current_version
                     )
                     self.record_query(q)
                 except QueryError as qe:

--- a/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss.py
@@ -2,6 +2,7 @@ import arrow
 from uas_standards.astm.f3548.v21.api import (
     OperationalIntentReference,
     OperationalIntentState,
+    UssAvailabilityState,
 )
 from uas_standards.astm.f3548.v21.constants import Scope
 
@@ -319,7 +320,7 @@ class DownUSS(TestScenario):
             try:
                 availability_version, avail_query = self.dss.set_uss_availability(
                     self.uss_qualifier_sub,
-                    True,
+                    UssAvailabilityState.Normal,
                 )
                 self.record_query(avail_query)
             except QueryError as e:

--- a/monitoring/uss_qualifier/scenarios/astm/utm/test_steps.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/test_steps.py
@@ -9,6 +9,7 @@ from uas_standards.astm.f3548.v21.api import (
     GetOperationalIntentDetailsResponse,
     OperationalIntentReference,
     OperationalIntentState,
+    UssAvailabilityState,
     Volume4D,
 )
 from uas_standards.astm.f3548.v21.constants import Scope
@@ -663,7 +664,7 @@ def set_uss_available(
         try:
             availability_version, avail_query = dss.set_uss_availability(
                 uss_sub,
-                True,
+                UssAvailabilityState.Normal,
             )
             scenario.record_query(avail_query)
         except QueryError as e:
@@ -695,7 +696,7 @@ def set_uss_down(
         try:
             availability_version, avail_query = dss.set_uss_availability(
                 uss_sub,
-                False,
+                UssAvailabilityState.Down,
             )
             scenario.record_query(avail_query)
         except QueryError as e:


### PR DESCRIPTION
`get_uss_availability` returns the `UssAvailabilityStatusResponse` containing the USS availability defined as `UssAvailabilityState`.

It would increase consistency to reuse this enum type in `set_uss_availability` instead of the more generic `bool | None` when updating the USS availability.