### PR TITLE
[uss_qualifier] Add validation of loaded flight data & tests

### DIFF
--- a/monitoring/uss_qualifier/resources/netrid/flight_data_resources_test.py
+++ b/monitoring/uss_qualifier/resources/netrid/flight_data_resources_test.py
@@ -1,0 +1,72 @@
+import pytest
+
+from monitoring.uss_qualifier.resources.files import ExternalFile
+
+from .flight_data import (
+    AdjacentCircularFlightsSimulatorConfiguration,
+    FlightDataKMLFileConfiguration,
+    FlightDataSpecification,
+)
+from .flight_data_resources import FlightDataResource
+
+
+def test_unknown_type():
+    specs = FlightDataSpecification()
+
+    with pytest.raises(ValueError):
+        FlightDataResource(specs, "test")
+
+
+def test_record():
+    specs = FlightDataSpecification(
+        record_source=ExternalFile(path="file://./test_data/test/zurich.json")
+    )
+    FlightDataResource(specs, "test")
+
+
+def test_invalid_record():
+    # accuracy_h is a field in position, speed_accuracy in state.
+    for file in [
+        "test/invalid_no_accuracy_h.kml",
+        "test/invalid_no_speed_accuracy.kml",
+    ]:
+        specs = FlightDataSpecification(
+            record_source=ExternalFile(path=f"file://./test_data/{file}")
+        )
+        with pytest.raises(Exception):
+            FlightDataResource(specs, "test")
+
+
+def test_kmls():
+    # We test all known KMLs, who should be valid
+    for file in ["usa/netrid/dcdemo.kml", "usa/kentland/rid.kml", "che/rid/zurich.kml"]:
+        specs = FlightDataSpecification(
+            kml_source=FlightDataKMLFileConfiguration(
+                kml_file=ExternalFile(path=f"file://./test_data/{file}")
+            )
+        )
+        FlightDataResource(specs, "test")
+
+
+def test_invalid_kmls():
+    # accuracy_h is a field in position, speed_accuracy in state. Notice it's
+    # hard to generate invalid values from others fields as kml parser will
+    # crash / generate most of them
+    for file in [
+        "test/invalid_no_accuracy_h.kml",
+        "test/invalid_no_speed_accuracy.kml",
+    ]:
+        specs = FlightDataSpecification(
+            kml_source=FlightDataKMLFileConfiguration(
+                kml_file=ExternalFile(path=f"file://./test_data/{file}")
+            )
+        )
+        with pytest.raises(Exception):
+            FlightDataResource(specs, "test")
+
+
+def test_adjacent_circular_flights_simuation_source():
+    specs = FlightDataSpecification(
+        adjacent_circular_flights_simulation_source=AdjacentCircularFlightsSimulatorConfiguration()
+    )
+    FlightDataResource(specs, "test")

--- a/monitoring/uss_qualifier/test_data/test/invalid_no_accuracy_h.json
+++ b/monitoring/uss_qualifier/test_data/test/invalid_no_accuracy_h.json
@@ -1,0 +1,785 @@
+{
+    "flights": [
+        {
+            "reference_time": "2022-01-01T00:00:00+00:00",
+            "states": [
+                {
+                    "timestamp": "2022-01-01T00:00:01+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.488106090860573,
+                        "lat": 47.37063724619898,
+                        "alt": 496.0,
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 0.0,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 0.0,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 162.3752362098515,
+                    "speed": 5.0,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 0.0
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:02+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.488126171527895,
+                        "lat": 47.37059443876779,
+                        "alt": 496.18307267903697,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 0.1830726790369681,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 0.1830726790369681,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 187.50097320343912,
+                    "speed": 5.0,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 0.18
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:03+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.488117678127974,
+                        "lat": 47.370550752380716,
+                        "alt": 498.53226199914917,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 2.5322619991491706,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 2.5322619991491706,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 192.42362296934377,
+                    "speed": 5.0,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 2.35
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:04+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.488103410051705,
+                        "lat": 47.37050688836104,
+                        "alt": 500.40031939929486,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 4.400319399294858,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 4.400319399294858,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 200.40286640336953,
+                    "speed": 5.61,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 1.87
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:05+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.488080501861498,
+                        "lat": 47.37046517716392,
+                        "alt": 501.65525225916707,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 5.655252259167071,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 5.655252259167071,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 208.23182285522853,
+                    "speed": 7.35,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 1.25
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:06+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.488049130286102,
+                        "lat": 47.37042560543707,
+                        "alt": 502.4106030975036,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 6.410603097503611,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 6.410603097503611,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 208.81982213774143,
+                    "speed": 8.15,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 0.76
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:07+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.488013259623491,
+                        "lat": 47.37038145191838,
+                        "alt": 503.1337164705349,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 7.133716470534921,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 7.133716470534921,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 202.1993676258766,
+                    "speed": 9.84,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 0.72
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:08+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.487985396361207,
+                        "lat": 47.37033520979453,
+                        "alt": 504.077325459153,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 8.077325459152974,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 8.077325459152974,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 193.30773490939308,
+                    "speed": 11.96,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 0.94
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:09+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.487973904140395,
+                        "lat": 47.3703023046547,
+                        "alt": 504.909136585584,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 8.909136585584008,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 8.909136585584008,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 186.94220133247893,
+                    "speed": 14.37,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 0.83
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:10+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.487962372282103,
+                        "lat": 47.37023816260832,
+                        "alt": 506.62385364810143,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 10.62385364810143,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 10.62385364810143,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 171.81024867542703,
+                    "speed": 16.74,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 1.71
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:11+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.487976559973054,
+                        "lat": 47.370171398603745,
+                        "alt": 508.75800509123735,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 12.75800509123735,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 12.75800509123735,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 154.86309008170363,
+                    "speed": 18.36,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 2.13
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:12+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.488019499902185,
+                        "lat": 47.37010942090538,
+                        "alt": 511.13171827832986,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 15.131718278329856,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 15.131718278329856,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 132.98217445043147,
+                    "speed": 23.11,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 2.37
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:13+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.488089449646983,
+                        "lat": 47.37006527181479,
+                        "alt": 513.3848015774483,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 17.384801577448343,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 17.384801577448343,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 116.6325467769568,
+                    "speed": 25.65,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 2.25
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:14+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.48815088026746,
+                        "lat": 47.37004440849303,
+                        "alt": 514.9199444465004,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 18.91994444650038,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 18.91994444650038,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 123.51221393134806,
+                    "speed": 27.84,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 1.54
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:15+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.48831139751754,
+                        "lat": 47.369972421106304,
+                        "alt": 518.8514455015629,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 22.85144550156292,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 22.85144550156292,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 126.39759736353494,
+                    "speed": 30.0,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 3.93
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:16+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.4883924829112,
+                        "lat": 47.3699319376166,
+                        "alt": 520.6710082621752,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 24.671008262175178,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 24.671008262175178,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 127.79792720040928,
+                    "speed": 30.0,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 1.82
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:17+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.48846068845649,
+                        "lat": 47.36989610981006,
+                        "alt": 522.1109485203592,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 26.110948520359216,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 26.110948520359216,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 122.00014201767304,
+                    "speed": 30.0,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 1.44
+                }
+            ],
+            "flight_details": {
+                "id": "d22a1cef-a3e0-437f-92b5-44c1453f4068",
+                "serial_number": "1AKGAAN8G70R7JS",
+                "operation_description": "U-turn south of takeoff",
+                "operator_location": {
+                    "lat": 47.37085983569079,
+                    "lng": 8.487908591798265
+                },
+                "operator_id": "CHE-RP-f39mqfitkh9e5"
+            },
+            "aircraft_type": "Helicopter"
+        },
+        {
+            "reference_time": "2022-01-01T00:00:00+00:00",
+            "states": [
+                {
+                    "timestamp": "2022-01-01T00:00:01+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.5082751179102,
+                        "lat": 47.37077841542829,
+                        "alt": 529.0,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 0.0,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 0.0,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 43.03829301396051,
+                    "speed": 5.0,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 0.0
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:02+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.508320380900203,
+                        "lat": 47.37081124427215,
+                        "alt": 529.0,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 0.0,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 0.0,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 44.471165943871895,
+                    "speed": 5.0,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 0.0
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:03+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.50836683820487,
+                        "lat": 47.37084329379501,
+                        "alt": 529.0,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 0.0,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 0.0,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 45.00987803090026,
+                    "speed": 5.0,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 0.0
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:04+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.508413742027768,
+                        "lat": 47.37087504853866,
+                        "alt": 529.0,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 0.0,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 0.0,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 42.283916233986616,
+                    "speed": 5.0,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 0.0
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:05+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.508456791062693,
+                        "lat": 47.370907107576116,
+                        "alt": 529.0,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 0.0,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 0.0,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 56.404457560286055,
+                    "speed": 6.78,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 0.0
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:06+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.508512033806365,
+                        "lat": 47.37093196068016,
+                        "alt": 534.3462453934874,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 5.346245393487379,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 5.346245393487379,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 56.40454827550896,
+                    "speed": 8.08,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 5.35
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:07+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.508567276608135,
+                        "lat": 47.37095681372497,
+                        "alt": 541.0071850407926,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 12.007185040792592,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 12.007185040792592,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 49.37103887319031,
+                    "speed": 9.5,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 6.66
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:08+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.508635411250422,
+                        "lat": 47.37099640465343,
+                        "alt": 549.7092175828766,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 20.70921758287659,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 20.70921758287659,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 55.26415971173848,
+                    "speed": 10.93,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 8.7
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:09+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.50872335395775,
+                        "lat": 47.37103770064569,
+                        "alt": 559.9711540980651,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 30.971154098065085,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 30.971154098065085,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 48.272018247873895,
+                    "speed": 12.34,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 10.26
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:10+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.5088116351726,
+                        "lat": 47.3710910227504,
+                        "alt": 570.9516494270789,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 41.951649427078905,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 41.951649427078905,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 11.45105545883768,
+                    "speed": 13.38,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 10.98
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:11+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.508840417269266,
+                        "lat": 47.37118725325097,
+                        "alt": 580.314615001263,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 51.31461500126295,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 51.31461500126295,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 11.820237778805804,
+                    "speed": 14.58,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 9.36
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:12+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.508861648775275,
+                        "lat": 47.37125596075003,
+                        "alt": 587.3889523597257,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 58.38895235972575,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 58.38895235972575,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 11.683449532931599,
+                    "speed": 16.24,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 7.07
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:13+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.50888532292006,
+                        "lat": 47.37133349567566,
+                        "alt": 595.7395125812138,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 66.73951258121383,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 66.73951258121383,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 358.70456587570527,
+                    "speed": 18.01,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 8.35
+                }
+            ],
+            "flight_details": {
+                "id": "b238e812-7282-49c4-8567-f15da4815430",
+                "serial_number": "ULYK563L5G",
+                "operation_description": "Circle flight",
+                "operator_location": {
+                    "lat": 47.370902783740675,
+                    "lng": 8.507979542766373
+                },
+                "operator_id": "CHE-RP-iwetcg7ucfopc"
+            },
+            "aircraft_type": "Helicopter"
+        }
+    ]
+}

