### PR TITLE
[utm] Add SCD0095 checks

### DIFF
--- a/monitoring/mock_uss/flight_planning/routes.py
+++ b/monitoring/mock_uss/flight_planning/routes.py
@@ -98,6 +98,17 @@ def flight_planning_v1_upsert_flight_plan(flight_plan_id: str) -> tuple[str, int
                     )
                 )
 
+        if "has_local_conflict" in inject_resp and inject_resp.has_local_conflict:
+            with db as tx:
+                tx.flight_planning_notifications.append(
+                    api.UserNotification(
+                        observed_at=api.Time(
+                            value=StringBasedDateTime(arrow.utcnow().datetime)
+                        ),
+                        conflicts="Single",
+                    )
+                )
+
     finally:
         release_flight_lock(flight_plan_id, log)
 

--- a/monitoring/mock_uss/scd_injection/routes_injection.py
+++ b/monitoring/mock_uss/scd_injection/routes_injection.py
@@ -23,6 +23,7 @@ from monitoring.mock_uss.dynamic_configuration.configuration import get_locality
 from monitoring.mock_uss.f3548v21 import utm_client
 from monitoring.mock_uss.f3548v21.flight_planning import (
     PlanningError,
+    check_for_local_conflits,
     check_op_intent,
     delete_op_intent,
     op_intent_from_flightinfo,
@@ -201,6 +202,10 @@ def inject_flight(
         with db as tx:
             tx.flights[flight_id] = record
 
+            has_local_conflict = check_for_local_conflits(
+                record.op_intent, tx.flights.values()
+            )
+
         step_name = "returning final successful result"
         log("Complete.")
 
@@ -211,6 +216,7 @@ def inject_flight(
             flight_plan_status=FlightPlanStatus.from_flightinfo(record.flight_info),
             notes=notes,
             has_conflict=has_conflict,
+            has_local_conflict=has_local_conflict,
         )
     except (ValueError, ConnectionError) as e:
         notes = (

--- a/monitoring/monitorlib/clients/flight_planning/planning.py
+++ b/monitoring/monitorlib/clients/flight_planning/planning.py
@@ -97,6 +97,9 @@ class PlanningActivityResponse(ImplicitDict):
     has_conflict: bool | None
     """If the planning activity has at least one conflict"""
 
+    has_local_conflict: bool | None
+    """If the planning activity has at least one conflict with a local flight"""
+
     def to_inject_flight_response(self) -> scd_api.InjectFlightResponse:
         if self.activity_result == PlanningActivityResult.Completed:
             if self.flight_plan_status == FlightPlanStatus.Planned:

--- a/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml
@@ -324,6 +324,7 @@ v1:
               - astm.f3548.v21.SCD0080
               - astm.f3548.v21.SCD0085
               - astm.f3548.v21.SCD0090
+              - astm.f3548.v21.SCD0095
               - astm.f3548.v21.GEN0500
               - astm.f3548.v21.USS0105,1
               - astm.f3548.v21.USS0105,3
@@ -398,6 +399,7 @@ v1:
               - astm.f3548.v21.SCD0080
               - astm.f3548.v21.SCD0085
               - astm.f3548.v21.SCD0090
+              - astm.f3548.v21.SCD0095
               - astm.f3548.v21.GEN0500
               - astm.f3548.v21.USS0105,1
               - astm.f3548.v21.USS0105,3

--- a/monitoring/uss_qualifier/scenarios/astm/utm/check_for_conflict_notification.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/check_for_conflict_notification.md
@@ -2,9 +2,16 @@
 
 This test step fragment verifies that a notification reporting the conflict was sent to the UAS personnel.
 
-## 🛑 New notification about conflict check
+## 🛑 New notification about conflict on creation/modification check
 
 If the USS doesn't send a notification within ConflictingOIMaxUserNotificationTime + 2 seconds,
 then we conclude it is very likely to be in violation of **[astm.f3548.v21.SCD0090](../../../requirements/astm/f3548/v21.md)**, and therefore this check will fail.
+
+Due to test design, the testing suite cannot verify that notifications are sent at least 95% of the time as stated in the standard and always expects a notification.
+
+## 🛑 New notification about conflict on awareness check
+
+If the USS doesn't send a notification within ConflictingOIMaxUserNotificationTime + 2 seconds,
+then we conclude it is very likely to be in violation of **[astm.f3548.v21.SCD0095](../../../requirements/astm/f3548/v21.md)**, and therefore this check will fail.
 
 Due to test design, the testing suite cannot verify that notifications are sent at least 95% of the time as stated in the standard and always expects a notification.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/notifications_to_operator/notification_checker.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/notifications_to_operator/notification_checker.py
@@ -25,17 +25,23 @@ EXTRA_DELAY = 2
 class NotificationChecker(GenericTestScenario, ABC):
     """Helper class to do notification checks"""
 
+    tested_uss: FlightPlannerClient
     control_uss: FlightPlannerClient
 
     def _record_current_notifications(self):
         self._notifications_start_point = arrow.utcnow().datetime
 
-        with self.check(
-            "Retrieve notifications", [self.control_uss.participant_id]
-        ) as check:
-            try:
-                self._base_notifications_response, query = (
-                    self.control_uss.get_user_notifications(
+        self._base_notifications_response = {}
+
+        for participant in [self.tested_uss, self.control_uss]:
+            with self.check(
+                "Retrieve notifications", [participant.participant_id]
+            ) as check:
+                try:
+                    (
+                        self._base_notifications_response[participant.participant_id],
+                        query,
+                    ) = participant.get_user_notifications(
                         before=self._notifications_start_point
                         + timedelta(
                             seconds=ConflictingOIMaxUserNotificationTimeSeconds
@@ -43,26 +49,29 @@ class NotificationChecker(GenericTestScenario, ABC):
                         ),
                         after=self._notifications_start_point,
                     )
-                )
 
-                self.record_query(query)
+                    self.record_query(query)
 
-            except PlanningActivityError:
-                self._base_notifications_response, query = (
-                    None,
-                    None,
-                )
+                except PlanningActivityError:
+                    (
+                        self._base_notifications_response[participant.participant_id],
+                        query,
+                    ) = (
+                        None,
+                        None,
+                    )
 
-            if (
-                not self._base_notifications_response
-                or "user_notifications" not in self._base_notifications_response
-            ):
-                check.record_failed(
-                    summary="Unable to retrieve base notifications",
-                    details=f"USS {self.control_uss.participant_id} didn't return a list of notifications before the action to compare as a base.",
-                    query_timestamps=[query.request.timestamp] if query else [],
-                )
-                self._base_notifications_response = None
+                if (
+                    not self._base_notifications_response[participant.participant_id]
+                    or "user_notifications"
+                    not in self._base_notifications_response[participant.participant_id]
+                ):
+                    check.record_failed(
+                        summary="Unable to retrieve base notifications",
+                        details=f"USS {participant.participant_id} didn't return a list of notifications before the action to compare as a base.",
+                        query_timestamps=[query.request.timestamp] if query else [],
+                    )
+                    self._base_notifications_response[participant.participant_id] = None
 
     def _wait_for_conflict_notification(self):
         def _notification_filter(n):
@@ -72,70 +81,94 @@ class NotificationChecker(GenericTestScenario, ABC):
                 Conflict.Multiple,
             ]
 
-        with self.check(
-            "New notification about conflict", [self.control_uss.participant_id]
-        ) as check:
-            if not self._base_notifications_response:
-                # No query: not supported API
-                check.skip()
-                return
-
-            base_count = len(
-                list(
-                    filter(
-                        _notification_filter,
-                        self._base_notifications_response.user_notifications,
-                    )
-                )
-            )
-
-            def _check_for_new_notifications():
-                notifications, query = self.control_uss.get_user_notifications(
-                    before=self._notifications_start_point
-                    + timedelta(
-                        seconds=ConflictingOIMaxUserNotificationTimeSeconds
-                        + EXTRA_DELAY
-                    ),
-                    after=self._notifications_start_point,
-                )
-
-                self.record_query(query)
-
-                if not notifications or "user_notifications" not in notifications:
-                    check.record_failed(
-                        summary="No notification returned",
-                        details=f"USS {self.control_uss.participant_id} didn't return a list of notifications when querying for new notifications.",
-                        query_timestamps=[query.request.timestamp],
-                    )
+        def _generic_check(participant, check_name, count=1):
+            with self.check(
+                check_name,
+                [participant.participant_id],
+            ) as check:
+                if not self._base_notifications_response[participant.participant_id]:
+                    # No query: not supported API
+                    check.skip()
                     return
 
-                return (
-                    len(
-                        list(
-                            filter(
-                                _notification_filter,
-                                notifications.user_notifications,
-                            )
+                base_count = len(
+                    list(
+                        filter(
+                            _notification_filter,
+                            self._base_notifications_response[
+                                participant.participant_id
+                            ].user_notifications,
                         )
                     )
-                    > base_count
                 )
 
-            deadline = arrow.utcnow() + timedelta(
-                seconds=ConflictingOIMaxUserNotificationTimeSeconds + EXTRA_DELAY
-            )
+                def _check_for_new_notifications():
+                    notifications, query = participant.get_user_notifications(
+                        before=self._notifications_start_point
+                        + timedelta(
+                            seconds=ConflictingOIMaxUserNotificationTimeSeconds
+                            + EXTRA_DELAY
+                        ),
+                        after=self._notifications_start_point,
+                    )
 
-            while arrow.utcnow() < deadline:
-                if _check_for_new_notifications():
-                    return
+                    self.record_query(query)
 
-                time.sleep(0.2)
+                    if not notifications or "user_notifications" not in notifications:
+                        check.record_failed(
+                            summary="No notification returned",
+                            details=f"USS {participant.participant_id} didn't return a list of notifications when querying for new notifications.",
+                            query_timestamps=[query.request.timestamp],
+                        )
+                        return
 
-            if not _check_for_new_notifications():  # Do a final check after the wait
-                # TODO: To test fully the requirements, we should record the
-                # failure and test in some aggregated analysis whether 95% of
-                # these notifications were received within that threshold
-                check.record_failed(
-                    summary="No new notification about conflict received",
-                    details=f"USS {self.control_uss.participant_id} didn't create a new notifications about conflict.",
+                    return (
+                        len(
+                            list(
+                                filter(
+                                    _notification_filter,
+                                    notifications.user_notifications,
+                                )
+                            )
+                        )
+                        >= base_count + count
+                    )
+
+                deadline = arrow.utcnow() + timedelta(
+                    seconds=ConflictingOIMaxUserNotificationTimeSeconds + EXTRA_DELAY
                 )
+
+                while arrow.utcnow() < deadline:
+                    if _check_for_new_notifications():
+                        return
+
+                    time.sleep(0.2)
+
+                if (
+                    not _check_for_new_notifications()
+                ):  # Do a final check after the wait
+                    # TODO: To test fully the requirements, we should record the
+                    # failure and test in some aggregated analysis whether 95% of
+                    # these notifications were received within that threshold
+                    check.record_failed(
+                        summary="No new notification about conflict received",
+                        details=f"USS {participant.participant_id} didn't create a new notifications about conflict.",
+                    )
+
+        _generic_check(
+            self.control_uss, "New notification about conflict on creation/modification"
+        )
+
+        # if control_uss and tested_uss USS are the same, we do expect 2
+        # notification, since one has already been 'consumed' for
+        # creation/modification
+        # We don't have much data on notification, so we don't know witch one
+        # is for creation and witch one is for awareness.
+        # We could also set both check to two, but that allow to differentiate
+        # the case where only one notification is send (that will be
+        # prioritized for creation/modification arbitrarily).
+        _generic_check(
+            self.tested_uss,
+            "New notification about conflict on awareness",
+            2 if self.control_uss == self.tested_uss else 1,
+        )

--- a/monitoring/uss_qualifier/suites/astm/utm/f3548_21.md
+++ b/monitoring/uss_qualifier/suites/astm/utm/f3548_21.md
@@ -39,7 +39,7 @@
     <th><a href="../../README.md#checked-in">Checked in</a></th>
   </tr>
   <tr>
-    <td rowspan="82" style="vertical-align:top;"><a href="../../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
+    <td rowspan="83" style="vertical-align:top;"><a href="../../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,1</a></td>
     <td>Implemented</td>
     <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../../scenarios/astm/utm/dss/oir_implicit_sub_handling.md">ASTM SCD DSS: Implicit Subscription handling</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/oir_explicit_sub_handling.md">ASTM SCD DSS: Operational Intent Explicit Subscription handling</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_simple.md">ASTM SCD DSS: Operational Intent Reference Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../../scenarios/interuss/ovn_request/dss_ovn_request.md">OVN Request Optional Extension to ASTM F3548-21</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../../scenarios/astm/utm/nominal_planning/solo_happy_path.md">Solo happy path</a></td>
@@ -416,6 +416,11 @@
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">SCD0090</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">SCD0095</a></td>
     <td>Implemented</td>
     <td><a href="../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a></td>
   </tr>

--- a/monitoring/uss_qualifier/suites/faa/uft/message_signing.md
+++ b/monitoring/uss_qualifier/suites/faa/uft/message_signing.md
@@ -18,7 +18,7 @@
     <th><a href="../../README.md#checked-in">Checked in</a></th>
   </tr>
   <tr>
-    <td rowspan="82" style="vertical-align:top;"><a href="../../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
+    <td rowspan="83" style="vertical-align:top;"><a href="../../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
     <td><a href="../../../requirements/astm/f3548/v21.md">DSS0005,1</a></td>
     <td>Implemented</td>
     <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../../scenarios/astm/utm/dss/oir_implicit_sub_handling.md">ASTM SCD DSS: Implicit Subscription handling</a><br><a href="../../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../../scenarios/astm/utm/dss/oir_explicit_sub_handling.md">ASTM SCD DSS: Operational Intent Explicit Subscription handling</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../../scenarios/astm/utm/dss/op_intent_ref_simple.md">ASTM SCD DSS: Operational Intent Reference Simple</a><br><a href="../../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../../scenarios/interuss/ovn_request/dss_ovn_request.md">OVN Request Optional Extension to ASTM F3548-21</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../../scenarios/astm/utm/nominal_planning/solo_happy_path.md">Solo happy path</a></td>
@@ -395,6 +395,11 @@
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3548/v21.md">SCD0090</a></td>
+    <td>Implemented</td>
+    <td><a href="../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../../requirements/astm/f3548/v21.md">SCD0095</a></td>
     <td>Implemented</td>
     <td><a href="../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a></td>
   </tr>

--- a/monitoring/uss_qualifier/suites/uspace/flight_auth.md
+++ b/monitoring/uss_qualifier/suites/uspace/flight_auth.md
@@ -19,7 +19,7 @@
     <th><a href="../README.md#checked-in">Checked in</a></th>
   </tr>
   <tr>
-    <td rowspan="82" style="vertical-align:top;"><a href="../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
+    <td rowspan="83" style="vertical-align:top;"><a href="../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0005,1</a></td>
     <td>Implemented</td>
     <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../scenarios/astm/utm/dss/oir_implicit_sub_handling.md">ASTM SCD DSS: Implicit Subscription handling</a><br><a href="../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../scenarios/astm/utm/dss/oir_explicit_sub_handling.md">ASTM SCD DSS: Operational Intent Explicit Subscription handling</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_simple.md">ASTM SCD DSS: Operational Intent Reference Simple</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../scenarios/interuss/ovn_request/dss_ovn_request.md">OVN Request Optional Extension to ASTM F3548-21</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../scenarios/astm/utm/nominal_planning/solo_happy_path.md">Solo happy path</a></td>
@@ -396,6 +396,11 @@
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">SCD0090</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3548/v21.md">SCD0095</a></td>
     <td>Implemented</td>
     <td><a href="../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a></td>
   </tr>

--- a/monitoring/uss_qualifier/suites/uspace/required_services.md
+++ b/monitoring/uss_qualifier/suites/uspace/required_services.md
@@ -634,7 +634,7 @@
     <td><a href="../../scenarios/astm/netrid/v22a/sp_notification_behavior.md">ASTM NetRID Service Provider notification behavior</a></td>
   </tr>
   <tr>
-    <td rowspan="82" style="vertical-align:top;"><a href="../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
+    <td rowspan="83" style="vertical-align:top;"><a href="../../requirements/astm/f3548/v21.md">astm<br>.f3548<br>.v21</a></td>
     <td><a href="../../requirements/astm/f3548/v21.md">DSS0005,1</a></td>
     <td>Implemented</td>
     <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_access_control.md">ASTM F3548-21 UTM DSS Operational Intent Reference Access Control</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_state_transitions.md">ASTM F3548-21 UTM DSS Operational Intent Reference State Transitions</a><br><a href="../../scenarios/astm/utm/dss/oir_implicit_sub_handling.md">ASTM SCD DSS: Implicit Subscription handling</a><br><a href="../../scenarios/astm/utm/dss/authentication/authentication_validation.md">ASTM SCD DSS: Interfaces authentication</a><br><a href="../../scenarios/astm/utm/dss/oir_explicit_sub_handling.md">ASTM SCD DSS: Operational Intent Explicit Subscription handling</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_key_validation.md">ASTM SCD DSS: Operational Intent Reference Key Validation</a><br><a href="../../scenarios/astm/utm/dss/op_intent_ref_simple.md">ASTM SCD DSS: Operational Intent Reference Simple</a><br><a href="../../scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md">ASTM SCD DSS: Operational Intent Reference Synchronization</a><br><a href="../../scenarios/astm/utm/dss/subscription_interactions_deletion.md">ASTM SCD DSS: Subscription and entity deletion interaction</a><br><a href="../../scenarios/astm/utm/dss/subscription_interactions.md">ASTM SCD DSS: Subscription and entity interaction</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md">Nominal planning: not permitted conflict with equal priority</a><br><a href="../../scenarios/interuss/ovn_request/dss_ovn_request.md">OVN Request Optional Extension to ASTM F3548-21</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss.md">Off-Nominal planning: down USS</a><br><a href="../../scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md">Off-Nominal planning: down USS with equal priority conflicts not permitted</a><br><a href="../../scenarios/astm/utm/nominal_planning/solo_happy_path.md">Solo happy path</a></td>
@@ -1011,6 +1011,11 @@
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3548/v21.md">SCD0090</a></td>
+    <td>Implemented</td>
+    <td><a href="../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a></td>
+  </tr>
+  <tr>
+    <td><a href="../../requirements/astm/f3548/v21.md">SCD0095</a></td>
     <td>Implemented</td>
     <td><a href="../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a></td>
   </tr>


### PR DESCRIPTION
This PR implements the SCD0095 check, in a similar way for SCD0090

I had to do some design choices on notification count (see comments) since we cannot separate SCD0090 and SCD0095 notification, but that should be fine.

Mock uss adapted as well to handle reception of operational intents.