### PR TITLE
[tooling] Move dev tools to a specifc group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       run: make image
     - name: Save monitoring image artifact
       run: |
-        docker save interuss/monitoring -o monitoring-image.tar
+        docker save interuss/monitoring interuss/monitoring-dev -o monitoring-image.tar
         mkdir -p image-artifact/monitoring
         mv monitoring-image.tar image-artifact/
         cp monitoring/image image-artifact/monitoring/

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,9 @@ endif
 
 .PHONY: format
 format: image
-	docker run --rm -u ${USER_GROUP} -v "$(CURDIR):/app" -w /app interuss/monitoring uv run ruff format
-	docker run --rm -u ${USER_GROUP} -v "$(CURDIR):/app" -w /app interuss/monitoring uv run ruff check --fix
-	docker run --rm -u ${USER_GROUP} -v "$(CURDIR):/app" -w /app interuss/monitoring uv run basedpyright
+	docker run --rm -u ${USER_GROUP} -v "$(CURDIR):/app" -w /app interuss/monitoring-dev uv run ruff format
+	docker run --rm -u ${USER_GROUP} -v "$(CURDIR):/app" -w /app interuss/monitoring-dev uv run ruff check --fix
+	docker run --rm -u ${USER_GROUP} -v "$(CURDIR):/app" -w /app interuss/monitoring-dev uv run basedpyright
 	cd monitoring && make format
 	cd schemas && make format
 
@@ -29,10 +29,10 @@ check-hygiene: image lint validate-uss-qualifier-docs
 .PHONY: python-lint
 python-lint: image
 
-	docker run --rm -u ${USER_GROUP} -v "$(CURDIR):/app" -w /app interuss/monitoring uv run ruff format --check || (echo "Linter didn't succeed. You can use the following command to fix python linter issues: make format" && exit 1)
-	docker run --rm -u ${USER_GROUP} -v "$(CURDIR):/app" -w /app interuss/monitoring uv run ruff check || (echo "Linter didn't succeed. You can use the following command to fix python linter issues: make format" && exit 1)
+	docker run --rm -u ${USER_GROUP} -v "$(CURDIR):/app" -w /app interuss/monitoring-dev uv run ruff format --check || (echo "Linter didn't succeed. You can use the following command to fix python linter issues: make format" && exit 1)
+	docker run --rm -u ${USER_GROUP} -v "$(CURDIR):/app" -w /app interuss/monitoring-dev uv run ruff check || (echo "Linter didn't succeed. You can use the following command to fix python linter issues: make format" && exit 1)
 	shasum -b -a 256 .basedpyright/baseline.json > /tmp/baseline-before.hash
-	docker run --rm -u ${USER_GROUP} -v "$(CURDIR):/app" -w /app interuss/monitoring uv run basedpyright || (echo "Typing check didn't succeed. Please fix issue and run make format to validate changes." && exit 1)
+	docker run --rm -u ${USER_GROUP} -v "$(CURDIR):/app" -w /app interuss/monitoring-dev uv run basedpyright || (echo "Typing check didn't succeed. Please fix issue and run make format to validate changes." && exit 1)
 	shasum -b -a 256 .basedpyright/baseline.json > /tmp/baseline-after.hash
 	diff /tmp/baseline-before.hash /tmp/baseline-after.hash || (echo "Basedpyright baseline changed, probably dues to issues that have been cleanup. Use the following command to update baseline: make format" && exit 1)
 

--- a/monitoring/Dockerfile
+++ b/monitoring/Dockerfile
@@ -9,15 +9,14 @@
 #
 # This image is intended to be built from the repository root context/folder.
 
-FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim AS base
 # Not -alpine because: https://stackoverflow.com/a/58028091/651139
 
 # Install system tools
 #   openssl: Provides TLS tools
 #   curl: Useful debugging utility
-#   gcc: Required to build various packages
 #   ca-certificates: Needed to accurately validate TLS connections
-RUN apt-get update --fix-missing && apt-get install -y make openssl curl libgeos-dev gcc g++ && apt-get install ca-certificates
+RUN apt-get update --fix-missing && apt-get install -y make openssl curl && apt-get install ca-certificates
 
 # Required to build in an ARM environment
 #   gevent: libffi-dev libssl-dev python3-dev build-essential
@@ -80,3 +79,12 @@ ENV GIT_COMMIT_HASH=$commit_hash
 
 # No entry point maximizes flexibility in the use of this image
 ENTRYPOINT []
+
+FROM base AS with-dev-dependencies
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=./uv.lock,target=/app/uv.lock \
+    --mount=type=bind,source=./pyproject.toml,target=/app/pyproject.toml \
+    cd /app/ && \
+    unset UV_FROZEN && \
+    uv sync --locked --no-install-project --compile-bytecode --group dev

--- a/monitoring/build.sh
+++ b/monitoring/build.sh
@@ -19,6 +19,16 @@ docker image build \
     -t "${TAG}" \
     --build-arg version="$(scripts/git/version.sh monitoring --long)" \
     --build-arg commit_hash="$(git rev-parse HEAD)" \
+    --target base \
+    . \
+  || exit 1
+
+docker image build \
+    -f monitoring/Dockerfile \
+    -t "${TAG}-dev" \
+    --build-arg version="$(scripts/git/version.sh monitoring --long)" \
+    --build-arg commit_hash="$(git rev-parse HEAD)" \
+    --target with-dev-dependencies \
     . \
   || exit 1
 echo "File created by monitoring/build.sh to keep track of the latest build run date time." > monitoring/image

