### PR TITLE
[mock_uss] Add utility to generate mock_uss historical KML offline

### DIFF
--- a/monitoring/mock_uss/tracer/README.md
+++ b/monitoring/mock_uss/tracer/README.md
@@ -40,3 +40,11 @@ current session has been running.
 
 ## Invocation
 An instance of tracer-enabled mock_uss is brought up as part of the [local deployment](../README.md#local-deployment).  It can also be deployed [with Google Cloud Platform](../deployment/gcp) when configured appropriately.
+
+## Offline historical KML generator
+
+With a large number of log files, KML generation via the server endpoint can
+require a prohibitive amount of time.  To generate a historical KML in these
+cases, the [make_historical_kml utility](./make_historical_kml.py) can be used
+to parse a folder of logs (generally acquired from downloading a .zip file of
+logs while the server is active) into a KML file.

--- a/monitoring/mock_uss/tracer/kml.py
+++ b/monitoring/mock_uss/tracer/kml.py
@@ -351,6 +351,8 @@ def render_historical_kml(log_folder: str) -> str:
     log_files = glob.glob(os.path.join(log_folder, "*.yaml"))
     log_files.sort()
     for log_file in log_files:
+        logger.debug(f"Processing {log_file}")
+
         if "nochange_queries" in log_file:
             continue  # This is a known case where we don't want to print a warning
 

--- a/monitoring/mock_uss/tracer/make_historical_kml.py
+++ b/monitoring/mock_uss/tracer/make_historical_kml.py
@@ -1,0 +1,36 @@
+import argparse
+import os
+import sys
+
+from monitoring.mock_uss.tracer.kml import render_historical_kml
+
+
+def main(log_folder: str, kml_file: str) -> int:
+    kml_text = render_historical_kml(log_folder)
+    with open(kml_file, "w") as f:
+        f.write(kml_text)
+    return os.EX_OK
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate an historical KML based on a folder of tracer logs"
+    )
+
+    parser.add_argument(
+        "--logfolder",
+        type=str,
+        default=None,
+        help="Path to the folder containing tracer log files",
+    )
+
+    parser.add_argument(
+        "--kmlfile", type=str, default=None, help="Path to the KML file to create"
+    )
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+    sys.exit(main(args.logfolder, args.kmlfile))


### PR DESCRIPTION
Enabled by the first steps toward #1218, this PR provides a tool to generate a historical KML from mock_uss log files offline since such generation can take a prohibitive amount of time for a server (order of 10 minutes in some cases).