### PR TITLE
[monitorlib] Handle gracefully missing field in versioning client

### DIFF
--- a/monitoring/monitorlib/clients/versioning/client_interuss.py
+++ b/monitoring/monitorlib/clients/versioning/client_interuss.py
@@ -43,6 +43,17 @@ class InterUSSVersioningClient(VersioningClient):
             raise VersionQueryError(
                 f"Response to get version could not be parsed: {str(e)}", query
             )
+
+        if not resp.has_field_with_value("system_identity"):
+            raise VersionQueryError(
+                "Response to get version didn't return a system identity"
+            )
+
+        if not resp.has_field_with_value("system_version"):
+            raise VersionQueryError(
+                "Response to get version didn't return a system version"
+            )
+
         if resp.system_identity != version_type:
             raise VersionQueryError(
                 f"Response to get version indicated version for system '{resp.system_identity}' when the version for system '{version_type}' was requested"

--- a/monitoring/monitorlib/clients/versioning/client_interuss_test.py
+++ b/monitoring/monitorlib/clients/versioning/client_interuss_test.py
@@ -1,0 +1,106 @@
+from datetime import datetime
+
+import pytest
+from implicitdict import StringBasedDateTime
+
+from monitoring.monitorlib.fetch import (
+    Query,
+    RequestDescription,
+    ResponseDescription,
+)
+from monitoring.monitorlib.infrastructure import UTMClientSession
+from monitoring.uss_qualifier.configurations.configuration import ParticipantID
+
+from .client_interuss import InterUSSVersioningClient, VersionQueryError
+
+
+@pytest.fixture
+def client():
+    return InterUSSVersioningClient(UTMClientSession(prefix_url="/"), ParticipantID())
+
+
+def build_query_response(code, data):
+    return Query(
+        request=RequestDescription(
+            method=None,
+            url=None,
+            initiated_at=StringBasedDateTime(datetime.fromtimestamp(0)),
+        ),
+        response=ResponseDescription(elapsed_s=0, reported=None, code=code, json=data),
+    )
+
+
+def test_get_version_nominal(mocker, client):
+    mocker.patch(
+        "monitoring.monitorlib.clients.versioning.client_interuss.query_and_describe",
+        return_value=build_query_response(
+            200, {"system_identity": "test", "system_version": "test_version"}
+        ),
+    )
+
+    assert client.get_version("test").version == "test_version"
+
+
+def test_get_version_non_200(mocker, client):
+    mocker.patch(
+        "monitoring.monitorlib.clients.versioning.client_interuss.query_and_describe",
+        return_value=build_query_response(
+            500, {"system_identity": "test", "system_version": "test_version"}
+        ),
+    )
+
+    with pytest.raises(VersionQueryError, match="rather than 200 as expected"):
+        client.get_version("test")
+
+
+def test_get_version_wrong_body(mocker, client):
+    mocker.patch(
+        "monitoring.monitorlib.clients.versioning.client_interuss.query_and_describe",
+        return_value=build_query_response(200, None),
+    )
+
+    with pytest.raises(
+        VersionQueryError, match="Response to get version could not be parsed"
+    ):
+        client.get_version("test")
+
+
+def test_get_version_no_system_identity(mocker, client):
+    mocker.patch(
+        "monitoring.monitorlib.clients.versioning.client_interuss.query_and_describe",
+        return_value=build_query_response(200, {"system_version": "test_version"}),
+    )
+
+    with pytest.raises(
+        VersionQueryError,
+        match="Response to get version didn't return a system identity",
+    ):
+        client.get_version("test")
+
+
+def test_get_version_no_system_version(mocker, client):
+    mocker.patch(
+        "monitoring.monitorlib.clients.versioning.client_interuss.query_and_describe",
+        return_value=build_query_response(200, {"system_identity": "test"}),
+    )
+
+    with pytest.raises(
+        VersionQueryError,
+        match="Response to get version didn't return a system version",
+    ):
+        client.get_version("test")
+
+
+def test_get_version_another_identity(mocker, client):
+    mocker.patch(
+        "monitoring.monitorlib.clients.versioning.client_interuss.query_and_describe",
+        return_value=build_query_response(
+            200, {"system_identity": "test2", "system_version": "test_version"}
+        ),
+    )
+
+    with pytest.raises(
+        VersionQueryError,
+        match="Response to get version indicated version for system 'test2'",
+    ):
+        client.get_version("test")


### PR DESCRIPTION
Fix #1311 

Check for field presence and raise a VersionQueryError if not present.
Add some unit tests. NB: Those test are not run in the code base. #1313 fixes that.

Also tested locally against a 'rogue' mockuss / f3548_self_contained config:

Before:

```
 ERROR    | monitoring.uss_qualifier.suites.suite:_run_test_scenario:181 - Execution error:
  Traceback (most recent call last):
    File "/venv/lib/python3.13/site-packages/implicitdict/__init__.py", line 156, in __getattribute__
      return self[item]
             ~~~~^^^^^^
  KeyError: 'system_identity'
  
  During handling of the above exception, another exception occurred:
  
  Traceback (most recent call last):
    File "/app/monitoring/uss_qualifier/suites/suite.py", line 163, in _run_test_scenario
      scenario.run(context)
      ~~~~~~~~~~~~^^^^^^^^^
    File "/app/monitoring/uss_qualifier/scenarios/versioning/get_system_versions.py", line 30, in run
      resp = version_provider.get_version(self._system_identity)
    File "/app/monitoring/monitorlib/clients/versioning/client_interuss.py", line 46, in get_version
      if resp.system_identity != version_type:
         ^^^^^^^^^^^^^^^^^^^^
    File "/venv/lib/python3.13/site-packages/implicitdict/__init__.py", line 158, in __getattribute__
      raise AttributeError
  AttributeError
```

After:

```
WARNING  | monitoring.uss_qualifier.suites.suite:_print_failed_check:71 - New failed check:
  details: 'Response to get version didn''t return a system identity
  
    Severity Severity.High upgraded to Critical because `stop_fast` flag set true in
    configuration'
  documentation_url: https://github.com/interuss/monitoring/blob/b1322faf3c107d3970efc6ed639176fe50ee0fb8/monitoring/uss_qualifier/scenarios/versioning/get_system_versions.md#valid-response-check
  name: Valid response
  participants:
  - uss1_core
  query_report_timestamps: []
  requirements:
  - versioning.ReportSystemVersion
  severity: Critical
  summary: Error querying version
```
