### PR TITLE
[dependencies] Update uas_standards to 4.2.0

### DIFF
--- a/monitoring/monitorlib/clients/flight_planning/flight_info.py
+++ b/monitoring/monitorlib/clients/flight_planning/flight_info.py
@@ -227,7 +227,7 @@ class BasicFlightPlanInformation(ImplicitDict):
     def to_flight_planning_api(self) -> fp_api.BasicFlightPlanInformation:
         return fp_api.BasicFlightPlanInformation(
             usage_state=fp_api.BasicFlightPlanInformationUsageState(self.usage_state),
-            uas_state=fp_api.BasicFlightPlanInformationUasState(self.uas_state),
+            uas_state=fp_api.FunctionalState(self.uas_state),
             area=[v.to_flight_planning_api() for v in self.area],
         )
 

--- a/monitoring/monitorlib/kml/flight_planning.py
+++ b/monitoring/monitorlib/kml/flight_planning.py
@@ -23,13 +23,17 @@ def upsert_flight_plan(req: UpsertFlightPlanRequest, resp: UpsertFlightPlanRespo
             f"Activity {resp.planning_result.value}, flight {resp.flight_plan_status.value}"
         )
     )
+    if "uas_state" in basic_info and basic_info.uas_state:
+        uas_state = basic_info.uas_state.value
+    else:
+        uas_state = None
     for i, v4_flight_planning in enumerate(basic_info.area or []):
         v4 = Volume4D.from_flight_planning_api(v4_flight_planning)
         folder.append(
             make_placemark_from_volume(
                 v4,
                 name=f"Volume {i}",
-                style_url=f"#{basic_info.usage_state.value}_{basic_info.uas_state.value}",
+                style_url=f"#{basic_info.usage_state.value}_{uas_state}",
             )
         )
     return folder

--- a/monitoring/uss_qualifier/scenarios/flight_planning/prioritization_test_steps.py
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/prioritization_test_steps.py
@@ -1,6 +1,6 @@
 from uas_standards.interuss.automated_testing.flight_planning.v1.api import (
-    BasicFlightPlanInformationUasState,
     BasicFlightPlanInformationUsageState,
+    FunctionalState,
 )
 
 from monitoring.monitorlib.clients.flight_planning.client import FlightPlannerClient
