### PR TITLE
[mock_uss] Add query type information to mock_uss handlers

### DIFF
--- a/monitoring/mock_uss/f3548v21/routes_scd.py
+++ b/monitoring/mock_uss/f3548v21/routes_scd.py
@@ -20,15 +20,18 @@ from monitoring.mock_uss.f3548v21.flight_planning import (
     op_intent_from_flightrecord,
 )
 from monitoring.mock_uss.flights.database import FlightRecord, db
+from monitoring.mock_uss.logging import query_type
 from monitoring.mock_uss.user_interactions.notifications import (
     UserNotification,
     UserNotificationType,
 )
 from monitoring.monitorlib import scd
 from monitoring.monitorlib.clients.flight_planning.planning import Conflict
+from monitoring.monitorlib.fetch import QueryType
 
 
 @webapp.route("/mock/scd/uss/v1/operational_intents/<entityid>", methods=["GET"])
+@query_type(QueryType.F3548v21USSGetOperationalIntentDetails)
 @requires_scope(scd.SCOPE_SC)
 def scdsc_get_operational_intent_details(entityid: str):
     """Implements getOperationalIntentDetails in ASTM SCD API."""
@@ -62,6 +65,7 @@ def scdsc_get_operational_intent_details(entityid: str):
 @webapp.route(
     "/mock/scd/uss/v1/operational_intents/<entityid>/telemetry", methods=["GET"]
 )
+@query_type(QueryType.F3548v21USSGetOperationalIntentTelemetry)
 @requires_scope(scd.SCOPE_CM_SA)
 def scdsc_get_operational_intent_telemetry(entityid: str):
     """Implements getOperationalIntentTelemetry in ASTM SCD API."""
@@ -110,6 +114,7 @@ def scdsc_get_operational_intent_telemetry(entityid: str):
 
 
 @webapp.route("/mock/scd/uss/v1/operational_intents", methods=["POST"])
+@query_type(QueryType.F3548v21USSNotifyOperationalIntentDetailsChanged)
 @requires_scope(scd.SCOPE_SC)
 def scdsc_notify_operational_intent_details_changed():
     """Implements notifyOperationalIntentDetailsChanged in ASTM SCD API."""
@@ -146,6 +151,7 @@ def scdsc_notify_operational_intent_details_changed():
 
 
 @webapp.route("/mock/scd/uss/v1/reports", methods=["POST"])
+@query_type(QueryType.F3548v21USSMakeUssReport)
 @requires_scope(
     [scd.SCOPE_SC, scd.SCOPE_CP, scd.SCOPE_CM, scd.SCOPE_CM_SA, scd.SCOPE_AA]
 )

--- a/monitoring/mock_uss/interaction_logging/logger.py
+++ b/monitoring/mock_uss/interaction_logging/logger.py
@@ -6,6 +6,7 @@ import flask
 
 from monitoring.mock_uss.app import require_config_value, webapp
 from monitoring.mock_uss.interaction_logging.config import KEY_INTERACTIONS_LOG_DIR
