### PR TITLE
[uss_quafilier] Lower severity of all cleanup steps

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dp_behavior.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dp_behavior.md
@@ -112,6 +112,6 @@ If the Display Provider has issued such requests, it is in violation of this req
 
 The cleanup phase of this test scenario attempts to remove injected data from all SPs.
 
-### [Clean ISA](./dss/test_steps/clean_workspace.md)
+### [Clean ISA](./dss/test_steps/clean_workspace_during_cleanup.md)
 
 Remove the created ISA from the DSS.

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/test_steps/clean_workspace_during_cleanup.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/test_steps/clean_workspace_during_cleanup.md
@@ -1,0 +1,27 @@
+# Ensure clean workspace test step fragment
+
+This page describes the content of a common test step that ensures a clean workspace for testing interactions with a DSS
+
+## ⚠️ Successful ISA query check
+
+**[interuss.f3411.dss_endpoints.GetISA](../../../../../../requirements/interuss/f3411/dss_endpoints.md)** requires the implementation of the DSS endpoint enabling retrieval of information about a specific ISA; if the individual ISA cannot be retrieved and the error isn't a 404, then this requirement isn't met.
+
+## ⚠️ Removed pre-existing ISA check
+
+If an ISA with the intended ID is already present in the DSS, it needs to be removed before proceeding with the test.  If that ISA cannot be deleted, then the **[astm.f3411.v19.DSS0030,d](../../../../../../requirements/astm/f3411/v19.md)** requirement to implement the ISA deletion endpoint might not be met.
+
+## ⚠️ Notified subscriber check
+
+When a pre-existing ISA needs to be deleted to ensure a clean workspace, any subscribers to ISAs in that area must be notified (as specified by the DSS).  If a notification cannot be delivered, then the **[astm.f3411.v19.NET0730](../../../../../../requirements/astm/f3411/v19.md)** requirement to implement the POST ISAs endpoint isn't met.
+
+## ⚠️ Successful subscription search query check
+
+**[astm.f3411.v19.DSS0030,f](../../../../../../requirements/astm/f3411/v19.md)** requires the implementation of the DSS endpoint to allow callers to retrieve the subscriptions they created.
+
+## ⚠️ Subscription can be queried by ID check
+
+If the DSS cannot be queried for the existing test ID, the DSS is likely not implementing **[astm.f3411.v19.DSS0030,e](../../../../../../requirements/astm/f3411/v19.md)** correctly.
+
+## ⚠️ Subscription can be deleted check
+
+**[astm.f3411.v19.DSS0030,d](../../../../../../requirements/astm/f3411/v19.md)** requires the implementation of the DSS endpoint to allow callers to delete subscriptions they created.

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/sp_notification_behavior.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/sp_notification_behavior.md
@@ -71,6 +71,6 @@ The cleanup phase of this test scenario attempts to remove injected data from al
 
 **[interuss.automated_testing.rid.injection.DeleteTestSuccess](../../../../requirements/interuss/automated_testing/rid/injection.md)**
 
-### [Clean Subscriptions](./dss/test_steps/clean_workspace.md)
+### [Clean Subscriptions](./dss/test_steps/clean_workspace_during_cleanup.md)
 
 Remove all created subscriptions from the DSS.

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dp_behavior.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dp_behavior.md
@@ -112,6 +112,6 @@ If the Display Provider has issued such requests, it is in violation of this req
 
 The cleanup phase of this test scenario attempts to remove injected data from all SPs.
 
