### PR TITLE
[uss_qualifier] display data evaluator: query details once per flight and per observer

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/netrid/display_data_evaluator.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/display_data_evaluator.py
@@ -262,9 +262,8 @@ class RIDObservationEvaluator:
             raise ValueError(
                 f"Cannot evaluate a system using RID version {rid_version} with a DSS using RID version {dss.rid_version}"
             )
-        self._retrieved_flight_details: set[str] = (
-            set()
-        )  # Contains the observed IDs of the flights whose details were retrieved.
+        # dict of observer (identified by its base_url) to set of flight ID for which details were retrieved.
+        self._retrieved_flight_details: dict[str, set[str]] = {}
 
     def evaluate_system_instantaneously(
         self,
@@ -454,14 +453,18 @@ class RIDObservationEvaluator:
                         ),
                     )
 
-        # Check details of flights (once per flight)
+        # Check details of flights (once per flight and per observer)
         for mapping in mapping_by_injection_id.values():
             with self._test_scenario.check(
                 "Successful details observation",
                 [mapping.injected_flight.uss_participant_id],
             ) as check:
-                # query for flight details only once per flight
-                if mapping.observed_flight.id in self._retrieved_flight_details:
+                # query for flight details only once per flight and per observer
+                if (
+                    observer.base_url in self._retrieved_flight_details
+                    and mapping.observed_flight.id
+                    in self._retrieved_flight_details[observer.base_url]
+                ):
                     continue
 
                 details_obs, query = observer.observe_flight_details(
@@ -484,7 +487,13 @@ class RIDObservationEvaluator:
                     details_inj = mapping.injected_flight.flight.get_details(
                         telemetry_inj.timestamp.datetime
                     )
-                    self._retrieved_flight_details.add(mapping.observed_flight.id)
+
+                    if observer.base_url not in self._retrieved_flight_details:
+                        self._retrieved_flight_details[observer.base_url] = set()
+                    self._retrieved_flight_details[observer.base_url].add(
+                        mapping.observed_flight.id
+                    )
+
                     self._common_dictionary_evaluator.evaluate_dp_details(
                         details_inj,
                         details_obs,


### PR DESCRIPTION
Skipping the details query if we have already obtained the details of the flight causes us to only query whichever observer is first in the list.

This causes some aggregate checks related to detail query performance on any subsequent USS to later be skipped, because we have no such query to look at.

This PR adapts the display data evaluator in order for it to query the details once per flight and per observer.

Note: this adds an `observer_id` property to the `RIDSystemObserver` class in order to distinguish different observers that might belong to the same `participant_id`