--- a/monitoring/uss_qualifier/scripts/run_unit_tests.sh
+++ b/monitoring/uss_qualifier/scripts/run_unit_tests.sh
@@ -24,5 +24,5 @@ docker run --name uss_qualifier_unit_test \
   -e MONITORING_GITHUB_ROOT=${MONITORING_GITHUB_ROOT:-} \
   -v "$(pwd):/app" \
   -v /var/run/docker.sock:/var/run/docker.sock \
-  interuss/monitoring \
+  interuss/monitoring-dev \
   uss_qualifier/scripts/in_container/run_unit_tests.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ requires-python = "==3.13.5"
 dependencies = [
     "aiohttp",
     "arrow",
-    "basedpyright>=1.31.1",
     "bc-jsonpath-ng",
     "cryptography",
     "deprecation",
@@ -38,11 +37,8 @@ dependencies = [
     "pykml",
     "pyopenssl",
     "pyproj",
-    "pytest",
-    "pytest-mock",
     "pyyaml",
     "requests",
-    "ruff",
     "s2sphere",
     "scipy",
     "shapely",
@@ -52,6 +48,18 @@ dependencies = [
     "uas-standards",
     "uuid6",
 ]
+
+[dependency-groups]
+dev = [
+    "basedpyright>=1.31.1",
+    "pytest",
+    "pytest-mock",
+    "ruff",
+    "types-lxml>=2025.8.25",
+]
+
+[tool.uv]
+default-groups = []
 
 [tool.ruff]
 target-version = "py313"
@@ -79,9 +87,4 @@ exclude = [
   "monitoring/prober/output/*",
   "monitoring/mock_uss/output/*",
   "monitoring/uss_qualifier/output/*",
-]
-
-[dependency-groups]
-dev = [
-    "types-lxml>=2025.8.25",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -559,6 +559,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
     { url = "https://files.pythonhosted.org/packages/a2/15/0d5e4e1a66fab130d98168fe984c509249c833c1a3c16806b90f253ce7b9/greenlet-3.2.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:d25c5091190f2dc0eaa3f950252122edbbadbb682aa7b1ef2f8af0f8c0afefae", size = 1149210, upload-time = "2025-08-07T13:18:24.072Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/53/f9c440463b3057485b8594d7a638bed53ba531165ef0ca0e6c364b5cc807/greenlet-3.2.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6e343822feb58ac4d0a1211bd9399de2b3a04963ddeec21530fc426cc121f19b", size = 1564759, upload-time = "2025-11-04T12:42:19.395Z" },
+    { url = "https://files.pythonhosted.org/packages/47/e4/3bb4240abdd0a8d23f4f88adec746a3099f0d86bfedb623f063b2e3b4df0/greenlet-3.2.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ca7f6f1f2649b89ce02f6f229d7c19f680a6238af656f61e0115b24857917929", size = 1634288, upload-time = "2025-11-04T12:42:21.174Z" },
     { url = "https://files.pythonhosted.org/packages/0b/55/2321e43595e6801e105fcfdee02b34c0f996eb71e6ddffca6b10b7e1d771/greenlet-3.2.4-cp313-cp313-win_amd64.whl", hash = "sha256:554b03b6e73aaabec3745364d6239e9e012d64c68ccd0b8430c64ccc14939a8b", size = 299685, upload-time = "2025-08-07T13:24:38.824Z" },
 ]
 
@@ -853,7 +855,6 @@ source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "arrow" },
-    { name = "basedpyright" },
     { name = "bc-jsonpath-ng" },
     { name = "cryptography" },
     { name = "deprecation" },
@@ -884,11 +885,8 @@ dependencies = [
     { name = "pykml" },
     { name = "pyopenssl" },
     { name = "pyproj" },
-    { name = "pytest" },
-    { name = "pytest-mock" },
     { name = "pyyaml" },
     { name = "requests" },
-    { name = "ruff" },
     { name = "s2sphere" },
     { name = "scipy" },
     { name = "shapely" },
@@ -901,6 +899,10 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "basedpyright" },
+    { name = "pytest" },
+    { name = "pytest-mock" },
+    { name = "ruff" },
     { name = "types-lxml" },
 ]
 
@@ -908,7 +910,6 @@ dev = [
 requires-dist = [
     { name = "aiohttp" },
     { name = "arrow" },
-    { name = "basedpyright", specifier = ">=1.31.1" },
     { name = "bc-jsonpath-ng" },
     { name = "cryptography" },
     { name = "deprecation" },
@@ -939,11 +940,8 @@ requires-dist = [
     { name = "pykml" },
     { name = "pyopenssl" },
     { name = "pyproj" },
-    { name = "pytest" },
-    { name = "pytest-mock" },
     { name = "pyyaml" },
     { name = "requests" },
-    { name = "ruff" },
     { name = "s2sphere" },
     { name = "scipy" },
     { name = "shapely" },
@@ -955,7 +953,13 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "types-lxml", specifier = ">=2025.8.25" }]
+dev = [
+    { name = "basedpyright", specifier = ">=1.31.1" },
+    { name = "pytest" },
+    { name = "pytest-mock" },
+    { name = "ruff" },
+    { name = "types-lxml", specifier = ">=2025.8.25" },
+]
 
 [[package]]
 name = "msgpack"


### PR DESCRIPTION
- Remove dev tools (like ruff) from base image.
- Build a second image with dev tools
- Use that second image to run unit test and hygiene
- Remove useless apt package installed image the image


Fix #1121 