### PR TITLE
[mock_uss] Fix clustering

### DIFF
--- a/monitoring/mock_uss/riddp/clustering.py
+++ b/monitoring/mock_uss/riddp/clustering.py
@@ -65,7 +65,7 @@ class Cluster(ImplicitDict):
         # So if the cluster is big enough, our min will be on the minimum edge of our
         # points
         #
-        # If random choose the maximium value:
+        # If random choose the maximum value:
         # x_offset = u_min - self.x_min - (self.x_max + x_offset - u_max)
         # x_offset = u_min - self.x_min - self.x_max - x_offset + u_max
         # x_max = self.x_max + x_offset


### PR DESCRIPTION
The randomize function of the mock_uss's clustering is wrong and can generate clusters outside the list of points.

Keeping it in one axes, if min = 0, max = 4 and points = [1, 3], this mean

```
u_min = 1
u_max = 3
x_offset = random.uniform(-3, 1)
```

Should we chose `-3` as value

`
x_min = -3
x_max = 1
`

Meaning our clustering window will have one point outside of the cluster.

This PR fixes it with another calculation with explanations, see the code.

This PR also fix `extend` that was wrongly used `self` instead of new cluster, and do a copy of points to avoid having the same list between cluster's copies.