-### [Clean ISA](./dss/test_steps/clean_workspace.md)
+### [Clean ISA](./dss/test_steps/clean_workspace_during_cleanup.md)
 
 Remove the created ISA from the DSS.

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/test_steps/clean_workspace_during_cleanup.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/test_steps/clean_workspace_during_cleanup.md
@@ -1,0 +1,27 @@
+# Ensure clean workspace test step fragment
+
+This page describes the content of a common test step that ensures a clean workspace for testing interactions with a DSS
+
+## ⚠️ Successful ISA query check
+
+**[interuss.f3411.dss_endpoints.GetISA](../../../../../../requirements/interuss/f3411/dss_endpoints.md)** requires the implementation of the DSS endpoint enabling retrieval of information about a specific ISA; if the individual ISA cannot be retrieved and the error isn't a 404, then this requirement isn't met.
+
+## ⚠️ Removed pre-existing ISA check
+
+If an ISA with the intended ID is already present in the DSS, it needs to be removed before proceeding with the test.  If that ISA cannot be deleted, then the **[astm.f3411.v22a.DSS0030,d](../../../../../../requirements/astm/f3411/v22a.md)** requirement to implement the ISA deletion endpoint might not be met.
+
+## ⚠️ Notified subscriber check
+
+When a pre-existing ISA needs to be deleted to ensure a clean workspace, any subscribers to ISAs in that area must be notified (as specified by the DSS).  If a notification cannot be delivered, then the **[astm.f3411.v22a.NET0730](../../../../../../requirements/astm/f3411/v22a.md)** requirement to implement the POST ISAs endpoint isn't met.
+
+## ⚠️ Successful subscription search query check
+
+**[astm.f3411.v22a.DSS0030,f](../../../../../../requirements/astm/f3411/v22a.md)** requires the implementation of the DSS endpoint to allow callers to retrieve the subscriptions they created.
+
+## ⚠️ Subscription can be queried by ID check
+
+If the DSS cannot be queried for the existing test ID, the DSS is likely not implementing **[astm.f3411.v22a.DSS0030,e](../../../../../../requirements/astm/f3411/v22a.md)** correctly.
+
+## ⚠️ Subscription can be deleted check
+
+**[astm.f3411.v22a.DSS0030,d](../../../../../../requirements/astm/f3411/v22a.md)** requires the implementation of the DSS endpoint to allow callers to delete subscriptions they created.

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/sp_notification_behavior.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/sp_notification_behavior.md
@@ -71,6 +71,6 @@ The cleanup phase of this test scenario attempts to remove injected data from al
 
 **[interuss.automated_testing.rid.injection.DeleteTestSuccess](../../../../requirements/interuss/automated_testing/rid/injection.md)**
 
-### [Clean Subscriptions](./dss/test_steps/clean_workspace.md)
+### [Clean Subscriptions](./dss/test_steps/clean_workspace_during_cleanup.md)
 
 Remove all created subscriptions from the DSS.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/authentication/authentication_validation.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/authentication/authentication_validation.md
@@ -550,14 +550,14 @@ Check response format of a search.
 
 ## Cleanup
 
-### [Clean any existing OIRs with known test IDs](../clean_workspace_op_intents.md)
+### [Clean any existing OIRs with known test IDs](../clean_workspace_op_intents_during_cleanup.md)
 
-### [Clean any existing subscriptions with known test IDs](../clean_workspace_subs.md)
+### [Clean any existing subscriptions with known test IDs](../clean_workspace_subs_during_cleanup.md)
 
-### [Clean any existing constraint references with known test IDs](../clean_workspace_constraints.md)
+### [Clean any existing constraint references with known test IDs](../clean_workspace_constraints_during_cleanup.md)
 
-### [Availability can be requested](../fragments/availability/read.md)
+### [Availability can be requested](../fragments/availability/read_during_cleanup.md)
 
-### [Availability can be set](../fragments/availability/update.md)
+### [Availability can be set](../fragments/availability/update_during_cleanup.md)
 
 The cleanup phase of this test scenario removes the subscription with the known test ID if it has not been removed before.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/clean_workspace_constraints_during_cleanup.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/clean_workspace_constraints_during_cleanup.md
