### PR TITLE
[datastore_access] split crdb and ybdb logic; correct ybdb implementotion

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -6934,24 +6934,6 @@
                 }
             }
         ],
-        "./monitoring/uss_qualifier/resources/interuss/datastore/datastore.py": [
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./monitoring/uss_qualifier/resources/interuss/id_generator.py": [
             {
                 "code": "reportAssignmentType",

--- a/monitoring/uss_qualifier/resources/interuss/datastore/__init__.py
+++ b/monitoring/uss_qualifier/resources/interuss/datastore/__init__.py
@@ -1,4 +1,7 @@
 from .datastore import (
+    CockroachDBNode as CockroachDBNode,
+)
+from .datastore import (
     DatastoreDBClusterResource as DatastoreDBClusterResource,
 )
 from .datastore import (
@@ -6,4 +9,7 @@ from .datastore import (
 )
 from .datastore import (
     DatastoreDBNodeResource as DatastoreDBNodeResource,
+)
+from .datastore import (
+    YugabyteDBNode as YugabyteDBNode,
 )

--- a/monitoring/uss_qualifier/resources/interuss/datastore/datastore.py
+++ b/monitoring/uss_qualifier/resources/interuss/datastore/datastore.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import socket
+import ssl
+from abc import ABC, abstractmethod
 
 import psycopg
 from implicitdict import ImplicitDict
@@ -18,6 +20,9 @@ class DatastoreDBNodeSpecification(ImplicitDict):
     port: int
     """Port to which DatastoreDB node is listening to."""
 
+    is_yugabyte: bool = False
+    """True if DatastoreDB node is a YugabyteDB node."""
+
     def __init__(self, *args, **kwargs):
         super().__init__(**kwargs)
 
@@ -34,7 +39,13 @@ class DatastoreDBNodeResource(Resource[DatastoreDBNodeSpecification]):
         self._specification = specification
 
     def get_client(self) -> DatastoreDBNode:
-        return DatastoreDBNode(
+        if self._specification.is_yugabyte:
+            return YugabyteDBNode(
+                self._specification.participant_id,
+                self._specification.host,
+                self._specification.port,
+            )
+        return CockroachDBNode(
             self._specification.participant_id,
             self._specification.host,
             self._specification.port,
@@ -69,7 +80,9 @@ class DatastoreDBClusterResource(Resource[DatastoreDBClusterSpecification]):
         ]
 
 
-class DatastoreDBNode:
+class DatastoreDBNode(ABC):
+    _NOT_IMPLEMENTED_MSG = "All methods of base DatastoreDBNode class must be implemented by each specific subclass"
+
     participant_id: str
     host: str
     port: int
@@ -84,7 +97,73 @@ class DatastoreDBNode:
         self.host = host
         self.port = port
 
-    def connect(self, **kwargs) -> psycopg.Connection:
+    def build_socket(self) -> socket.socket:
+        return socket.create_connection(
+            (self.host, self.port),
+            timeout=5,
+        )
+
+    def is_reachable(self) -> tuple[bool, Exception | None]:
+        """This is detected by attempting to open a socket with the node."""
+        try:
+            sock = self.build_socket()
+            sock.close()
+            return True, None
+        except (TimeoutError, ConnectionError) as e:
+            return False, e
+
+    @abstractmethod
+    def no_tls_rejected(self) -> tuple[bool, Exception | None]:
+        """Returns True if the node rejects cleartext communications."""
+        raise NotImplementedError(DatastoreDBNode._NOT_IMPLEMENTED_MSG)
+
+    @abstractmethod
+    def unauthenticated_rejected(self) -> tuple[bool, Exception | None]:
+        """Returns True if the node rejects unauthenticated communications."""
+        raise NotImplementedError(DatastoreDBNode._NOT_IMPLEMENTED_MSG)
+
+    @abstractmethod
+    def legacy_tls_version_rejected(self) -> tuple[bool, Exception | None]:
+        """Returns True if the node rejects the usage of the legacy cryptographic protocols TLSv1 and TLSv1.1."""
+        raise NotImplementedError(DatastoreDBNode._NOT_IMPLEMENTED_MSG)
+
+    def build_client_hello(self):
+        """Builds a client hello"""
+
+        return bytes.fromhex(
+            "16"  # Handshake
+            "0301"  # TLS Version: 1.0
+            "0063"  # Length
+            "01"  # Handshake type: Client hello
+            "00005f"  # Length
+            "0302"  # TLS Version: 1.1
+            "4895335bae2d2d929e34bdd5ccc89d800807bb01bbaaa7bf86efbb83a9249206"  # Random value
+            "00"  # Session ID Length
+            "0012"  # Cipher suite Length
+            "c00ac0140039c009c01300330035002f00ff"  # Cipher suites
+            "01"  # Compression method length
+            "00"  # No compression
+            "0024"  # Extentions length
+            "000b000403000102000a000c000a001d0017001e00190018002300000016000000170000"  # Extensions
+        )
+
+    def is_protocol_failure(self, data):
+        """Tests whether the server sends a protocol failure."""
+        # Format:
+        # 15     TLS Alert
+        # 03 01  TLS Version (Ignored)
+        # 00 02  Length (Ignored)
+        # 02     Level: Fatal (Ignored)
+        # 46     Description: Protocol version
+
+        content_type = data[0]
+        alert_description = data[6]
+
+        return content_type == 0x15 and alert_description == 0x46
+
+
+class CockroachDBNode(DatastoreDBNode):
+    def _connect(self, **kwargs) -> psycopg.Connection:
         return psycopg.connect(
             host=self.host,
             port=self.port,
@@ -92,53 +171,118 @@ class DatastoreDBNode:
             **kwargs,
         )
 
-    def is_reachable(self) -> tuple[bool, psycopg.Error | None]:
-        """
-        Returns True if the node is reachable.
-        This is detected by attempting to establish a connection with the node
-        not requiring encryption and validating either 1) that the connection
-        fails with the error message reporting that the authentication failed;
-        or 2) that the connection succeeds.
-        """
+    def no_tls_rejected(self) -> tuple[bool, Exception | None]:
         try:
-            c = self.connect(
+            c = self._connect(sslmode="disable")
+            c.close()
+        except psycopg.OperationalError as e:
+            err_msg = str(e)
+            did_reject = "node is running secure mode" in err_msg
+            return did_reject, e
+        return False, Exception("Connection was successful")
+
+    def unauthenticated_rejected(self) -> tuple[bool, Exception | None]:
+        try:
+            c = self._connect(
                 sslmode="prefer", require_auth="password", password="dummy"
             )
             c.close()
         except psycopg.OperationalError as e:
             err_msg = str(e)
-            # First message is returned if password authentication is enabled
-            # (CockroachDB), second one if not (Yugabyte use certificates)
-            is_reachable = (
+            did_reject = (
                 "password authentication failed" in err_msg
                 or "server did not complete authentication" in err_msg
                 or "server requested a hashed password" in err_msg
             )
-            return is_reachable, e
-        return True, None
+            return did_reject, e
+        return False, Exception("Connection was successful")
 
-    def runs_in_secure_mode(self) -> tuple[bool, psycopg.Error | None]:
+    def legacy_tls_version_rejected(self) -> tuple[bool, Exception | None]:
         """
-        Returns True if the node is running in secure mode.
         This is detected by attempting to establish a connection with the node
-        in insecure mode and validating that the connection fails with the error
-        message reporting that the node is running in secure mode.
-        """
-        try:
-            c = self.connect(sslmode="disable")
-            c.close()
-        except psycopg.OperationalError as e:
-            err_msg = str(e)
-            # First message is returned by CockroachDB, second one by Yugabyte
-            # (No hba entries for authentication outside SSL)
-            secure_mode = (
-                "node is running secure mode" in err_msg
-                or "no pg_hba.conf entry for host" in err_msg
-            )
-            return secure_mode, e
-        return False, None
+        forcing the client to use a TLS version < 1.2 and validating that the
+        connection fails with the expected error message.
 
-    def legacy_ssl_version_rejected(self) -> tuple[bool, psycopg.Error | None]:
+        Modern libraries and Python have dropped support for TLS versions older than 1.2, as these are now considered legacy.
+
+        To be able to test those old protocols, we manually send TLS packets (captured from legacy code) and parse the result.
+        Parsing is limited, but should be good enough for our cases.
+        """
+
+        try:
+            with self.build_socket() as sock:
+                sock.sendall(bytes.fromhex("0000000804d2162f"))  # Postgres hello
+                sock.recv(16)
+                sock.sendall(self.build_client_hello())
+                data = sock.recv(1024)
+
+                if not data:
+                    return False, Exception("No response from server")
+
+                return self.is_protocol_failure(data), None
+        except Exception as e:
+            return False, e
+
+
+class YugabyteDBNode(DatastoreDBNode):
+    @classmethod
+    def _build_dummy_rpc_request(cls):
+        """Builds an RPC request for service 'yb.master.MasterService', method 'GetMasterRegistration' with call ID '5'.
+        Reference: https://gruchalski.com/posts/2022-02-12-a-brief-look-at-yugabytedb-rpc-api/"""
+
+        return bytes.fromhex(
+            "594201"  # 'YB1' preamble
+            "0000003a"  # message byte length
+            "38"  # request header protobuf message length
+            "0805"  # field 1: call_id
+            "12300a1779622e6d61737465722e4d61737465725365727669636512154765744d6173746572526567697374726174696f6e"  # field 2: remote_method (service_name = 'yb.master.MasterService', method_name = 'GetMasterRegistration')
+            "18e0d403"  # field 3: timeout_millis
+            "00"  # request payload protobuf message length (no payload)
+        )
+
+    def _attempt_insecure_request(
+        self, with_tls: bool
+    ) -> tuple[bool, Exception | None]:
+        sock = self.build_socket()  # we expect node to be reachable
+        if with_tls:
+            ctx = ssl.create_default_context()
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
+            try:
+                sock = ctx.wrap_socket(sock)
+                sock.do_handshake(block=True)
+            except ssl.SSLError as e:
+                # if we fail to create the SSL context: insecure
+                sock.close()
+                return False, e
+
+        sock.sendall(self._build_dummy_rpc_request())
+        msg_size_bytes = sock.recv(4)  # message byte length (32-bits integer)
+        if len(msg_size_bytes) == 0:
+            # server closed connection upon receiving a valid RPC through insecure channel: secure
+            sock.close()
+            return True, None
+
+        # server did not close connection: read response, msg_bytes is expected to look like:
+        # 04 # protobuf message length (response header)
+        # 0805 # field 1: call_id
+        # 1000 # field 2: is_error
+        # 8701 # protobuf message length (response payload)
+        # 0a34... # protobuf response payload
+        msg_size = int.from_bytes(msg_size_bytes, byteorder="big")
+        msg_bytes = sock.recv(msg_size)
+        sock.close()
+        return False, Exception(
+            f"Received RPC response from node, hex: {bytes.hex(msg_bytes)}"
+        )
+
+    def no_tls_rejected(self) -> tuple[bool, Exception | None]:
+        return self._attempt_insecure_request(with_tls=False)
+
+    def unauthenticated_rejected(self) -> tuple[bool, Exception | None]:
+        return self._attempt_insecure_request(with_tls=True)
+
+    def legacy_tls_version_rejected(self) -> tuple[bool, Exception | None]:
         """
         Returns True if the node rejects the usage of the legacy cryptographic
         protocols TLSv1 and TLSv1.1.
@@ -152,50 +296,14 @@ class DatastoreDBNode:
         Parsing is limited, but should be good enough for our cases.
         """
 
-        def _build_client_hello():
-            """Builds a client hello"""
-
-            return bytes.fromhex(
-                "16"  # Handshake
-                "0301"  # TLS Version: 1.0
-                "0063"  # Length
-                "01"  # Handshake type: Client hello
-                "00005f"  # Length
-                "0302"  # TLS Version: 1.1
-                "4895335bae2d2d929e34bdd5ccc89d800807bb01bbaaa7bf86efbb83a9249206"  # Random value
-                "00"  # Session ID Length
-                "0012"  # Cipher suite Length
-                "c00ac0140039c009c01300330035002f00ff"  # Cipher suites
-                "01"  # Compression method length
-                "00"  # No compression
-                "0024"  # Extentions length
-                "000b000403000102000a000c000a001d0017001e00190018002300000016000000170000"  # Extensions
-            )
-
-        def _is_protocol_failure(data):
-            """Tests whether the server sends a protocol failure."""
-            # Format:
-            # 15     TLS Alert
-            # 03 01  TLS Version (Ignored)
-            # 00 02  Length (Ignored)
-            # 02     Level: Fatal (Ignored)
-            # 46     Description: Protocol version
-
-            content_type = data[0]
-            alert_description = data[6]
-
-            return content_type == 0x15 and alert_description == 0x46
-
         try:
-            with socket.create_connection((self.host, self.port), timeout=5) as sock:
-                sock.sendall(bytes.fromhex("0000000804d2162f"))  # Postgres hello
-                sock.recv(16)
-                sock.sendall(_build_client_hello())
+            with self.build_socket() as sock:
+                sock.sendall(self.build_client_hello())
                 data = sock.recv(1024)
 
                 if not data:
-                    return False, "No response from server"
+                    return True, None  # Server will close the connection without reply
 
-                return _is_protocol_failure(data), None
+                return self.is_protocol_failure(data), None
         except Exception as e:
-            return False, str(e)
+            return False, e

--- a/monitoring/uss_qualifier/resources/interuss/datastore/datastore_test.py
+++ b/monitoring/uss_qualifier/resources/interuss/datastore/datastore_test.py
@@ -2,50 +2,65 @@ import pytest
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.wait_strategies import LogMessageWaitStrategy
 
-from . import DatastoreDBNode
+from . import CockroachDBNode, YugabyteDBNode
+
+COCKROACHDB_IMAGE = "cockroachdb/cockroach:v24.1.3"
+INSECURE_COCKROACHDB_IMAGE = "interuss/insecurecockroach:latest"
+YUGABYTE_IMAGE = "interuss/yugabyte:2025.1.2.1-interuss"
+INSECURE_YUGABYTE_IMAGE = "yugabytedb/yugabyte:2.25.2.0-b359"
 
 
 @pytest.fixture(scope="module")
 def good_cockroach(request):
     server = DockerContainer(
-        image="cockroachdb/cockroach:v24.1.3",
+        image=COCKROACHDB_IMAGE,
         ports=[26257],
         command="start-single-node",
     )
     server.waiting_for(LogMessageWaitStrategy("start_node_query"))
     server.start()
 
-    return DatastoreDBNode(
+    return CockroachDBNode(
         "test", server.get_container_host_ip(), server.get_exposed_port(26257)
     )
 
 
 @pytest.fixture(scope="module")
-def no_ssl_cockroach(request):
+def not_running_cockroach(request):
+    return CockroachDBNode("test", "127.0.0.1", 1)
+
+
+@pytest.fixture(scope="module")
+def not_running_yugabyte(request):
+    return YugabyteDBNode("test", "127.0.0.1", 1)
+
+
+@pytest.fixture(scope="module")
+def no_tls_cockroach(request):
     server = DockerContainer(
-        image="cockroachdb/cockroach:v24.1.3",
+        image=COCKROACHDB_IMAGE,
         ports=[26257],
         command="start-single-node --insecure",
     )
     server.waiting_for(LogMessageWaitStrategy("start_node_query"))
     server.start()
 
-    return DatastoreDBNode(
+    return CockroachDBNode(
         "test", server.get_container_host_ip(), server.get_exposed_port(26257)
     )
 
 
 @pytest.fixture(scope="module")
-def old_ssl_cockroach(request):
+def old_tls_cockroach(request):
     server = DockerContainer(
-        image="interuss/insecurecockroach:latest",
+        image=INSECURE_COCKROACHDB_IMAGE,
         ports=[26257],
         command="start-single-node",
     )
     server.waiting_for(LogMessageWaitStrategy("start_node_query"))
     server.start()
 
-    return DatastoreDBNode(
+    return CockroachDBNode(
         "test", server.get_container_host_ip(), server.get_exposed_port(26257)
     )
 
@@ -53,25 +68,42 @@ def old_ssl_cockroach(request):
 @pytest.fixture(scope="module")
 def good_yugabyte(request):
     server = DockerContainer(
-        image="yugabytedb/yugabyte:2.25.2.0-b359",
-        ports=[5433],
-        command='bash -c "bin/yugabyted cert generate_server_certs --base_dir /yugabyte/certs --hostnames `hostname`  && bin/yugabyted start --secure --certs_dir=/yugabyte/certs/generated_certs/`hostname` --advertise_address=`hostname` --background=false"',
+        image=YUGABYTE_IMAGE,
+        ports=[7100],
+        command='bash -c "bin/yugabyted cert generate_server_certs --base_dir /yugabyte/certs --hostnames `hostname` && bin/yugabyted start --secure --certs_dir=/yugabyte/certs/generated_certs/`hostname` --advertise_address=`hostname` --background=false --tserver_flags=node_to_node_encryption_use_client_certificates=true --master_flags=node_to_node_encryption_use_client_certificates=true,use_node_to_node_encryption=true"',
     )
     server.waiting_for(
         LogMessageWaitStrategy("Data placement constraint successfully verified")
     )
     server.start()
 
-    return DatastoreDBNode(
-        "test", server.get_container_host_ip(), server.get_exposed_port(5433)
+    return YugabyteDBNode(
+        "test", server.get_container_host_ip(), server.get_exposed_port(7100)
     )
 
 
 @pytest.fixture(scope="module")
-def no_ssl_yugabyte(request):
+def yugabyte_without_client_auth(request):
     server = DockerContainer(
-        image="yugabytedb/yugabyte:2.25.2.0-b359",
-        ports=[5433],
+        image=INSECURE_YUGABYTE_IMAGE,
+        ports=[7100],
+        command='bash -c "bin/yugabyted cert generate_server_certs --base_dir /yugabyte/certs --hostnames `hostname` && bin/yugabyted start --secure --certs_dir=/yugabyte/certs/generated_certs/`hostname` --advertise_address=`hostname` --background=false"',
+    )
+    server.waiting_for(
+        LogMessageWaitStrategy("Data placement constraint successfully verified")
+    )
+    server.start()
+
+    return YugabyteDBNode(
+        "test", server.get_container_host_ip(), server.get_exposed_port(7100)
+    )
+
+
+@pytest.fixture(scope="module")
+def no_tls_yugabyte(request):
+    server = DockerContainer(
+        image=INSECURE_YUGABYTE_IMAGE,
+        ports=[7100],
         command="bin/yugabyted start --background=false",
     )
     server.waiting_for(
@@ -79,108 +111,163 @@ def no_ssl_yugabyte(request):
     )
     server.start()
 
-    return DatastoreDBNode(
-        "test", server.get_container_host_ip(), server.get_exposed_port(5433)
-    )
-
-
-@pytest.fixture(scope="module")
-def old_ssl_yugabyte(request):
-    import base64
-
-    config = '{"tserver_flags": "ysql_pg_conf_csv=\\"ssl_min_protocol_version=\'TLSv1.1\'\\""}'
-    config = base64.b64encode(config.encode("utf-8"))  # Avoid escaping hell
-
-    server = DockerContainer(
-        image="yugabytedb/yugabyte:2.25.2.0-b359",
-        ports=[5433],
-        command=f'bash -c "echo {config.decode("utf-8")} | base64 -d > /conf.conf && cat /conf.conf && bin/yugabyted cert generate_server_certs --base_dir /yugabyte/certs --hostnames `hostname` && bin/yugabyted start --secure --certs_dir=/yugabyte/certs/generated_certs/`hostname` --advertise_address=`hostname` --background=false --conf /conf.conf"',
-    )
-    server.waiting_for(
-        LogMessageWaitStrategy("Data placement constraint successfully verified")
-    )
-    server.start()
-
-    return DatastoreDBNode(
-        "test", server.get_container_host_ip(), server.get_exposed_port(5433)
+    return YugabyteDBNode(
+        "test", server.get_container_host_ip(), server.get_exposed_port(7100)
     )
 
 
 def test_datastoredbmode_connect_good_cockroach(good_cockroach):
     is_reachable, _ = good_cockroach.is_reachable()
-    assert is_reachable
+    assert is_reachable, "Running CockroachDB server shall be reachable"
 
 
 def test_datastoredbmode_connect_good_yugabyte(good_yugabyte):
     is_reachable, _ = good_yugabyte.is_reachable()
-    assert is_reachable
+    assert is_reachable, "Running Yugabyte server shall be reachable"
 
 
-def test_datastoredbmode_connect_no_ssl_cockroach(no_ssl_cockroach):
-    is_reachable, _ = no_ssl_cockroach.is_reachable()
-    assert is_reachable
+def test_datastoredbmode_connect_yugabyte_without_client_auth(
+    yugabyte_without_client_auth,
+):
+    is_reachable, _ = yugabyte_without_client_auth.is_reachable()
+    assert is_reachable, "Running Yugabyte server shall be reachable"
 
 
-def test_datastoredbmode_connect_no_ssl_yugabyte(no_ssl_yugabyte):
-    is_reachable, _ = no_ssl_yugabyte.is_reachable()
-    assert is_reachable
+def test_datastoredbmode_connect_no_tls_cockroach(no_tls_cockroach):
+    is_reachable, _ = no_tls_cockroach.is_reachable()
+    assert is_reachable, "Running CockroachDB server shall be reachable"
 
 
-def test_datastoredbmode_connect_old_ssl_cockroach(old_ssl_cockroach):
-    is_reachable, _ = old_ssl_cockroach.is_reachable()
-    assert is_reachable
+def test_datastoredbmode_connect_no_tls_yugabyte(no_tls_yugabyte):
+    is_reachable, _ = no_tls_yugabyte.is_reachable()
+    assert is_reachable, "Running Yugabyte server shall be reachable"
 
 
-def test_datastoredbmode_connect_old_ssl_yugabyte(old_ssl_yugabyte):
-    is_reachable, _ = old_ssl_yugabyte.is_reachable()
-    assert is_reachable
+def test_datastoredbmode_connect_not_running_cockroach(not_running_cockroach):
+    is_reachable, _ = not_running_cockroach.is_reachable()
+    assert not is_reachable, "Non-running CockroachDB server shall not be reachable"
 
 
-def test_datastoredbmode_secure_mode_good_cockroach(good_cockroach):
-    is_secure, _ = good_cockroach.runs_in_secure_mode()
-    assert is_secure
+def test_datastoredbmode_connect_not_running_yugabyte(not_running_yugabyte):
+    is_reachable, _ = not_running_yugabyte.is_reachable()
+    assert not is_reachable, "Non-running Yugabyte server shall not be reachable"
 
 
-def test_datastoredbmode_secure_mode_good_yugabyte(good_yugabyte):
-    is_secure, _ = good_yugabyte.runs_in_secure_mode()
-    assert is_secure
+def test_datastoredbmode_no_tls_rejected_good_cockroach(good_cockroach):
+    no_tls_rejected, _ = good_cockroach.no_tls_rejected()
+    assert no_tls_rejected, (
+        "Nominal CockroachDB server shall reject connections without TLS"
+    )
 
 
-def test_datastoredbmode_secure_mode_no_ssl_cockroach(no_ssl_cockroach):
-    is_secure, _ = no_ssl_cockroach.runs_in_secure_mode()
-    assert not is_secure
+def test_datastoredbmode_no_tls_rejected_good_yugabyte(good_yugabyte):
+    no_tls_rejected, _ = good_yugabyte.no_tls_rejected()
+    assert no_tls_rejected, (
+        "Nominal Yugabyte server shall reject connections without TLS"
+    )
 
 
-def test_datastoredbmode_secure_mode_no_ssl_yugabyte(no_ssl_yugabyte):
-    is_secure, _ = no_ssl_yugabyte.runs_in_secure_mode()
-    assert not is_secure
+def test_datastoredbmode_no_tls_rejected_yugabyte_without_client_auth(
+    yugabyte_without_client_auth,
+):
+    no_tls_rejected, _ = yugabyte_without_client_auth.no_tls_rejected()
+    assert no_tls_rejected, (
+        "Yugabyte server without mTLS shall still reject connections without TLS"
+    )
 
 
-def test_datastoredbmode_secure_mode_old_ssl_cockroach(old_ssl_cockroach):
-    is_secure, _ = old_ssl_cockroach.runs_in_secure_mode()
-    assert is_secure
+def test_datastoredbmode_no_tls_rejected_no_tls_cockroach(no_tls_cockroach):
+    no_tls_rejected, _ = no_tls_cockroach.no_tls_rejected()
+    assert not no_tls_rejected, (
+        "CockroachDB server, with TLS disabled, shall not reject connections without TLS"
+    )
 
 
-def test_datastoredbmode_secure_mode_old_ssl_yugabyte(old_ssl_yugabyte):
-    is_secure, _ = old_ssl_yugabyte.runs_in_secure_mode()
-    assert is_secure
+def test_datastoredbmode_no_tls_rejected_no_tls_yugabyte(no_tls_yugabyte):
+    no_tls_rejected, _ = no_tls_yugabyte.no_tls_rejected()
+    assert not no_tls_rejected, (
+        "Yugabyte server, with TLS disabled, shall not reject connections without TLS"
+    )
+
+
+def test_datastoredbmode_no_tls_rejected_old_tls_cockroach(old_tls_cockroach):
+    no_tls_rejected, _ = old_tls_cockroach.no_tls_rejected()
+    assert no_tls_rejected, (
+        "CockroachDB server, with old TLS version enabled, shall not reject connections without TLS"
+    )
+
+
+def test_datastoredbmode_unauthenticated_rejected_good_cockroach(good_cockroach):
+    unauthenticated_rejected, _ = good_cockroach.unauthenticated_rejected()
+    assert unauthenticated_rejected, (
+        "Nominal CockroachDB server shall reject unauthenticated connections"
+    )
+
+
+def test_datastoredbmode_unauthenticated_rejected_good_yugabyte(good_yugabyte):
+    unauthenticated_rejected, _ = good_yugabyte.unauthenticated_rejected()
+    assert unauthenticated_rejected, (
+        "Nominal Yugabyte server shall reject unauthenticated connections"
+    )
+
+
+def test_datastoredbmode_unauthenticated_rejected_yugabyte_without_client_auth(
+    yugabyte_without_client_auth,
+):
+    unauthenticated_rejected, _ = (
+        yugabyte_without_client_auth.unauthenticated_rejected()
+    )
+    assert not unauthenticated_rejected, (
+        "Yugabyte without mTLS shall accept unauthenticated requests (since mTLS is the authentication method)"
+    )
+
+
+def test_datastoredbmode_unauthenticated_rejected_no_tls_cockroach(no_tls_cockroach):
+    unauthenticated_rejected, _ = no_tls_cockroach.unauthenticated_rejected()
+    assert unauthenticated_rejected, (
+        "CockroachDB server, with TLS disabled, shall reject authenticated requests"
+    )
+
+
+def test_datastoredbmode_unauthenticated_rejected_no_tls_yugabyte(no_tls_yugabyte):
+    unauthenticated_rejected, _ = no_tls_yugabyte.unauthenticated_rejected()
+    assert not unauthenticated_rejected, (
+        "Yugabyte without TLS shall accept unauthenticated requests (since mTLS is the authentication method)"
+    )
+
+
+def test_datastoredbmode_unauthenticated_rejected_old_tls_cockroach(old_tls_cockroach):
+    unauthenticated_rejected, _ = old_tls_cockroach.unauthenticated_rejected()
+    assert unauthenticated_rejected, (
+        "CockroachDB server, with old TLS version enabled, shall reject authenticated requests"
+    )
 
 
 def test_datastoredbmode_reject_legacy_good_cockroach(good_cockroach):
-    legacy_rejected, _ = good_cockroach.legacy_ssl_version_rejected()
-    assert legacy_rejected
+    legacy_rejected, _ = good_cockroach.legacy_tls_version_rejected()
+    assert legacy_rejected, (
+        "Nominal CockroachDB server shall reject connections wtih legacy TLS version"
+    )
 
 
 def test_datastoredbmode_reject_legacy_good_yugabyte(good_yugabyte):
-    legacy_rejected, _ = good_yugabyte.legacy_ssl_version_rejected()
-    assert legacy_rejected
+    legacy_rejected, _ = good_yugabyte.legacy_tls_version_rejected()
+    assert legacy_rejected, (
+        "Nominal Yugabyte server shall reject connections wtih legacy TLS version"
+    )
 
 
-def test_datastoredbmode_reject_legacy_old_ssl_cockroach(old_ssl_cockroach):
-    legacy_rejected, _ = old_ssl_cockroach.legacy_ssl_version_rejected()
-    assert not legacy_rejected
+def test_datastoredbmode_reject_legacy_yugabyte_without_client_auth(
+    yugabyte_without_client_auth,
+):
+    legacy_rejected, _ = yugabyte_without_client_auth.legacy_tls_version_rejected()
+    assert legacy_rejected, (
+        "Yugabyte without mTLS shall reject connections wtih legacy TLS version"
+    )
 
 
-def test_datastoredbmode_reject_legacy_old_ssl_yugabyte(old_ssl_yugabyte):
-    legacy_rejected, _ = old_ssl_yugabyte.legacy_ssl_version_rejected()
-    assert not legacy_rejected
+def test_datastoredbmode_reject_legacy_old_tls_cockroach(old_tls_cockroach):
+    legacy_rejected, _ = old_tls_cockroach.legacy_tls_version_rejected()
+    assert not legacy_rejected, (
+        "CockroachDB server, with old TLS version enabled, shall not reject connections wtih legacy TLS versions"
+    )

--- a/monitoring/uss_qualifier/scenarios/astm/dss/datastore_access.py
+++ b/monitoring/uss_qualifier/scenarios/astm/dss/datastore_access.py
@@ -50,13 +50,23 @@ class DatastoreAccess(GenericTestScenario):
         self.begin_test_step("Attempt to connect in insecure mode")
         for node in self.datastore_nodes:
             with self.check(
-                "Node runs in secure mode",
+                "Node enforces encryption of its communications",
                 node.participant_id,
             ) as check:
-                secure_mode, e = node.runs_in_secure_mode()
-                if not secure_mode:
+                encrypted, e = node.no_tls_rejected()
+                if not encrypted:
                     check.record_failed(
-                        "Node is not in secure mode",
+                        "Node did not reject cleartext communication",
+                        details=f"Reported connection error (if any): {e}",
+                    )
+            with self.check(
+                "Node enforces authentication of its communications",
+                node.participant_id,
+            ) as check:
+                authenticated, e = node.unauthenticated_rejected()
+                if not authenticated:
+                    check.record_failed(
+                        "Node did not reject unauthenticated communication",
                         details=f"Reported connection error (if any): {e}",
                     )
         self.end_test_step()
@@ -67,7 +77,7 @@ class DatastoreAccess(GenericTestScenario):
                 "Node rejects legacy encryption protocols",
                 node.participant_id,
             ) as check:
-                rejected, e = node.legacy_ssl_version_rejected()
+                rejected, e = node.legacy_tls_version_rejected()
                 if not rejected:
                     check.record_failed(
                         "Node did not reject connection with legacy encryption protocol",

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/datastore_access.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/datastore_access.md
@@ -3,7 +3,9 @@
 ## Overview
 
 Attempt to directly access the datastore (CockroachDB or Yugabyte) nodes intercommunicating to form the DSS Airspace Representation for the DSS instances under test, for the purpose of determining compliance to certain DSS interoperability requirements.
-The psycopg library is used to attempt standard PostgreSQL connections to the nodes as it is the most straightforward way of connecting directly to the datastore nodes while controlling the connection parameters (such as for encryption).
+
+For CockroachDB, the psycopg library is used to attempt standard PostgreSQL connections to the nodes as it is the most straightforward way of connecting directly to the datastore nodes while controlling the connection parameters (such as for encryption).
+For YugabyteDB, RPC messages are sent to the nodes directly.
 
 This scenario aims at validating the following requirements:
 - **[astm.f3411.v19.DSS0110](../../../../../requirements/astm/f3411/v19.md)**
@@ -15,12 +17,10 @@ DatastoreDBClusterResource that provides access to a set of CockroachDB or Yugab
 
 ## Setup test case
 ### Validate nodes are reachable test step
-Attempt connection with nodes of the cluster to validate that they are reachable.
-To do so, this step attempts a connection to each node without strictly requiring an encrypted connection and forcing the use of a password authentication with a dummy password.
-As such we expect the node to respond with a failed password authentication.
+Attempt connection with nodes of the cluster to validate that they are reachable, by opening a TCP connection to the node.
 
 #### 🛑 Node is reachable check
-This check succeeds if the node can be reached and that the password authentication attempted by the USS qualifier is rejected.
+This check succeeds if the node is reachable.
 It fails in all other cases.
 
 ## Verify security interoperability test case
@@ -28,12 +28,13 @@ It fails in all other cases.
 Attempt connection with nodes of the cluster in insecure mode.
 It is expected that the connection attempts are rejected due to the fact that all nodes are running in secure mode.
 
-#### ⚠️ Node runs in secure mode check
+#### ⚠️ Node enforces encryption of its communications check
 This check succeeds if the node rejects the insecure connection attempt by the USS qualifier because it is in secure mode.
-It fails in all other cases.
-
-If it is in insecure mode, it means that the node does not authenticate incoming connection attempt as it should per **[astm.f3411.v19.DSS0110](../../../../../requirements/astm/f3411/v19.md)**.
 If it is in insecure mode, it means that the node does not encrypt its communications as it should per **[astm.f3411.v19.DSS0120](../../../../../requirements/astm/f3411/v19.md)**.
+
+#### ⚠️ Node enforces authentication of its communications check
+This check succeeds if the node rejects the insecure connection attempt by the USS qualifier because it is in secure mode.
+If it is in insecure mode, it means that the node does not authenticate incoming connection attempt as it should per **[astm.f3411.v19.DSS0110](../../../../../requirements/astm/f3411/v19.md)**.
 
 ### Attempt to connect with legacy encryption protocol test step
 Attempt connection with nodes of the cluster forcing the use of legacy encryption protocols, namely between TLSv1 and TLSv1.1.

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/datastore_access.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/datastore_access.md
@@ -3,7 +3,9 @@
 ## Overview
 
 Attempt to directly access the datastore (CockroachDB or Yugabyte) nodes intercommunicating to form the DSS Airspace Representation for the DSS instances under test, for the purpose of determining compliance to certain DSS interoperability requirements.
-The psycopg library is used to attempt standard PostgreSQL connections to the nodes as it is the most straightforward way of connecting directly to the datastore nodes while controlling the connection parameters (such as for encryption).
+
+For CockroachDB, the psycopg library is used to attempt standard PostgreSQL connections to the nodes as it is the most straightforward way of connecting directly to the datastore nodes while controlling the connection parameters (such as for encryption).
+For YugabyteDB, RPC messages are sent to the nodes directly.
 
 This scenario aims at validating the following requirements:
 - **[astm.f3411.v22a.DSS0110](../../../../../requirements/astm/f3411/v22a.md)**
@@ -15,12 +17,10 @@ DatastoreDBClusterResource that provides access to a set of CockroachDB or Yugab
 
 ## Setup test case
 ### Validate nodes are reachable test step
-Attempt connection with nodes of the cluster to validate that they are reachable.
-To do so, this step attempts a connection to each node without strictly requiring an encrypted connection and forcing the use of a password authentication with a dummy password.
-As such we expect the node to respond with a failed password authentication.
+Attempt connection with nodes of the cluster to validate that they are reachable, by opening a TCP connection to the node.
 
 #### 🛑 Node is reachable check
-This check succeeds if the node can be reached and that the password authentication attempted by the USS qualifier is rejected.
+This check succeeds if the node is reachable.
 It fails in all other cases.
 
 ## Verify security interoperability test case
@@ -28,12 +28,13 @@ It fails in all other cases.
 Attempt connection with nodes of the cluster in insecure mode.
 It is expected that the connection attempts are rejected due to the fact that all nodes are running in secure mode.
 
-#### ⚠️ Node runs in secure mode check
+#### ⚠️ Node enforces encryption of its communications check
 This check succeeds if the node rejects the insecure connection attempt by the USS qualifier because it is in secure mode.
-It fails in all other cases.
-
-If it is in insecure mode, it means that the node does not authenticate incoming connection attempt as it should per **[astm.f3411.v22a.DSS0110](../../../../../requirements/astm/f3411/v22a.md)**.
 If it is in insecure mode, it means that the node does not encrypt its communications as it should per **[astm.f3411.v22a.DSS0120](../../../../../requirements/astm/f3411/v22a.md)**.
+
+#### ⚠️ Node enforces authentication of its communications check
+This check succeeds if the node rejects the insecure connection attempt by the USS qualifier because it is in secure mode.
+If it is in insecure mode, it means that the node does not authenticate incoming connection attempt as it should per **[astm.f3411.v22a.DSS0110](../../../../../requirements/astm/f3411/v22a.md)**.
 
 ### Attempt to connect with legacy encryption protocol test step
 Attempt connection with nodes of the cluster forcing the use of legacy encryption protocols, namely between TLSv1 and TLSv1.1.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/datastore_access.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/datastore_access.md
@@ -3,7 +3,9 @@
 ## Overview
 
 Attempt to directly access the datastore (CockroachDB or Yugabyte) nodes intercommunicating to form the DSS Airspace Representation for the DSS instances under test, for the purpose of determining compliance to certain DSS interoperability requirements.
-The psycopg library is used to attempt standard PostgreSQL connections to the nodes as it is the most straightforward way of connecting directly to the datastore nodes while controlling the connection parameters (such as for encryption).
+
+For CockroachDB, the psycopg library is used to attempt standard PostgreSQL connections to the nodes as it is the most straightforward way of connecting directly to the datastore nodes while controlling the connection parameters (such as for encryption).
+For YugabyteDB, RPC messages are sent to the nodes directly.
 
 This scenario aims at validating the following requirements:
 - **[astm.f3548.v21.DSS0200](../../../../requirements/astm/f3548/v21.md)**
@@ -15,12 +17,10 @@ DatastoreDBClusterResource that provides access to a set of CockroachDB or Yugab
 
 ## Setup test case
 ### Validate nodes are reachable test step
-Attempt connection with nodes of the cluster to validate that they are reachable.
-To do so, this step attempts a connection to each node without strictly requiring an encrypted connection and forcing the use of a password authentication with a dummy password.
-As such we expect the node to respond with a failed password authentication.
+Attempt connection with nodes of the cluster to validate that they are reachable, by opening a TCP connection to the node.
 
 #### 🛑 Node is reachable check
-This check succeeds if the node can be reached and that the password authentication attempted by the USS qualifier is rejected.
+This check succeeds if the node is reachable.
 It fails in all other cases.
 
 ## Verify security interoperability test case
@@ -28,12 +28,13 @@ It fails in all other cases.
 Attempt connection with nodes of the cluster in insecure mode.
 It is expected that the connection attempts are rejected due to the fact that all nodes are running in secure mode.
 
-#### ⚠️ Node runs in secure mode check
+#### ⚠️ Node enforces encryption of its communications check
 This check succeeds if the node rejects the insecure connection attempt by the USS qualifier because it is in secure mode.
-It fails in all other cases.
-
-If it is in insecure mode, it means that the node does not authenticate incoming connection attempt as it should per **[astm.f3548.v21.DSS0200](../../../../requirements/astm/f3548/v21.md)**.
 If it is in insecure mode, it means that the node does not encrypt its communications as it should per **[astm.f3548.v21.DSS0205](../../../../requirements/astm/f3548/v21.md)**.
+
+#### ⚠️ Node enforces authentication of its communications check
+This check succeeds if the node rejects the insecure connection attempt by the USS qualifier because it is in secure mode.
+If it is in insecure mode, it means that the node does not authenticate incoming connection attempt as it should per **[astm.f3548.v21.DSS0200](../../../../requirements/astm/f3548/v21.md)**.
 
 ### Attempt to connect with legacy encryption protocol test step
 Attempt connection with nodes of the cluster forcing the use of legacy encryption protocols, namely between TLSv1 and TLSv1.1.

--- a/schemas/monitoring/uss_qualifier/resources/interuss/datastore/datastore/DatastoreDBNodeSpecification.json
+++ b/schemas/monitoring/uss_qualifier/resources/interuss/datastore/datastore/DatastoreDBNodeSpecification.json
@@ -11,6 +11,10 @@
       "description": "Host where the DatastoreDB node is reachable.",
       "type": "string"
     },
+    "is_yugabyte": {
+      "description": "True if DatastoreDB node is a YugabyteDB node.",
+      "type": "boolean"
+    },
     "participant_id": {
       "description": "ID of the USS responsible for this DatastoreDB node",
       "type": "string"


### PR DESCRIPTION
Fix #1239 by testing 'correctly' yugabyte connections.

I created the PR but mostly implemented by @mickmis , I just did the final fixes to make it working 'for real' with yugabyte + finalized unit test (with a custom image for now).

Update:

The test have now been normalized between the two implementations, ssl has been renamed to tls, unit test have been updated and comments have been added.

