### PR TITLE
[CI/mock_uss] Add optionnal 'modification of activated flight' behaviour

### DIFF
--- a/.github/workflows/monitoring-test.yml
+++ b/.github/workflows/monitoring-test.yml
@@ -18,6 +18,9 @@ jobs:
     name: ${{ inputs.name }} test
     permissions:
       contents: read
+    strategy:
+      matrix:
+        behaviour_activated_flights_editables: [true, false]
     steps:
     - name: Job information
       run: |
@@ -36,12 +39,12 @@ jobs:
     - name: Load monitoring image
       uses: ./.github/actions/load-image
     - name: Run ${{ inputs.name }} test
-      run: ${{ inputs.script }}
+      run: export MOCK_USS_BEHAVIOUR_ACTIVATED_FLIGHTS_EDITABLE=${{ matrix.behaviour_activated_flights_editables }} && ${{ inputs.script }}
     - name: Save containers and tracer logs as artifact
       if: always()
       uses: actions/upload-artifact@v5
       with:
-        name: monitoring-test-${{ inputs.name }}-logs
+        name: monitoring-test-${{ inputs.name }}-${{ matrix.behaviour_activated_flights_editables }}-logs
         path: |
           logs
           monitoring/mock_uss/output
@@ -49,7 +52,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v5
       with:
-        name: monitoring-test-${{ inputs.name }}-reports
+        name: monitoring-test-${{ inputs.name }}-${{ matrix.behaviour_activated_flights_editables }}-reports
         path: |
           monitoring/uss_qualifier/output
           monitoring/prober/output

--- a/monitoring/mock_uss/config.py
+++ b/monitoring/mock_uss/config.py
@@ -9,6 +9,9 @@ KEY_SERVICES = "MOCK_USS_SERVICES"
 KEY_DSS_URL = "MOCK_USS_DSS_URL"
 KEY_BEHAVIOR_LOCALITY = "MOCK_USS_BEHAVIOR_LOCALITY"
 KEY_CODE_VERSION = "MONITORING_VERSION"