--- a/monitoring/uss_qualifier/test_data/test/invalid_no_accuracy_h.kml
+++ b/monitoring/uss_qualifier/test_data/test/invalid_no_accuracy_h.kml
@@ -1,0 +1,530 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:kml="http://www.opengis.net/kml/2.2" xmlns:atom="http://www.w3.org/2005/Atom">
+<Document>
+	<name>rid.kml</name>
+	<StyleMap id="m_ylw-pushpin">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#s_ylw-pushpin</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#s_ylw-pushpin_hl0</styleUrl>
+		</Pair>
+	</StyleMap>
+	<StyleMap id="m_ylw-pushpin0">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#s_ylw-pushpin0</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#s_ylw-pushpin_hl</styleUrl>
+		</Pair>
+	</StyleMap>
+	<StyleMap id="m_ylw-pushpin1">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#s_ylw-pushpin1</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#s_ylw-pushpin_hl00</styleUrl>
+		</Pair>
+	</StyleMap>
+	<StyleMap id="msn_ylw-pushpin">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#sn_ylw-pushpin</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#sh_ylw-pushpin</styleUrl>
+		</Pair>
+	</StyleMap>
+	<StyleMap id="msn_ylw-pushpin0">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#sn_ylw-pushpin0</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#sh_ylw-pushpin2</styleUrl>
+		</Pair>
+	</StyleMap>
+	<StyleMap id="msn_ylw-pushpin10">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#sn_ylw-pushpin10</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#sh_ylw-pushpin1</styleUrl>
+		</Pair>
+	</StyleMap>
+	<StyleMap id="msn_ylw-pushpin2">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#sn_ylw-pushpin20</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#sh_ylw-pushpin00</styleUrl>
+		</Pair>
+	</StyleMap>
+	<StyleMap id="msn_ylw-pushpin20">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#sn_ylw-pushpin2</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#sh_ylw-pushpin0</styleUrl>
+		</Pair>
+	</StyleMap>
+	<StyleMap id="msn_ylw-pushpin3">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#sn_ylw-pushpin3</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#sh_ylw-pushpin3</styleUrl>
+		</Pair>
+	</StyleMap>
+	<Style id="s_ylw-pushpin">
+		<IconStyle>
+			<scale>1.1</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+	</Style>
+	<Style id="s_ylw-pushpin0">
+		<IconStyle>
+			<scale>1.1</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<PolyStyle>
+			<fill>0</fill>
+		</PolyStyle>
+	</Style>
+	<Style id="s_ylw-pushpin1">
+		<IconStyle>
+			<scale>1.1</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+	</Style>
+	<Style id="s_ylw-pushpin_hl">
+		<IconStyle>
+			<scale>1.3</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<PolyStyle>
+			<fill>0</fill>
+		</PolyStyle>
+	</Style>
+	<Style id="s_ylw-pushpin_hl0">
+		<IconStyle>
+			<scale>1.3</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+	</Style>
+	<Style id="s_ylw-pushpin_hl00">
+		<IconStyle>
+			<scale>1.3</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+	</Style>
+	<Style id="sh_ylw-pushpin">
+		<IconStyle>
+			<scale>1.3</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<PolyStyle>
+			<fill>0</fill>
+		</PolyStyle>
+	</Style>
+	<Style id="sh_ylw-pushpin0">
+		<IconStyle>
+			<scale>1.3</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<LineStyle>
+			<color>ff0880fd</color>
+		</LineStyle>
+		<PolyStyle>
+			<fill>0</fill>
+		</PolyStyle>
+	</Style>
+	<Style id="sh_ylw-pushpin00">
+		<IconStyle>
+			<scale>1.3</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<LineStyle>
+			<color>ff0880fd</color>
+		</LineStyle>
+		<PolyStyle>
+			<fill>0</fill>
+		</PolyStyle>
+	</Style>
+	<Style id="sh_ylw-pushpin1">
+		<IconStyle>
+			<scale>1.3</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<LineStyle>
+			<color>ffffff20</color>
+		</LineStyle>
+	</Style>
+	<Style id="sh_ylw-pushpin2">
+		<IconStyle>
+			<scale>1.3</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<PolyStyle>
+			<fill>0</fill>
+		</PolyStyle>
+	</Style>
+	<Style id="sh_ylw-pushpin3">
+		<IconStyle>
+			<scale>1.3</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<PolyStyle>
+			<fill>0</fill>
+		</PolyStyle>
+	</Style>
+	<Style id="sn_ylw-pushpin">
+		<IconStyle>
+			<scale>1.1</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<PolyStyle>
+			<fill>0</fill>
+		</PolyStyle>
+	</Style>
+	<Style id="sn_ylw-pushpin0">
+		<IconStyle>
+			<scale>1.1</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<PolyStyle>
+			<fill>0</fill>
+		</PolyStyle>
+	</Style>
+	<Style id="sn_ylw-pushpin10">
+		<IconStyle>
+			<scale>1.1</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<LineStyle>
+			<color>ffffff20</color>
+		</LineStyle>
+	</Style>
+	<Style id="sn_ylw-pushpin2">
+		<IconStyle>
+			<scale>1.1</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<LineStyle>
+			<color>ff0880fd</color>
+		</LineStyle>
+		<PolyStyle>
+			<fill>0</fill>
+		</PolyStyle>
+	</Style>
+	<Style id="sn_ylw-pushpin20">
+		<IconStyle>
+			<scale>1.1</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<LineStyle>
+			<color>ff0880fd</color>
+		</LineStyle>
+		<PolyStyle>
+			<fill>0</fill>
+		</PolyStyle>
+	</Style>
+	<Style id="sn_ylw-pushpin3">
+		<IconStyle>
+			<scale>1.1</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<PolyStyle>
+			<fill>0</fill>
+		</PolyStyle>
+	</Style>
+	<Folder>
+		<name>zurich</name>
+		<open>1</open>
+		<Folder>
+			<name>flight: south u</name>
+			<open>1</open>
+			<description>serial_number: 1AKGAAN8G70R7JS
+aircraft_type: Helicopter
+operation_description: U-turn south of takeoff
+operator_id: CHE-RP-f39mqfitkh9e5
+operator_name: Jane Doe
+timestamp_accuracy: 1.0
+speed_accuracy: SA3mps
+sample_rate: 1.0
+accuracy_v: VAUnknown</description>
+			<Placemark>
+				<name>U turn south</name>
+				<styleUrl>#msn_ylw-pushpin10</styleUrl>
+				<LineString>
+					<tessellate>1</tessellate>
+					<coordinates>
+						8.488086010193248,47.37068005363017,0.0 8.48812954746956,47.370587242025366,0.0 8.488096461986222,47.37048552808266,0.0 8.488058869601295,47.370437593647054,0.0 8.487992713476777,47.37035616148304,0.0 8.48798464448449,47.370333056885144,0.0 8.487973904140395,47.3703023046547,0.0 8.487966840917556,47.370266323893794,0.0 8.487962372282103,47.37023816260832,0.0 8.487967675859187,47.370207342634934,0.0 8.487976559973054,47.370171398603745,0.0 8.48799807719684,47.37014036227894,0.0 8.488019499902185,47.37010942090538,0.0 8.488053429665532,47.37008339144921,0.0 8.488089449646983,47.37006527181478,0.0 8.488121925894466,47.370052282478674,0.0 8.48815088026746,47.37004440849303,0.0 8.48827518488533,47.36999864947174,0.0 8.48831139751754,47.369972421106304,0.0 8.48835375032042,47.36995426515459,0.0 8.4883924829112,47.3699319376166,0.0 8.488426644184889,47.369913985083514,0.0 8.48846068845649,47.36989610981006,0.0 8.488495983730138,47.369878322762034,0.0 8.48853439095125,47.369864919157145,0.0 8.488562728428482,47.36985722273458,0.0 8.488595159283255,47.369853852306214,0.0 8.488636589108003,47.369849906174295,0.0 8.48867952953342,47.36985020494702,0.0 8.488708578938505,47.36984763686421,0.0
+					</coordinates>
+				</LineString>
+			</Placemark>
+			<Placemark>
+				<name>alt: Takeoff</name>
+				<styleUrl>#m_ylw-pushpin0</styleUrl>
+				<Polygon>
+					<tessellate>1</tessellate>
+					<altitudeMode>absolute</altitudeMode>
+					<outerBoundaryIs>
+						<LinearRing>
+							<coordinates>
+								8.487599206246548,47.370506331316705,496.0 8.48773686257555,47.370357145137795,496.0 8.488527190331814,47.37084454793311,496.0 8.488389720684472,47.371003666625,496.0 8.487599206246548,47.370506331316705,496.0
+							</coordinates>
+						</LinearRing>
+					</outerBoundaryIs>
+				</Polygon>
+			</Placemark>
+			<Placemark>
+				<name>alt: High</name>
+				<styleUrl>#msn_ylw-pushpin</styleUrl>
+				<Polygon>
+					<extrude>1</extrude>
+					<tessellate>1</tessellate>
+					<altitudeMode>absolute</altitudeMode>
+					<outerBoundaryIs>
+						<LinearRing>
+							<coordinates>
+								8.48957979534743,47.369927140429084,551.0 8.490587218626521,47.37027611497966,551.0 8.490661563415705,47.37107682800347,551.0 8.489204440074536,47.370663517599084,551.0 8.48957979534743,47.369927140429084,551.0
+							</coordinates>
+						</LinearRing>
+					</outerBoundaryIs>
+				</Polygon>
+			</Placemark>
+			<Placemark>
+				<name>alt: Low</name>
+				<styleUrl>#msn_ylw-pushpin</styleUrl>
+				<Polygon>
+					<extrude>1</extrude>
+					<tessellate>1</tessellate>
+					<altitudeMode>absolute</altitudeMode>
+					<outerBoundaryIs>
+						<LinearRing>
+							<coordinates>
+								8.491850511360857,47.36774777095399,521.0 8.493236481345823,47.37021642084468,521.0 8.490620125766261,47.369968081354884,521.0 8.48962145300232,47.368391591949525,521.0 8.491850511360857,47.36774777095399,521.0
+							</coordinates>
+						</LinearRing>
+					</outerBoundaryIs>
+				</Polygon>
+			</Placemark>
+			<Placemark>
+				<name>speed: Departure (5)</name>
+				<styleUrl>#msn_ylw-pushpin20</styleUrl>
+				<Polygon>
+					<tessellate>1</tessellate>
+					<outerBoundaryIs>
+						<LinearRing>
+							<coordinates>
+								8.487627177694923,47.37022567192925,0.0 8.488541433192031,47.370700520846526,0.0 8.488146211772209,47.371136886332906,0.0 8.487235428789324,47.37064948552166,0.0 8.487627177694923,47.37022567192925,0.0
+							</coordinates>
+						</LinearRing>
+					</outerBoundaryIs>
+				</Polygon>
+			</Placemark>
+			<Placemark>
+				<name>speed: Enroute (30)</name>
+				<styleUrl>#msn_ylw-pushpin20</styleUrl>
+				<Polygon>
+					<tessellate>1</tessellate>
+					<outerBoundaryIs>
+						<LinearRing>
+							<coordinates>
+								8.489638509156725,47.367439591965365,0.0 8.492925998859539,47.37003155923135,0.0 8.49104344194709,47.371956544316674,0.0 8.488021081836711,47.369439356682854,0.0 8.489638509156725,47.367439591965365,0.0
+							</coordinates>
+						</LinearRing>
+					</outerBoundaryIs>
+				</Polygon>
+			</Placemark>
+			<Placemark>
+				<name>operator_location</name>
+				<styleUrl>#m_ylw-pushpin1</styleUrl>
+				<Point>
+					<gx:drawOrder>1</gx:drawOrder>
+					<coordinates>8.487908591798265,47.37085983569079,0.0</coordinates>
+				</Point>
+			</Placemark>
+		</Folder>
+		<Folder>
+			<name>flight: circle</name>
+			<open>1</open>
+			<description>serial_number: ULYK563L5G
+aircraft_type: Helicopter
+operation_description: Circle flight
+operator_id: CHE-RP-iwetcg7ucfopc
+operator_name: John Doe
+timestamp_accuracy: 1.0
+speed_accuracy: SA3mps
+sample_rate: 1.0
+accuracy_h: HAUnknown
+accuracy_v: VAUnknown</description>
+			<Placemark>
+				<name>South</name>
+				<styleUrl>#msn_ylw-pushpin10</styleUrl>
+				<LineString>
+					<tessellate>1</tessellate>
+					<coordinates>
+						8.508229854920197,47.37074558658443,0.0 8.508329471365594,47.370817837505804,0.0 8.508375471496616,47.37084917525504,0.0 8.508421911721352,47.37088057176483,0.0 8.508456791062694,47.370907107576116,0.0 8.508519008377102,47.370935098462986,0.0 8.508581245669442,47.37096309822762,0.0 8.508647221360685,47.371003666692424,0.0 8.50878573903851,47.371065588974794,0.0 8.5088116351726,47.3710910227504,0.0 8.508825848236209,47.37113965697517,0.0 8.508843658918347,47.37119784355049,0.0 8.508861648775275,47.37125596075003,0.0 8.508870643430166,47.371285017030544,0.0 8.50888532292006,47.37133349567566,0.0 8.508888431723344,47.37140544348874,0.0 8.508881475041415,47.371448736079756,0.0 8.508854363332072,47.37150754532702,0.0 8.508812856615459,47.37157081371983,0.0 8.50877499150027,47.371644036289254,0.0 8.5087471867464,47.371693159220264,0.0
+					</coordinates>
+				</LineString>
+			</Placemark>
+			<Placemark>
+				<name>alt: Takeoff</name>
+				<styleUrl>#m_ylw-pushpin0</styleUrl>
+				<Polygon>
+					<tessellate>1</tessellate>
+					<altitudeMode>absolute</altitudeMode>
+					<outerBoundaryIs>
+						<LinearRing>
+							<coordinates>
+								8.507599206246548,47.370506331316705,529.0 8.50773686257555,47.370357145137795,529.0 8.508527190331814,47.37084454793311,529.0 8.508389720684472,47.371003666625,529.0 8.507599206246548,47.370506331316705,529.0
+							</coordinates>
+						</LinearRing>
+					</outerBoundaryIs>
+				</Polygon>
+			</Placemark>
+			<Placemark>
+				<name>alt: High</name>
+				<styleUrl>#msn_ylw-pushpin3</styleUrl>
+				<Polygon>
+					<extrude>1</extrude>
+					<tessellate>1</tessellate>
+					<altitudeMode>absolute</altitudeMode>
+					<outerBoundaryIs>
+						<LinearRing>
+							<coordinates>
+								8.509267459600915,47.37166062967849,655.0 8.509977536459923,47.370984073534544,655.0 8.513313619548607,47.37238015512596,655.0 8.511518892767237,47.374387522193466,655.0 8.509267459600915,47.37166062967849,655.0
+							</coordinates>
+						</LinearRing>
+					</outerBoundaryIs>
+				</Polygon>
+			</Placemark>
+			<Placemark>
+				<name>alt: Low</name>
+				<styleUrl>#msn_ylw-pushpin0</styleUrl>
+				<Polygon>
+					<extrude>1</extrude>
+					<tessellate>1</tessellate>
+					<altitudeMode>absolute</altitudeMode>
+					<outerBoundaryIs>
+						<LinearRing>
+							<coordinates>
+								8.510488970874699,47.375428562929855,570.0 8.511780618890493,47.378005797139494,570.0 8.5087685286589,47.378074018769155,570.0 8.507453168467146,47.37563485906732,570.0 8.510488970874699,47.375428562929855,570.0
+							</coordinates>
+						</LinearRing>
+					</outerBoundaryIs>
+				</Polygon>
+			</Placemark>
+			<Placemark>
+				<name>speed: Departure (5)</name>
+				<styleUrl>#msn_ylw-pushpin2</styleUrl>
+				<Polygon>
+					<tessellate>1</tessellate>
+					<outerBoundaryIs>
+						<LinearRing>
+							<coordinates>
+								8.507706170711212,47.36995718766655,0.0 8.508846636784208,47.37042600425997,0.0 8.508196425088466,47.371282684720995,0.0 8.507065280715347,47.37068957178074,0.0 8.507706170711212,47.36995718766655,0.0
+							</coordinates>
+						</LinearRing>
+					</outerBoundaryIs>
+				</Polygon>
+			</Placemark>
+			<Placemark>
+				<name>speed: Enroute (30)</name>
+				<styleUrl>#msn_ylw-pushpin2</styleUrl>
+				<Polygon>
+					<tessellate>1</tessellate>
+					<outerBoundaryIs>
+						<LinearRing>
+							<coordinates>
+								8.508098610981899,47.371873583853734,0.0 8.513152274264935,47.37332523922927,0.0 8.514160531251842,47.37729110145004,0.0 8.509590109282963,47.37815602158183,0.0 8.50515942299658,47.37523070910003,0.0 8.508098610981899,47.371873583853734,0.0
+							</coordinates>
+						</LinearRing>
+					</outerBoundaryIs>
+				</Polygon>
+			</Placemark>
+			<Placemark>
+				<name>operator_location</name>
+				<styleUrl>#m_ylw-pushpin</styleUrl>
+				<Point>
+					<gx:drawOrder>1</gx:drawOrder>
+					<coordinates>8.507979542766373,47.370902783740675,0.0</coordinates>
+				</Point>
+			</Placemark>
+		</Folder>
+	</Folder>
+</Document>
+</kml>
+

