### PR TITLE
[tooling] Define no-response Action permissions explicitly

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -11,6 +11,8 @@ on:
 
 jobs:
   noResponse:
+    permissions:
+      issues: write
     runs-on: ubuntu-latest
     steps:
       - uses: lee-dohm/no-response@9bb0a4b5e6a45046f00353d5de7d90fb8bd773bb


### PR DESCRIPTION
Adding this Action permission explicitly addresses a code scanning finding.