### PR TITLE
[uss_qualifier] Update interuss/pooled_dss_probing configuration to omit non-testable requirements

### DIFF
--- a/monitoring/uss_qualifier/configurations/interuss/pooled_dss_probing.yaml
+++ b/monitoring/uss_qualifier/configurations/interuss/pooled_dss_probing.yaml
@@ -57,6 +57,11 @@ v1:
                   - astm.f3411.v22a.dss_provider
                   - astm.f3411.v19.dss_provider
                   - astm.f3548.v21.dss_provider
+                exclude:
+                  requirements:
+                    - astm.f3411.v19.DSS0040
+                    - astm.f3411.v22a.DSS0040
+                    - astm.f3548.v21.DSS0010
         participant_requirements:
           uss1: all_astm_dss_requirements
           uss2: all_astm_dss_requirements

--- a/monitoring/uss_qualifier/configurations/interuss/pooled_dss_probing.yaml
+++ b/monitoring/uss_qualifier/configurations/interuss/pooled_dss_probing.yaml
@@ -59,6 +59,7 @@ v1:
                   - astm.f3548.v21.dss_provider
                 exclude:
                   requirements:
+                    # the following 3 requirements are about the DSS not retaining precise geographical extents, which cannot be tested automatically
                     - astm.f3411.v19.DSS0040
                     - astm.f3411.v22a.DSS0040
                     - astm.f3548.v21.DSS0010


### PR DESCRIPTION
This mark non-testable requirements as excluded in configuration used to test releases.

This contribute to fix the issue in DSS repository here: https://github.com/interuss/dss/issues/1439