### PR TITLE
[prober] uss availability: support multiple run

### DIFF
--- a/monitoring/prober/scd/test_uss_availability.py
+++ b/monitoring/prober/scd/test_uss_availability.py
@@ -61,13 +61,6 @@ def test_set_invalid_uss_availability(ids, scd_session2):
     resp = scd_session2.put("/uss_availability/uss1", json={"availability": "pUrPlE"})
     assert resp.status_code == 400, resp.content
 
-    resp = scd_session2.put(
-        "/uss_availability/uss1",
-        scope=SCOPE_AA,
-        json={"availability": "normal", "old_version": "invalid"},
-    )
-    assert resp.status_code == 409, resp.content
-
 
 @default_scope(SCOPE_AA)
 def test_get_unknown_uss_availability(ids, scd_session2):


### PR DESCRIPTION
Since https://github.com/interuss/dss/pull/1245, the DSS is stricter in terms of updates of uss availabilities. It is not possible to update the status without providing the old version. However, since this change, the prober can't be run twice on a dss instance because a status record already exits.

Note that the availability endpoint does not allow to clear the status for a already defined uss. Therefore, it is not possible to test at all times setting a new uss without creating a new uss entry every time. 

To avoid database polution, the implementation in this PR checks for an existing record version before setting it. Though, this can be revisited in a follow up PR.
