### PR TITLE
[uss_qualifier] Add filter option when running tests

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -5192,74 +5192,10 @@
                 }
             },
             {
-                "code": "reportOperatorIssue",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 28,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 55,
-                    "endColumn": 64,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 28,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 24,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 8,
                     "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOperatorIssue",
-                "range": {
-                    "startColumn": 51,
-                    "endColumn": 72,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 42,
                     "lineCount": 1
                 }
             },

--- a/monitoring/uss_qualifier/configurations/configuration.py
+++ b/monitoring/uss_qualifier/configurations/configuration.py
@@ -132,6 +132,9 @@ class ExecutionConfiguration(ImplicitDict):
     stop_when_resource_not_created: bool | None = False
     """If true, stop test execution if one of the resources cannot be created.  Otherwise, resources that cannot be created due to missing prerequisites are simply treated as omitted."""
 
+    scenarios_filter: str | None
+    """Filter test scenarios by class name using a regex. When empty, all scenarios are executed. Useful for targeted debugging. Overridden by --filter"""
+
 
 class TestConfiguration(ImplicitDict):
     action: TestSuiteActionDeclaration

--- a/monitoring/uss_qualifier/suites/suite.py
+++ b/monitoring/uss_qualifier/suites/suite.py
@@ -158,6 +158,7 @@ class TestSuiteAction[T: ActionGenerator]:
         scenario.time_context[TimeDuringTest.StartOfScenario] = Time(
             arrow.utcnow().datetime
         )
+
         try:
             try:
                 scenario.run(context)
@@ -629,6 +630,21 @@ class ExecutionContext:
                         reason=f"Action selected to be skipped by skip_action_when condition {f}",
                         declaration=self.current_frame.action.declaration,
                     )
+
+        if (
+            "scenarios_filter" in self.config
+            and self.config.scenarios_filter
+            and self.current_frame.action.test_scenario
+        ):
+            if not re.match(
+                self.config.scenarios_filter,
+                self.current_frame.action.test_scenario.__class__.__name__,
+            ):
+                return SkippedActionReport(
+                    timestamp=StringBasedDateTime(arrow.utcnow()),
+                    reason="Filtered scenario",
+                    declaration=self.current_frame.action.declaration,
+                )
 
         return None
 

--- a/schemas/monitoring/uss_qualifier/configurations/configuration/ExecutionConfiguration.json
+++ b/schemas/monitoring/uss_qualifier/configurations/configuration/ExecutionConfiguration.json
@@ -17,6 +17,13 @@
         "null"
       ]
     },
+    "scenarios_filter": {
+      "description": "Filter test scenarios by class name using a regex. When empty, all scenarios are executed. Useful for targeted debugging. Overridden by --filter",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "skip_action_when": {
       "description": "If specified, do not execute test actions if they are selected by ANY of these conditions.",
       "items": {


### PR DESCRIPTION
When developing / debugging the application, we usually want to run a specific test (or subset of tests), but in the context of existing configuration set.

I usually used the approach of 'commenting unwanted tests' in yml configuration files, but that can be tedious, especially since they reference them self.

This PR propose to add a new option, `--filter`, that, if used, will apply a regex on the test scenario ran.

Eg. to run ConflictEqualPriorityNotPermitted, `--filter ConflictEqualPriorityNotPermitted` can be used. Or to run the two conflicts tests, `--filter ConflictEqualPriorityNotPermitted\|ConflictHigherPriority` (or just `--filter Conflict` in that case).
