### PR TITLE
[tooling/CI] Extend mock_uss startup timeout, separate unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,8 +69,33 @@ jobs:
       uses: ./.github/actions/load-image
     - name: Automated hygiene verification
       run: make check-hygiene
-    - name: Unit tests
-      run: make unit-test
+
+  unit-tests:
+    name: Unit tests
+    needs:
+      - build-monitoring-image
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Job information
+        run: |
+          echo "Job information"
+          echo "Trigger: ${{ github.event_name }}"
+          echo "Host: ${{ runner.os }}"
+          echo "Repository: ${{ github.repository }}"
+          echo "Branch: ${{ github.ref }}"
+          docker images
+          docker version
+          docker compose version
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: true
+      - name: Load monitoring image
+        uses: ./.github/actions/load-image
+      - name: Unit tests
+        run: make unit-test
 
   mock_uss-test:
     name: mock_uss tests

--- a/monitoring/mock_uss/start_all_local_mocks.sh
+++ b/monitoring/mock_uss/start_all_local_mocks.sh
@@ -17,4 +17,4 @@ cd monitoring || exit 1
 make image
 )
 
-./monitoring/mock_uss/run_locally.sh up --wait --wait-timeout 60 -d
+./monitoring/mock_uss/run_locally.sh up --wait --wait-timeout 90 -d


### PR DESCRIPTION
This PR attempts to address two CI issues I've seen recently:

1. Sometimes tests spuriously fail (and succeed when retried without any changes) because the suite of mock_uss instances doesn't become healthy in time.  This PR extends the startup timeout from 60 seconds to 90 seconds.
2. Unit tests are currently being run in a job named "hygiene".  When this job fails, it is misleading where to look for the problem.  This PR separates unit tests into their own job and keeps hygiene as hygiene-only (often fixable with `make format`).