### PR TITLE
[reports] Raise an exception if a generator fail during execution

### DIFF
--- a/monitoring/uss_qualifier/reports/artifacts.py
+++ b/monitoring/uss_qualifier/reports/artifacts.py
@@ -156,3 +156,7 @@ def generate_artifacts(
         p.start()
     for p in generators:
         p.join()
+
+    failed = [p for p in generators if p.exitcode != 0]
+    if failed:
+        raise RuntimeError(f"{len(failed)} generator(s) failed. Check exception above.")


### PR DESCRIPTION
Follows #1435 , to have reports working.

Contrib and close #1434 by checking process exit code of generator to ensure errors are not hidden.

Tested locally with a typo:

```
2026-04-22 17:44:13.828 | INFO     | monitoring.uss_qualifier.reports.artifacts:make_globally_expanded_report:134 - Wrote globally-expanded report in 0.0s
Process Process-4:
Traceback (most recent call last):
  File "/root/.local/share/uv/python/cpython-3.13.5-linux-x86_64-gnu/lib/python3.13/multiprocessing/process.py", line 313, in _bootstrap
    self.run()
    ~~~~~~~~^^
  File "/root/.local/share/uv/python/cpython-3.13.5-linux-x86_64-gnu/lib/python3.13/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/monitoring/uss_qualifier/reports/artifacts.py", line 103, in make_tested_requirements
    generate_tested_requirements(redacted_report, tested_reqs_config, path)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/monitoring/uss_qualifier/reports/tested_requirements/generate.py", line 137, in generate_tested_requirements
    template.render(
    ~~~~~~~~~~~~~~~^
        participant_id=participant_id,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<9 lines>...
        anchor_name_of=_anchor_name_of,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/venv/lib/python3.13/site-packages/jinja2/environment.py", line 1295, in render
    self.environment.handle_exception()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/venv/lib/python3.13/site-packages/jinja2/environment.py", line 942, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "/app/monitoring/uss_qualifier/reports/templates/tested_requirements/participant_tested_requirements.html", line 148, in top-level template code
    {% if check.passses + check.failures > 1 %}
    ^^^
jinja2.exceptions.UndefinedError: 'monitoring.uss_qualifier.reports.tested_requirements.data_types.TestedCheck object' has no attribute 'passses'
2026-04-22 17:44:13.894 | INFO     | monitoring.uss_qualifier.reports.artifacts:make_sequence_view:118 - Wrote sequence view in 0.1s
Traceback (most recent call last):
  File "/app/monitoring/uss_qualifier/main.py", line 331, in <module>
    sys.exit(main())
             ~~~~^^
  File "/app/monitoring/uss_qualifier/main.py", line 311, in main
    exit_code = run_config(
        config_name,
    ...<6 lines>...
        scenarios_filter,
    )
  File "/app/monitoring/uss_qualifier/main.py", line 267, in run_config
    generate_artifacts(report, config.artifacts, output_path, disallow_unredacted)
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/monitoring/uss_qualifier/reports/artifacts.py", line 162, in generate_artifacts
    raise RuntimeError(f"{len(failed)} generator(s) failed. Check exception above.")
RuntimeError: 1 generator(s) failed. Check exception above.
```