### PR TITLE
[uss_qualifier/scenarios/utm/conflict_equal_priority_not_permitted] Allow USS to return 'NotSupported' upon Flight 1m modification

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.md
@@ -251,10 +251,13 @@ rejection of the modification does not constitute a violation of a requirement. 
 not result in a failure per **[interuss.automated_testing.flight_planning.ExpectedBehavior](../../../../../requirements/interuss/automated_testing/flight_planning.md)**.
 Nor should Flight 1 have been removed, because doing so would leave an aircraft in flight without any flight plan.
 
-#### 🛑 Successful modification or rejection check
-All flight intent data provided is correct and the USS should have either successfully modified the flight or rejected
-properly the modification per **[interuss.automated_testing.flight_planning.ExpectedBehavior](../../../../../requirements/interuss/automated_testing/flight_planning.md)**.
-If the USS indicates that the injection attempt failed, this check will fail.
+#### 🛑 Successful flight intent handling check
+All flight intent data provided is correct and the USS should have either:
+- successfully modified the flight; or
+- properly rejected the modification; or
+- indicated that it does not support modification
+per **[interuss.automated_testing.flight_planning.ExpectedBehavior](../../../../../requirements/interuss/automated_testing/flight_planning.md)**.
+In any other case, this check will fail.
 
 #### 🛑 Failure check
 All flight intent data provided was complete and correct. It should have been processed successfully, allowing the USS

--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/conflict_equal_priority_not_permitted/conflict_equal_priority_not_permitted.py
@@ -494,10 +494,11 @@ class ConflictEqualPriorityNotPermitted(TestScenario):
         ) as validator:
             resp_flight_1, _ = submit_flight(
                 scenario=self,
-                success_check="Successful modification or rejection",
+                success_check="Successful flight intent handling",
                 expected_results={
                     (PlanningActivityResult.Completed, FlightPlanStatus.OkToFly),
                     (PlanningActivityResult.Rejected, FlightPlanStatus.OkToFly),
+                    (PlanningActivityResult.NotSupported, FlightPlanStatus.OkToFly),
                 },
                 failed_checks={PlanningActivityResult.Failed: "Failure"},
                 flight_planner=self.tested_uss,
@@ -507,7 +508,10 @@ class ConflictEqualPriorityNotPermitted(TestScenario):
 
             if resp_flight_1.activity_result == PlanningActivityResult.Completed:
                 validator.expect_shared(flight1m_activated)
-            elif resp_flight_1.activity_result == PlanningActivityResult.Rejected:
+            elif resp_flight_1.activity_result in {
+                PlanningActivityResult.Rejected,
+                PlanningActivityResult.NotSupported,
+            }:
                 validator.expect_not_shared()
         self.end_test_step()
 


### PR DESCRIPTION
Stacked on top of #1267, please review only 7cca3edaeb18e87a7865c1b2c4f76a1fa99d23f7