+KEY_BEHAVIOUR_ACTIVATED_FLIGHTS_EDITABLES = (
+    "MOCK_USS_BEHAVIOUR_ACTIVATED_FLIGHTS_EDITABLE"
+)
 
 
 import_environment_variable(
@@ -27,3 +30,9 @@ import_environment_variable(
 import_environment_variable(KEY_DSS_URL, required=False)
 import_environment_variable(KEY_BEHAVIOR_LOCALITY, default="US.IndustryCollaboration")
 import_environment_variable(KEY_CODE_VERSION, default="Unknown")
+
+import_environment_variable(
+    KEY_BEHAVIOUR_ACTIVATED_FLIGHTS_EDITABLES,
+    default="true",
+    mutator=lambda s: s.lower() == "true",
+)

--- a/monitoring/mock_uss/docker-compose.yaml
+++ b/monitoring/mock_uss/docker-compose.yaml
@@ -21,6 +21,7 @@ services:
       - MOCK_USS_INTERACTIONS_LOG_DIR=output/scdsc_a_interaction_logs
       - MOCK_USS_PORT=80
       - MOCK_USS_PROXY_VALUES=x_for=1,x_proto=1,x_host=1,x_prefix=1,x_port=1
+      - MOCK_USS_BEHAVIOUR_ACTIVATED_FLIGHTS_EDITABLE
     expose:
       - 80
     ports:
@@ -52,6 +53,7 @@ services:
       - MOCK_USS_SERVICES=scdsc,versioning,flight_planning
       - MOCK_USS_PORT=80
       - MOCK_USS_PROXY_VALUES=x_for=1,x_proto=1,x_host=1,x_prefix=1,x_port=1
+      - MOCK_USS_BEHAVIOUR_ACTIVATED_FLIGHTS_EDITABLE
     expose:
       - 80
     ports:
@@ -78,6 +80,7 @@ services:
       - MOCK_USS_SERVICES=geoawareness
       - MOCK_USS_PORT=80
       - MOCK_USS_PROXY_VALUES=x_for=1,x_proto=1,x_host=1,x_prefix=1,x_port=1
+      - MOCK_USS_BEHAVIOUR_ACTIVATED_FLIGHTS_EDITABLE
     expose:
       - 80
     ports:
@@ -109,6 +112,7 @@ services:
       - MOCK_USS_RID_VERSION=F3411-22a
       - MOCK_USS_PORT=80
       - MOCK_USS_PROXY_VALUES=x_for=1,x_proto=1,x_host=1,x_prefix=1,x_port=1
+      - MOCK_USS_BEHAVIOUR_ACTIVATED_FLIGHTS_EDITABLE
     expose:
       - 80
     ports:
@@ -141,6 +145,7 @@ services:
       - MOCK_USS_RID_VERSION=F3411-22a
       - MOCK_USS_PORT=80
       - MOCK_USS_PROXY_VALUES=x_for=1,x_proto=1,x_host=1,x_prefix=1,x_port=1
+      - MOCK_USS_BEHAVIOUR_ACTIVATED_FLIGHTS_EDITABLE
     expose:
       - 80
     ports:
@@ -173,6 +178,7 @@ services:
       - MOCK_USS_RID_VERSION=F3411-19
       - MOCK_USS_PORT=80
       - MOCK_USS_PROXY_VALUES=x_for=1,x_proto=1,x_host=1,x_prefix=1,x_port=1
+      - MOCK_USS_BEHAVIOUR_ACTIVATED_FLIGHTS_EDITABLE
     expose:
       - 80
     ports:
@@ -205,6 +211,7 @@ services:
       - MOCK_USS_RID_VERSION=F3411-19
       - MOCK_USS_PORT=80
       - MOCK_USS_PROXY_VALUES=x_for=1,x_proto=1,x_host=1,x_prefix=1,x_port=1
+      - MOCK_USS_BEHAVIOUR_ACTIVATED_FLIGHTS_EDITABLE
     expose:
       - 80
     ports:
@@ -240,6 +247,7 @@ services:
       - MOCK_USS_SERVICES=tracer
       - MOCK_USS_PORT=80
       - MOCK_USS_PROXY_VALUES=x_for=1,x_proto=1,x_host=1,x_prefix=1,x_port=1
+      - MOCK_USS_BEHAVIOUR_ACTIVATED_FLIGHTS_EDITABLE
     expose:
       - 80
     ports:
@@ -274,6 +282,7 @@ services:
       - MOCK_USS_INTERACTIONS_LOG_DIR=output/scdsc_interaction_logs
       - MOCK_USS_PORT=80
       - MOCK_USS_PROXY_VALUES=x_for=1,x_proto=1,x_host=1,x_prefix=1,x_port=1
+      - MOCK_USS_BEHAVIOUR_ACTIVATED_FLIGHTS_EDITABLE
     expose:
       - 80
     ports:

--- a/monitoring/mock_uss/scd_injection/__init__.py
+++ b/monitoring/mock_uss/scd_injection/__init__.py
@@ -1,0 +1,4 @@
+from monitoring.mock_uss.app import require_config_value
+from monitoring.mock_uss.config import KEY_BEHAVIOUR_ACTIVATED_FLIGHTS_EDITABLES
+
+require_config_value(KEY_BEHAVIOUR_ACTIVATED_FLIGHTS_EDITABLES)

--- a/monitoring/mock_uss/scd_injection/routes_injection.py
+++ b/monitoring/mock_uss/scd_injection/routes_injection.py
@@ -19,7 +19,10 @@ from uas_standards.interuss.automated_testing.scd.v1.api import (
 
 from monitoring.mock_uss.app import require_config_value, webapp
 from monitoring.mock_uss.auth import requires_scope
-from monitoring.mock_uss.config import KEY_BASE_URL
+from monitoring.mock_uss.config import (
+    KEY_BASE_URL,
+    KEY_BEHAVIOUR_ACTIVATED_FLIGHTS_EDITABLES,
+)
 from monitoring.mock_uss.dynamic_configuration.configuration import get_locality
 from monitoring.mock_uss.f3548v21 import utm_client
 from monitoring.mock_uss.f3548v21.flight_planning import (
@@ -177,6 +180,14 @@ def inject_flight(
         validate_request(new_flight.op_intent)
     except PlanningError as e:
         return unsuccessful(PlanningActivityResult.Rejected, str(e))
+
+    if (
+        not webapp.config[KEY_BEHAVIOUR_ACTIVATED_FLIGHTS_EDITABLES]
+        and old_status == FlightPlanStatus.OkToFly
+    ):
+        return unsuccessful(
+            PlanningActivityResult.NotSupported, "Unable to modify an activated flight"
+        )
 
     step_name = "performing unknown operation"
     notes: str | None = None


### PR DESCRIPTION
Proposition for #1276 for start to have multiple mock_uss behaviour.

A few things to notice:

- I tried with "USS may not support modification of an activated flight", I do hope it's implemented correctly.
- I started a matrix, but this may explode into a lots of jobs, should we want to test each individual behavior with each others (2^behaviors * tests). We could also want to test only one behavior at a time, but that won't cover all cased
- Seems tests are broken with new behavior ^^'