### PR TITLE
[uss_qualifier] Streamline conflict validation for all entities

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -16266,24 +16266,8 @@
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 62,
-                    "endColumn": 70,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
                     "startColumn": 58,
                     "endColumn": 75,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 62,
-                    "endColumn": 70,
                     "lineCount": 1
                 }
             },

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/constraint_ref_simple.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/constraint_ref_simple.py
@@ -123,19 +123,17 @@ class CRSimple(TestScenario):
                 # We don't expect the reach this point:
                 check.record_failed(
                     summary="CR Deletion with empty OVN was not expected to succeed",
-                    details=f"Was expecting an HTTP 400, 404 or 409 response because of an empty OVN, but got {q.status_code} instead",
+                    details=f"Was expecting an HTTP 400, 404 or 409 response because of an empty OVN, but got {q.status_code}",
                     query_timestamps=[q.request.timestamp],
                 )
             except QueryError as qe:
                 self.record_queries(qe.queries)
-                if qe.cause_status_code in [400, 404, 409]:
-                    # An empty OVN can be seen as:
-                    # an incorrect parameter (400), a reference to a non-existing entity (404) as well as a conflict (409)
-                    pass
-                else:
+                # An empty OVN can be seen as:
+                # an incorrect parameter (400), a reference to a non-existing entity (404) as well as a conflict (409)
+                if qe.cause_status_code not in [400, 404, 409]:
                     check.record_failed(
                         summary="CR Deletion with empty OVN failed for unexpected reason",
-                        details=f"Was expecting an HTTP 400, 404 or 409 response because of an empty OVN, but got {qe.cause_status_code} instead",
+                        details=f"Was expecting an HTTP 400, 404 or 409 response because of an empty OVN, but got {qe.cause_status_code}: {qe.msg}",
                         query_timestamps=qe.query_timestamps,
                     )
 
@@ -155,18 +153,16 @@ class CRSimple(TestScenario):
                 # We don't expect the reach this point:
                 check.record_failed(
                     summary="CR Deletion with incorrect OVN was not expected to succeed",
-                    details=f"Was expecting an HTTP 409 response because of an incorrect OVN, but got {q.status_code} instead",
+                    details=f"Was expecting an HTTP 409 response because of an incorrect OVN, but got {q.status_code}",
                     query_timestamps=[q.request.timestamp],
                 )
             except QueryError as qe:
                 self.record_queries(qe.queries)
-                if qe.cause_status_code == 409:
-                    # The spec explicitly requests a 409 response code for incorrect OVNs.
-                    pass
-                else:
+                # The spec explicitly requests a 409 response code for incorrect OVNs.
+                if qe.cause_status_code != 409:
                     check.record_failed(
                         summary="CR Deletion with incorrect OVN failed for unexpected reason",
-                        details=f"Was expecting an HTTP 409 response because of an incorrect OVN, but got {qe.cause_status_code} instead",
+                        details=f"Was expecting an HTTP 409 response because of an incorrect OVN, but got {qe.cause_status_code}: {qe.msg}",
                         query_timestamps=qe.query_timestamps,
                     )
 
@@ -193,19 +189,17 @@ class CRSimple(TestScenario):
                 # We don't expect the reach this point:
                 check.record_failed(
                     summary="CR mutation with empty OVN was not expected to succeed",
-                    details=f"Was expecting an HTTP 400, 404 or 409 response because of an empty OVN, but got {q.status_code} instead",
+                    details=f"Was expecting an HTTP 400, 404 or 409 response because of an empty OVN, but got {q.status_code}",
                     query_timestamps=[q.request.timestamp],
                 )
             except QueryError as qe:
                 self.record_queries(qe.queries)
-                if qe.cause_status_code in [400, 404, 409]:
-                    # An empty OVN can be seen as:
-                    # an incorrect parameter (400), a reference to a non-existing entity (404) as well as a conflict (409)
-                    pass
-                else:
+                # An empty OVN can be seen as:
+                # an incorrect parameter (400), a reference to a non-existing entity (404) as well as a conflict (409)
+                if qe.cause_status_code not in [400, 404, 409]:
                     check.record_failed(
                         summary="CR mutation with empty OVN failed for unexpected reason",
-                        details=f"Was expecting an HTTP 400, 404 or 409 response because of an empty OVN, but got {qe.cause_status_code} instead",
+                        details=f"Was expecting an HTTP 400, 404 or 409 response because of an empty OVN, but got {qe.cause_status_code}: {qe.msg}",
                         query_timestamps=qe.query_timestamps,
                     )
 
