### PR TITLE
[tooling] Fix codebase version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
       uses: actions/checkout@v6
       with:
         submodules: true
+        fetch-tags: true
+        fetch-depth: 0
+        filter: tree:0
     - name: Build monitoring image
       run: make image
     - name: Save monitoring image artifact

--- a/scripts/git/version.sh
+++ b/scripts/git/version.sh
@@ -2,6 +2,8 @@
 
 set -eo pipefail
 
+set -o xtrace
+
 # This script prints the current version of a component in the repository based on the tags
 # of the upstream repository (remote origin) matching the following convention:
 # owner/component/version. Examples of values:


### PR DESCRIPTION
This PR aim to fix #1349 by allowing scripts to access commit history and such creating the correct tag / version.

The core issue is that the shallow clone don't have tags information / history.

```
+ git describe --abbrev=1 --tags '--match=interuss/monitoring/*'
fatal: No tags can describe '54038cc5017109d65cad330be306040b6ccb4e7f'.
Try --always, or create some tags.
```

Always doesn't help:

```
 git describe --abbrev=1 --tags '--match=interuss/monitoring/*' --always
105f
```

This change the checkout config to:

- Fetch tags
- Fetch all history but
- Create a tree less clone with `filter: tree:0`

> git clone --filter=tree:0 <url> creates a treeless clone. These clones download all reachable commits while fetching trees and blobs on-demand. These clones are best for build environments where the repository will be deleted after a single build, but you still need access to commit history.
https://github.blog/open-source/git/get-up-to-speed-with-partial-clone-and-shallow-clone/

This make all required information to build the image with the correct tag. This at least fix the version in PR's CI:

<img width="717" height="612" alt="image" src="https://github.com/user-attachments/assets/93c432ea-27af-4436-8510-3833e3effefd" />


