### PR TITLE
[uss_qualifier/reports] Add timing report coloring and fix artifact generation pipeline

### DIFF
--- a/github_pages/static/index.md
+++ b/github_pages/static/index.md
@@ -10,6 +10,7 @@ These reports were generated during continuous integration for the most recent P
 
 * [Sequence view](./artifacts/uss_qualifier/reports/uspace/sequence)
 * [Tested requirements](./artifacts/uss_qualifier/reports/uspace/requirements)
+* [Timing report](./artifacts/uss_qualifier/reports/uspace/timing)
 * [Demonstrated capabilities](./artifacts/uss_qualifier/reports/uspace/capabilities.html)
 * [Raw report](./artifacts/uss_qualifier/reports/uspace/report.json) (large)
 
@@ -18,27 +19,32 @@ These reports were generated during continuous integration for the most recent P
 * [Raw report](./artifacts/uss_qualifier/reports/noop/report.json) (indented to be human-readable)
 * [Interactive report](./artifacts/uss_qualifier/reports/noop/report.html)
 * [Sequence view](./artifacts/uss_qualifier/reports/noop/sequence)
+* [Timing report](./artifacts/uss_qualifier/reports/noop/timing)
 
 ### [ASTM F3548-21 test configuration](https://github.com/interuss/monitoring/blob/main/monitoring/uss_qualifier/configurations/dev/f3548_self_contained.yaml)
 
 * [Sequence view](./artifacts/uss_qualifier/reports/f3548_self_contained/sequence)
 * [Tested requirements](./artifacts/uss_qualifier/reports/f3548_self_contained/gate3)
 * [Globally-expanded report](./artifacts/uss_qualifier/reports/f3548_self_contained/globally_expanded/report.html)
+* [Timing report](./artifacts/uss_qualifier/reports/f3548_self_contained/timing)
 
 ### [US UTM Implementation test configuration](https://github.com/interuss/monitoring/blob/main/monitoring/uss_qualifier/configurations/dev/utm_implementation_us/environments/local/test_1.jsonnet)
 
 * [Sequence view](./artifacts/uss_qualifier/reports/test_1/sequence)
 * [Tested requirements](./artifacts/uss_qualifier/reports/test_1/scd)
+* [Timing report](./artifacts/uss_qualifier/reports/test_1/timing)
 
 ### [ASTM F3411-22a test configuration](https://github.com/interuss/monitoring/blob/main/monitoring/uss_qualifier/configurations/dev/netrid_v22a.yaml)
 
 * [Sequence view](./artifacts/uss_qualifier/reports/netrid_v22a/sequence)
 * [Tested requirements](./artifacts/uss_qualifier/reports/netrid_v22a/requirements)
+* [Timing report](./artifacts/uss_qualifier/reports/netrid_v22a/timing)
 
 ### [DSS integration test configuration](https://github.com/interuss/monitoring/blob/main/monitoring/uss_qualifier/configurations/dev/dss_probing.yaml)
 
 * [Sequence view](./artifacts/uss_qualifier/reports/dss_probing/sequence)
 * [Tested requirements](./artifacts/uss_qualifier/reports/dss_probing/requirements)
+* [Timing report](./artifacts/uss_qualifier/reports/dss_probing/timing)
 
 ### [General flight authorization configuration](https://github.com/interuss/monitoring/blob/main/monitoring/uss_qualifier/configurations/dev/general_flight_auth.yaml)
 

--- a/monitoring/uss_qualifier/configurations/dev/dss_probing.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/dss_probing.yaml
@@ -57,6 +57,7 @@ v1:
         participant_requirements:
           uss1: null
           uss2: all_astm_dss_requirements
+    timing_report: { }
   validation:
     criteria:
       - $ref: ./library/validation.yaml#/execution_error_none

