### PR TITLE
[uss_qualifier/scenarios/netrid] Validate operator altitude and location type

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -8230,22 +8230,6 @@
                 }
             },
             {
-                "code": "reportAssignmentType",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 5,
-                    "lineCount": 94
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 52,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 32,

--- a/monitoring/monitorlib/kml/parsing.py
+++ b/monitoring/monitorlib/kml/parsing.py
@@ -33,12 +33,25 @@ def get_folder_details(folder_elem):
         polygons = placemark.xpath(".//kml:Polygon", namespaces=KML_NAMESPACE)
 
         if placemark_name == "operator_location":
-            operator_point = folder_elem.xpath(
-                ".//kml:Placemark/kml:Point/kml:coordinates", namespaces=KML_NAMESPACE
-            )[0]
-            if operator_point:
-                operator_point = str(operator_point).split(",")
-                operator_location = {"lng": operator_point[0], "lat": operator_point[1]}
+            point_elem = placemark.xpath(".//kml:Point", namespaces=KML_NAMESPACE)
+            if point_elem:
+                operator_point = point_elem[0].xpath(
+                    ".//kml:coordinates", namespaces=KML_NAMESPACE
+                )
+                if operator_point:
+                    operator_point = str(operator_point[0]).split(",")
+                    operator_location = {
+                        "lng": operator_point[0],
+                        "lat": operator_point[1],
+                    }
+
+                    # parse the altitude only if it is above MSL
+                    altitude_mode = point_elem[0].xpath(
+                        ".//kml:altitudeMode", namespaces=KML_NAMESPACE
+                    )
+                    if altitude_mode and altitude_mode[0] == "absolute":
+                        operator_location["alt"] = operator_point[2]
+
         if polygons:
             if placemark_name.startswith("alt:"):
                 polygon_coords = get_coordinates_from_kml(

--- a/monitoring/uss_qualifier/configurations/dev/uspace.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/uspace.yaml
@@ -140,6 +140,8 @@ v1:
                   - astm.f3411.v22a.service_provider#UAS ID Serial Number provider
                   - astm.f3411.v22a.service_provider#Height provider
                   - astm.f3411.v22a.service_provider#Operator Position provider
+                  - astm.f3411.v22a.service_provider#Operator Altitude provider
+                  - astm.f3411.v22a.service_provider#Operator Location Type provider
                   - astm.f3411.v22a.service_provider#Operational Status provider
                   - astm.f3411.v22a.display_provider#Mandatory requirements
                   - astm.f3411.v22a.display_provider#UAS ID transmitter
@@ -160,6 +162,8 @@ v1:
                   - astm.f3411.v22a.display_provider#Speed transmitter
                   - astm.f3411.v22a.display_provider#Vertical Speed transmitter
                   - astm.f3411.v22a.display_provider#Operator Position transmitter
+                  - astm.f3411.v22a.display_provider#Operator Altitude transmitter
+                  - astm.f3411.v22a.display_provider#Operator Location Type transmitter
                   - astm.f3411.v22a.dss_provider
                   - astm.f3548.v21.scd#Automated verification
                   - astm.f3548.v21.dss_provider

--- a/monitoring/uss_qualifier/requirements/astm/f3411/v22a/service_provider.md
+++ b/monitoring/uss_qualifier/requirements/astm/f3411/v22a/service_provider.md
@@ -101,6 +101,14 @@ All Service Provider Role requirements can be verified by automation.
 * **astm.f3411.v22a.NET0260,Table1,23**
 * **astm.f3411.v22a.NET0260,Table1,24**
 
+#### Operator Altitude provider
+
+* **astm.f3411.v22a.NET0260,Table1,25**
+
+#### Operator Location Type provider
+
+* **astm.f3411.v22a.NET0260,Table1,26**
+
 #### Operational Status provider
 
 * **astm.f3411.v22a.NET0260,Table1,7**

--- a/monitoring/uss_qualifier/resources/netrid/simulation/kml_flights.py
+++ b/monitoring/uss_qualifier/resources/netrid/simulation/kml_flights.py
@@ -12,6 +12,9 @@ from implicitdict import StringBasedDateTime
 from shapely.geometry import LineString, Point, Polygon
 from uas_standards.astm.f3411.v22a import constants
 from uas_standards.interuss.automated_testing.rid.v1 import injection
+from uas_standards.interuss.automated_testing.rid.v1.injection import (
+    OperatorAltitudeAltitudeType,
+)
 
 from monitoring.monitorlib.geo import flatten, unflatten
 from monitoring.monitorlib.kml.parsing import get_kml_content, get_polygon_speed
@@ -265,6 +268,12 @@ def generate_flight_record(
         registration_number=flight_description.get("registration_number"),
         eu_classification=eu_classification,
     )
+
+    if operator_location.get("alt"):
+        rid_details.operator_altitude = injection.OperatorAltitude(
+            altitude=float(operator_location.get("alt")),
+            altitude_type=OperatorAltitudeAltitudeType.Fixed,
+        )
 
     return FullFlightRecord(
         reference_time=StringBasedDateTime(now_isoformat),

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common_dictionary_evaluator.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common_dictionary_evaluator.py
@@ -37,7 +37,14 @@ from uas_standards.interuss.automated_testing.rid.v1.injection import (
 )
 
 from monitoring.monitorlib.fetch.rid import Flight, FlightDetails, Position
-from monitoring.monitorlib.geo import Altitude, LatLngPoint, validate_lat, validate_lng
+from monitoring.monitorlib.geo import (
+    Altitude,
+    AltitudeDatum,
+    DistanceUnits,
+    LatLngPoint,
+    validate_lat,
+    validate_lng,
+)
 from monitoring.monitorlib.rid import RIDVersion
 from monitoring.uss_qualifier.configurations.configuration import ParticipantID
 from monitoring.uss_qualifier.resources.netrid.evaluation import EvaluationConfiguration
@@ -169,10 +176,17 @@ class RIDCommonDictionaryEvaluator:
             )
 
         self._evaluate_operator_id(None, observed_details.operator_id, [participant_id])
+
+        operator_altitude_inj = injected_details.get("operator_altitude", {}).get(
+            "altitude", None
+        )
+        operator_altitude_type_inj = injected_details.get("operator_altitude", {}).get(
+            "altitude_type", None
+        )
         self._evaluate_operator_location(
             None,
-            None,
-            None,
+            operator_altitude_inj,
+            operator_altitude_type_inj,
             observed_details.operator_location,
             observed_details.operator_altitude,
             observed_details.operator_altitude_type,
@@ -211,9 +225,7 @@ class RIDCommonDictionaryEvaluator:
         operator_altitude_inj = injected_details.get("operator_altitude", {})
         self._evaluate_operator_location(
             injected_details.get("operator_location", None),
-            operator_altitude_inj.get(
-                "altitude", None
-            ),  # should be of the correct type already
+            operator_altitude_inj.get("altitude", None),
             operator_altitude_inj.get("altitude_type", None),
             operator_obs.get("location", None),
             Altitude.w84m(value=operator_altitude_value_obs),
@@ -760,7 +772,7 @@ class RIDCommonDictionaryEvaluator:
     def _evaluate_operator_location(
         self,
         position_inj: LatLngPoint | None,
-        altitude_inj: Altitude | None,
+        altitude_inj: injection.Altitude | None,
         altitude_type_inj: injection.OperatorAltitudeAltitudeType | None,
         position_obs: LatLngPoint | None,
         altitude_obs: Altitude | None,
@@ -830,10 +842,11 @@ class RIDCommonDictionaryEvaluator:
                         participants,
                     ) as check:
                         if (
-                            alt.units != altitude_inj.units
-                            or alt.reference != altitude_inj.reference
-                            or abs(alt.value - altitude_inj.value)
-                            > 1  # TODO  replace with constants.MinOperatorAltitudeResolution
+                            # right now we inject only altitude in meters with W84 reference
+                            alt.units != DistanceUnits.M
+                            or alt.reference != AltitudeDatum.W84
+                            or abs(alt.value - altitude_inj)
+                            > constants.MinOperatorAltitudeResolution
                         ):
                             check.record_failed(
                                 "Observed operator altitude inconsistent with injected one",

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common_dictionary_evaluator_test.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common_dictionary_evaluator_test.py
@@ -9,9 +9,7 @@ from implicitdict import ImplicitDict
 from uas_standards.ansi_cta_2063_a import SerialNumber
 from uas_standards.astm.f3411 import v22a
 from uas_standards.astm.f3411.v22a.api import (
-    Altitude,
     HorizontalAccuracy,
-    LatLngPoint,
     RIDHeightReference,
     RIDOperationalStatus,
     SpeedAccuracy,
@@ -23,6 +21,7 @@ from uas_standards.interuss.automated_testing.rid.v1.observation import (
     OperatorAltitudeAltitudeType,
 )
 
+from monitoring.monitorlib import geo
 from monitoring.monitorlib.fetch.rid import Flight
 from monitoring.monitorlib.rid import RIDVersion
 from monitoring.uss_qualifier.resources.netrid.evaluation import EvaluationConfiguration
@@ -95,45 +94,45 @@ def _assert_operator_location(
 def test_operator_location():
     valid_locations: list[
         tuple[
-            LatLngPoint | None,
-            Altitude | None,
-            OperatorAltitudeAltitudeType | None,
-            LatLngPoint | None,
-            Altitude | None,
+            geo.LatLngPoint | None,
+            injection.Altitude | None,
+            injection.OperatorAltitudeAltitudeType | None,
+            geo.LatLngPoint | None,
+            geo.Altitude | None,
             OperatorAltitudeAltitudeType | None,
             int,
         ]
     ] = [
         (
-            LatLngPoint(lat=1.0, lng=1.0),
+            geo.LatLngPoint(lat=1.0, lng=1.0),
             None,
             None,
-            LatLngPoint(lat=1.0, lng=1.0),
-            None,
-            None,
-            2,
-        ),
-        (
-            LatLngPoint(lat=-90.0, lng=180.0),
-            None,
-            None,
-            LatLngPoint(lat=-90.0, lng=180.0),
+            geo.LatLngPoint(lat=1.0, lng=1.0),
             None,
             None,
             2,
         ),
         (
-            LatLngPoint(
+            geo.LatLngPoint(lat=-90.0, lng=180.0),
+            None,
+            None,
+            geo.LatLngPoint(lat=-90.0, lng=180.0),
+            None,
+            None,
+            2,
+        ),
+        (
+            geo.LatLngPoint(
                 lat=46.2,
                 lng=6.1,
             ),
-            Altitude(value=1),
-            OperatorAltitudeAltitudeType("Takeoff"),
-            LatLngPoint(
+            injection.Altitude(1),
+            injection.OperatorAltitudeAltitudeType("Takeoff"),
+            geo.LatLngPoint(
                 lat=46.2,
                 lng=6.1,
             ),
-            Altitude(value=1),
+            geo.Altitude.w84m(1),
             OperatorAltitudeAltitudeType("Takeoff"),
             6,
         ),
@@ -143,31 +142,34 @@ def test_operator_location():
 
     invalid_locations: list[
         tuple[
-            LatLngPoint | None,
-            Altitude | None,
+            geo.LatLngPoint | None,
+            injection.Altitude | None,
+            injection.OperatorAltitudeAltitudeType | None,
+            geo.LatLngPoint | None,
+            geo.Altitude | None,
             OperatorAltitudeAltitudeType | None,
             int,
             int,
         ]
     ] = [
         (
-            LatLngPoint(lat=-90.001, lng=0),  # out of range and valid
+            geo.LatLngPoint(lat=-90.001, lng=0),  # out of range and valid
             None,
             None,
-            LatLngPoint(lat=-90.001, lng=0),  # out of range and valid
+            geo.LatLngPoint(lat=-90.001, lng=0),  # out of range and valid
             None,
             None,
             1,
             1,
         ),
         (
-            LatLngPoint(
+            geo.LatLngPoint(
                 lat=0,  # valid
                 lng=180.001,  # out of range
             ),
             None,
             None,
-            LatLngPoint(
+            geo.LatLngPoint(
                 lat=0,  # valid
                 lng=180.001,  # out of range
             ),
@@ -177,23 +179,23 @@ def test_operator_location():
             1,
         ),
         (
-            LatLngPoint(lat=-90.001, lng=180.001),  # both out of range
+            geo.LatLngPoint(lat=-90.001, lng=180.001),  # both out of range
             None,
             None,
-            LatLngPoint(lat=-90.001, lng=180.001),  # both out of range
+            geo.LatLngPoint(lat=-90.001, lng=180.001),  # both out of range
             None,
             None,
             0,
             2,
         ),
         (
-            LatLngPoint(
+            geo.LatLngPoint(
                 lat=46.2,
                 lng=6.1,
             ),
             None,
             None,
-            LatLngPoint(
+            geo.LatLngPoint(
                 lat="46°12'7.99 N",  # Float required
                 lng="6°08'44.48 E",  # Float required
             ),
@@ -203,44 +205,40 @@ def test_operator_location():
             2,
         ),
         (
-            LatLngPoint(
+            geo.LatLngPoint(
                 lat=46.2,
                 lng=6.1,
             ),
-            Altitude(value=1),
-            "invalid",  # Invalid value
-            LatLngPoint(
+            injection.Altitude(1),
+            injection.OperatorAltitudeAltitudeType("Fixed"),
+            geo.LatLngPoint(
                 lat=46.2,
                 lng=6.1,
             ),
-            Altitude(value=1),
-            "invalid",  # Invalid value
+            geo.Altitude.w84m(1),
+            OperatorAltitudeAltitudeType("Takeoff"),
             5,
             1,
         ),
         (
-            LatLngPoint(
+            geo.LatLngPoint(
                 lat=46.2,
                 lng=6.1,
             ),
-            Altitude(
+            injection.Altitude(1000.9),
+            injection.OperatorAltitudeAltitudeType("Takeoff"),
+            geo.LatLngPoint(
+                lat=46.2,
+                lng=6.1,
+            ),
+            geo.Altitude(
                 value=1000.9,
                 units="FT",  # Invalid value
                 reference="UNKNOWN",  # Invalid value
             ),
-            "Takeoff",
-            LatLngPoint(
-                lat=46.2,
-                lng=6.1,
-            ),
-            Altitude(
-                value=1000.9,
-                units="FT",  # Invalid value
-                reference="UNKNOWN",  # Invalid value
-            ),
-            "Takeoff",
-            5,
-            2,
+            OperatorAltitudeAltitudeType("Takeoff"),
+            4,
+            3,
         ),
     ]
     for invalid_location in invalid_locations:

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/common_dictionary_evaluator_sp_flight_details.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/common_dictionary_evaluator_sp_flight_details.md
@@ -93,6 +93,14 @@ NET0260 requires that relevant Remote ID data, consistent with the common data d
 
 NET0260 requires that relevant Remote ID data, consistent with the common data dictionary, be reported by the Service Provider. This check validates that if the Operator Altitude is based on WGS-84 height above ellipsoid (HAE) and is provided in meters. (**[astm.f3411.v22a.NET0260,Table1,25](../../../../requirements/astm/f3411/v22a.md)**)
 
+## ⚠️ Operator Altitude is consistent with injected one check
+
+If the operator altitude is exposed by the SP API, but is inconsistent with the injected value, this check will fail per **[astm.f3411.v22a.NET0260,Table1,25](../../../../requirements/astm/f3411/v22a.md)**.
+
 ## ⚠️ Operator Altitude Type consistency with Common Dictionary check
 
 NET0260 requires that relevant Remote ID data, consistent with the common data dictionary, be reported by the Service Provider. This check validates that if the Operator Altitude Type is valid, if present. (**[astm.f3411.v22a.NET0260,Table1,26](../../../../requirements/astm/f3411/v22a.md)**)
+
+## ⚠️ Operator Altitude Type is consistent with injected one check
+
+If the operator altitude type is exposed by the SP API, but is inconsistent with the injected value, this check will fail per **[astm.f3411.v22a.NET0260,Table1,26](../../../../requirements/astm/f3411/v22a.md)**.

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a.yaml
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a.yaml
@@ -198,6 +198,32 @@ participant_verifiable_capabilities:
             checked:
               requirement_sets:
                 - "astm.f3411.v22a.service_provider#Operator Position provider"
+  - id: service_provider_operator_altitude_provider
+    name: NetRID Service Provider providing operator altitude data field
+    description: Participant fulfills testable requirements necessary to provide operator altitude data field according to F3411-22a.
+    verification_condition:
+      all_conditions:
+        conditions:
+          - capability_verified:
+              capability_ids:
+                - service_provider
+          - requirements_checked:
+              checked:
+                requirement_sets:
+                  - "astm.f3411.v22a.service_provider#Operator Altitude provider"
+  - id: service_provider_operator_location_type_provider
+    name: NetRID Service Provider providing operator location type data field
+    description: Participant fulfills testable requirements necessary to provide operator location type data field according to F3411-22a.
+    verification_condition:
+      all_conditions:
+        conditions:
+          - capability_verified:
+              capability_ids:
+                - service_provider
+          - requirements_checked:
+              checked:
+                requirement_sets:
+                  - "astm.f3411.v22a.service_provider#Operator Location Type provider"
   - id: service_provider_operational_status_provider
     name: NetRID Service Provider providing operational status data field
     description: Participant fulfills testable requirements necessary to provide operational status data field according to F3411-22a.

--- a/monitoring/uss_qualifier/suites/uspace/network_identification.yaml
+++ b/monitoring/uss_qualifier/suites/uspace/network_identification.yaml
@@ -56,6 +56,8 @@ participant_verifiable_capabilities:
               - service_provider_uas_id_serial_number_provider # Serial Number
               - service_provider_height_provider # Height
               - service_provider_operator_position_provider # Operator Location
+              - service_provider_operator_altitude_provider # Operator Altitude
+              - service_provider_operator_location_type_provider # Operator Location Type
               - service_provider_operational_status_provider # Operational Status
               - display_provider_operator_id_transmitter # Operator Registration
               - display_provider_uas_id_serial_number_transmitter # Serial Number
@@ -65,5 +67,7 @@ participant_verifiable_capabilities:
               - display_provider_track_direction_transmitter # Track
               - display_provider_speed_transmitter # Speed
               - display_provider_operator_position_transmitter # Operator Location
+              - display_provider_operator_altitude_transmitter # Operator Altitude
+              - display_provider_operator_location_type_transmitter # Operator Location Type
               - display_provider_operational_status_transmitter # Operational Status
             capability_location: '$..*[?(@.suite_type=="suites.astm.netrid.f3411_22a")]'

--- a/monitoring/uss_qualifier/test_data/che/rid/zurich.kml
+++ b/monitoring/uss_qualifier/test_data/che/rid/zurich.kml
@@ -415,8 +415,9 @@ accuracy_v: VAUnknown</description>
 				<Point>
 					<gx:drawOrder>1</gx:drawOrder>
 					<coordinates>
-            8.523948,47.370838,0
+            8.523948,47.370838,412.2
           </coordinates>
+          <altitudeMode>absolute</altitudeMode>
 				</Point>
 			</Placemark>
 		</Folder>
@@ -523,7 +524,8 @@ accuracy_v: VAUnknown</description>
 				<styleUrl>#m_ylw-pushpin</styleUrl>
 				<Point>
 					<gx:drawOrder>1</gx:drawOrder>
-					<coordinates>8.5510206,47.3757389,0</coordinates>
+					<coordinates>8.5510206,47.3757389,459.0</coordinates>
+					<altitudeMode>absolute</altitudeMode>
 				</Point>
 			</Placemark>
 		</Folder>

--- a/monitoring/uss_qualifier/test_data/usa/kentland/rid.kml
+++ b/monitoring/uss_qualifier/test_data/usa/kentland/rid.kml
@@ -424,7 +424,8 @@ accuracy_v: VAUnknown</description>
 				<styleUrl>#m_ylw-pushpin1</styleUrl>
 				<Point>
 					<gx:drawOrder>1</gx:drawOrder>
-					<coordinates>-80.57819770820173,37.19732333569079,0</coordinates>
+					<coordinates>-80.57819770820173,37.19732333569079,526.3</coordinates>
+					<altitudeMode>absolute</altitudeMode>
 				</Point>
 			</Placemark>
 		</Folder>
@@ -541,7 +542,8 @@ accuracy_v: VAUnknown</description>
 				<styleUrl>#m_ylw-pushpin</styleUrl>
 				<Point>
 					<gx:drawOrder>1</gx:drawOrder>
-					<coordinates>-80.57812675723362,37.19736628374068,0</coordinates>
+					<coordinates>-80.57812675723362,37.19736628374068,526.1</coordinates>
+					<altitudeMode>absolute</altitudeMode>
 				</Point>
 			</Placemark>
 		</Folder>

--- a/monitoring/uss_qualifier/test_data/usa/netrid/dcdemo.kml
+++ b/monitoring/uss_qualifier/test_data/usa/netrid/dcdemo.kml
@@ -133,7 +133,8 @@ accuracy_v: VAUnknown</description>
 				<styleUrl>#m_ylw-pushpin</styleUrl>
 				<Point>
 					<gx:drawOrder>1</gx:drawOrder>
-					<coordinates>-77.55542883349777,39.07891533092457,0</coordinates>
+					<coordinates>-77.55542883349777,39.07891533092457,115.5</coordinates>
+					<altitudeMode>absolute</altitudeMode>
 				</Point>
 			</Placemark>
 			<Placemark>
@@ -251,7 +252,8 @@ accuracy_v: VAUnknown</description>
 				<styleUrl>#m_ylw-pushpin</styleUrl>
 				<Point>
 					<gx:drawOrder>1</gx:drawOrder>
-					<coordinates>-77.55603567233382,39.07873049771908,0</coordinates>
+					<coordinates>-77.55603567233382,39.07873049771908,116.2</coordinates>
+					<altitudeMode>absolute</altitudeMode>
 				</Point>
 			</Placemark>
 			<Placemark>
@@ -348,7 +350,8 @@ accuracy_v: VAUnknown</description>
 				<styleUrl>#m_ylw-pushpin</styleUrl>
 				<Point>
 					<gx:drawOrder>1</gx:drawOrder>
-					<coordinates>-77.55582470247435,39.07830669746138,0</coordinates>
+					<coordinates>-77.55582470247435,39.07830669746138,117.0</coordinates>
+					<altitudeMode>absolute</altitudeMode>
 				</Point>
 			</Placemark>
 			<Placemark>


### PR DESCRIPTION
Fix #1445 

- parse operator altitude in kml, only support MSL altitude as this is what we need to output to, and probably don't want to compute elevation in the parsing
- add in two kml files the altitude of the operator (determined manually by checking elevation of coordinates)
- add the requirements (NET0260|NET0470),Table1,(25|26) to relevant requirements and configurations 
- fix broken tests