### PR TITLE
[uss_qualifier/scenarios/utm/conflict_equal_prio_not_permitted] Fix deletion step: call tested USS instead of control USS

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.py
@@ -400,7 +400,7 @@ class ConflictEqualPriorityNotPermitted(TestScenario):
             )
             if self.flight1_id is None:
                 raise ValueError("flight1_id is None")
-            delete_flight(self, self.control_uss, self.flight1_id)
+            delete_flight(self, self.tested_uss, self.flight1_id)
             self.flight1_id = None
             self.end_test_step()
 


### PR DESCRIPTION
Fix issue introduced in #1268