--- a/monitoring/uss_qualifier/make_artifacts.sh
+++ b/monitoring/uss_qualifier/make_artifacts.sh
@@ -3,11 +3,14 @@
 set -eo pipefail
 
 if [[ $# -lt 1 ]]; then
-  echo "Usage: $0 <CONFIG_NAME(s)> [<REPORT_NAME(s)> [<OUTPUT_PATH>]]"
+  echo "Usage: $0 <REPORT_PATH> [<CONFIG_NAME(s)> [<OUTPUT_PATH>]]"
   echo "Generates artifacts according to the specified configuration(s) using the specified report(s)"
-  echo "<REPORT_NAME>: Location of the report file (or multiple locations separated by commas).  Relative paths are relative to this folder.  Use file:// prefix to explicitly specify file-based location."
-  echo "<CONFIG_NAME>: Location of the configuration file (or multiple locations separated by commas)."
-  echo "<OUTPUT_PATH>: Location to which artifacts should be written (defaults to output/<SIMPLE_CONFIG_NAME>)"
+  echo "  <REPORT_PATH>: Location (on the host machine) of the report file.  Relative paths are RELATIVE TO THE REPO ROOT."
+  echo "  <CONFIG_NAME>: Location of the configuration file describing what artifacts to make.  Must be built into the monitoring image (in configurations/personal, for instance).  If not specified, use artifacts configuration from report."
+  echo "  <OUTPUT_PATH>: Location (on the host machine) to which artifacts should be written.  Defaults to folder containing the report."
+  echo "Examples:"
+  echo "  ./monitoring/uss_qualifier/make_artifacts.sh ~/Downloads/be0bbe7c-4670-43f5-906a-594be69087f4/report.json configurations.dev.f3548_self_contained"
+  echo "  ./make_artifacts.sh monitoring/uss_qualifier/output/f3548_self_contained/report.json configurations.personal.custom_artifacts"
   exit 1
 fi
 
@@ -26,23 +29,31 @@ cd monitoring || exit 1
 make image
 )
 
-REPORT_NAME="${1}"
-echo "Reading report(s) from: ${REPORT_NAME}"
-MAKE_ARTIFACTS_OPTIONS="--report $REPORT_NAME"
+REPORT_LOCATION="${1}"
+
+# TODO: Retrieve local copy of report if location starts with "http"
+
+REPORT_PATH=$(realpath "${REPORT_LOCATION}")
+echo "Reading report from (host machine): ${REPORT_PATH}"
+REPORT_FILENAME=$(basename "${REPORT_PATH}")
+MAKE_ARTIFACTS_OPTIONS="--report file:///input/${REPORT_FILENAME}"
 
 if [ "$#" -gt 1 ]; then
   CONFIG_NAME="${2}"
-  echo "Generating artifacts from configuration(s): ${CONFIG_NAME}"
+  echo "Generating artifacts from configuration (in image): ${CONFIG_NAME}"
   MAKE_ARTIFACTS_OPTIONS="$MAKE_ARTIFACTS_OPTIONS --config $CONFIG_NAME"
 fi
 
 if [ "$#" -gt 2 ]; then
-  OUTPUT_PATH="${3}"
-  MAKE_ARTIFACTS_OPTIONS="$MAKE_ARTIFACTS_OPTIONS --output-path $OUTPUT_PATH"
+  OUTPUT_PATH=$(realpath "${3}")
+else
+  OUTPUT_PATH=$(dirname "${REPORT_PATH}")
 fi
+OUTPUT_FOLDERNAME=$(basename "${OUTPUT_PATH}")
+echo "Writing artifacts to (host machine): ${OUTPUT_PATH}"
+MAKE_ARTIFACTS_OPTIONS="$MAKE_ARTIFACTS_OPTIONS --output-path output/${OUTPUT_FOLDERNAME}"
 
-OUTPUT_DIR="monitoring/uss_qualifier/output"
-mkdir -p "$OUTPUT_DIR"
+mkdir -p "$OUTPUT_PATH"
 
 CACHE_DIR="monitoring/uss_qualifier/.templates_cache"
 mkdir -p "$CACHE_DIR"
@@ -53,7 +64,8 @@ docker run --name uss_qualifier \
   -u "$(id -u):$(id -g)" \
   -e PYTHONBUFFERED=1 \
   -e MONITORING_GITHUB_ROOT=${MONITORING_GITHUB_ROOT:-} \
-  -v "$(pwd)/$OUTPUT_DIR:/app/$OUTPUT_DIR" \
+  -v "${REPORT_PATH}:/input/${REPORT_FILENAME}" \
+  -v "${OUTPUT_PATH}:/app/monitoring/uss_qualifier/output/${OUTPUT_FOLDERNAME}" \
   -v "$(pwd)/$CACHE_DIR:/app/$CACHE_DIR" \
   -w /app/monitoring/uss_qualifier \
   interuss/monitoring \

--- a/monitoring/uss_qualifier/reports/artifacts.py
+++ b/monitoring/uss_qualifier/reports/artifacts.py
@@ -37,7 +37,10 @@ def generate_artifacts(
     disallow_unredacted: bool,
 ):
     logger.debug(f"Writing artifacts to {os.path.abspath(output_path)}")
-    os.makedirs(output_path, exist_ok=True)
+    try:
+        os.makedirs(output_path, exist_ok=True)
+    except PermissionError:
+        pass  # This may be ok if writing directly to a single specific output folder provided to a container
 
     def _should_redact(cfg) -> bool:
         result = "redact_access_tokens" in cfg and cfg.redact_access_tokens

--- a/monitoring/uss_qualifier/reports/templates/timing/report.html
+++ b/monitoring/uss_qualifier/reports/templates/timing/report.html
@@ -73,6 +73,14 @@
           font-style: italic;
           font-size: 10px;
         }
+        .server_name_container {
+          text-align: center;
+        }
+        .server_name {
+          writing-mode: vertical-rl;
+          transform: rotate(180deg);
+          white-space: nowrap;
+        }
     </style>
 </head>
 <body>
@@ -133,18 +141,21 @@
             {% for row in scenario_breakdown %}
             <tr>
                 <td>{{ row.scenario }}</td>
