### PR TITLE
[mock_uss] Add uses_cmsa option

### DIFF
--- a/monitoring/mock_uss/scd_injection/routes_injection.py
+++ b/monitoring/mock_uss/scd_injection/routes_injection.py
@@ -178,6 +178,16 @@ def inject_flight(
     except PlanningError as e:
         return unsuccessful(PlanningActivityResult.Rejected, str(e))
 
+    if not locality.uses_cmsa():
+        if new_flight.op_intent.reference.state in [
+            scd_api.OperationalIntentState.Nonconforming,
+            scd_api.OperationalIntentState.Contingent,
+        ]:
+            return unsuccessful(
+                PlanningActivityResult.NotSupported,
+                f"The current locality {locality} does not support CMSA, flight cannot transition to {new_flight.op_intent.reference.state}",
+            )
+
     step_name = "performing unknown operation"
     notes: str | None = None
     try:

--- a/monitoring/monitorlib/locality.py
+++ b/monitoring/monitorlib/locality.py
@@ -37,6 +37,11 @@ class Locality(ABC):
         """Returns the highest priority level for ASTM F3548-21 defined by the regulator of this locality"""
         raise NotImplementedError(Locality._NOT_IMPLEMENTED_MSG)
 
+    @abstractmethod
+    def uses_cmsa(self) -> bool:
+        """Return true if the ecosystem supports CMSA operations"""
+        raise NotImplementedError(Locality._NOT_IMPLEMENTED_MSG)
+
     def __str__(self):
         return self.__class__.__name__
 
@@ -69,6 +74,13 @@ class Switzerland(Locality):
     def highest_priority(self) -> int:
         return 100
 
+    def uses_cmsa(self) -> bool:
+        # Return True for now as Switzerland didn't determined yet if CMSA is
+        # used.
+        # If switched to False, ensure tests have a locality with CMSA enabled.
+        # See https://github.com/interuss/monitoring/pull/1304#pullrequestreview-3594632974
+        return True
+
 
 class UnitedStatesIndustryCollaboration(Locality):
     @classmethod
@@ -86,3 +98,6 @@ class UnitedStatesIndustryCollaboration(Locality):
 
     def highest_priority(self) -> int:
         return 100
+
+    def uses_cmsa(self) -> bool:
+        return False


### PR DESCRIPTION
Fix #878 

Add an option for the mock_uss to support or not cmsa.

This is done on flight injection level, preventing the injection of flights in the Nonconforming/Contingent state. This should prevent the mock_uss to do CMSA calls, but I may have missed some others cases.