+from monitoring.mock_uss.logging import get_query_type
 from monitoring.monitorlib.clients import QueryHook, query_hooks
 from monitoring.monitorlib.clients.mock_uss.interactions import (
     Interaction,
@@ -76,12 +77,22 @@ def interaction_log_after_request(response):
     elapsed_s = (
         datetime.datetime.now(datetime.UTC) - flask.current_app.custom_profiler["start"]
     ).total_seconds()
+    query_type = get_query_type()
     # TODO: Make this configurable instead of hardcoding exactly these query types
-    if (
-        "/uss/v1/" in flask.request.url
-        or "/uss/identification_service_areas/" in flask.request.url
-        or "/uss/flights" in flask.request.url
+    if query_type in (
+        QueryType.F3548v21USSGetConstraintDetails,
+        QueryType.F3548v21USSGetOperationalIntentDetails,
+        QueryType.F3548v21USSGetOperationalIntentTelemetry,
+        QueryType.F3548v21USSMakeUssReport,
+        QueryType.F3548v21USSNotifyConstraintDetailsChanged,
+        QueryType.F3548v21USSNotifyOperationalIntentDetailsChanged,
+        QueryType.F3411v22aUSSSearchFlights,
+        QueryType.F3411v22aUSSPostIdentificationServiceArea,
+        QueryType.F3411v19USSSearchFlights,
+        QueryType.F3411v19USSPostIdentificationServiceArea,
     ):
         query = describe_flask_query(flask.request, response, elapsed_s)
+        if query_type:
+            query.query_type = query_type
         log_interaction(QueryDirection.Incoming, query)
     return response

--- a/monitoring/mock_uss/logging.py
+++ b/monitoring/mock_uss/logging.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+from functools import wraps
 
 import flask
 import loguru
@@ -9,6 +10,7 @@ from flask import Request, Response
 from loguru import logger
 
 from monitoring.mock_uss.app import webapp
+from monitoring.monitorlib.fetch import QueryType
 
 
 def _get_request_id(req: Request) -> str:
@@ -96,3 +98,33 @@ def end_request_log(e: BaseException | None) -> None:
     request_logger = get_request_logger()
     if request_logger is not None:
         request_logger.remove_from_loguru()
+
+
+def query_type(q_type: QueryType):
+    """Decorator for a view function that indicates which QueryType it handles."""
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            return func(*args, **kwargs)
+
+        # Attach the attribute directly to the wrapper function object
+        setattr(wrapper, "query_type", q_type)
+        return wrapper
+
+    return decorator
+
+
+def get_query_type() -> QueryType | None:
+    """Get the query type handled by the active Flask view function (as indicated by the query_type decorator)."""
+    if (
+        flask.request.endpoint
+        and flask.request.endpoint in flask.current_app.view_functions
+    ):
+        handler_func = flask.current_app.view_functions[flask.request.endpoint]
+
+        q_type = getattr(handler_func, "query_type", None)
+
+        return q_type
+    else:
+        return None

--- a/monitoring/mock_uss/riddp/routes_riddp_v19.py
+++ b/monitoring/mock_uss/riddp/routes_riddp_v19.py
@@ -10,8 +10,9 @@ from uas_standards.astm.f3411.v19.constants import Scope
 
 from monitoring.mock_uss.app import webapp
 from monitoring.mock_uss.auth import requires_scope
+from monitoring.mock_uss.logging import query_type
 from monitoring.mock_uss.riddp.database import db
-from monitoring.monitorlib.fetch import describe_flask_query
+from monitoring.monitorlib.fetch import QueryType, describe_flask_query
 from monitoring.monitorlib.mutate.rid import UpdatedISA
 
 
@@ -22,6 +23,7 @@ def rid_v19_operation(op_id: OperationID):
 
 
 @rid_v19_operation(OperationID.PostIdentificationServiceArea)
+@query_type(QueryType.F3411v19USSPostIdentificationServiceArea)
 @requires_scope(Scope.Write)
 def riddp_notify_isa_v19(id: str):
     try:

--- a/monitoring/mock_uss/riddp/routes_riddp_v22a.py
+++ b/monitoring/mock_uss/riddp/routes_riddp_v22a.py
@@ -10,8 +10,9 @@ from uas_standards.astm.f3411.v22a.constants import Scope
 
 from monitoring.mock_uss.app import webapp
 from monitoring.mock_uss.auth import requires_scope
+from monitoring.mock_uss.logging import query_type
 from monitoring.mock_uss.riddp.database import db
-from monitoring.monitorlib.fetch import describe_flask_query
+from monitoring.monitorlib.fetch import QueryType, describe_flask_query
 from monitoring.monitorlib.mutate.rid import UpdatedISA
 
 
@@ -22,6 +23,7 @@ def rid_v22a_operation(op_id: OperationID):
 
 
 @rid_v22a_operation(OperationID.PostIdentificationServiceArea)
+@query_type(QueryType.F3411v22aUSSPostIdentificationServiceArea)
 @requires_scope(Scope.ServiceProvider)
 def riddp_notify_isa_v22a(id: str):
     try:

--- a/monitoring/mock_uss/ridsp/routes_ridsp_v19.py
+++ b/monitoring/mock_uss/ridsp/routes_ridsp_v19.py
@@ -26,7 +26,9 @@ from uas_standards.interuss.automated_testing.rid.v1 import injection
 
 from monitoring.mock_uss.app import webapp
 from monitoring.mock_uss.auth import requires_scope
+from monitoring.mock_uss.logging import query_type
 from monitoring.monitorlib import geo
+from monitoring.monitorlib.fetch import QueryType
 from monitoring.monitorlib.rid import RIDVersion
 from monitoring.monitorlib.rid_automated_testing.injection_api import TestFlight
 
@@ -94,18 +96,8 @@ def rid_v19_operation(op_id: OperationID):
     return webapp.route("/mock/ridsp" + path, methods=[op.verb])
 
 
-@rid_v19_operation(OperationID.PostIdentificationServiceArea)
-@requires_scope(Scope.Write)
-def ridsp_notify_isa_v19(id: str):
-    return (
-        flask.jsonify(
-            {"message": "mock_ridsp never solicits subscription notifications"}
-        ),
-        400,
-    )
-
-
 @rid_v19_operation(OperationID.SearchFlights)
+@query_type(QueryType.F3411v19USSSearchFlights)
 @requires_scope(Scope.Read)
 def ridsp_flights_v19():
     if "view" not in flask.request.args:
@@ -150,6 +142,7 @@ def ridsp_flights_v19():
 
 
 @rid_v19_operation(OperationID.GetFlightDetails)
+@query_type(QueryType.F3411v19USSGetFlightDetails)
 @requires_scope(Scope.Read)
 def ridsp_flight_details_v19(id: str):
     now = arrow.utcnow().datetime

--- a/monitoring/mock_uss/ridsp/routes_ridsp_v22a.py
+++ b/monitoring/mock_uss/ridsp/routes_ridsp_v22a.py
@@ -29,7 +29,9 @@ from uas_standards.interuss.automated_testing.rid.v1 import injection
 
 from monitoring.mock_uss.app import webapp
 from monitoring.mock_uss.auth import requires_scope
+from monitoring.mock_uss.logging import query_type
 from monitoring.monitorlib import geo
+from monitoring.monitorlib.fetch import QueryType
 from monitoring.monitorlib.rid import RIDVersion
 from monitoring.monitorlib.rid_automated_testing.injection_api import TestFlight
 from monitoring.monitorlib.rid_v2 import make_time
@@ -151,18 +153,8 @@ def rid_v22a_operation(op_id: OperationID):
     return webapp.route("/mock/ridsp/v2" + path, methods=[op.verb])
 
 
-@rid_v22a_operation(OperationID.PostIdentificationServiceArea)
-@requires_scope(Scope.ServiceProvider)
-def ridsp_notify_isa_v22a(id: str):
-    return (
-        flask.jsonify(
-            {"message": "mock_ridsp never solicits subscription notifications"}
-        ),
-        400,
-    )
-
-
 @rid_v22a_operation(OperationID.SearchFlights)
+@query_type(QueryType.F3411v22aUSSSearchFlights)
 @requires_scope(Scope.DisplayProvider)
 def ridsp_flights_v22a():
     if "view" not in flask.request.args:
@@ -225,6 +217,7 @@ def ridsp_flights_v22a():
 
 
 @rid_v22a_operation(OperationID.GetFlightDetails)
+@query_type(QueryType.F3411v22aUSSGetFlightDetails)
 @requires_scope(Scope.DisplayProvider)
 def ridsp_flight_details_v22a(id: str):
     now = arrow.utcnow().datetime


### PR DESCRIPTION
As a step toward #1444, this PR explicitly associates each standards-defined handler in mock_uss with its InterUSS `fetch` QueryType.  This makes the query type explicit when retrieving interactions from interaction_logging, and avoids our previous approach of guessing the query type according to the presence of a URL substring.

Verified by examining the sequence view of the netrid_v22a configuration and seeing that the s25e10 interaction log query's response contains query_type for each interaction returned.