-                <td>{{ format_time(row.total_time) }}</td>
-                <td>{{ format_time(row.average_time) }}</td>
-                <td>{{ round(row.query_fraction * 100, 1) }}%
+                <td style="background-color: #{{ color_of(row.total_time.total_seconds() / max_total_seconds_scenario) }};">{{ format_time(row.total_time) }}</td>
+                <td style="background-color: #{{ color_of(row.average_time.total_seconds() / max_average_seconds_scenario) }};">{{ format_time(row.average_time) }}</td>
+                <td style="background-color: #{{ color_of(1 - row.query_fraction) }};">{{ round(row.query_fraction * 100, 1) }}%
                 {% if row.query_fraction > 1 %} (concurrent queries){% endif %}
                 </td>
-                <td>{{ round(row.delay_fraction * 100, 1) }}%</td>
+                <td style="background-color: #{{ color_of(row.delay_fraction) }};">{{ round(row.delay_fraction * 100, 1) }}%</td>
             </tr>
             {% endfor %}
         </table>
     </div>
     <div>
         <h2>Breakdown by query</h2>
+        <div class="minor_note">
+            Note that differing performance between servers may be due to differing queries sent to the servers (and/or conditions at the times of those queries) in addition to, or instead of, fundamental server performance differences.
+        </div>
         <table>
             <tr>
                 <th rowspan="2">Query type</th>
@@ -154,16 +165,24 @@
             <tr>
                 <th>Overall</th>
                 {% for server in servers %}
-                <th>{{ server }}</th>
+                <th class="server_name_container"><span class="server_name">{{ server }}</span></th>
                 {% endfor %}
             </tr>
             {% for row in query_breakdown %}
             <tr>
                 <td>{{ row.query_type }}</td>
-                <td>{{ format_time(row.total_time) }}</td>
-                <td>{{ format_time(row.average_time) }}</td>
+                <td style="background-color: #{{ color_of(row.total_time.total_seconds() / max_total_seconds_query) }};">{{ format_time(row.total_time) }}</td>
+                <td style="background-color: #{{ color_of(row.average_time.total_seconds() / max_average_seconds_query) }};">{{ format_time(row.average_time) }}</td>
+                {% set max_seconds = row.max_average_server_time().total_seconds() %}
                 {% for server in servers %}
-                <td>{% if server in row.times_per_server %}{{ format_time(sum(row.times_per_server[server]) / len(row.times_per_server[server])) }}{% endif %}</td>
+                    {% if server in row.times_per_server %}
+                        {% set server_time = sum(row.times_per_server[server]) / len(row.times_per_server[server]) %}
+                        <td style="background-color:#{{ color_of(server_time.total_seconds() / max_seconds) }};">
+                            {{ format_time(server_time) }}
+                        </td>
+                    {% else %}
+                        <td></td>
+                    {% endif %}
                 {% endfor %}
             </tr>
             {% endfor %}
@@ -182,8 +201,8 @@
             <tr>
                 <td>{{ row.scenario_type }}</td>
                 <td>{{ row.reason }}</td>
-                <td>{{ format_time(row.total_time) }}</td>
-                <td>{{ format_time(row.average_time) }}</td>
+                <td style="background-color: #{{ color_of(row.total_time.total_seconds() / max_total_seconds_delay) }};">{{ format_time(row.total_time) }}</td>
+                <td style="background-color: #{{ color_of(row.average_time.total_seconds() / max_average_seconds_delay) }};">{{ format_time(row.average_time) }}</td>
             </tr>
             {% endfor %}
         </table>

--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/solo_happy_path.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/solo_happy_path.md
@@ -1,0 +1,7 @@
+# Solo happy path test scenario
+
+## Description
+
+This test scenario is deprecated and removed since monitoring v0.26.0.
+
+## Resources

--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/solo_happy_path.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/solo_happy_path.py
@@ -1,0 +1,9 @@
+from deprecation import deprecated
+
+from monitoring.uss_qualifier.scenarios.scenario import TestScenario
+
+
+class SoloHappyPath(TestScenario):
+    @deprecated(deprecated_in="0.26.0")
+    def run(self, context):
+        pass


### PR DESCRIPTION
This PR primarily adds severity coloring to the timing report artifact, but also addresses a number of issues in the artifact generation pipeline and various related user journeys:

* Adds links to CI timing reports in github_pages
* Adds timing report to dss_probing (to compare "pure" DSS tests to application tests that merely use a DSS)
* Reworks make_artifacts.sh to more easily support the use case of the user having a report somewhere on their host machine, and wanting to generate artifacts somewhere (else) on their host machine (previously, it was difficult to figure out how to coordinate accessibility to the report input and artifact output between the container and host machine)
* Enables generation of timing report artifacts from older reports by falling back to a new `latest_timestamp` property when `end_time` is not populated
* Enables analysis of older reports by re-adding a deprecated placeholder for the SoloHappyPath test scenario