### PR TITLE
[mock_uss/tracer] Remove obsolete YAML representers

### DIFF
--- a/monitoring/mock_uss/tracer/context.py
+++ b/monitoring/mock_uss/tracer/context.py
@@ -1,7 +1,3 @@
-import yaml
-from implicitdict import StringBasedDateTime
-from yaml.representer import Representer
-
 from monitoring.mock_uss.app import webapp
 from monitoring.mock_uss.config import KEY_AUTH_SPEC, KEY_DSS_URL
 from monitoring.mock_uss.tracer.config import (
@@ -16,9 +12,6 @@ from monitoring.monitorlib.auth import make_auth_adapter
 from monitoring.monitorlib.fetch import scd
 from monitoring.monitorlib.infrastructure import AuthAdapter, AuthSpec, UTMClientSession
 from monitoring.monitorlib.rid import RIDVersion
-
-yaml.add_representer(StringBasedDateTime, Representer.represent_str)
-
 
 scd_cache: dict[ObservationAreaID, dict[str, scd.FetchedEntity]] = {}
 

--- a/monitoring/mock_uss/tracer/subscriptions.py
+++ b/monitoring/mock_uss/tracer/subscriptions.py
@@ -1,9 +1,7 @@
 import uuid
 
 import arrow
-import yaml
 from implicitdict import StringBasedDateTime
-from yaml.representer import Representer
 
 import monitoring.monitorlib.fetch.rid as fetch_rid
 import monitoring.monitorlib.fetch.scd as fetch_scd
@@ -22,8 +20,6 @@ from monitoring.monitorlib.geo import get_latlngrect_vertices, make_latlng_rect
 from monitoring.monitorlib.geotemporal import Volume4D
 from monitoring.monitorlib.infrastructure import UTMClientSession
 from monitoring.monitorlib.rid import RIDVersion
-
-yaml.add_representer(StringBasedDateTime, Representer.represent_str)
 
 
 class SubscriptionManagementError(RuntimeError):

--- a/monitoring/monitorlib/clients/mock_uss/interactions.py
+++ b/monitoring/monitorlib/clients/mock_uss/interactions.py
@@ -1,9 +1,7 @@
 from datetime import datetime
 from enum import Enum
 
-import yaml
 from implicitdict import ImplicitDict
-from yaml.representer import Representer
 
 from monitoring.monitorlib.fetch import Query
 
@@ -40,9 +38,6 @@ class Interaction(ImplicitDict):
             raise ValueError(
                 f"There is no received_at or initiated_at field in the interaction {self}"
             )
-
-
-yaml.add_representer(Interaction, Representer.represent_dict)
 
 
 class ListLogsResponse(ImplicitDict):

--- a/monitoring/monitorlib/fetch/__init__.py
+++ b/monitoring/monitorlib/fetch/__init__.py
@@ -14,10 +14,8 @@ import flask
 import jwt
 import requests
 import urllib3
-import yaml
 from implicitdict import ImplicitDict, Optional, StringBasedDateTime
 from loguru import logger
-from yaml.representer import Representer
 
 from monitoring.monitorlib import infrastructure
 from monitoring.monitorlib.errors import stacktrace_string
@@ -97,9 +95,6 @@ class RequestDescription(ImplicitDict):
             return self.body
 
 
-yaml.add_representer(RequestDescription, Representer.represent_dict)
-
-
 def describe_flask_request(request: flask.Request) -> RequestDescription:
     headers = {k: v for k, v in request.headers}
     kwargs = {
@@ -164,9 +159,6 @@ class ResponseDescription(ImplicitDict):
             return json.dumps(self.json)
         else:
             return self.body
-
-
-yaml.add_representer(ResponseDescription, Representer.represent_dict)
 
 
 def describe_response(resp: requests.Response) -> ResponseDescription:
@@ -572,11 +564,6 @@ class QueryError(RuntimeError):
     @property
     def stacktrace(self) -> str:
         return stacktrace_string(self)
-
-
-yaml.add_representer(Query, Representer.represent_dict)
-
-yaml.add_representer(StringBasedDateTime, Representer.represent_str)
 
 
 def describe_query(

--- a/monitoring/monitorlib/fetch/rid.py
+++ b/monitoring/monitorlib/fetch/rid.py
@@ -4,7 +4,6 @@ import datetime
 from typing import Any
 
 import s2sphere
-import yaml
 from implicitdict import ImplicitDict, Optional, StringBasedDateTime
 from uas_standards.ansi_cta_2063_a import SerialNumber
 from uas_standards.astm.f3411 import v19, v22a
@@ -13,7 +12,6 @@ from uas_standards.astm.f3411.v22a.api import (
     RIDHeight,
     VerticalAccuracy,
 )
-from yaml.representer import Representer
 
 from monitoring.monitorlib import fetch, geo, rid_v1, rid_v2
 from monitoring.monitorlib.fetch import Query, QueryType
@@ -1625,12 +1623,3 @@ def subscriptions(
         raise NotImplementedError(
             f"Cannot query DSS for subscriptions using RID version {rid_version}"
         )
-
-
-yaml.add_representer(FetchedISA, Representer.represent_dict)
-yaml.add_representer(FetchedISAs, Representer.represent_dict)
-yaml.add_representer(FetchedUSSFlights, Representer.represent_dict)
-yaml.add_representer(FetchedUSSFlightDetails, Representer.represent_dict)
-yaml.add_representer(FetchedFlights, Representer.represent_dict)
-yaml.add_representer(FetchedSubscription, Representer.represent_dict)
-yaml.add_representer(FetchedSubscriptions, Representer.represent_dict)

--- a/monitoring/monitorlib/fetch/scd.py
+++ b/monitoring/monitorlib/fetch/scd.py
@@ -1,7 +1,6 @@
 import datetime
 
 import s2sphere
-import yaml
 from implicitdict import ImplicitDict, Optional
 from uas_standards.astm.f3548.v21.api import (
     OPERATIONS,
@@ -10,7 +9,6 @@ from uas_standards.astm.f3548.v21.api import (
     Subscription,
 )
 from uas_standards.astm.f3548.v21.api import Volume4D as SCDVolume4D
-from yaml.representer import Representer
 
 from monitoring.monitorlib import fetch, infrastructure, scd
 from monitoring.monitorlib.fetch import QueryType
@@ -70,9 +68,6 @@ class FetchedEntityReferences(fetch.Query):
                 if id not in other_refs or r != other_refs[id]:
                     return True
         return False
-
-
-yaml.add_representer(FetchedEntityReferences, Representer.represent_dict)
 
 
 def _entity_references(
@@ -176,9 +171,6 @@ class FetchedEntity(fetch.Query):
             return self.error != other.error
 
 
-yaml.add_representer(FetchedEntity, Representer.represent_dict)
-
-
 def _full_entity(
     uss_resource_name: str,
     uss_base_url: str,
@@ -252,9 +244,6 @@ class FetchedEntities(ImplicitDict):
         for id in other_entities:
             if id not in my_entities:
                 return True
-
-
-yaml.add_representer(FetchedEntities, Representer.represent_dict)
 
 
 class CachedEntity(ImplicitDict):
@@ -404,9 +393,6 @@ class FetchedSubscription(fetch.Query):
             return None
 
 
-yaml.add_representer(FetchedSubscription, Representer.represent_dict)
-
-
 class FetchedSubscriptions(fetch.Query):
     @property
     def success(self) -> bool:
@@ -440,9 +426,6 @@ class FetchedSubscriptions(fetch.Query):
             return {}
         else:
             return {sub.id: sub for sub in self._subscriptions}
-
-
-yaml.add_representer(FetchedSubscriptions, Representer.represent_dict)
 
 
 def get_subscription(

--- a/monitoring/monitorlib/mutate/rid.py
+++ b/monitoring/monitorlib/mutate/rid.py
@@ -6,10 +6,8 @@ import uas_standards.astm.f3411.v19.api as v19_api
 import uas_standards.astm.f3411.v19.constants as v19_constants
 import uas_standards.astm.f3411.v22a.api as v22a_api
 import uas_standards.astm.f3411.v22a.constants as v22a_constants
-import yaml
 from implicitdict import ImplicitDict, Optional
 from uas_standards import Operation
-from yaml.representer import Representer
 
 from monitoring.monitorlib import fetch, infrastructure, rid_v1, rid_v2
 from monitoring.monitorlib.fetch import QueryType
@@ -728,8 +726,3 @@ class UpdatedISA(RIDQuery):
                 f"Cannot retrieve ISA ID using RID version {self.rid_version}"
             )
         return url.split("?")[0].split("/")[-1]
-
-
-yaml.add_representer(ChangedSubscription, Representer.represent_dict)
-yaml.add_representer(ChangedISA, Representer.represent_dict)
-yaml.add_representer(ISAChange, Representer.represent_dict)

--- a/monitoring/monitorlib/mutate/scd.py
+++ b/monitoring/monitorlib/mutate/scd.py
@@ -1,7 +1,6 @@
 import datetime
 
 import s2sphere
-import yaml
 from implicitdict import ImplicitDict, Optional
 from uas_standards.astm.f3548.v21.api import (
     OPERATIONS,
@@ -10,7 +9,6 @@ from uas_standards.astm.f3548.v21.api import (
     PutSubscriptionParameters,
     Subscription,
 )
-from yaml.representer import Representer
 
 from monitoring.monitorlib import fetch, infrastructure, scd
 from monitoring.monitorlib.fetch import QueryType
@@ -62,9 +60,6 @@ class MutatedSubscription(fetch.Query):
             ]
         except ValueError:
             return []
-
-
-yaml.add_representer(MutatedSubscription, Representer.represent_dict)
 
 
 def upsert_subscription(


### PR DESCRIPTION
Back in ancient history, tracer (before it was part of mock_uss) used YAML representers for (de)serialization.  Since then, ImplicitDict has taken over as the tool for that kind of de(serialization) and the YAML representers are not needed for anything.  This PR cleans up these old vestiges of the previous approach.

I tested this PR by running the uspace CI test after adding observation areas to tracer covering the F3548 and F3411 areas, then observing tracer correctly record and serve (in the UI) F3411 and F3548 events.