### PR TITLE
[tooling] Make basedpyright fail on warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ line-length = 88
 
 [tool.basedpyright]
 typeCheckingMode = "standard"
+failOnWarnings = true
 
 exclude = [
   "**/__pycache__",


### PR DESCRIPTION
When we do have warning, basedpyright don't update the baseline, witch may create issues when they are side fixed.

This make it fail on warning, so we don't allow warnings anymore, witch is probably something we want anyways :)