### PR TITLE
[uss_qualifier] Examine pre-existing notifications for SCD0090/95

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md
@@ -108,7 +108,6 @@ higher priority. As such it should be rejected per **[astm.f3548.v21.SCD0015](..
 
 ### [Delete Flight 2 test step](../../../../flight_planning/delete_flight_intent.md)
 
-
 ## Attempt to modify planned flight in conflict test case
 ![Test case summary illustration](assets/attempt_to_modify_planned_flight_into_conflict.svg)
 
@@ -120,6 +119,10 @@ The first flight should be successfully planned by the tested USS.
 #### [Validate Flight 1 sharing](../../validate_shared_operational_intent.md)
 
 ### Plan Flight 2 test step
+
+#### ℹ️ Retrieve pre-existing notifications check
+
+Just before directing the planning activity, the test director observes pre-existing notifications which cannot relate to the planning activity that has not yet happened.  If these notifications cannot be retrieved, the USS has not fully implemented **[interuss.automated_testing.flight_planning.ImplementAPI](../../../../../requirements/interuss/automated_testing/flight_planning.md)**.
 
 #### [Plan Flight 2](../../../../flight_planning/plan_flight_intent.md)
 The second flight should be successfully planned by the control USS.
@@ -133,9 +136,11 @@ The test director checks whether a notification reporting the creation of a conf
 
 The test director also checks whether a notification reporting the creation of a new conflict with Flight 1 was sent to the UAS personnel for the tested_uss managing Flight 1.
 
+Note that these actions will not be performed if the test director was unable to retrieve the notifications before the planning activity.
+
 #### ℹ️ Retrieve notifications check
 
-We fetch the list of notifications. If the USS doesn't return a valid answer, we cannot proceed with notification tests.
+We fetch the list of notifications. If the USS doesn't return a valid answer, the USS has not fully implemented **[interuss.automated_testing.flight_planning.ImplementAPI](../../../../../requirements/interuss/automated_testing/flight_planning.md)** and we cannot proceed with notification tests.
 
 ### Attempt to modify planned Flight 1 in conflict test step
 
@@ -185,6 +190,10 @@ The second flight should be successfully planned by the control USS.
 
 ### Activate Flight 2 test step
 
+#### ℹ️ Retrieve pre-existing notifications check
+
+Just before directing the planning activity, the test director observes pre-existing notifications which cannot relate to the planning activity that has not yet happened.  If these notifications cannot be retrieved, the USS has not fully implemented **[interuss.automated_testing.flight_planning.ImplementAPI](../../../../../requirements/interuss/automated_testing/flight_planning.md)**.
+
 #### [Activate Flight 2](../../../../flight_planning/activate_flight_intent.md)
 The test driver activates Flight 2, which should be done successfully given that it is the highest-priority flight.
 
@@ -196,9 +205,11 @@ The test director checks whether a notification reporting the modification of Fl
 
 The test director also checks whether a notification reporting the modification of a flight conflicting with Flight 1 was sent to the UAS personnel for the tested_uss managing Flight 1.
 
+Note that these actions will not be performed if the test director was unable to retrieve the notifications before the planning activity.
+
 #### ℹ️ Retrieve notifications check
 
-We fetch the list of notifications. If the USS doesn't return a valid answer, we cannot proceed with notification tests.
+We fetch the list of notifications. If the USS doesn't return a valid answer, the USS has not fully implemented **[interuss.automated_testing.flight_planning.ImplementAPI](../../../../../requirements/interuss/automated_testing/flight_planning.md)** and we cannot proceed with notification tests.
 
 ### Modify activated Flight 1 in conflict with activated Flight 2 test step
 
@@ -227,7 +238,6 @@ If the modification was accepted, Flight 1 should have been modified.
 If the modification was not supported, Flight 1 should not have been modified.
 If the modification was rejected, Flight 1 should not have been modified and should still exist. If it does not exist,
 it means that there is an active flight without an operational intent, which is a failure to meet **[interuss.automated_testing.flight_planning.FlightCoveredByOperationalIntent](../../../../../requirements/interuss/automated_testing/flight_planning.md)**.
-
 
 ## Attempt to modify activated flight in conflict test case
 ![Test case summary illustration](assets/attempt_to_modify_activated_flight_into_conflict.svg)

--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.py
@@ -276,6 +276,9 @@ class ConflictHigherPriority(TestScenario, NotificationChecker):
         self.end_test_step()
 
         self.begin_test_step("Plan Flight 2")
+        preexisting_notifications = self._get_preexisting_notifications(
+            [self.control_uss, self.tested_uss]
+        )
         flight2_planned = self.resolve_flight(self.flight2_planned)
 
         with OpIntentValidator(
@@ -296,10 +299,11 @@ class ConflictHigherPriority(TestScenario, NotificationChecker):
 
         self.begin_test_step("Check for conflict notifications")
         self._check_for_user_notifications(
-            self.control_uss,
-            self.tested_uss,
-            earliest_creation_time,
-            latest_creation_time,
+            causing_conflict=self.control_uss,
+            observing_conflict=self.tested_uss,
+            preexisting_notifications=preexisting_notifications,
+            earliest_action_time=earliest_creation_time,
+            latest_action_time=latest_creation_time,
         )
         self.end_test_step()
 
@@ -399,6 +403,9 @@ class ConflictHigherPriority(TestScenario, NotificationChecker):
         self.end_test_step()
 
         self.begin_test_step("Activate Flight 2")
+        preexisting_notifications = self._get_preexisting_notifications(
+            [self.control_uss, self.tested_uss]
+        )
         flight2_activated = self.resolve_flight(self.flight2_activated)
 
         with OpIntentValidator(
@@ -421,10 +428,11 @@ class ConflictHigherPriority(TestScenario, NotificationChecker):
 
         self.begin_test_step("Check for conflict notifications")
         self._check_for_user_notifications(
-            self.control_uss,
-            self.tested_uss,
-            earliest_activation_time,
-            latest_activation_time,
+            causing_conflict=self.control_uss,
+            observing_conflict=self.tested_uss,
+            preexisting_notifications=preexisting_notifications,
+            earliest_action_time=earliest_activation_time,
+            latest_action_time=latest_activation_time,
         )
         self.end_test_step()
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/notifications_to_operator/notification_checker.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/notifications_to_operator/notification_checker.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 import arrow
 from uas_standards.astm.f3548.v21.constants import (
     ConflictingOIMaxUserNotificationTimeSeconds,
+    TimeSyncMaxDifferentialSeconds,
 )
 
 from monitoring.monitorlib.clients.flight_planning.client import (
@@ -19,6 +20,7 @@ from monitoring.monitorlib.fetch import Query
 from monitoring.uss_qualifier.configurations.configuration import ParticipantID
 from monitoring.uss_qualifier.scenarios.scenario import GenericTestScenario
 
+NOTIFICATIONS_MAX_CLOCK_SKEW = timedelta(seconds=TimeSyncMaxDifferentialSeconds)
 SCD0090_NOTE_PREFIX = "scd0090_notification"
 SCD0095_NOTE_PREFIX = "scd0095_notification"
 NOTIFICATION_NOTE_FORMAT = "{participant_id} notification latency: >{latency}s"
@@ -35,18 +37,54 @@ class Notifications:
 class NotificationChecker(GenericTestScenario, ABC):
     """Helper class to do notification checks"""
 
+    def _get_preexisting_notifications(
+        self, clients: list[FlightPlannerClient]
+    ) -> dict[ParticipantID, Notifications]:
+        notifications = {}
+        start_point = arrow.utcnow().datetime - NOTIFICATIONS_MAX_CLOCK_SKEW
+        for client in clients:
+            resp, query = client.get_user_notifications(after=start_point)
+            self.record_query(query)
+            with self.check(
+                "Retrieve pre-existing notifications", client.participant_id
+            ) as check:
+                if not resp or "user_notifications" not in resp:
+                    notifications[client.participant_id] = Notifications(
+                        notifications=None, query=query
+                    )
+                    check.record_failed(
+                        summary="No notifications returned",
+                        details=f"{client.participant_id} didn't return a list of notifications when querying for pre-existing notifications",
+                        query_timestamps=[query.request.timestamp],
+                    )
+                    continue
+                notifications[client.participant_id] = Notifications(
+                    notifications=resp.user_notifications, query=query
+                )
+        return notifications
+
     def _get_notifications(
         self,
         clients: list[FlightPlannerClient],
         start_point: datetime,
         deadline: datetime,
+        preexisting_notifications: dict[ParticipantID, Notifications],
     ) -> dict[ParticipantID, Notifications]:
+        start_point -= NOTIFICATIONS_MAX_CLOCK_SKEW
         notifications = {}
         most_recent_check = arrow.utcnow().datetime
         while most_recent_check < deadline:
             for client in clients:
                 if client.participant_id in notifications:
                     # We've already found notifications for this participant
+                    continue
+                if (
+                    client.participant_id not in preexisting_notifications
+                    or preexisting_notifications[client.participant_id].notifications
+                    is None
+                ):
+                    # We weren't able to retrieve the "before" notifications, so don't attempt to retrieve the "after" notifications
+                    notifications[client.participant_id] = None
                     continue
                 resp, query = client.get_user_notifications(after=start_point)
                 self.record_query(query)
@@ -68,10 +106,18 @@ class NotificationChecker(GenericTestScenario, ABC):
                         continue
 
                 # If there was at least one qualifying notification, use the response obtained for this participant
+                previously_observed = {
+                    n.observed_at
+                    for n in preexisting_notifications[
+                        client.participant_id
+                    ].notifications
+                    or []
+                }
                 qualifying_notifications = [
-                    notification
-                    for notification in resp.user_notifications
-                    if notification.conflicts in _ACCEPTABLE_CONFLICTS
+                    n
+                    for n in resp.user_notifications
+                    if n.conflicts in _ACCEPTABLE_CONFLICTS
+                    and n.observed_at not in previously_observed
                 ]
                 if qualifying_notifications:
                     notifications[client.participant_id] = Notifications(
@@ -91,20 +137,22 @@ class NotificationChecker(GenericTestScenario, ABC):
             else:
                 break
 
-        return notifications
+        return {k: v for k, v in notifications.items() if v is not None}
 
     def _check_for_user_notifications(
         self,
         causing_conflict: FlightPlannerClient,
         observing_conflict: FlightPlannerClient,
+        preexisting_notifications: dict[ParticipantID, Notifications],
         earliest_action_time: datetime,
         latest_action_time: datetime,
     ):
         new_notifications = self._get_notifications(
-            [causing_conflict, observing_conflict],
-            earliest_action_time,
-            latest_action_time
+            clients=[causing_conflict, observing_conflict],
+            start_point=earliest_action_time,
+            deadline=latest_action_time
             + timedelta(seconds=ConflictingOIMaxUserNotificationTimeSeconds),
+            preexisting_notifications=preexisting_notifications,
         )
 
         def _latency_of(notifications: list[UserNotification]) -> str:
@@ -130,7 +178,10 @@ class NotificationChecker(GenericTestScenario, ABC):
             )
 
         def _maybe_record_note(prefix: str, client: FlightPlannerClient) -> None:
-            if new_notifications[client.participant_id].notifications is not None:
+            if (
+                client.participant_id in new_notifications
+                and new_notifications[client.participant_id].notifications is not None
+            ):
                 self.record_note(prefix, _note_for(client))
 
         _maybe_record_note(SCD0090_NOTE_PREFIX, causing_conflict)

--- a/monitoring/uss_qualifier/suites/astm/utm/f3548_21.md
+++ b/monitoring/uss_qualifier/suites/astm/utm/f3548_21.md
@@ -478,7 +478,7 @@
   <tr>
     <td><a href="../../../requirements/interuss/automated_testing/flight_planning.md">ImplementAPI</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a></td>
+    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/interuss/automated_testing/flight_planning.md">Readiness</a></td>

--- a/monitoring/uss_qualifier/suites/faa/uft/message_signing.md
+++ b/monitoring/uss_qualifier/suites/faa/uft/message_signing.md
@@ -457,7 +457,7 @@
   <tr>
     <td><a href="../../../requirements/interuss/automated_testing/flight_planning.md">ImplementAPI</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a></td>
+    <td><a href="../../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/interuss/automated_testing/flight_planning.md">Readiness</a></td>

--- a/monitoring/uss_qualifier/suites/uspace/flight_auth.md
+++ b/monitoring/uss_qualifier/suites/uspace/flight_auth.md
@@ -458,7 +458,7 @@
   <tr>
     <td><a href="../../requirements/interuss/automated_testing/flight_planning.md">ImplementAPI</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/flight_planning/prep_planners.md">Generic flight planners preparation</a></td>
+    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/flight_planning/prep_planners.md">Generic flight planners preparation</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/interuss/automated_testing/flight_planning.md">Readiness</a></td>

--- a/monitoring/uss_qualifier/suites/uspace/required_services.md
+++ b/monitoring/uss_qualifier/suites/uspace/required_services.md
@@ -1073,7 +1073,7 @@
   <tr>
     <td><a href="../../requirements/interuss/automated_testing/flight_planning.md">ImplementAPI</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/flight_planning/prep_planners.md">Generic flight planners preparation</a></td>
+    <td><a href="../../scenarios/astm/utm/prep_planners.md">ASTM F3548 flight planners preparation</a><br><a href="../../scenarios/flight_planning/prep_planners.md">Generic flight planners preparation</a><br><a href="../../scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md">Nominal planning: conflict with higher priority</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/interuss/automated_testing/flight_planning.md">Readiness</a></td>


### PR DESCRIPTION
This PR primarily enhances SCD0090 and SCD0095 testing by checking pre-existing notifications before the flight planning action so that those notifications can be definitively excluded as notifications that may have been triggered by the flight planning action.  This makes it possible to incorporate more robust behavior in the presence of clock skew between uss_qualifier and USSs under test (previously, clock skew could have caused by false positives and false negatives).  Finally, a bug observed in the wild is fixed for a timing edge case (where `new_notifications` wasn't populated with all clients under certain conditions).