@@ -1,0 +1,18 @@
+# Ensure clean workspace test step fragment
+
+Ensure a clean workspace for testing interactions with a DSS by removing any constraint references from the DSS that may have been left behind from testing efforts.
+
+## ⚠️ Constraint references can be queried by ID check
+
+If an existing constraint reference cannot directly be queried by its ID, or if for a non-existing one the DSS replies with a status code different than 404,
+the DSS implementation is in violation of **[astm.f3548.v21.DSS0005,3](../../../../requirements/astm/f3548/v21.md)**.
+
+## ⚠️ Constraint references can be searched for check
+
+A client with valid credentials should be allowed to search for constraint references in a given area.
+Otherwise, the DSS is not in compliance with **[astm.f3548.v21.DSS0005,4](../../../../requirements/astm/f3548/v21.md)**.
+
+## ⚠️ Constraint reference removed check
+
+If an existing constraint cannot be deleted by its manager when providing the proper ID and OVN, the DSS implementation is in violation of
+**[astm.f3548.v21.DSS0005,3](../../../../requirements/astm/f3548/v21.md)**.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/clean_workspace_op_intents_during_cleanup.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/clean_workspace_op_intents_during_cleanup.md
@@ -1,0 +1,18 @@
+# Ensure clean workspace test step fragment
+
+Ensure a clean workspace for testing interactions with a DSS by removing any operational intent references from the DSS that may have been left behind from testing efforts.
+
+## ⚠️ Operational intent references can be queried by ID check
+
+If an existing operational intent reference cannot directly be queried by its ID, or if for a non-existing one the DSS replies with a status code different than 404,
+the DSS implementation is in violation of **[astm.f3548.v21.DSS0005,1](../../../../requirements/astm/f3548/v21.md)**.
+
+## ⚠️ Operational intent references can be searched for check
+
+A client with valid credentials should be allowed to search for operational intents in a given area.
+Otherwise, the DSS is not in compliance with **[astm.f3548.v21.DSS0005,2](../../../../requirements/astm/f3548/v21.md)**.
+
+## ⚠️ Operational intent reference removed check
+
+If an existing operational intent cannot be deleted when providing the proper ID and OVN, the DSS implementation is in violation of
+**[astm.f3548.v21.DSS0005,1](../../../../requirements/astm/f3548/v21.md)**.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/clean_workspace_subs_during_cleanup.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/clean_workspace_subs_during_cleanup.md
@@ -1,0 +1,15 @@
+# Ensure clean workspace test step fragment
+
+Ensure a clean workspace for testing interactions with a DSS by removing any subscriptions from the DSS that may have been left behind from testing efforts.
+
+## ⚠️ Successful subscription search query check
+
+**[astm.f3548.v21.DSS0005,5](../../../../requirements/astm/f3548/v21.md)** requires the implementation of the DSS endpoint to allow callers to retrieve the subscriptions they created.
+
+## ⚠️ Subscription can be queried by ID check
+
+If the DSS cannot be queried for the existing test ID, the DSS is likely not implementing **[astm.f3548.v21.DSS0005,5](../../../../requirements/astm/f3548/v21.md)** correctly.
+
+## ⚠️ Subscription can be deleted check
+
+**[astm.f3548.v21.DSS0005,5](../../../../requirements/astm/f3548/v21.md)** requires the implementation of the DSS endpoint to allow callers to delete subscriptions they created.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/constraint_ref_simple.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/constraint_ref_simple.md
@@ -76,4 +76,4 @@ This step verifies that an existing CR cannot be mutated with an incorrect OVN.
 If the DSS under test allows the qualifier to mutate an existing CR with a request that provided an incorrect OVN,
 it is in violation of **[astm.f3548.v21.DSS0005,3](../../../../requirements/astm/f3548/v21.md)**
 
