### PR TITLE
[monitorlib] Make UTMClientSession a singleton

### DIFF
--- a/monitoring/monitorlib/infrastructure.py
+++ b/monitoring/monitorlib/infrastructure.py
@@ -75,6 +75,9 @@ class AuthAdapter:
         return None
 
 
+_sessions: dict[tuple, "UTMClientSession"] = {}
+
+
 class UTMClientSession(requests.Session):
     """Requests session that enables easy access to ASTM-specified UTM endpoints.
 
@@ -86,12 +89,25 @@ class UTMClientSession(requests.Session):
     DSS).
     """
 
+    def __new__(cls, prefix_url, auth_adapter=None, timeout_seconds=None):
+        """Make the session a singleton based on parameter combinaison"""
+
+        key = (prefix_url, auth_adapter, timeout_seconds)
+        if key not in _sessions:
+            _sessions[key] = super().__new__(cls)
+        return _sessions[key]
+
     def __init__(
         self,
         prefix_url: str,
         auth_adapter: AuthAdapter | None = None,
         timeout_seconds: float | None = None,
     ):
+        if hasattr(
+            self, "_prefix_url"
+        ):  # If set, we have been reused from the singleton pattern, no need to do anything
+            return
+
         super().__init__()
 
         self._prefix_url = prefix_url[0:-1] if prefix_url[-1] == "/" else prefix_url


### PR DESCRIPTION
Proposition 2 to fix connections leaking. See #1408 for alternative version (or we could have both, but that probably not needed).

The test suite is currently creating a set of `UTMClientSession` during initialization, for each test and endpoint used.

This create issues, as connections use keep-alive mechanism and are never closed. #1407 is an example of that with a lot USS, reaching the limit after a while.

This version of the fix make `UTMClientSession` a singleton, based on it parameters, meaning it will be reused across tests.
This may have side effects, but I'm not sure how it's could be used across the whole codebase (eg. if the session / AuthAdapter are dynamically modified).

Tested manually by checking the number of open sockets that stay to a reasonable value. Connections are still reused.