### PR TITLE
[uss_qualifier/flight_planning] Handle USSs not supporting flight modifications

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.md
@@ -249,6 +249,8 @@ The test driver modifies (activated) Flight 2 with the control USS so that it is
 flight of test USS.
 As Flight 2 is of higher priority, this should succeed and leave Flight 1 clear of conflict.
 
+If flight modification is not supported by the USS, the next test step is going to be skipped and the test case will end here.
+
 #### [Validate Flight 2 sharing](../../validate_shared_operational_intent.md)
 
 ### Attempt to modify activated Flight 1 in conflict test step

--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.py
@@ -483,14 +483,22 @@ class ConflictHigherPriority(TestScenario, NotificationChecker):
             flight2m_activated,
             flight_2_oi_ref,
         ) as validator:
-            modify_activated_flight(
+            resp = modify_activated_flight(
                 self,
                 self.control_uss,
                 flight2m_activated,
                 self.flight2_id,
             )
-            validator.expect_shared(flight2m_activated)
+            if resp.activity_result == PlanningActivityResult.Completed:
+                validator.expect_shared(flight2m_activated)
         self.end_test_step()
+
+        if resp.activity_result == PlanningActivityResult.NotSupported:
+            self.record_note(
+                "conflict_higher_priority_skip_step",
+                f"Skip next step since USS {self.control_uss} did not modify flight 2.",
+            )
+            return
 
         self.begin_test_step("Attempt to modify activated Flight 1 in conflict")
         flight1c_activated = self.resolve_flight(self.flight1c_activated)

--- a/monitoring/uss_qualifier/scenarios/flight_planning/prioritization_test_steps.py
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/prioritization_test_steps.py
@@ -81,6 +81,10 @@ def modify_planned_priority_conflict_flight(
                 PlanningActivityResult.Rejected,
                 FlightPlanStatus.Closed,
             ),  # case where the USS closes the flight plan as a result of the rejected modification attempt
+            (
+                PlanningActivityResult.NotSupported,
+                FlightPlanStatus.Planned,
+            ),  # case where the USS does not support modification of flights
         },
         failed_checks={PlanningActivityResult.Failed: "Failure"},
         flight_planner=flight_planner,
@@ -163,6 +167,10 @@ def modify_activated_priority_conflict_flight(
                 PlanningActivityResult.Rejected,
                 FlightPlanStatus.Closed,
             ),  # case where the USS closes the flight plan as a result of the rejected modification attempt; note: is this actually desirable if the flight was activated?
+            (
+                PlanningActivityResult.NotSupported,
+                FlightPlanStatus.OkToFly,
+            ),  # case where the USS does not support modification of flights
         },
         failed_checks={PlanningActivityResult.Failed: "Failure"},
         flight_planner=flight_planner,
@@ -235,6 +243,10 @@ def modify_planned_conflict_flight(
                 PlanningActivityResult.Rejected,
                 FlightPlanStatus.Closed,
             ),  # case where the USS closes the flight plan as a result of the rejected modification attempt
+            (
+                PlanningActivityResult.NotSupported,
+                FlightPlanStatus.Planned,
+            ),  # case where the USS does not support modification of flights
         },
         failed_checks={PlanningActivityResult.Failed: "Failure"},
         flight_planner=flight_planner,
@@ -317,6 +329,10 @@ def modify_activated_conflict_flight(
                 PlanningActivityResult.Rejected,
                 FlightPlanStatus.Closed,
             ),  # case where the USS closes the flight plan as a result of the rejected modification attempt; note: is this actually desirable if the flight was activated?
+            (
+                PlanningActivityResult.NotSupported,
+                FlightPlanStatus.OkToFly,
+            ),  # case where the USS does not support modification of flights
         },
         failed_checks={PlanningActivityResult.Failed: "Failure"},
         flight_planner=flight_planner,

--- a/monitoring/uss_qualifier/scenarios/flight_planning/test_steps.py
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/test_steps.py
@@ -111,7 +111,13 @@ def modify_planned_flight(
     return submit_flight(
         scenario=scenario,
         success_check="Successful modification",
-        expected_results={(PlanningActivityResult.Completed, FlightPlanStatus.Planned)},
+        expected_results={
+            (PlanningActivityResult.Completed, FlightPlanStatus.Planned),
+            (
+                PlanningActivityResult.NotSupported,
+                FlightPlanStatus.Planned,
+            ),  # case where the USS does not support modification of flights
+        },
         failed_checks={PlanningActivityResult.Failed: "Failure"},
         flight_planner=flight_planner,
         flight_info=flight_info,
@@ -178,7 +184,11 @@ def modify_activated_flight(
             scenario=scenario,
             success_check="Successful modification",
             expected_results={
-                (PlanningActivityResult.Completed, FlightPlanStatus.OkToFly)
+                (PlanningActivityResult.Completed, FlightPlanStatus.OkToFly),
+                (
+                    PlanningActivityResult.NotSupported,
+                    FlightPlanStatus.OkToFly,
+                ),  # case where the USS does not support modification of flights
             },
             failed_checks={PlanningActivityResult.Failed: "Failure"},
             flight_planner=flight_planner,


### PR DESCRIPTION
See initial inquiry here: https://interuss.slack.com/archives/C05UVBHKQ0G/p1760626709666109

This PR updates flight planning test steps where the flight is modified so that the USS may return `PlanningActivityResult.NotSupported` without failing the test.

## Impact analysis
- No impact because test step is not supposed to successfully modify the flight:
  - `modify_planned_priority_conflict_flight`
  - `modify_activated_priority_conflict_flight`
  - `modify_planned_conflict_flight`
  - `modify_activated_conflict_flight`
- `modify_planned_flight`: [the only caller](https://github.com/interuss/monitoring/blob/ca9f01d53d95cd06e07b44277c5d0ca3a82e6bb9/monitoring/uss_qualifier/scenarios/astm/utm/subscription_notifications/receive_notifications_for_awareness/receive_notifications_for_awareness.py#L235) does so onto specifically a mock USS, which will not return `NotSupported`
- `modify_activated_flight`:
  - [first caller](https://github.com/interuss/monitoring/blob/3a6e5bbdda597cdd4266c3addd22202139c9a24a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.py#L451) already handles `NotSupported` response (since `preexisting_conflict=True` is used)
  - [second caller](https://github.com/interuss/monitoring/blob/3a6e5bbdda597cdd4266c3addd22202139c9a24a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_higher_priority/conflict_higher_priority.py#L486) is adapted in this PR to handle the `NotSupported` response, resulting in skipping the next (and last) step. This means that the USS in that case will not be able to validate SCD0030.

## Testing
Unfortunately none. We would probably need a separate mock USS which implements this behavior (i.e. not supporting flight modification) to do so. Inputs welcome on this topic. 