### PR TITLE
[monitorlib] Enable unit tests

### DIFF
--- a/monitoring/Makefile
+++ b/monitoring/Makefile
@@ -9,6 +9,7 @@ format:
 .PHONY: unit-test
 unit-test:
 	cd uss_qualifier && make unit_test
+	cd monitorlib && make unit_test
 
 image: ../uv.lock ../pyproject.toml $(shell find . -type f ! -path "*/output/*" ! -name image ! -name *.pyc) $(shell find ../interfaces -type f)
 	./build.sh

--- a/monitoring/monitorlib/Makefile
+++ b/monitoring/monitorlib/Makefile
@@ -1,0 +1,3 @@
+.PHONY: unit_test
+unit_test:
+	./scripts/run_unit_tests.sh

--- a/monitoring/monitorlib/scripts/in_container/run_unit_tests.sh
+++ b/monitoring/monitorlib/scripts/in_container/run_unit_tests.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+# This script is intended to be called from within a Docker container running
+# mock_uss via the interuss/monitoring image.  In that context, this script is
+# the entrypoint into the test definition validation tool.
+
+# Ensure uss_qualifier is the working directory
+OS=$(uname)
+if [[ $OS == "Darwin" ]]; then
+	# OSX uses BSD readlink
+	BASEDIR="$(dirname "$0")"
+else
+	BASEDIR=$(readlink -e "$(dirname "$0")")
+fi
+cd "${BASEDIR}/../.." || exit 1
+
+uv run pytest

--- a/monitoring/monitorlib/scripts/run_unit_tests.sh
+++ b/monitoring/monitorlib/scripts/run_unit_tests.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+set -o xtrace
+
+# Find and change to repo root directory
+OS=$(uname)
+if [[ "$OS" == "Darwin" ]]; then
+	# OSX uses BSD readlink
+	BASEDIR="$(dirname "$0")"
+else
+	BASEDIR=$(readlink -e "$(dirname "$0")")
+fi
+cd "${BASEDIR}/../../.." || exit 1
+
+(
+cd monitoring || exit 1
+make image
+)
+
+# shellcheck disable=SC2086
+docker run --name monitorlib_unit_test \
+  --rm \
+  -e MONITORING_GITHUB_ROOT=${MONITORING_GITHUB_ROOT:-} \
+  -v "$(pwd):/app" \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  interuss/monitoring-dev \
+  monitorlib/scripts/in_container/run_unit_tests.sh
+


### PR DESCRIPTION
I noticed when adding tests for #1312 that unit tests are not run for the monitorlib part of the code, even when two passing tests already exists (fetch/evaluation_test.py, geo_test.py).

This PR do enable them (based on the same script from uss_qualifier).