### PR TITLE
[uss_qualifier] Don't try to cleanup None area in down_uss

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss.py
@@ -299,6 +299,9 @@ class DownUSS(TestScenario):
         self.end_test_step()
 
     def _clear_op_intents(self, area):
+        if area is None:
+            return
+
         with self.check(
             "Successful operational intents cleanup", [self.dss.participant_id]
         ) as check:


### PR DESCRIPTION
#1405 removed by mistake the `None` check that seems to appear in some cases. This fixes #1422 