--- a/monitoring/uss_qualifier/test_data/test/invalid_no_speed_accuracy.json
+++ b/monitoring/uss_qualifier/test_data/test/invalid_no_speed_accuracy.json
@@ -1,0 +1,785 @@
+{
+    "flights": [
+        {
+            "reference_time": "2022-01-01T00:00:00+00:00",
+            "states": [
+                {
+                    "timestamp": "2022-01-01T00:00:01+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.488106090860573,
+                        "lat": 47.37063724619898,
+                        "alt": 496.0,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 0.0,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 0.0,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 162.3752362098515,
+                    "speed": 5.0,
+                    "timestamp_accuracy": 1.0,
+                    "vertical_speed": 0.0
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:02+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.488126171527895,
+                        "lat": 47.37059443876779,
+                        "alt": 496.18307267903697,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 0.1830726790369681,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 0.1830726790369681,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 187.50097320343912,
+                    "speed": 5.0,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 0.18
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:03+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.488117678127974,
+                        "lat": 47.370550752380716,
+                        "alt": 498.53226199914917,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 2.5322619991491706,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 2.5322619991491706,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 192.42362296934377,
+                    "speed": 5.0,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 2.35
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:04+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.488103410051705,
+                        "lat": 47.37050688836104,
+                        "alt": 500.40031939929486,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 4.400319399294858,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 4.400319399294858,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 200.40286640336953,
+                    "speed": 5.61,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 1.87
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:05+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.488080501861498,
+                        "lat": 47.37046517716392,
+                        "alt": 501.65525225916707,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 5.655252259167071,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 5.655252259167071,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 208.23182285522853,
+                    "speed": 7.35,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 1.25
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:06+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.488049130286102,
+                        "lat": 47.37042560543707,
+                        "alt": 502.4106030975036,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 6.410603097503611,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 6.410603097503611,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 208.81982213774143,
+                    "speed": 8.15,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 0.76
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:07+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.488013259623491,
+                        "lat": 47.37038145191838,
+                        "alt": 503.1337164705349,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 7.133716470534921,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 7.133716470534921,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 202.1993676258766,
+                    "speed": 9.84,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 0.72
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:08+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.487985396361207,
+                        "lat": 47.37033520979453,
+                        "alt": 504.077325459153,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 8.077325459152974,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 8.077325459152974,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 193.30773490939308,
+                    "speed": 11.96,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 0.94
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:09+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.487973904140395,
+                        "lat": 47.3703023046547,
+                        "alt": 504.909136585584,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 8.909136585584008,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 8.909136585584008,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 186.94220133247893,
+                    "speed": 14.37,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 0.83
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:10+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.487962372282103,
+                        "lat": 47.37023816260832,
+                        "alt": 506.62385364810143,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 10.62385364810143,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 10.62385364810143,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 171.81024867542703,
+                    "speed": 16.74,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 1.71
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:11+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.487976559973054,
+                        "lat": 47.370171398603745,
+                        "alt": 508.75800509123735,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 12.75800509123735,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 12.75800509123735,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 154.86309008170363,
+                    "speed": 18.36,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 2.13
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:12+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.488019499902185,
+                        "lat": 47.37010942090538,
+                        "alt": 511.13171827832986,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 15.131718278329856,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 15.131718278329856,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 132.98217445043147,
+                    "speed": 23.11,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 2.37
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:13+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.488089449646983,
+                        "lat": 47.37006527181479,
+                        "alt": 513.3848015774483,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 17.384801577448343,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 17.384801577448343,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 116.6325467769568,
+                    "speed": 25.65,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 2.25
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:14+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.48815088026746,
+                        "lat": 47.37004440849303,
+                        "alt": 514.9199444465004,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 18.91994444650038,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 18.91994444650038,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 123.51221393134806,
+                    "speed": 27.84,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 1.54
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:15+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.48831139751754,
+                        "lat": 47.369972421106304,
+                        "alt": 518.8514455015629,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 22.85144550156292,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 22.85144550156292,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 126.39759736353494,
+                    "speed": 30.0,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 3.93
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:16+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.4883924829112,
+                        "lat": 47.3699319376166,
+                        "alt": 520.6710082621752,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 24.671008262175178,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 24.671008262175178,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 127.79792720040928,
+                    "speed": 30.0,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 1.82
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:17+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.48846068845649,
+                        "lat": 47.36989610981006,
+                        "alt": 522.1109485203592,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 26.110948520359216,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 26.110948520359216,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 122.00014201767304,
+                    "speed": 30.0,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 1.44
+                }
+            ],
+            "flight_details": {
+                "id": "d22a1cef-a3e0-437f-92b5-44c1453f4068",
+                "serial_number": "1AKGAAN8G70R7JS",
+                "operation_description": "U-turn south of takeoff",
+                "operator_location": {
+                    "lat": 47.37085983569079,
+                    "lng": 8.487908591798265
+                },
+                "operator_id": "CHE-RP-f39mqfitkh9e5"
+            },
+            "aircraft_type": "Helicopter"
+        },
+        {
+            "reference_time": "2022-01-01T00:00:00+00:00",
+            "states": [
+                {
+                    "timestamp": "2022-01-01T00:00:01+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.5082751179102,
+                        "lat": 47.37077841542829,
+                        "alt": 529.0,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 0.0,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 0.0,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 43.03829301396051,
+                    "speed": 5.0,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 0.0
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:02+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.508320380900203,
+                        "lat": 47.37081124427215,
+                        "alt": 529.0,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 0.0,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 0.0,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 44.471165943871895,
+                    "speed": 5.0,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 0.0
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:03+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.50836683820487,
+                        "lat": 47.37084329379501,
+                        "alt": 529.0,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 0.0,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 0.0,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 45.00987803090026,
+                    "speed": 5.0,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 0.0
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:04+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.508413742027768,
+                        "lat": 47.37087504853866,
+                        "alt": 529.0,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 0.0,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 0.0,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 42.283916233986616,
+                    "speed": 5.0,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 0.0
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:05+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.508456791062693,
+                        "lat": 47.370907107576116,
+                        "alt": 529.0,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 0.0,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 0.0,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 56.404457560286055,
+                    "speed": 6.78,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 0.0
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:06+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.508512033806365,
+                        "lat": 47.37093196068016,
+                        "alt": 534.3462453934874,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 5.346245393487379,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 5.346245393487379,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 56.40454827550896,
+                    "speed": 8.08,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 5.35
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:07+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.508567276608135,
+                        "lat": 47.37095681372497,
+                        "alt": 541.0071850407926,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 12.007185040792592,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 12.007185040792592,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 49.37103887319031,
+                    "speed": 9.5,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 6.66
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:08+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.508635411250422,
+                        "lat": 47.37099640465343,
+                        "alt": 549.7092175828766,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 20.70921758287659,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 20.70921758287659,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 55.26415971173848,
+                    "speed": 10.93,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 8.7
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:09+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.50872335395775,
+                        "lat": 47.37103770064569,
+                        "alt": 559.9711540980651,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 30.971154098065085,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 30.971154098065085,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 48.272018247873895,
+                    "speed": 12.34,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 10.26
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:10+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.5088116351726,
+                        "lat": 47.3710910227504,
+                        "alt": 570.9516494270789,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 41.951649427078905,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 41.951649427078905,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 11.45105545883768,
+                    "speed": 13.38,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 10.98
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:11+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.508840417269266,
+                        "lat": 47.37118725325097,
+                        "alt": 580.314615001263,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 51.31461500126295,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 51.31461500126295,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 11.820237778805804,
+                    "speed": 14.58,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 9.36
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:12+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.508861648775275,
+                        "lat": 47.37125596075003,
+                        "alt": 587.3889523597257,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 58.38895235972575,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 58.38895235972575,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 11.683449532931599,
+                    "speed": 16.24,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 7.07
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:13+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.50888532292006,
+                        "lat": 47.37133349567566,
+                        "alt": 595.7395125812138,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 66.73951258121383,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 66.73951258121383,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 358.70456587570527,
+                    "speed": 18.01,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 8.35
+                }
+            ],
+            "flight_details": {
+                "id": "b238e812-7282-49c4-8567-f15da4815430",
+                "serial_number": "ULYK563L5G",
+                "operation_description": "Circle flight",
+                "operator_location": {
+                    "lat": 47.370902783740675,
+                    "lng": 8.507979542766373
+                },
+                "operator_id": "CHE-RP-iwetcg7ucfopc"
+            },
+            "aircraft_type": "Helicopter"
+        }
+    ]
+}

