### PR TITLE
[mock_uss] Increase start_period for healthchecks and add timeout for mock_uss healthchecks.

### DIFF
--- a/monitoring/mock_uss/docker-compose.yaml
+++ b/monitoring/mock_uss/docker-compose.yaml
@@ -34,6 +34,8 @@ services:
       - interop_ecosystem_network
     extra_hosts:
       - host.docker.internal:host-gateway
+    healthcheck:
+      start_period: 30s
     profiles:
       - '' # starts when no profile is provided
       - scd
@@ -63,6 +65,8 @@ services:
       - interop_ecosystem_network
     extra_hosts:
       - host.docker.internal:host-gateway
+    healthcheck:
+      start_period: 30s
     profiles:
       - '' # starts when no profile is provided
       - scd
@@ -89,6 +93,8 @@ services:
       - interop_ecosystem_network
     extra_hosts:
       - host.docker.internal:host-gateway
+    healthcheck:
+      start_period: 30s
     profiles:
       - '' # starts when no profile is provided
       - geoawareness
@@ -121,6 +127,8 @@ services:
       - interop_ecosystem_network
     extra_hosts:
       - host.docker.internal:host-gateway
+    healthcheck:
+      start_period: 30s
     profiles:
       - '' # starts when no profile is provided
       - rid
@@ -153,6 +161,8 @@ services:
       - interop_ecosystem_network
     extra_hosts:
       - host.docker.internal:host-gateway
+    healthcheck:
+      start_period: 30s
     profiles:
       - '' # starts when no profile is provided
       - rid
@@ -185,6 +195,8 @@ services:
       - interop_ecosystem_network
     extra_hosts:
       - host.docker.internal:host-gateway
+    healthcheck:
+      start_period: 30s
     profiles:
       - '' # starts when no profile is provided
       - rid_v19
@@ -217,6 +229,8 @@ services:
       - interop_ecosystem_network
     extra_hosts:
       - host.docker.internal:host-gateway
+    healthcheck:
+      start_period: 30s
     profiles:
       - '' # starts when no profile is provided
       - rid_v19
@@ -253,6 +267,8 @@ services:
       - interop_ecosystem_network
     extra_hosts:
       - host.docker.internal:host-gateway
+    healthcheck:
+      start_period: 30s
     profiles:
       - '' # starts when no profile is provided
       - scd
@@ -287,6 +303,8 @@ services:
       - interop_ecosystem_network
     extra_hosts:
       - host.docker.internal:host-gateway
+    healthcheck:
+      start_period: 30s
     profiles:
       - '' # starts when no profile is provided
       - scd
@@ -313,4 +331,3 @@ services:
 networks:
   interop_ecosystem_network:
     external: true
-

--- a/monitoring/mock_uss/health_check.sh
+++ b/monitoring/mock_uss/health_check.sh
@@ -4,4 +4,4 @@
 # mock_uss via the interuss/monitoring image to determine the health status of
 # the container.
 
-curl --fail "http://localhost:${MOCK_USS_PORT:-5000}/status" || exit 1
+curl --fail --max-time 1 "http://localhost:${MOCK_USS_PORT:-5000}/status" || exit 1


### PR DESCRIPTION
This should fix #1390.

It seems that if a service is marked as unhealthy, docker compose will stop immediately to wait ( https://github.com/docker/compose/pull/10209 )
The change on the wait period had no impact in that case.

I switched to 30s in the compose-file, that should give more time for the containers to start (instead of default value of 5s).

I also fixed the healthcheck command used to have a short timeout, should the issue being that a curl is stuck waiting on tcp timeout, that could also explain the issue.