-## [Cleanup](./clean_workspace_constraints.md)
+## [Cleanup](./clean_workspace_constraints_during_cleanup.md)

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/availability/read_during_cleanup.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/availability/read_during_cleanup.md
@@ -1,0 +1,9 @@
+# USS Availability Read test step fragment
+
+This fragment contains the steps for the USS Availability scenario
+where we confirm that a USS availability can be correctly read from a DSS instance
+
+## ⚠️ USS Availability can be requested check
+
+If, when queried for the availability of a USS using valid credentials, the DSS does not return a valid 200 response,
+it is in violation of the OpenAPI specification referenced by **[astm.f3548.v21.DSS0100,1](../../../../../../requirements/astm/f3548/v21.md)**.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/availability/update_during_cleanup.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/fragments/availability/update_during_cleanup.md
@@ -1,0 +1,9 @@
+# USS Availability Update test step fragment
+
+This fragment contains the steps for the USS Availability scenario
+where we confirm that a USS availability can be correctly read from a DSS instance
+
+## ⚠️ USS Availability can be updated check
+
+If, when presented with a valid query to update the availability state of a USS, a DSS
+responds with anything else than a 200 OK response, it is in violation of the OpenAPI specification referenced by **[astm.f3548.v21.DSS0100,1](../../../../../../requirements/astm/f3548/v21.md)**.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/oir_explicit_sub_handling.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/oir_explicit_sub_handling.md
@@ -137,6 +137,6 @@ Checks that an OIR in the ACCEPTED state that is attached to an explicit subscri
 
 ## Cleanup
 
-### [Cleanup OIRs test step](./clean_workspace_op_intents.md)
+### [Cleanup OIRs test step](./clean_workspace_op_intents_during_cleanup.md)
 