--- a/monitoring/uss_qualifier/test_data/test/invalid_no_speed_accuracy.kml
+++ b/monitoring/uss_qualifier/test_data/test/invalid_no_speed_accuracy.kml
@@ -1,0 +1,531 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:kml="http://www.opengis.net/kml/2.2" xmlns:atom="http://www.w3.org/2005/Atom">
+<Document>
+	<name>rid.kml</name>
+	<StyleMap id="m_ylw-pushpin">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#s_ylw-pushpin</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#s_ylw-pushpin_hl0</styleUrl>
+		</Pair>
+	</StyleMap>
+	<StyleMap id="m_ylw-pushpin0">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#s_ylw-pushpin0</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#s_ylw-pushpin_hl</styleUrl>
+		</Pair>
+	</StyleMap>
+	<StyleMap id="m_ylw-pushpin1">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#s_ylw-pushpin1</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#s_ylw-pushpin_hl00</styleUrl>
+		</Pair>
+	</StyleMap>
+	<StyleMap id="msn_ylw-pushpin">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#sn_ylw-pushpin</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#sh_ylw-pushpin</styleUrl>
+		</Pair>
+	</StyleMap>
+	<StyleMap id="msn_ylw-pushpin0">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#sn_ylw-pushpin0</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#sh_ylw-pushpin2</styleUrl>
+		</Pair>
+	</StyleMap>
+	<StyleMap id="msn_ylw-pushpin10">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#sn_ylw-pushpin10</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#sh_ylw-pushpin1</styleUrl>
+		</Pair>
+	</StyleMap>
+	<StyleMap id="msn_ylw-pushpin2">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#sn_ylw-pushpin20</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#sh_ylw-pushpin00</styleUrl>
+		</Pair>
+	</StyleMap>
+	<StyleMap id="msn_ylw-pushpin20">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#sn_ylw-pushpin2</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#sh_ylw-pushpin0</styleUrl>
+		</Pair>
+	</StyleMap>
+	<StyleMap id="msn_ylw-pushpin3">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#sn_ylw-pushpin3</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#sh_ylw-pushpin3</styleUrl>
+		</Pair>
+	</StyleMap>
+	<Style id="s_ylw-pushpin">
+		<IconStyle>
+			<scale>1.1</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+	</Style>
+	<Style id="s_ylw-pushpin0">
+		<IconStyle>
+			<scale>1.1</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<PolyStyle>
+			<fill>0</fill>
+		</PolyStyle>
+	</Style>
+	<Style id="s_ylw-pushpin1">
+		<IconStyle>
+			<scale>1.1</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+	</Style>
+	<Style id="s_ylw-pushpin_hl">
+		<IconStyle>
+			<scale>1.3</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<PolyStyle>
+			<fill>0</fill>
+		</PolyStyle>
+	</Style>
+	<Style id="s_ylw-pushpin_hl0">
+		<IconStyle>
+			<scale>1.3</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+	</Style>
+	<Style id="s_ylw-pushpin_hl00">
+		<IconStyle>
+			<scale>1.3</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+	</Style>
+	<Style id="sh_ylw-pushpin">
+		<IconStyle>
+			<scale>1.3</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<PolyStyle>
+			<fill>0</fill>
+		</PolyStyle>
+	</Style>
+	<Style id="sh_ylw-pushpin0">
+		<IconStyle>
+			<scale>1.3</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<LineStyle>
+			<color>ff0880fd</color>
+		</LineStyle>
+		<PolyStyle>
+			<fill>0</fill>
+		</PolyStyle>
+	</Style>
+	<Style id="sh_ylw-pushpin00">
+		<IconStyle>
+			<scale>1.3</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<LineStyle>
+			<color>ff0880fd</color>
+		</LineStyle>
+		<PolyStyle>
+			<fill>0</fill>
+		</PolyStyle>
+	</Style>
+	<Style id="sh_ylw-pushpin1">
+		<IconStyle>
+			<scale>1.3</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<LineStyle>
+			<color>ffffff20</color>
+		</LineStyle>
+	</Style>
+	<Style id="sh_ylw-pushpin2">
+		<IconStyle>
+			<scale>1.3</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<PolyStyle>
+			<fill>0</fill>
+		</PolyStyle>
+	</Style>
+	<Style id="sh_ylw-pushpin3">
+		<IconStyle>
+			<scale>1.3</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<PolyStyle>
+			<fill>0</fill>
+		</PolyStyle>
+	</Style>
+	<Style id="sn_ylw-pushpin">
+		<IconStyle>
+			<scale>1.1</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<PolyStyle>
+			<fill>0</fill>
+		</PolyStyle>
+	</Style>
+	<Style id="sn_ylw-pushpin0">
+		<IconStyle>
+			<scale>1.1</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<PolyStyle>
+			<fill>0</fill>
+		</PolyStyle>
+	</Style>
+	<Style id="sn_ylw-pushpin10">
+		<IconStyle>
+			<scale>1.1</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<LineStyle>
+			<color>ffffff20</color>
+		</LineStyle>
+	</Style>
+	<Style id="sn_ylw-pushpin2">
+		<IconStyle>
+			<scale>1.1</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<LineStyle>
+			<color>ff0880fd</color>
+		</LineStyle>
+		<PolyStyle>
+			<fill>0</fill>
+		</PolyStyle>
+	</Style>
+	<Style id="sn_ylw-pushpin20">
+		<IconStyle>
+			<scale>1.1</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<LineStyle>
+			<color>ff0880fd</color>
+		</LineStyle>
+		<PolyStyle>
+			<fill>0</fill>
+		</PolyStyle>
+	</Style>
+	<Style id="sn_ylw-pushpin3">
+		<IconStyle>
+			<scale>1.1</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<PolyStyle>
+			<fill>0</fill>
+		</PolyStyle>
+	</Style>
+	<Folder>
+		<name>zurich</name>
+		<open>1</open>
+		<Folder>
+			<name>flight: south u</name>
+			<open>1</open>
+			<description>serial_number: 1AKGAAN8G70R7JS
+aircraft_type: Helicopter
+operation_description: U-turn south of takeoff
+operator_id: CHE-RP-f39mqfitkh9e5
+operator_name: Jane Doe
+timestamp_accuracy: 1.0
+sample_rate: 1.0
+accuracy_h: HAUnknown
+accuracy_v: VAUnknown
+    </description>
+			<Placemark>
+				<name>U turn south</name>
+				<styleUrl>#msn_ylw-pushpin10</styleUrl>
+				<LineString>
+					<tessellate>1</tessellate>
+					<coordinates>
+						8.488086010193248,47.37068005363017,0.0 8.48812954746956,47.370587242025366,0.0 8.488096461986222,47.37048552808266,0.0 8.488058869601295,47.370437593647054,0.0 8.487992713476777,47.37035616148304,0.0 8.48798464448449,47.370333056885144,0.0 8.487973904140395,47.3703023046547,0.0 8.487966840917556,47.370266323893794,0.0 8.487962372282103,47.37023816260832,0.0 8.487967675859187,47.370207342634934,0.0 8.487976559973054,47.370171398603745,0.0 8.48799807719684,47.37014036227894,0.0 8.488019499902185,47.37010942090538,0.0 8.488053429665532,47.37008339144921,0.0 8.488089449646983,47.37006527181478,0.0 8.488121925894466,47.370052282478674,0.0 8.48815088026746,47.37004440849303,0.0 8.48827518488533,47.36999864947174,0.0 8.48831139751754,47.369972421106304,0.0 8.48835375032042,47.36995426515459,0.0 8.4883924829112,47.3699319376166,0.0 8.488426644184889,47.369913985083514,0.0 8.48846068845649,47.36989610981006,0.0 8.488495983730138,47.369878322762034,0.0 8.48853439095125,47.369864919157145,0.0 8.488562728428482,47.36985722273458,0.0 8.488595159283255,47.369853852306214,0.0 8.488636589108003,47.369849906174295,0.0 8.48867952953342,47.36985020494702,0.0 8.488708578938505,47.36984763686421,0.0
+					</coordinates>
+				</LineString>
+			</Placemark>
+			<Placemark>
+				<name>alt: Takeoff</name>
+				<styleUrl>#m_ylw-pushpin0</styleUrl>
+				<Polygon>
+					<tessellate>1</tessellate>
+					<altitudeMode>absolute</altitudeMode>
+					<outerBoundaryIs>
+						<LinearRing>
+							<coordinates>
+								8.487599206246548,47.370506331316705,496.0 8.48773686257555,47.370357145137795,496.0 8.488527190331814,47.37084454793311,496.0 8.488389720684472,47.371003666625,496.0 8.487599206246548,47.370506331316705,496.0
+							</coordinates>
+						</LinearRing>
+					</outerBoundaryIs>
+				</Polygon>
+			</Placemark>
+			<Placemark>
+				<name>alt: High</name>
+				<styleUrl>#msn_ylw-pushpin</styleUrl>
+				<Polygon>
+					<extrude>1</extrude>
+					<tessellate>1</tessellate>
+					<altitudeMode>absolute</altitudeMode>
+					<outerBoundaryIs>
+						<LinearRing>
+							<coordinates>
+								8.48957979534743,47.369927140429084,551.0 8.490587218626521,47.37027611497966,551.0 8.490661563415705,47.37107682800347,551.0 8.489204440074536,47.370663517599084,551.0 8.48957979534743,47.369927140429084,551.0
+							</coordinates>
+						</LinearRing>
+					</outerBoundaryIs>
+				</Polygon>
+			</Placemark>
+			<Placemark>
+				<name>alt: Low</name>
+				<styleUrl>#msn_ylw-pushpin</styleUrl>
+				<Polygon>
+					<extrude>1</extrude>
+					<tessellate>1</tessellate>
+					<altitudeMode>absolute</altitudeMode>
+					<outerBoundaryIs>
+						<LinearRing>
+							<coordinates>
+								8.491850511360857,47.36774777095399,521.0 8.493236481345823,47.37021642084468,521.0 8.490620125766261,47.369968081354884,521.0 8.48962145300232,47.368391591949525,521.0 8.491850511360857,47.36774777095399,521.0
+							</coordinates>
+						</LinearRing>
+					</outerBoundaryIs>
+				</Polygon>
+			</Placemark>
+			<Placemark>
+				<name>speed: Departure (5)</name>
+				<styleUrl>#msn_ylw-pushpin20</styleUrl>
+				<Polygon>
+					<tessellate>1</tessellate>
+					<outerBoundaryIs>
+						<LinearRing>
+							<coordinates>
+								8.487627177694923,47.37022567192925,0.0 8.488541433192031,47.370700520846526,0.0 8.488146211772209,47.371136886332906,0.0 8.487235428789324,47.37064948552166,0.0 8.487627177694923,47.37022567192925,0.0
+							</coordinates>
+						</LinearRing>
+					</outerBoundaryIs>
+				</Polygon>
+			</Placemark>
+			<Placemark>
+				<name>speed: Enroute (30)</name>
+				<styleUrl>#msn_ylw-pushpin20</styleUrl>
+				<Polygon>
+					<tessellate>1</tessellate>
+					<outerBoundaryIs>
+						<LinearRing>
+							<coordinates>
+								8.489638509156725,47.367439591965365,0.0 8.492925998859539,47.37003155923135,0.0 8.49104344194709,47.371956544316674,0.0 8.488021081836711,47.369439356682854,0.0 8.489638509156725,47.367439591965365,0.0
+							</coordinates>
+						</LinearRing>
+					</outerBoundaryIs>
+				</Polygon>
+			</Placemark>
+			<Placemark>
+				<name>operator_location</name>
+				<styleUrl>#m_ylw-pushpin1</styleUrl>
+				<Point>
+					<gx:drawOrder>1</gx:drawOrder>
+					<coordinates>8.487908591798265,47.37085983569079,0.0</coordinates>
+				</Point>
+			</Placemark>
+		</Folder>
+		<Folder>
+			<name>flight: circle</name>
+			<open>1</open>
+			<description>serial_number: ULYK563L5G
+aircraft_type: Helicopter
+operation_description: Circle flight
+operator_id: CHE-RP-iwetcg7ucfopc
+operator_name: John Doe
+timestamp_accuracy: 1.0
+speed_accuracy: SA3mps
+sample_rate: 1.0
+accuracy_h: HAUnknown
+accuracy_v: VAUnknown</description>
+			<Placemark>
+				<name>South</name>
+				<styleUrl>#msn_ylw-pushpin10</styleUrl>
+				<LineString>
+					<tessellate>1</tessellate>
+					<coordinates>
+						8.508229854920197,47.37074558658443,0.0 8.508329471365594,47.370817837505804,0.0 8.508375471496616,47.37084917525504,0.0 8.508421911721352,47.37088057176483,0.0 8.508456791062694,47.370907107576116,0.0 8.508519008377102,47.370935098462986,0.0 8.508581245669442,47.37096309822762,0.0 8.508647221360685,47.371003666692424,0.0 8.50878573903851,47.371065588974794,0.0 8.5088116351726,47.3710910227504,0.0 8.508825848236209,47.37113965697517,0.0 8.508843658918347,47.37119784355049,0.0 8.508861648775275,47.37125596075003,0.0 8.508870643430166,47.371285017030544,0.0 8.50888532292006,47.37133349567566,0.0 8.508888431723344,47.37140544348874,0.0 8.508881475041415,47.371448736079756,0.0 8.508854363332072,47.37150754532702,0.0 8.508812856615459,47.37157081371983,0.0 8.50877499150027,47.371644036289254,0.0 8.5087471867464,47.371693159220264,0.0
+					</coordinates>
+				</LineString>
+			</Placemark>
+			<Placemark>
+				<name>alt: Takeoff</name>
+				<styleUrl>#m_ylw-pushpin0</styleUrl>
+				<Polygon>
+					<tessellate>1</tessellate>
+					<altitudeMode>absolute</altitudeMode>
+					<outerBoundaryIs>
+						<LinearRing>
+							<coordinates>
+								8.507599206246548,47.370506331316705,529.0 8.50773686257555,47.370357145137795,529.0 8.508527190331814,47.37084454793311,529.0 8.508389720684472,47.371003666625,529.0 8.507599206246548,47.370506331316705,529.0
+							</coordinates>
+						</LinearRing>
+					</outerBoundaryIs>
+				</Polygon>
+			</Placemark>
+			<Placemark>
+				<name>alt: High</name>
+				<styleUrl>#msn_ylw-pushpin3</styleUrl>
+				<Polygon>
+					<extrude>1</extrude>
+					<tessellate>1</tessellate>
+					<altitudeMode>absolute</altitudeMode>
+					<outerBoundaryIs>
+						<LinearRing>
+							<coordinates>
+								8.509267459600915,47.37166062967849,655.0 8.509977536459923,47.370984073534544,655.0 8.513313619548607,47.37238015512596,655.0 8.511518892767237,47.374387522193466,655.0 8.509267459600915,47.37166062967849,655.0
+							</coordinates>
+						</LinearRing>
+					</outerBoundaryIs>
+				</Polygon>
+			</Placemark>
+			<Placemark>
+				<name>alt: Low</name>
+				<styleUrl>#msn_ylw-pushpin0</styleUrl>
+				<Polygon>
+					<extrude>1</extrude>
+					<tessellate>1</tessellate>
+					<altitudeMode>absolute</altitudeMode>
+					<outerBoundaryIs>
+						<LinearRing>
+							<coordinates>
+								8.510488970874699,47.375428562929855,570.0 8.511780618890493,47.378005797139494,570.0 8.5087685286589,47.378074018769155,570.0 8.507453168467146,47.37563485906732,570.0 8.510488970874699,47.375428562929855,570.0
+							</coordinates>
+						</LinearRing>
+					</outerBoundaryIs>
+				</Polygon>
+			</Placemark>
+			<Placemark>
+				<name>speed: Departure (5)</name>
+				<styleUrl>#msn_ylw-pushpin2</styleUrl>
+				<Polygon>
+					<tessellate>1</tessellate>
+					<outerBoundaryIs>
+						<LinearRing>
+							<coordinates>
+								8.507706170711212,47.36995718766655,0.0 8.508846636784208,47.37042600425997,0.0 8.508196425088466,47.371282684720995,0.0 8.507065280715347,47.37068957178074,0.0 8.507706170711212,47.36995718766655,0.0
+							</coordinates>
+						</LinearRing>
+					</outerBoundaryIs>
+				</Polygon>
+			</Placemark>
+			<Placemark>
+				<name>speed: Enroute (30)</name>
+				<styleUrl>#msn_ylw-pushpin2</styleUrl>
+				<Polygon>
+					<tessellate>1</tessellate>
+					<outerBoundaryIs>
+						<LinearRing>
+							<coordinates>
+								8.508098610981899,47.371873583853734,0.0 8.513152274264935,47.37332523922927,0.0 8.514160531251842,47.37729110145004,0.0 8.509590109282963,47.37815602158183,0.0 8.50515942299658,47.37523070910003,0.0 8.508098610981899,47.371873583853734,0.0
+							</coordinates>
+						</LinearRing>
+					</outerBoundaryIs>
+				</Polygon>
+			</Placemark>
+			<Placemark>
+				<name>operator_location</name>
+				<styleUrl>#m_ylw-pushpin</styleUrl>
+				<Point>
+					<gx:drawOrder>1</gx:drawOrder>
+					<coordinates>8.507979542766373,47.370902783740675,0.0</coordinates>
+				</Point>
+			</Placemark>
+		</Folder>
+	</Folder>
+</Document>
+</kml>
+