@@ -34,7 +34,7 @@ def plan_priority_conflict_flight(
     expect_flight_intent_state(
         flight_info,
         BasicFlightPlanInformationUsageState.Planned,
-        BasicFlightPlanInformationUasState.Nominal,
+        FunctionalState.Nominal,
         scenario,
     )
 
@@ -68,7 +68,7 @@ def modify_planned_priority_conflict_flight(
     expect_flight_intent_state(
         flight_info,
         BasicFlightPlanInformationUsageState.Planned,
-        BasicFlightPlanInformationUasState.Nominal,
+        FunctionalState.Nominal,
         scenario,
     )
 
@@ -111,7 +111,7 @@ def activate_priority_conflict_flight(
     expect_flight_intent_state(
         flight_info,
         BasicFlightPlanInformationUsageState.InUse,
-        BasicFlightPlanInformationUasState.Nominal,
+        FunctionalState.Nominal,
         scenario,
     )
 
@@ -154,7 +154,7 @@ def modify_activated_priority_conflict_flight(
     expect_flight_intent_state(
         flight_info,
         BasicFlightPlanInformationUsageState.InUse,
-        BasicFlightPlanInformationUasState.Nominal,
+        FunctionalState.Nominal,
         scenario,
     )
 
@@ -192,7 +192,7 @@ def plan_conflict_flight(
     expect_flight_intent_state(
         flight_info,
         BasicFlightPlanInformationUsageState.Planned,
-        BasicFlightPlanInformationUasState.Nominal,
+        FunctionalState.Nominal,
         scenario,
     )
 
@@ -226,7 +226,7 @@ def modify_planned_conflict_flight(
     expect_flight_intent_state(
         flight_info,
         BasicFlightPlanInformationUsageState.Planned,
-        BasicFlightPlanInformationUasState.Nominal,
+        FunctionalState.Nominal,
         scenario,
     )
 
@@ -269,7 +269,7 @@ def activate_conflict_flight(
     expect_flight_intent_state(
         flight_info,
         BasicFlightPlanInformationUsageState.InUse,
-        BasicFlightPlanInformationUasState.Nominal,
+        FunctionalState.Nominal,
         scenario,
     )
 
@@ -312,7 +312,7 @@ def modify_activated_conflict_flight(
     expect_flight_intent_state(
         flight_info,
         BasicFlightPlanInformationUsageState.InUse,
-        BasicFlightPlanInformationUasState.Nominal,
+        FunctionalState.Nominal,
         scenario,
     )
 

--- a/monitoring/uss_qualifier/scenarios/flight_planning/test_steps.py
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/test_steps.py
@@ -3,8 +3,8 @@ from collections.abc import Iterable
 
 import arrow
 from uas_standards.interuss.automated_testing.flight_planning.v1.api import (
-    BasicFlightPlanInformationUasState,
     BasicFlightPlanInformationUsageState,
+    FunctionalState,
 )
 
 from monitoring.monitorlib.clients.flight_planning.client import PlanningActivityError
@@ -30,7 +30,7 @@ from monitoring.uss_qualifier.scenarios.scenario import (
 def expect_flight_intent_state(
     flight_intent: FlightInfo,
     expected_usage_state: BasicFlightPlanInformationUsageState,
-    expected_uas_state: BasicFlightPlanInformationUasState,
+    expected_uas_state: FunctionalState,
     scenario: TestScenario,
 ) -> None:
     """Confirm that provided flight intent test data has the expected state or raise a ValueError."""
@@ -104,7 +104,7 @@ def modify_planned_flight(
     expect_flight_intent_state(
         flight_info,
         BasicFlightPlanInformationUsageState.Planned,
-        BasicFlightPlanInformationUasState.Nominal,
+        FunctionalState.Nominal,
         scenario,
     )
 
@@ -144,7 +144,7 @@ def modify_activated_flight(
     expect_flight_intent_state(
         flight_info,
         BasicFlightPlanInformationUsageState.InUse,
-        BasicFlightPlanInformationUasState.Nominal,
+        FunctionalState.Nominal,
         scenario,
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -1854,14 +1854,14 @@ wheels = [
 
 [[package]]
 name = "uas-standards"
-version = "4.1.1"
+version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "implicitdict" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/1b/7e660b8e4ee02344e76f9c45da18556793f4512f916bc324c7043e50d207/uas_standards-4.1.1.tar.gz", hash = "sha256:b3ed61fc13abcdc2ae66167c7306b10c19e6b274d47a006d94700fd444024e38", size = 123229, upload-time = "2025-10-06T21:21:17.525Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/f9/23a2857405c72c9bb24ca06ef55317ef4ae03e8e43a905be7bc29fa8c1e0/uas_standards-4.2.0.tar.gz", hash = "sha256:5ef61a8a163422eac8525461a950f3f4fb443563ed5b610343da625c1eb5d95f", size = 126658, upload-time = "2025-10-30T16:07:39.238Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/5a/4dd947e91b51b9b76f4148b5ec64d97dd3bfda3907611a28e26033fc2c10/uas_standards-4.1.1-py3-none-any.whl", hash = "sha256:e8bd0ec3ccf6572c043ce92ef51f3fc0dc79e42bea410bee3a11587668d50c09", size = 85428, upload-time = "2025-10-06T21:21:16.445Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/6d/ac2ce5c67185b4d63e11815c705902432980dd4fb208130d110adb9a0803/uas_standards-4.2.0-py3-none-any.whl", hash = "sha256:732e2b293cfde7f75132d9abfddd63a97347273221ef2534f03676a1f0f623d5", size = 88533, upload-time = "2025-10-30T16:07:38.003Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR updates uas_standards to 4.2.0 which includes an update of the automated testing flight_planning API to 0.7.0 (adding as_planned to response and telemetry data).  This required some slightly-nontrivial adjustments due to naming changes and fixing a newly-revealed technical usage issue.