@@ -232,19 +226,16 @@ class CRSimple(TestScenario):
                 # We don't expect the reach this point:
                 check.record_failed(
                     summary="CR mutation with incorrect OVN was not expected to succeed",
-                    details=f"Was expecting an HTTP 400 or 409 response because of an incorrect OVN, but got {q.status_code} instead",
+                    details=f"Was expecting an HTTP 409 response because of an incorrect OVN, but got {q.status_code}",
                     query_timestamps=[q.request.timestamp],
                 )
             except QueryError as qe:
                 self.record_queries(qe.queries)
-                if qe.cause_status_code in [400, 409]:
-                    # An empty OVN cen be seen as both an incorrect parameter as well as a conflict
-                    # because the value is incorrect: we accept both a 400 and 409 return code here.
-                    pass
-                else:
+                # The spec explicitly requests a 409 response code for incorrect OVNs.
+                if qe.cause_status_code != 409:
                     check.record_failed(
                         summary="CR mutation with incorrect OVN failed for unexpected reason",
-                        details=f"Was expecting an HTTP 400 or 409 response because of an incorrect OVN, but got {qe.cause_status_code} instead",
+                        details=f"Was expecting an HTTP 409 response because of an incorrect OVN, but got {qe.cause_status_code}: {qe.msg}",
                         query_timestamps=qe.query_timestamps,
                     )
         self.end_test_step()

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/op_intent_ref_key_validation.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/op_intent_ref_key_validation.py
@@ -189,13 +189,13 @@ class OIRKeyValidation(TestScenario):
                 self.record_query(q)
                 check.record_failed(
                     summary="Operational intent reference with OVN missing in key was created",
-                    details=f"Was expecting an HTTP 409 response because of a conflict with OIR {conflicting_ids}, but got a successful response ({q.status_code}) instead",
+                    details=f"Was expecting an HTTP 409 response because of a conflict with OIR {conflicting_ids}, but got {q.status_code}",
                     query_timestamps=[q.request.timestamp],
                 )
                 return
             except QueryError as qe:
                 self.record_queries(qe.queries)
-                _expect_conflict_code(check, conflicting_ids, qe.cause)
+                _expect_conflict_code(check, conflicting_ids, qe)
                 conflicting_query = qe.cause
 
         self._validate_conflict_response(conflicting_ids, conflicting_query)
@@ -222,13 +222,13 @@ class OIRKeyValidation(TestScenario):
                 self.record_query(q)
                 check.record_failed(
                     summary="Operational intent reference with OVN missing in key was mutated",
-                    details=f"Was expecting an HTTP 409 response because of a conflict with OIR {conflicting_ids}, but got a successful response ({q.status_code}) instead",
+                    details=f"Was expecting an HTTP 409 response because of a conflict with OIR {conflicting_ids}, but got {q.status_code}",
                     query_timestamps=[q.request.timestamp],
                 )
                 return
             except QueryError as qe:
                 self.record_queries(qe.queries)
-                _expect_conflict_code(check, conflicting_ids, qe.cause)
+                _expect_conflict_code(check, conflicting_ids, qe)
                 conflicting_query = qe.cause
 
         self._validate_conflict_response(conflicting_ids, conflicting_query)
@@ -431,11 +431,11 @@ class OIRKeyValidation(TestScenario):
 
 
 def _expect_conflict_code(
-    check: PendingCheck, conflicting_ids: list[EntityID], query: fetch.Query
+    check: PendingCheck, conflicting_ids: list[EntityID], qe: fetch.QueryError
 ):
