### PR TITLE
[uss_qualifier/scenarios/utm/conflict_equal_prio] Delete Flight 1c if USS does not support modifications

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md
@@ -194,6 +194,11 @@ exist when the modification was initiated, it should be rejected per **[astm.f35
 Because the modification attempt was invalid, either Flight 1c should not have been modified (because the USS kept the
 original accepted request), or it should have been removed (because the USS rejected the replacement plan provided).
 
+### [Delete Flight 1c if USS did not support its modification test step](../../../../flight_planning/delete_flight_intent.md)
+If, during the previous step, the USS indicated that it does not support modifications, then it will not be able to
+modify Flight 1c into Flight 1 during the next test case. As such, the test driver deletes Flight 1c from the system so
+that Flight 1 can be created directly activated during the next test case.
+
 ### [Delete Flight 2 test step](../../../../flight_planning/delete_flight_intent.md)
 To prepare for the next test case, Flight 2 must be removed from the system.
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.py
@@ -383,7 +383,7 @@ class ConflictEqualPriorityNotPermitted(TestScenario):
             [flight1c_activated, flight1_activated],
             flight_1_oi_ref,
         ) as validator:
-            modify_activated_conflict_flight(
+            modify_resp = modify_activated_conflict_flight(
                 self,
                 self.tested_uss,
                 flight1_activated,
@@ -393,6 +393,16 @@ class ConflictEqualPriorityNotPermitted(TestScenario):
                 flight1c_activated, skip_if_not_found=True
             )
         self.end_test_step()
+
+        if modify_resp.activity_result == PlanningActivityResult.NotSupported:
+            self.begin_test_step(
+                "Delete Flight 1c if USS did not support its modification"
+            )
+            if self.flight1_id is None:
+                raise ValueError("flight1_id is None")
+            delete_flight(self, self.control_uss, self.flight1_id)
+            self.flight1_id = None
+            self.end_test_step()
 
         self.begin_test_step("Delete Flight 2")
         delete_flight(self, self.control_uss, self.flight2_id)
@@ -415,7 +425,7 @@ class ConflictEqualPriorityNotPermitted(TestScenario):
             flight1_activated,
             flight_1_oi_ref,
         ) as validator:
-            activate_flight(
+            _, self.flight1_id = activate_flight(
                 self,
                 self.tested_uss,
                 flight1_activated,


### PR DESCRIPTION
Fix #1264 

This implements 'phase 2' directly (https://github.com/interuss/monitoring/issues/1264#issuecomment-3452697117):
> A phase 1 fix of this can be to detect NotSupported for this operation and then not attempt the rest of the test case since the current approach to setting up the preconditions of the test case did not succeed. A phase 2 fix could be to set up the preconditions using a different method (delete flight, create new flight) if the current flight-modification approach is not supported.