### PR TITLE
[tooling] Ignore git-ignored files in shell-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ validate-uss-qualifier-docs:
 
 .PHONY: shell-lint
 shell-lint:
-	find . -name '*.sh' ! -path "./interfaces/*" | xargs docker run --rm -v "$(CURDIR):/monitoring" -w /monitoring koalaman/shellcheck:v0.11.0
+	find . -name '*.sh' ! -path "./interfaces/*" | git check-ignore --stdin --no-index -n -v --non-matching | grep '^::' | cut -f2 | xargs docker run --rm -v "$(CURDIR):/monitoring" -w /monitoring koalaman/shellcheck:v0.11.0
 
 .PHONY: unit-test
 unit-test:


### PR DESCRIPTION
This PR fixes #1427 by excluding files that are excluded by git ignore files in the shell lint command.

Diffing the file list before & after the extra filter show expected results:

```patch
*** /tmp/b      2026-04-20 09:58:38.074510445 +0200
--- /tmp/a      2026-04-20 09:58:28.231460147 +0200
***************
*** 29,36 ****
  ./schemas/manage_type_schemas.sh
  ./github_pages/make_site_content.sh
  ./test/repo_hygiene/repo_hygiene.sh
- ./.venv/lib/python3.13/site-packages/nodejs_wheel/lib/node_modules/npm/lib/utils/completion.sh
- ./.venv/lib/python3.13/site-packages/nodejs_wheel/lib/node_modules/npm/node_modules/node-gyp/macOS_Catalina_acid_test.sh
  ./build/build_and_push.sh
  ./build/dev/startup/core_service.sh
  ./build/dev/run_locally.sh
--- 29,34 ----
***************
*** 38,41 ****
  ./scripts/git/version.sh
  ./scripts/git/commit.sh
  ./scripts/tag.sh
- 
--- 36,38 ----
```