### PR TITLE
[monitorlib, mock_uss] Improve SynchronizedValue

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -1366,6 +1366,14 @@
                     "endColumn": 26,
                     "lineCount": 1
                 }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 44,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
             }
         ],
         "./monitoring/mock_uss/geoawareness/ed269.py": [
@@ -1943,22 +1951,6 @@
                     "startColumn": 11,
                     "endColumn": 5,
                     "lineCount": 3
-                }
-            },
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 38,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 11,
-                    "endColumn": 32,
-                    "lineCount": 1
                 }
             },
             {

--- a/monitoring/mock_uss/f3548v21/flight_planning.py
+++ b/monitoring/mock_uss/f3548v21/flight_planning.py
@@ -464,9 +464,9 @@ def query_operational_intents(
                 raise e
     result.extend(updated_op_intents)
 
-    with db as tx:
+    with db.transact() as tx:
         for op_intent in updated_op_intents:
-            tx.cached_operations[op_intent.reference.id] = op_intent
+            tx.value.cached_operations[op_intent.reference.id] = op_intent
 
     return result
 

--- a/monitoring/mock_uss/f3548v21/routes_scd.py
+++ b/monitoring/mock_uss/f3548v21/routes_scd.py
@@ -127,12 +127,12 @@ def scdsc_notify_operational_intent_details_changed():
 
     if "operational_intent" in op_intent_data and op_intent_data.operational_intent:
         # An op intent is being created or modified; check if it conflicts with any flights we're managing
-        with db as tx:
+        with db.transact() as tx:
             if conflicts_with_flightrecords(
-                op_intent_data.operational_intent, tx.flights.values()
+                op_intent_data.operational_intent, list(tx.value.flights.values())
             ):
                 # Virtually notify user that another op intent conflicts with their flight
-                tx.flight_planning_notifications.append(
+                tx.value.flight_planning_notifications.append(
                     UserNotification(
                         type=UserNotificationType.DetectedConflict,
                         observed_at=StringBasedDateTime(arrow.utcnow().datetime),

--- a/monitoring/mock_uss/flights/database.py
+++ b/monitoring/mock_uss/flights/database.py
@@ -33,7 +33,7 @@ class Database(ImplicitDict):
     """List of notifications sent during flight planning operations"""
 
 
-db = SynchronizedValue(
+db = SynchronizedValue[Database](
     Database(),
     decoder=lambda b: ImplicitDict.parse(json.loads(b.decode("utf-8")), Database),
 )

--- a/monitoring/mock_uss/flights/planning.py
+++ b/monitoring/mock_uss/flights/planning.py
@@ -10,17 +10,17 @@ def lock_flight(flight_id: str, log: Callable[[str], None]) -> FlightRecord:
     log(f"Acquiring lock for flight {flight_id}")
     deadline = datetime.now(UTC) + DEADLOCK_TIMEOUT
     while True:
-        with db as tx:
-            if flight_id in tx.flights:
+        with db.transact() as tx:
+            if flight_id in tx.value.flights:
                 # This is an existing flight being modified
-                existing_flight = tx.flights[flight_id]
+                existing_flight = tx.value.flights[flight_id]
                 if existing_flight and not existing_flight.locked:
                     log("Existing flight locked for update")
                     existing_flight.locked = True
                     break
             else:
                 log("Request is for a new flight (lock established)")
-                tx.flights[flight_id] = None
+                tx.value.flights[flight_id] = None
                 existing_flight = None
                 break
         # We found an existing flight but it was locked; wait for it to become
@@ -35,27 +35,27 @@ def lock_flight(flight_id: str, log: Callable[[str], None]) -> FlightRecord:
 
 
 def release_flight_lock(flight_id: str, log: Callable[[str], None]) -> None:
-    with db as tx:
-        if flight_id in tx.flights:
-            if tx.flights[flight_id]:
+    with db.transact() as tx:
+        if flight_id in tx.value.flights:
+            if tx.value.flights[flight_id]:
                 # FlightRecord was a true existing flight
                 log(f"Releasing lock on existing flight_id {flight_id}")
-                tx.flights[flight_id].locked = False
+                tx.value.flights[flight_id].locked = False
             else:
                 # FlightRecord was just a placeholder for a new flight
                 log(f"Releasing placeholder for existing flight_id {flight_id}")
-                del tx.flights[flight_id]
+                del tx.value.flights[flight_id]
 
 
 def delete_flight_record(flight_id: str) -> FlightRecord | None:
     deadline = datetime.now(UTC) + DEADLOCK_TIMEOUT
     while True:
-        with db as tx:
-            if flight_id in tx.flights:
-                flight = tx.flights[flight_id]
+        with db.transact() as tx:
+            if flight_id in tx.value.flights:
+                flight = tx.value.flights[flight_id]
                 if flight and not flight.locked:
                     # FlightRecord was a true existing flight not being mutated anywhere else
-                    del tx.flights[flight_id]
+                    del tx.value.flights[flight_id]
                     return flight
             else:
                 # No FlightRecord found

--- a/monitoring/monitorlib/idempotency.py
+++ b/monitoring/monitorlib/idempotency.py
@@ -51,7 +51,7 @@ def _set_responses(responses: dict[str, Response]) -> bytes:
     return s.encode("utf-8")
 
 
-_fulfilled_requests = SynchronizedValue(
+_fulfilled_requests = SynchronizedValue[dict](
     {},
     decoder=_get_responses,
     encoder=_set_responses,
@@ -148,8 +148,8 @@ def idempotent_request(get_request_id: Callable[[], str | None] | None = None):
                     f"Unable to cache Flask view handler result of type '{type(result).__name__}'"
                 )
 
-            with _fulfilled_requests as cached_requests:
-                cached_requests[request_id] = response
+            with _fulfilled_requests.transact() as cached_requests_tx:
+                cached_requests_tx.value[request_id] = response
 
             return to_return
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "basedpyright>=1.31.1",
     "bc-jsonpath-ng",
     "cryptography",
+    "deprecation",
     "faker",
     "flask",
     "flask-login",

--- a/uv.lock
+++ b/uv.lock
@@ -298,6 +298,18 @@ wheels = [
 ]
 
 [[package]]
+name = "deprecation"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/d3/8ae2869247df154b64c1884d7346d412fed0c49df84db635aab2d1c40e62/deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff", size = 173788, upload-time = "2020-04-20T14:23:38.738Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/c3/253a89ee03fc9b9682f1541728eb66db7db22148cd94f89ab22528cd1e1b/deprecation-2.1.0-py2.py3-none-any.whl", hash = "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a", size = 11178, upload-time = "2020-04-20T14:23:36.581Z" },
+]
+
+[[package]]
 name = "docker"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -822,6 +834,7 @@ dependencies = [
     { name = "basedpyright" },
     { name = "bc-jsonpath-ng" },
     { name = "cryptography" },
+    { name = "deprecation" },
     { name = "faker" },
     { name = "flask" },
     { name = "flask-login" },
@@ -871,6 +884,7 @@ requires-dist = [
     { name = "basedpyright", specifier = ">=1.31.1" },
     { name = "bc-jsonpath-ng" },
     { name = "cryptography" },
+    { name = "deprecation" },
     { name = "faker" },
     { name = "flask" },
     { name = "flask-login" },


### PR DESCRIPTION
In a number of places, we synchronize data across multiple threads using SynchronizedValue.  This tool ensures read-modify-write transactions are not interrupted by changes from another thread.  Currently, however, the `__enter__`/`__exit__` pattern used does not provide useful type-hinting for IDEs nor for correctness checks like ruff/basedpyright, and it also prevents certain operations like replacing content rather than mutating it during a transaction.  This PR attempts to address these shortcomings by adding a `transact()` method to SynchronizedValue so that usage is now `with db.transact() as tx:` rather than the more confusing and less inspectable `with db as tx:`.

The old behavior is retained as deprecation-annotated methods to avoid making this PR huge by changing all usages at once.  However, the flights storage of mock_uss is entirely switched to the new usage to verify functionality.

A number of ruff/basedpyright errors revealed by the improved inspectability of SynchronizedValue types are fixed, though one is added; see comment below.