-### [Cleanup Subscriptions test step](./clean_workspace_subs.md)
+### [Cleanup Subscriptions test step](./clean_workspace_subs_during_cleanup.md)

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/oir_implicit_sub_handling.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/oir_implicit_sub_handling.md
@@ -360,7 +360,7 @@ it is in violation of **[astm.f3548.v21.DSS0005,1](../../../../requirements/astm
 
 ## Cleanup
 
-### [Remove OIRs created during this test](clean_workspace_op_intents.md)
+### [Remove OIRs created during this test](clean_workspace_op_intents_during_cleanup.md)
 
-### [Remove subscriptions created during this test](clean_workspace_subs.md)
+### [Remove subscriptions created during this test](clean_workspace_subs_during_cleanup.md)
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/op_intent_ref_access_control.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/op_intent_ref_access_control.md
@@ -112,4 +112,4 @@ in violation of **[astm.f3548.v21.OPIN0035](../../../../requirements/astm/f3548/
 If an operational intent reference can be deleted by a client which did not create it, the DSS implementation is
 in violation of **[astm.f3548.v21.OPIN0035](../../../../requirements/astm/f3548/v21.md)**.
 
-## [Cleanup](clean_workspace_op_intents.md)
+## [Cleanup](clean_workspace_op_intents_during_cleanup.md)

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/op_intent_ref_key_validation.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/op_intent_ref_key_validation.md
@@ -141,4 +141,4 @@ The expectation is that the DSS will require the missing OVN.
 
 #### [Non de-conflicted mutation request fails](fragments/oir/crud/update_conflict.md)
 
-## [Cleanup](./clean_workspace_op_intents.md)
+## [Cleanup](./clean_workspace_op_intents_during_cleanup.md)

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/op_intent_ref_simple.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/op_intent_ref_simple.md
@@ -106,6 +106,6 @@ Confirm that an OIR can be mutated when the correct OVN is provided.
 
 ## Cleanup
 
-### [Cleanup OIRs test step](./clean_workspace_op_intents.md)
+### [Cleanup OIRs test step](./clean_workspace_op_intents_during_cleanup.md)
 
 Remove any lingering OIRs left by this scenario.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/op_intent_ref_state_transitions.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/op_intent_ref_state_transitions.md
@@ -124,4 +124,4 @@ If the DSS allows a client with the `utm.strategic_coordination` scope to transi
 it is in violation of **[astm.f3548.v21.SCD0100](../../../../requirements/astm/f3548/v21.md)** and **[astm.f3548.v21.DSS0005,1](../../../../requirements/astm/f3548/v21.md)**.
 
 
-## [Cleanup](clean_workspace_op_intents.md)
+## [Cleanup](clean_workspace_op_intents_during_cleanup.md)

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_interactions.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_interactions.md
@@ -173,6 +173,6 @@ If the subscription still exists on one of the other DSS instances, one of the i
 
 ## Cleanup
 
-### [Clean any straggling OIRs with known test IDs](clean_workspace_op_intents.md)
+### [Clean any straggling OIRs with known test IDs](clean_workspace_op_intents_during_cleanup.md)
 
-### [Clean any straggling subscriptions with known test IDs](clean_workspace_subs.md)
+### [Clean any straggling subscriptions with known test IDs](clean_workspace_subs_during_cleanup.md)

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_interactions_deletion.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_interactions_deletion.md
@@ -125,6 +125,6 @@ If the DSS includes a deleted subscription, it fails to implement **[astm.f3548.
 
 ## Cleanup
 
-### [Clean any straggling OIRs with known test IDs](clean_workspace_op_intents.md)
+### [Clean any straggling OIRs with known test IDs](clean_workspace_op_intents_during_cleanup.md)
 
-### [Clean any straggling subscriptions with known test IDs](clean_workspace_subs.md)
+### [Clean any straggling subscriptions with known test IDs](clean_workspace_subs_during_cleanup.md)

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_simple.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_simple.md
@@ -185,4 +185,4 @@ If the DSS returns the deleted subscription in a search that covers the area it 
 
 ## Cleanup
 
-### [Clean any straggling subscriptions with known test IDs](clean_workspace_subs.md)
+### [Clean any straggling subscriptions with known test IDs](clean_workspace_subs_during_cleanup.md)

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_validation.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/subscription_validation.md
@@ -52,4 +52,4 @@ or fails to truncate the duration of the subscription to this duration, it is in
 
 ## Cleanup
 
-### [Clean any straggling subscriptions with known test IDs](clean_workspace_subs.md)
+### [Clean any straggling subscriptions with known test IDs](clean_workspace_subs_during_cleanup.md)

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/constraint_ref_synchronization.md
@@ -170,4 +170,4 @@ If a DSS returns an constraint reference that was previously successfully delete
 either one of the primary DSS or the DSS that returned the constraint reference is in violation of **[astm.f3548.v21.DSS0210,2a](../../../../../requirements/astm/f3548/v21.md)**, **[astm.f3548.v21.DSS0210,A2-7-2,3a](../../../../../requirements/astm/f3548/v21.md)**,
 **[astm.f3548.v21.DSS0215](../../../../../requirements/astm/f3548/v21.md)** and **[astm.f3548.v21.DSS0020](../../../../../requirements/astm/f3548/v21.md)**.
 
-## [Cleanup](../clean_workspace_constraints.md)
+## [Cleanup](../clean_workspace_constraints_during_cleanup.md)

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/op_intent_ref_synchronization.md
@@ -134,4 +134,4 @@ If a DSS returns an operational intent reference that was previously successfull
 either one of the primary DSS or the DSS that returned the operational intent reference is in violation of **[astm.f3548.v21.DSS0210,2a](../../../../../requirements/astm/f3548/v21.md)**
 and **[astm.f3548.v21.DSS0210,A2-7-2,3a](../../../../../requirements/astm/f3548/v21.md)**.
 
-## [Cleanup](../clean_workspace_op_intents.md)
+## [Cleanup](../clean_workspace_op_intents_during_cleanup.md)

--- a/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/subscription_synchronization.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/dss/synchronization/subscription_synchronization.md
@@ -192,7 +192,7 @@ As a result, the DSS pool under test is failing to meet **[astm.f3548.v21.DSS002
 
 ## Cleanup
 
-### [Ensure that no subscriptions with the known test IDs remain in the DSS](../clean_workspace_subs.md)
+### [Ensure that no subscriptions with the known test IDs remain in the DSS](../clean_workspace_subs_during_cleanup.md)
 
 This includes the main test subscription used in this test, as well as the extra subscription
 used for testing the `manager` field sync, if the test is configured to test for it.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss.md
@@ -115,7 +115,7 @@ If the planning was accepted, Flight 1 should have been shared.
 If the planning was rejected, Flight 1 should not have been shared, thus should not exist.
 
 ## Cleanup
-### [Restore virtual USS availability test step](../set_uss_available.md)
+### [Restore virtual USS availability test step](../set_uss_available_during_cleanup.md)
 
 ### ⚠️ Successful flight deletion check
 Delete flights injected at USS through the flight planning interface.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/off_nominal_planning/down_uss_equal_priority_not_permitted.md
@@ -173,7 +173,7 @@ to reject or accept Flight 2. If the USS indicates that the injection attempt fa
 
 
 ## Cleanup
-### [Restore virtual USS availability test step](../set_uss_available.md)
+### [Restore virtual USS availability test step](../set_uss_available_during_cleanup.md)
 
 ### ⚠️ Successful flight deletion check
 Delete flights injected at USS through the flight planning interface.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/set_uss_available_during_cleanup.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/set_uss_available_during_cleanup.md
@@ -1,0 +1,9 @@
+# Set USS availability to 'Available' test step fragment
+
+This step sets the USS availability to 'Available' at the DSS.
+
+See `set_uss_available` in [test_steps.py](test_steps.py).
+
+## [Availability can be read](./dss/fragments/availability/read_during_cleanup.md)
+
+## [Availability can be updated](./dss/fragments/availability/update_during_cleanup.md)

--- a/monitoring/uss_qualifier/scenarios/interuss/mock_uss/configure_locality.md
+++ b/monitoring/uss_qualifier/scenarios/interuss/mock_uss/configure_locality.md
@@ -30,6 +30,6 @@ If a mock USS instance doesn't respond properly to a request to change its local
 
 ## Cleanup
 
-### 🛑 Restore locality check
+### ⚠️ Restore locality check
 
 If uss_qualifier cannot restore a mock_uss instance's locality to its old value when rolling back incomplete locality changes, **[interuss.mock_uss.hosted_instance.ExposeInterface](../../../requirements/interuss/mock_uss/hosted_instance.md)** is not met.

--- a/monitoring/uss_qualifier/scenarios/interuss/ovn_request/dss_ovn_request.md
+++ b/monitoring/uss_qualifier/scenarios/interuss/ovn_request/dss_ovn_request.md
@@ -65,4 +65,4 @@ If the DSS accepts the OVN suffix, or fails with an unexpected error, this check
 Check that the DSS rejects OVN suffix that are outdated UUIDv7.
 If the DSS accepts the OVN suffix, or fails with an unexpected error, this check will fail.
 
-## [Cleanup](../../astm/utm/dss/clean_workspace_op_intents.md)
+## [Cleanup](../../astm/utm/dss/clean_workspace_op_intents_during_cleanup.md)


### PR DESCRIPTION
This PR finalize #1400 by removing checks that where still too high in cleanup phases.

Most of them used fragments used in non-cleanup phrase. I duplicated them in specific `_during_cleanup` files, but I'm not sure that the best solution.

This has been tested by running whole CI with something like 

```

        if self._phase == ScenarioPhase.CleaningUp and check_documentation.severity in [
            Severity.High,
            Severity.Critical,
        ]:
            raise RuntimeError()
```

in `monitoring/uss_qualifier/scenarios/scenario.py`'s `check()` function, showing no left over checks.
