### PR TITLE
[tooling] Add support for yugabyte in local docker-compose

### DIFF
--- a/build/dev/docker-compose.yaml
+++ b/build/dev/docker-compose.yaml
@@ -1,6 +1,7 @@
 # Brings up a local interoperability ecosystem consisting of a DSS instance and dummy OAuth server.
 
 # To bring up this system, run ./run_locally.sh up -d and wait for all containers to succeed or become healthy.
+# If needed, set environment variable `COMPOSE_PROFILES` to `with-yugabyte` to use Yugabyte instead of CockroachDB
 
 services:
 
@@ -21,6 +22,26 @@ services:
       interval: 3m
       start_period: 30s
       start_interval: 5s
+
+  ybdb:
+    image: interuss/yugabyte:2025.1.2.1-interuss
+    # ysql_output_buffer_size needs to be increased to allow ysql to retry read restart errors. https://docs.yugabyte.com/preview/reference/configuration/yb-tserver/#ysql-output-buffer-size
+    command: bin/yugabyted start --background=false --tserver_flags="ysql_output_buffer_size=1048576"
+    ports:
+      - "7000:7000"
+      - "9000:9000"
+      - "15433:15433"
+      - "5433:5433"
+      - "9042:9042"
+    restart: always
+    networks:
+      - dss_internal_network
+    profiles: ["with-yugabyte"]
+    healthcheck:
+      test: ["CMD", "/home/yugabyte/postgres/bin/pg_isready", "-h", "ybdb"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
 
   rid_bootstrapper:
     image: interuss/dss:v0.21.0-rc1
@@ -49,6 +70,36 @@ services:
     networks:
       - dss_internal_network
 
+  rid_bootstrapper-ybdb:
+    image: interuss/dss:v0.21.0-rc1
+    entrypoint: /usr/bin/db-manager migrate --schemas_dir=/db-schemas/yugabyte/rid --db_version "latest" --datastore_host ybdb --datastore_user yugabyte --datastore_port 5433
+    depends_on:
+      ybdb:
+        condition: service_healthy
+    networks:
+      - dss_internal_network
+    profiles: ["with-yugabyte"]
+
+  scd_bootstrapper-ybdb:
+    image: interuss/dss:v0.21.0-rc1
+    entrypoint: /usr/bin/db-manager migrate --schemas_dir=/db-schemas/yugabyte/scd --db_version "latest" --datastore_host ybdb --datastore_user yugabyte --datastore_port 5433
+    depends_on:
+      ybdb:
+        condition: service_healthy
+    networks:
+      - dss_internal_network
+    profiles: ["with-yugabyte"]
+
+  aux_bootstrapper-ybdb:
+    image: interuss/dss:v0.21.0-rc1
+    entrypoint: /usr/bin/db-manager migrate --schemas_dir=/db-schemas/yugabyte/aux_ --db_version "latest" --datastore_host ybdb --datastore_user yugabyte --datastore_port 5433
+    depends_on:
+      ybdb:
+        condition: service_healthy
+    networks:
+      - dss_internal_network
+    profiles: ["with-yugabyte"]
+
   dss:
     hostname: dss.uss1.localutm
     image: interuss/dss:v0.21.0-rc1
@@ -56,6 +107,8 @@ services:
       - $PWD/../test-certs:/var/test-certs:ro
       - $PWD/startup/core_service.sh:/startup/core_service.sh:ro
     command: /startup/core_service.sh ${DEBUG_ON:-0}
+    environment:
+      COMPOSE_PROFILES: ${COMPOSE_PROFILES}
     expose:
       - 8082
     ports:
@@ -66,6 +119,17 @@ services:
         condition: service_completed_successfully
       scd_bootstrapper:
         condition: service_completed_successfully
+      aux_bootstrapper:
+        condition: service_completed_successfully
+      rid_bootstrapper-ybdb:
+        condition: service_completed_successfully
+        required: false
+      scd_bootstrapper-ybdb:
+        required: false
+        condition: service_completed_successfully
+      aux_bootstrapper-ybdb:
+        condition: service_completed_successfully
+        required: false
     networks:
       dss_internal_network: {}
       interop_ecosystem_network:

--- a/build/dev/startup/core_service.sh
+++ b/build/dev/startup/core_service.sh
@@ -7,11 +7,22 @@ set -e
 
 DEBUG_ON=${1:-0}
 
+# POSIX compliant test to check if with-yugabyte profile is enabled.
+if [ "${COMPOSE_PROFILES#*"with-yugabyte"}" != "${COMPOSE_PROFILES}" ]; then
+  echo "Using Yugabyte"
+  DATASTORE_CONNECTION="-datastore_host ybdb -datastore_user yugabyte --datastore_port 5433"
+else
+  echo "Using CockroachDB"
+  DATASTORE_CONNECTION="-datastore_host crdb.uss1.localutm"
+fi
+
 if [ "$DEBUG_ON" = "1" ]; then
   echo "Debug Mode: on"
 
+  # Linter is disabled to properly unwrap $DATASTORE_CONNECTION.
+  # shellcheck disable=SC2086
   dlv --headless --listen=:4000 --api-version=2 --accept-multiclient exec --continue /usr/bin/core-service -- \
-  -cockroach_host crdb.uss1.localutm \
+  ${DATASTORE_CONNECTION} \
   -public_key_files /var/test-certs/auth2.pem \
   -log_format console \
   -dump_requests \
@@ -24,8 +35,10 @@ if [ "$DEBUG_ON" = "1" ]; then
 else
   echo "Debug Mode: off"
 
+  # Linter is disabled to properly unwrap $DATASTORE_CONNECTION.
+  # shellcheck disable=SC2086
   /usr/bin/core-service \
-  -cockroach_host crdb.uss1.localutm \
+  ${DATASTORE_CONNECTION} \
   -public_key_files /var/test-certs/auth2.pem \
   -log_format console \
   -dump_requests \


### PR DESCRIPTION
The build/dev docker compose doesn't support Yugabyte. This PR adds the feature to it, copied from [the one in the DSS repository](https://github.com/interuss/dss/blob/master/build/dev/docker-compose_dss.yaml).

Tested locally by running `COMPOSE_PROFILES=with-yugabyte build/dev/run_locally.sh up`.