### PR TITLE
[tooling] Exclude more dirs from docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,7 @@ build/workspace
 *.pyc
 .git
 .venv
+monitoring/uss_qualifier/output/*
+monitoring/uss_qualifier/htmlcov/*
+monitoring/mock_uss/output/*
+**/__pycache__


### PR DESCRIPTION
When building the image locally, output / coverage files are send into the local image, unnecessary bloating it up and making image building longer.

This fix it by excluding such dir.

This also exclude __pycache__ folders, excluded only at root folder.