### PR TITLE
[uss_qualifier] introduce distance error tolerance for some DisplayProviderBehavior

### DIFF
--- a/monitoring/uss_qualifier/scenarios/scenario.py
+++ b/monitoring/uss_qualifier/scenarios/scenario.py
@@ -57,6 +57,12 @@ SQUELCH_WARN_ON_QUERY_TYPE = [
     QueryType.F3411v22aUSSGetFlightDetails,
 ]
 
+# Different spherical models have different precisions: implementations may use a different model
+# than uss_qualifier. We thus accept an error margin of 0.7% around distance limits and thresholds
+# to avoid failing USSes for minor differences in precision whenever the relevant standard is not
+# prescriptive in that regard.
+DISTANCE_ERROR_TOLERANCE_FRACTION = 0.007
+
 
 class ScenarioCannotContinueError(Exception):
     def __init__(self, msg):


### PR DESCRIPTION
Add an error margin when checking for specific USS behavior around specific thresholds, such as the maximum diagonal of an observed area.

This updates the display provider maximum allowed area observation

(Updating other checks such as the clustering thresholds require some unrelated adaptations and will happen in a separate PR)


## Notes

Some context from a [Slack thread](https://interuss.slack.com/archives/C05UVBHKQ0G/p1761237938960819?thread_ts=1760591518.131849&cid=C05UVBHKQ0G):

> [...] uss_qualifier's spherical approximation method is not as accurate as Vincenty's ellipsoidal approximation, so it indeed requests too large of a diagonal by the 1.9 meters noted.  This is a little unintuitive because uss_qualifier's spherical approximation is larger than the Vincenty ellipsoid, yet Vincenty produces a larger distance (and therefore we should expect uss_qualifier to overestimate distance, but instead it under estimates distance).  My understanding is that this is because the circles of the same latitude are sometimes larger on the ellipsoid even though the overall ellipsoid is smaller.
>
> [...] In general, when we're checking a limit X, we shouldn't send exactly X because systems differ in the computations and comparisons and therefore exact equality in floating points is never a good idea outside of special values like 0.  Instead, we should send X-sigma or X*(1-sigma) to check that values less than X are accepted, where sigma is a constant describing how large of a computation difference is acceptable.  In the case of distances, an LLM tells me the maximum distance error between uss_qualifier's less-correct spherical model and a more-correct ellipsoidal model like Vincenty is 0.674%.  So, we should pick a diagonal of 7000*(1-0.00674) meters to verify that participants accept large but valid diagonals.  (but probably round up a bit to account for other sources of computation difference, so perhaps use 0.7% instead)