--- a/monitoring/uss_qualifier/test_data/test/zurich.json
+++ b/monitoring/uss_qualifier/test_data/test/zurich.json
@@ -1,0 +1,786 @@
+{
+    "flights": [
+        {
+            "reference_time": "2022-01-01T00:00:00+00:00",
+            "states": [
+                {
+                    "timestamp": "2022-01-01T00:00:01+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.488106090860573,
+                        "lat": 47.37063724619898,
+                        "alt": 496.0,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 0.0,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 0.0,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 162.3752362098515,
+                    "speed": 5.0,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 0.0
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:02+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.488126171527895,
+                        "lat": 47.37059443876779,
+                        "alt": 496.18307267903697,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 0.1830726790369681,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 0.1830726790369681,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 187.50097320343912,
+                    "speed": 5.0,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 0.18
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:03+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.488117678127974,
+                        "lat": 47.370550752380716,
+                        "alt": 498.53226199914917,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 2.5322619991491706,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 2.5322619991491706,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 192.42362296934377,
+                    "speed": 5.0,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 2.35
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:04+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.488103410051705,
+                        "lat": 47.37050688836104,
+                        "alt": 500.40031939929486,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 4.400319399294858,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 4.400319399294858,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 200.40286640336953,
+                    "speed": 5.61,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 1.87
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:05+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.488080501861498,
+                        "lat": 47.37046517716392,
+                        "alt": 501.65525225916707,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 5.655252259167071,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 5.655252259167071,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 208.23182285522853,
+                    "speed": 7.35,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 1.25
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:06+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.488049130286102,
+                        "lat": 47.37042560543707,
+                        "alt": 502.4106030975036,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 6.410603097503611,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 6.410603097503611,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 208.81982213774143,
+                    "speed": 8.15,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 0.76
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:07+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.488013259623491,
+                        "lat": 47.37038145191838,
+                        "alt": 503.1337164705349,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 7.133716470534921,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 7.133716470534921,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 202.1993676258766,
+                    "speed": 9.84,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 0.72
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:08+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.487985396361207,
+                        "lat": 47.37033520979453,
+                        "alt": 504.077325459153,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 8.077325459152974,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 8.077325459152974,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 193.30773490939308,
+                    "speed": 11.96,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 0.94
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:09+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.487973904140395,
+                        "lat": 47.3703023046547,
+                        "alt": 504.909136585584,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 8.909136585584008,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 8.909136585584008,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 186.94220133247893,
+                    "speed": 14.37,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 0.83
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:10+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.487962372282103,
+                        "lat": 47.37023816260832,
+                        "alt": 506.62385364810143,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 10.62385364810143,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 10.62385364810143,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 171.81024867542703,
+                    "speed": 16.74,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 1.71
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:11+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.487976559973054,
+                        "lat": 47.370171398603745,
+                        "alt": 508.75800509123735,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 12.75800509123735,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 12.75800509123735,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 154.86309008170363,
+                    "speed": 18.36,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 2.13
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:12+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.488019499902185,
+                        "lat": 47.37010942090538,
+                        "alt": 511.13171827832986,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 15.131718278329856,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 15.131718278329856,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 132.98217445043147,
+                    "speed": 23.11,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 2.37
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:13+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.488089449646983,
+                        "lat": 47.37006527181479,
+                        "alt": 513.3848015774483,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 17.384801577448343,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 17.384801577448343,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 116.6325467769568,
+                    "speed": 25.65,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 2.25
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:14+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.48815088026746,
+                        "lat": 47.37004440849303,
+                        "alt": 514.9199444465004,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 18.91994444650038,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 18.91994444650038,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 123.51221393134806,
+                    "speed": 27.84,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 1.54
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:15+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.48831139751754,
+                        "lat": 47.369972421106304,
+                        "alt": 518.8514455015629,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 22.85144550156292,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 22.85144550156292,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 126.39759736353494,
+                    "speed": 30.0,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 3.93
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:16+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.4883924829112,
+                        "lat": 47.3699319376166,
+                        "alt": 520.6710082621752,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 24.671008262175178,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 24.671008262175178,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 127.79792720040928,
+                    "speed": 30.0,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 1.82
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:17+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.48846068845649,
+                        "lat": 47.36989610981006,
+                        "alt": 522.1109485203592,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 26.110948520359216,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 26.110948520359216,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 122.00014201767304,
+                    "speed": 30.0,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 1.44
+                }
+            ],
+            "flight_details": {
+                "id": "d22a1cef-a3e0-437f-92b5-44c1453f4068",
+                "serial_number": "1AKGAAN8G70R7JS",
+                "operation_description": "U-turn south of takeoff",
+                "operator_location": {
+                    "lat": 47.37085983569079,
+                    "lng": 8.487908591798265
+                },
+                "operator_id": "CHE-RP-f39mqfitkh9e5"
+            },
+            "aircraft_type": "Helicopter"
+        },
+        {
+            "reference_time": "2022-01-01T00:00:00+00:00",
+            "states": [
+                {
+                    "timestamp": "2022-01-01T00:00:01+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.5082751179102,
+                        "lat": 47.37077841542829,
+                        "alt": 529.0,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 0.0,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 0.0,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 43.03829301396051,
+                    "speed": 5.0,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 0.0
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:02+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.508320380900203,
+                        "lat": 47.37081124427215,
+                        "alt": 529.0,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 0.0,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 0.0,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 44.471165943871895,
+                    "speed": 5.0,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 0.0
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:03+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.50836683820487,
+                        "lat": 47.37084329379501,
+                        "alt": 529.0,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 0.0,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 0.0,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 45.00987803090026,
+                    "speed": 5.0,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 0.0
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:04+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.508413742027768,
+                        "lat": 47.37087504853866,
+                        "alt": 529.0,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 0.0,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 0.0,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 42.283916233986616,
+                    "speed": 5.0,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 0.0
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:05+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.508456791062693,
+                        "lat": 47.370907107576116,
+                        "alt": 529.0,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 0.0,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 0.0,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 56.404457560286055,
+                    "speed": 6.78,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 0.0
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:06+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.508512033806365,
+                        "lat": 47.37093196068016,
+                        "alt": 534.3462453934874,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 5.346245393487379,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 5.346245393487379,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 56.40454827550896,
+                    "speed": 8.08,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 5.35
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:07+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.508567276608135,
+                        "lat": 47.37095681372497,
+                        "alt": 541.0071850407926,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 12.007185040792592,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 12.007185040792592,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 49.37103887319031,
+                    "speed": 9.5,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 6.66
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:08+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.508635411250422,
+                        "lat": 47.37099640465343,
+                        "alt": 549.7092175828766,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 20.70921758287659,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 20.70921758287659,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 55.26415971173848,
+                    "speed": 10.93,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 8.7
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:09+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.50872335395775,
+                        "lat": 47.37103770064569,
+                        "alt": 559.9711540980651,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 30.971154098065085,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 30.971154098065085,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 48.272018247873895,
+                    "speed": 12.34,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 10.26
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:10+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.5088116351726,
+                        "lat": 47.3710910227504,
+                        "alt": 570.9516494270789,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 41.951649427078905,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 41.951649427078905,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 11.45105545883768,
+                    "speed": 13.38,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 10.98
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:11+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.508840417269266,
+                        "lat": 47.37118725325097,
+                        "alt": 580.314615001263,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 51.31461500126295,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 51.31461500126295,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 11.820237778805804,
+                    "speed": 14.58,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 9.36
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:12+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.508861648775275,
+                        "lat": 47.37125596075003,
+                        "alt": 587.3889523597257,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 58.38895235972575,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 58.38895235972575,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 11.683449532931599,
+                    "speed": 16.24,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 7.07
+                },
+                {
+                    "timestamp": "2022-01-01T00:00:13+00:00",
+                    "operational_status": "Airborne",
+                    "position": {
+                        "lng": 8.50888532292006,
+                        "lat": 47.37133349567566,
+                        "alt": 595.7395125812138,
+                        "accuracy_h": "HAUnknown",
+                        "accuracy_v": "VAUnknown",
+                        "extrapolated": false,
+                        "height": {
+                            "distance": 66.73951258121383,
+                            "reference": "TakeoffLocation"
+                        }
+                    },
+                    "height": {
+                        "distance": 66.73951258121383,
+                        "reference": "TakeoffLocation"
+                    },
+                    "track": 358.70456587570527,
+                    "speed": 18.01,
+                    "timestamp_accuracy": 1.0,
+                    "speed_accuracy": "SA3mps",
+                    "vertical_speed": 8.35
+                }
+            ],
+            "flight_details": {
+                "id": "b238e812-7282-49c4-8567-f15da4815430",
+                "serial_number": "ULYK563L5G",
+                "operation_description": "Circle flight",
+                "operator_location": {
+                    "lat": 47.370902783740675,
+                    "lng": 8.507979542766373
+                },
+                "operator_id": "CHE-RP-iwetcg7ucfopc"
+            },
+            "aircraft_type": "Helicopter"
+        }
+    ]
+}


### PR DESCRIPTION
Add validation of loaded data for flights.

Invalid flights may crash the test suite or generate unexpected test results (as we sometime generate invalid flights from valid ones).

Fix #924 

Added some units tests as well :)