### PR TITLE
[uss_qualifier/reports] Make requirements identifier more prominent

### DIFF
--- a/monitoring/uss_qualifier/configurations/configuration.py
+++ b/monitoring/uss_qualifier/configurations/configuration.py
@@ -151,7 +151,11 @@ class TestConfiguration(ImplicitDict):
 
 
 TestedRequirementsCollectionIdentifier = str
-"""Identifier for a requirements collection, local to a TestedRequirementsConfiguration artifact configuration."""
+"""Identifier for a requirements collection, local to a TestedRequirementsConfiguration artifact configuration.
+
+This value will be displayed as RC-<VALUE> in the artifact.  To avoid confusion, no spaces are recommended in values of
+this type; e.g., 'SCD_with_DSS' rather than 'SCD with DSS' or 'ServerProviderAndDisplayProvider' versus 'Service Provider
+and Display Provider'.  Succinct names are recommended over lengthy ones."""
 
 
 class TestedRequirementsConfiguration(ImplicitDict):

--- a/monitoring/uss_qualifier/reports/templates/tested_requirements/participant_tested_requirements.html
+++ b/monitoring/uss_qualifier/reports/templates/tested_requirements/participant_tested_requirements.html
@@ -52,6 +52,10 @@
       <td>TE-{{ test_run.environment[0:7] }}</td>
     </tr>
     <tr>
+      <td>Requirements identifier</td>
+      <td>RC-{{ req_set_name }}</td>
+    </tr>
+    <tr>
       <td>Requirement verification status</td>
       <td class="{{ overall_status.get_class() }}">{{ overall_status.get_text() }}</td>
     </tr>
@@ -76,7 +80,6 @@
 {% endif %}
 <div>
   <h2>Tested requirements</h2>
-  <div class="minor_note">Requirements: {{ req_set_name }}</div>
   <table>
     <tr class="header_row">
       <th>Package</th>


### PR DESCRIPTION
In the tested requirements artifact, each participant can be assigned a different collection of requirements to be verified.  The collection chosen is currently noted in small text, but this collection is actually very important for the interpretation of results.  This PR promotes this identifier to the top summary and prefixes it with RC- to make it easy to identify what kind of identifier someone is referring to (similar to TB- and TE- for test baseline identifier and test environment identifier).  The significance of this identifier is expanded in its documentation as well.