### PR TITLE
[mock_uss] Regular cleanup of outdated flights

### DIFF
--- a/monitoring/mock_uss/f3548v21/routes_scd.py
+++ b/monitoring/mock_uss/f3548v21/routes_scd.py
@@ -139,7 +139,6 @@ def scdsc_notify_operational_intent_details_changed():
                         conflicts=Conflict.Single,  # TODO: detect multiple conflicts
                     )
                 )
-            tx.value.cleanup_notifications()
 
     # Do nothing else because this USS is unsophisticated and polls the DSS for
     # every change in its operational intents

--- a/monitoring/mock_uss/flights/database.py
+++ b/monitoring/mock_uss/flights/database.py
@@ -5,6 +5,7 @@ import arrow
 from implicitdict import ImplicitDict, Optional
 from uas_standards.astm.f3548.v21.api import OperationalIntent
 
+from monitoring.mock_uss.app import webapp
 from monitoring.mock_uss.user_interactions.notifications import UserNotification
 from monitoring.monitorlib.clients.flight_planning.flight_info import FlightInfo
 from monitoring.monitorlib.clients.mock_uss.mock_uss_scd_injection_api import (
@@ -14,6 +15,9 @@ from monitoring.monitorlib.multiprocessing import SynchronizedValue
 
 DEADLOCK_TIMEOUT = timedelta(seconds=5)
 NOTIFICATIONS_LIMIT = timedelta(hours=1)
+DB_CLEANUP_INTERVAL = timedelta(hours=1)
+FLIGHTS_LIMIT = timedelta(hours=1)
+OPERATIONAL_INTENTS_LIMIT = timedelta(hours=1)
 
 
 class FlightRecord(ImplicitDict):
@@ -42,8 +46,49 @@ class Database(ImplicitDict):
             > arrow.utcnow().datetime
         ]
 
+    def cleanup_flights(self):
+        to_cleanup = []
+
+        for flight_id, flight in self.flights.items():
+            if (
+                flight
+                and not flight.locked
+                and flight.op_intent.reference.time_end.value.datetime + FLIGHTS_LIMIT
+                < arrow.utcnow().datetime
+            ):
+                to_cleanup.append(flight_id)
+
+        for flight_id in to_cleanup:
+            del self.flights[flight_id]
+
+    def cleanup_operational_intents(self):
+        to_cleanup = []
+
+        for op_id, op_intent in self.cached_operations.items():
+            if (
+                op_intent.reference.time_end.value.datetime + FLIGHTS_LIMIT
+                < arrow.utcnow().datetime
+            ):
+                to_cleanup.append(op_id)
+
+        for op_id in to_cleanup:
+            del self.cached_operations[op_id]
+
 
 db = SynchronizedValue[Database](
     Database(),
     decoder=lambda b: ImplicitDict.parse(json.loads(b.decode("utf-8")), Database),
 )
+
+TASK_DATABASE_CLEANUP = "flights database cleanup"
+
+
+@webapp.periodic_task(TASK_DATABASE_CLEANUP)
+def database_cleanup() -> None:
+    with db.transact() as tx:
+        tx.value.cleanup_notifications()
+        tx.value.cleanup_flights()
+        tx.value.cleanup_operational_intents()
+
+
+webapp.set_task_period(TASK_DATABASE_CLEANUP, DB_CLEANUP_INTERVAL)

--- a/monitoring/mock_uss/scd_injection/routes_injection.py
+++ b/monitoring/mock_uss/scd_injection/routes_injection.py
@@ -245,8 +245,6 @@ def inject_flight(
                     )
                 )
 
-            tx.value.cleanup_notifications()
-
         step_name = "returning final successful result"
         log("Complete.")
 


### PR DESCRIPTION
This PR add a regular cleaning job of flights and operational intents in mock_uss/flights/database.

Idea is to prevent building-up of flights if mock uss stay up for a long time. Memory is still limited (in `SynchronizedValue`), but it should help for #1059.

Interval values has been set arbitrary, they should work most of the time and don't interfere with regular tests.

I switched to a period task instead of having manual calls everywhere (including notifications).

Similar changes should be done for ridsp database as we do have flights that can build-up there. For others instances of databases, we could have build-up of elements but we don't have time information (e.g. riddp has only flight urls).