### PR TITLE
[uss_qualifier] Expand and clarify --filter capability

### DIFF
--- a/monitoring/uss_qualifier/configurations/configuration.py
+++ b/monitoring/uss_qualifier/configurations/configuration.py
@@ -133,7 +133,7 @@ class ExecutionConfiguration(ImplicitDict):
     """If true, stop test execution if one of the resources cannot be created.  Otherwise, resources that cannot be created due to missing prerequisites are simply treated as omitted."""
 
     scenarios_filter: str | None
-    """Filter test scenarios by class name using a regex. When empty, all scenarios are executed. Useful for targeted debugging. Overridden by --filter"""
+    """Filter test scenarios by scenario type using a regex. If the filter regex does not match within the scenario type, the scenario is skipped. When empty, all scenarios are executed. Useful for targeted debugging. Overridden by --filter"""
 
 
 class TestConfiguration(ImplicitDict):

--- a/monitoring/uss_qualifier/suites/suite.py
+++ b/monitoring/uss_qualifier/suites/suite.py
@@ -636,13 +636,13 @@ class ExecutionContext:
             and self.config.scenarios_filter
             and self.current_frame.action.test_scenario
         ):
-            if not re.match(
-                self.config.scenarios_filter,
-                self.current_frame.action.test_scenario.__class__.__name__,
-            ):
+            scenario_type = (
+                self.current_frame.action.test_scenario.declaration.scenario_type
+            )
+            if not re.search(self.config.scenarios_filter, scenario_type):
                 return SkippedActionReport(
                     timestamp=StringBasedDateTime(arrow.utcnow()),
-                    reason="Filtered scenario",
+                    reason=f"Scenario type '{scenario_type}' did not match against scenarios_filter regex `{self.config.scenarios_filter}`",
                     declaration=self.current_frame.action.declaration,
                 )
 

--- a/schemas/monitoring/uss_qualifier/configurations/configuration/ExecutionConfiguration.json
+++ b/schemas/monitoring/uss_qualifier/configurations/configuration/ExecutionConfiguration.json
@@ -18,7 +18,7 @@
       ]
     },
     "scenarios_filter": {
-      "description": "Filter test scenarios by class name using a regex. When empty, all scenarios are executed. Useful for targeted debugging. Overridden by --filter",
+      "description": "Filter test scenarios by scenario type using a regex. If the filter regex does not match within the scenario type, the scenario is skipped. When empty, all scenarios are executed. Useful for targeted debugging. Overridden by --filter",
       "type": [
         "string",
         "null"


### PR DESCRIPTION
Currently, the --filter option only matches against the local (rather than fully-qualified) class name which means there can be collisions (for instance, across similar scenarios for F3411-19 and F3411-22a).  Also, the message users see when scenarios are skipped could be more informative.

This PR attempts to make --filter more versatile and clear by matching anywhere in the scenario type, which is a standard identifier easily available in most artifact types.  This adjustment maintains conceptual parity with the current implementation as I tested all of the below to work:

`./monitoring/uss_qualifier/run_locally.sh configurations.dev.f3548_self_contained --filter ConflictHigherPriority`

`./monitoring/uss_qualifier/run_locally.sh configurations.dev.f3548_self_contained --filter scenarios.astm.utm.ConflictHigherPriority`

`./monitoring/uss_qualifier/run_locally.sh configurations.dev.f3548_self_contained --filter ^scenarios.astm.utm.ConflictHigherPriority$`

The documentation is updated to attempt to clearly reflect this behavior, and the message indicating the reason a scenario was skipped (seen in test report artifacts) is clarified to deliver as much information and hints as practical.