### PR TITLE
[uss_qualifier/scenarios/uss_down] Only clean op intents when some were created

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss.py
@@ -298,7 +298,7 @@ class DownUSS(TestScenario):
 
         self.end_test_step()
 
-    def _clear_op_intents(self, area):
+    def _clear_op_intents(self, area: Volume4D):
         with self.check(
             "Successful operational intents cleanup", [self.dss.participant_id]
         ) as check:
@@ -334,6 +334,7 @@ class DownUSS(TestScenario):
         self.begin_cleanup()
         set_uss_available(self, self.dss, self.uss_qualifier_sub)
         cleanup_flights(self, [self.tested_uss])
-        self._clear_op_intents(self.scenario_execution_max_extents)
+        if self.scenario_execution_max_extents:
+            self._clear_op_intents(self.scenario_execution_max_extents)
 
         self.end_cleanup()


### PR DESCRIPTION
This PR fixes #1422 by first making sure the problem would have been caught by basedpyright by adding a type annotation to `area` in `_clear_op_intents` -- this results in a basedpyright finding that "None" is not assignable to "Volume4D" (reportArgumentType).  This finding is then resolved by only calling _clear_op_intents from cleanup when one or more op intents were actually created during the scenario (self.scenario_execution_max_extents is not None).