-    if query.status_code != 409:
+    if qe.cause_status_code != 409:
         check.record_failed(
             summary="OIR Creation failed for the unexpected reason",
-            details=f"Was expecting an HTTP 409 response because of a conflict with OIR {conflicting_ids}, but got a {query.status_code} instead",
-            query_timestamps=[query.request.timestamp],
+            details=f"Was expecting an HTTP 409 response because of a conflict with OIR {conflicting_ids}, but got {qe.cause_status_code}: {qe.msg}",
+            query_timestamps=qe.query_timestamps,
         )

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/op_intent_ref_simple.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/op_intent_ref_simple.py
@@ -120,19 +120,17 @@ class OIRSimple(TestScenario):
                 # We don't expect to reach this point:
                 check.record_failed(
                     summary="OIR Deletion with empty OVN was not expected to succeed",
-                    details=f"Was expecting an HTTP 400, 404 or 409 response because of an empty OVN, but got {q.status_code} instead",
+                    details=f"Was expecting an HTTP 400, 404 or 409 response because of an empty OVN, but got {q.status_code}",
                     query_timestamps=[q.request.timestamp],
                 )
             except QueryError as qe:
                 self.record_queries(qe.queries)
-                if qe.cause_status_code in [400, 404, 409]:
-                    # An empty OVN can be seen as:
-                    # an incorrect parameter (400), a reference to a non-existing entity (404) as well as a conflict (409)
-                    pass
-                else:
+                # An empty OVN can be seen as:
+                # an incorrect parameter (400), a reference to a non-existing entity (404) as well as a conflict (409)
+                if qe.cause_status_code not in [400, 404, 409]:
                     check.record_failed(
                         summary="OIR Deletion with empty OVN failed for unexpected reason",
-                        details=f"Was expecting an HTTP 400, 404 or 409 response because of an empty OVN, but got {qe.cause_status_code} instead",
+                        details=f"Was expecting an HTTP 400, 404 or 409 response because of an empty OVN, but got {qe.cause_status_code}: {qe.msg}",
                         query_timestamps=qe.query_timestamps,
                     )
 
@@ -152,18 +150,16 @@ class OIRSimple(TestScenario):
                 # We don't expect to reach this point:
                 check.record_failed(
                     summary="OIR Deletion with incorrect OVN was not expected to succeed",
-                    details=f"Was expecting an HTTP 400, 404 or 409 response because of an incorrect OVN, but got {q.status_code} instead",
+                    details=f"Was expecting an HTTP 409 response because of an incorrect OVN, but got {q.status_code}",
                     query_timestamps=[q.request.timestamp],
                 )
             except QueryError as qe:
                 self.record_queries(qe.queries)
-                if qe.cause_status_code in [400, 404, 409]:
-                    # The spec explicitly requests a 409 response code for incorrect OVNs.
-                    pass
-                else:
+                # The spec explicitly requests a 409 response code for incorrect OVNs.
+                if qe.cause_status_code != 409:
                     check.record_failed(
                         summary="OIR Deletion with incorrect OVN failed for unexpected reason",
-                        details=f"Was expecting an HTTP 400, 404 or 409 response because of an incorrect OVN, but got {qe.cause_status_code} instead",
+                        details=f"Was expecting an HTTP 409 response because of an incorrect OVN, but got {qe.cause_status_code}: {qe.msg}",
                         query_timestamps=qe.query_timestamps,
                     )
 
@@ -189,19 +185,17 @@ class OIRSimple(TestScenario):
                 # We don't expect to reach this point:
                 check.record_failed(
                     summary="OIR Mutation with missing OVN was not expected to succeed",
-                    details=f"Was expecting an HTTP 400, 404 or 409 response because of a missing OVN, but got {query.status_code} instead",
+                    details=f"Was expecting an HTTP 400, 404 or 409 response because of a missing OVN, but got {query.status_code}",
                     query_timestamps=[query.request.timestamp],
                 )
             except QueryError as qe:
                 self.record_queries(qe.queries)
-                if qe.cause_status_code in [400, 404, 409]:
-                    # An empty OVN can be seen as:
-                    # an incorrect parameter (400), a reference to a non-existing entity (404) as well as a conflict (409)
-                    pass
-                else:
+                # An empty OVN can be seen as:
+                # an incorrect parameter (400), a reference to a non-existing entity (404) as well as a conflict (409)
+                if qe.cause_status_code not in [400, 404, 409]:
                     check.record_failed(
                         summary="OIR Mutation with missing OVN failed for unexpected reason",
-                        details=f"Was expecting an HTTP 400, 404 or 409 response because of a missing OVN, but got {qe.cause_status_code} instead",
+                        details=f"Was expecting an HTTP 400, 404 or 409 response because of a missing OVN, but got {qe.cause_status_code}: {qe.msg}",
                         query_timestamps=qe.query_timestamps,
                     )
         self.end_test_step()
@@ -226,17 +220,16 @@ class OIRSimple(TestScenario):
                 # We don't expect to reach this point:
                 check.record_failed(
                     summary="OIR Mutation with incorrect OVN was not expected to succeed",
-                    details=f"Was expecting an HTTP 400, 404 or 409 response because of an incorrect OVN, but got {query.status_code} instead",
+                    details=f"Was expecting an HTTP 409 response because of an incorrect OVN, but got {query.status_code}",
                     query_timestamps=[query.request.timestamp],
                 )
             except QueryError as qe:
                 self.record_queries(qe.queries)
-                if qe.cause_status_code in [400, 404, 409]:
-                    pass
-                else:
+                # The spec explicitly requests a 409 response code for incorrect OVNs.
+                if qe.cause_status_code != 409:
                     check.record_failed(
                         summary="OIR Mutation with incorrect OVN failed for unexpected reason",
-                        details=f"Was expecting an HTTP 400, 404 or 409 response because of an incorrect OVN, but got {qe.cause_status_code} instead",
+                        details=f"Was expecting an HTTP 409 response because of an incorrect OVN, but got {qe.cause_status_code}: {qe.msg}",
                         query_timestamps=qe.query_timestamps,
                     )
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/uss_availability_mutation.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/uss_availability_mutation.py
@@ -86,15 +86,17 @@ class UssAvailabilityMutation(TestScenario):
                 # We don't expect the reach this point:
                 check.record_failed(
                     summary="Set USS availability with missing version was not expected to succeed",
-                    details=f"Was expecting an HTTP 409 response because of an missing version, but got {q.status_code} instead",
+                    details=f"Was expecting an HTTP 400, 404 or 409 response because of an missing version, but got {q.status_code}",
                     query_timestamps=[q.request.timestamp],
                 )
             except QueryError as qe:
                 self.record_queries(qe.queries)
-                if qe.cause_status_code != 409:
+                # An empty version can be seen as:
+                # an incorrect parameter (400), a reference to a non-existing entity (404) as well as a conflict (409)
+                if qe.cause_status_code not in [400, 404, 409]:
                     check.record_failed(
                         summary="Set USS availability with missing version failed for unexpected reason",
-                        details=f"Was expecting an HTTP 409 response because of an missing version, but got {qe.cause_status_code} instead",
+                        details=f"Was expecting an HTTP 400, 404 or 409 response because of an missing version, but got {qe.cause_status_code}: {qe.msg}",
                         query_timestamps=qe.query_timestamps,
                     )
         self.end_test_step()
@@ -115,15 +117,16 @@ class UssAvailabilityMutation(TestScenario):
                 # We don't expect the reach this point:
                 check.record_failed(
                     summary="Set USS availability with incorrect version was not expected to succeed",
-                    details=f"Was expecting an HTTP 409 response because of an incorrect version, but got {q.status_code} instead",
+                    details=f"Was expecting an HTTP 409 response because of an incorrect version, but got {q.status_code}",
                     query_timestamps=[q.request.timestamp],
                 )
             except QueryError as qe:
                 self.record_queries(qe.queries)
+                # The spec explicitly requests a 409 response code for incorrect version.
                 if qe.cause_status_code != 409:
                     check.record_failed(
                         summary="Set USS availability with incorrect version failed for unexpected reason",
-                        details=f"Was expecting an HTTP 409 response because of an incorrect version, but got {qe.cause_status_code} instead",
+                        details=f"Was expecting an HTTP 409 response because of an incorrect version, but got {qe.cause_status_code}: {qe.msg}",
                         query_timestamps=qe.query_timestamps,
                     )
         self.end_test_step()


### PR DESCRIPTION
Follow-up from https://github.com/interuss/monitoring/pull/1137#discussion_r2884719926

- Add query error message in failure details
- Modify OVN/version checks to remove some discrepencies
  - missing: expect one of 400, 404, 409
  - invalid: expect 409

