### PR TITLE
[tooling] Separate image-dev from image

### DIFF
--- a/.github/actions/load-image/action.yml
+++ b/.github/actions/load-image/action.yml
@@ -14,4 +14,5 @@ runs:
         set -euo pipefail
         docker load --input monitoring-image/monitoring-image.tar
         cp monitoring-image/monitoring/image monitoring/image
+        cp monitoring-image/monitoring/image-dev monitoring/image-dev
         rm -rf monitoring-image

--- a/.github/actions/load-image/action.yml
+++ b/.github/actions/load-image/action.yml
@@ -15,4 +15,5 @@ runs:
         docker load --input monitoring-image/monitoring-image.tar
         cp monitoring-image/monitoring/image monitoring/image
         cp monitoring-image/monitoring/image-dev monitoring/image-dev
+        touch monitoring/image monitoring/image-dev
         rm -rf monitoring-image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
         mkdir -p image-artifact/monitoring
         mv monitoring-image.tar image-artifact/
         cp monitoring/image image-artifact/monitoring/
+        cp monitoring/image-dev image-artifact/monitoring/
     - name: Upload monitoring image artifact
       uses: actions/upload-artifact@v7
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,8 @@ on:
     branches:
     - main
 jobs:
-  build-monitoring-image:
-    name: Build monitoring image
+  build-monitoring-images:
+    name: Build monitoring images
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -28,8 +28,10 @@ jobs:
         fetch-tags: true
         fetch-depth: 0
         filter: tree:0
-    - name: Build monitoring image
-      run: make image
+    - name: Build monitoring images
+      run: |
+        make image
+        make image-dev
     - name: Save monitoring image artifact
       run: |
         docker save interuss/monitoring interuss/monitoring-dev -o monitoring-image.tar
@@ -45,7 +47,7 @@ jobs:
   hygiene-tests:
     name: Repository hygiene
     needs:
-      - build-monitoring-image
+      - build-monitoring-images
     # https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#permissions
     permissions:
       contents: read
@@ -73,7 +75,7 @@ jobs:
   unit-tests:
     name: Unit tests
     needs:
-      - build-monitoring-image
+      - build-monitoring-images
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -100,7 +102,7 @@ jobs:
   mock_uss-test:
     name: mock_uss tests
     needs:
-      - build-monitoring-image
+      - build-monitoring-images
     permissions:
       contents: read
     uses: ./.github/workflows/monitoring-test.yml
@@ -113,7 +115,7 @@ jobs:
   uss_qualifier-noop-test:
     name: uss_qualifier configurations.dev.noop tests
     needs:
-      - build-monitoring-image
+      - build-monitoring-images
     permissions:
       contents: read
     uses: ./.github/workflows/monitoring-test.yml
@@ -128,7 +130,7 @@ jobs:
   uss_qualifier-geoawareness_cis-test:
     name: uss_qualifier configurations.dev.geoawareness_cis tests
     needs:
-      - build-monitoring-image
+      - build-monitoring-images
     permissions:
       contents: read
     uses: ./.github/workflows/monitoring-test.yml
@@ -143,7 +145,7 @@ jobs:
   uss_qualifier-generate_rid_test_data-test:
     name: uss_qualifier configurations.dev.generate_rid_test_data tests
     needs:
-      - build-monitoring-image
+      - build-monitoring-images
     permissions:
       contents: read
     uses: ./.github/workflows/monitoring-test.yml
@@ -158,7 +160,7 @@ jobs:
   uss_qualifier-geospatial_comprehension-test:
     name: uss_qualifier configurations.dev.geospatial_comprehension tests
     needs:
-      - build-monitoring-image
+      - build-monitoring-images
     permissions:
       contents: read
     uses: ./.github/workflows/monitoring-test.yml
@@ -173,7 +175,7 @@ jobs:
   uss_qualifier-general_flight_auth-test:
     name: uss_qualifier configurations.dev.general_flight_auth tests
     needs:
-      - build-monitoring-image
+      - build-monitoring-images
     permissions:
       contents: read
     uses: ./.github/workflows/monitoring-test.yml
@@ -188,7 +190,7 @@ jobs:
   uss_qualifier-message_signing-test:
     name: uss_qualifier configurations.dev.message_signing tests
     needs:
-      - build-monitoring-image
+      - build-monitoring-images
     permissions:
       contents: read
     uses: ./.github/workflows/monitoring-test.yml
@@ -203,7 +205,7 @@ jobs:
   uss_qualifier-dss_probing-test:
     name: uss_qualifier configurations.dev.dss_probing tests
     needs:
-      - build-monitoring-image
+      - build-monitoring-images
     permissions:
       contents: read
     uses: ./.github/workflows/monitoring-test.yml
@@ -218,7 +220,7 @@ jobs:
   uss_qualifier-f3548_self_contained-test:
     name: uss_qualifier configurations.dev.f3548_self_contained tests
     needs:
-      - build-monitoring-image
+      - build-monitoring-images
     permissions:
       contents: read
     uses: ./.github/workflows/monitoring-test.yml
@@ -233,7 +235,7 @@ jobs:
   uss_qualifier-utm_implementation_us-test:
     name: uss_qualifier configurations.dev.utm_implementation_us tests
     needs:
-      - build-monitoring-image
+      - build-monitoring-images
     permissions:
       contents: read
     uses: ./.github/workflows/monitoring-test.yml
@@ -248,7 +250,7 @@ jobs:
   uss_qualifier-netrid_v22a-test:
     name: uss_qualifier configurations.dev.netrid_v22a tests
     needs:
-      - build-monitoring-image
+      - build-monitoring-images
     permissions:
       contents: read
     uses: ./.github/workflows/monitoring-test.yml
@@ -263,7 +265,7 @@ jobs:
   uss_qualifier-netrid_v19-test:
     name: uss_qualifier configurations.dev.netrid_v19 tests
     needs:
-      - build-monitoring-image
+      - build-monitoring-images
     permissions:
       contents: read
     uses: ./.github/workflows/monitoring-test.yml
@@ -278,7 +280,7 @@ jobs:
   uss_qualifier-uspace-test:
     name: uss_qualifier configurations.dev.uspace tests
     needs:
-      - build-monitoring-image
+      - build-monitoring-images
     permissions:
       contents: read
     uses: ./.github/workflows/monitoring-test.yml
@@ -293,7 +295,7 @@ jobs:
   uss_qualifier-minimal_probing_simulations-crdb-test:
     name: uss_qualifier configurations.dev.minimal_probing_simulations tests with crdb
     needs:
-      - build-monitoring-image
+      - build-monitoring-images
     permissions:
       contents: read
     uses: ./.github/workflows/monitoring-test.yml
@@ -313,7 +315,7 @@ jobs:
   uss_qualifier-minimal_probing_simulations-ybdb-test:
     name: uss_qualifier configurations.dev.minimal_probing_simulations tests with ybdb
     needs:
-      - build-monitoring-image
+      - build-monitoring-images
     permissions:
       contents: read
     uses: ./.github/workflows/monitoring-test.yml
@@ -333,7 +335,7 @@ jobs:
   prober-test:
     name: prober tests
     needs:
-      - build-monitoring-image
+      - build-monitoring-images
     permissions:
       contents: read
     uses: ./.github/workflows/monitoring-test.yml

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ else
 endif
 
 .PHONY: format
-format: image
+format: image-dev
 	docker run --rm -u ${USER_GROUP} -v "$(CURDIR):/app" -w /app interuss/monitoring-dev uv run ruff format
 	docker run --rm -u ${USER_GROUP} -v "$(CURDIR):/app" -w /app interuss/monitoring-dev uv run ruff check --fix
 	docker run --rm -u ${USER_GROUP} -v "$(CURDIR):/app" -w /app interuss/monitoring-dev uv run basedpyright
@@ -23,11 +23,11 @@ lint: shell-lint python-lint
 	cd schemas && make lint
 
 .PHONY: check-hygiene
-check-hygiene: image lint validate-uss-qualifier-docs
+check-hygiene: image-dev lint validate-uss-qualifier-docs
 	test/repo_hygiene/repo_hygiene.sh
 
 .PHONY: python-lint
-python-lint: image
+python-lint: image-dev
 
 	docker run --rm -u ${USER_GROUP} -v "$(CURDIR):/app" -w /app interuss/monitoring-dev uv run ruff format --check || (echo "Linter didn't succeed. You can use the following command to fix python linter issues: make format" && exit 1)
 	docker run --rm -u ${USER_GROUP} -v "$(CURDIR):/app" -w /app interuss/monitoring-dev uv run ruff check || (echo "Linter didn't succeed. You can use the following command to fix python linter issues: make format" && exit 1)
@@ -51,6 +51,10 @@ unit-test:
 .PHONY: image
 image:
 	cd monitoring && make image
+
+.PHONY: image-dev
+image-dev:
+	cd monitoring && make image-dev
 
 tag:
 	scripts/tag.sh $(UPSTREAM_OWNER)/monitoring/v$(VERSION)

--- a/monitoring/.gitignore
+++ b/monitoring/.gitignore
@@ -5,3 +5,4 @@ run_locally_scd_deploy_others.sh
 
 # Make target placeholders
 image
+image-dev

--- a/monitoring/Makefile
+++ b/monitoring/Makefile
@@ -11,10 +11,10 @@ unit-test:
 	cd uss_qualifier && make unit_test
 	cd monitorlib && make unit_test
 
-image: ../uv.lock ../pyproject.toml $(shell find . -type f ! -path "*/output/*" ! -name image ! -name image-dev ! -name *.pyc) $(shell find ../interfaces -type f)
+image: ../uv.lock ../pyproject.toml $(shell find . -type f ! -path "*/output/*" ! -path "*/.*" ! -path "*/__pycache__/*" ! -name image ! -name image-dev ! -name "*.pyc") $(shell find ../interfaces -type f)
 	./build.sh
 
-image-dev: ../uv.lock ../pyproject.toml $(shell find . -type f ! -path "*/output/*" ! -name image ! -name image-dev ! -name *.pyc) $(shell find ../interfaces -type f)
+image-dev: ../uv.lock ../pyproject.toml $(shell find . -type f ! -path "*/output/*" ! -path "*/.*" ! -path "*/__pycache__/*" ! -name image ! -name image-dev ! -name "*.pyc") $(shell find ../interfaces -type f)
 	./build_dev.sh
 
 .PHONY: test

--- a/monitoring/Makefile
+++ b/monitoring/Makefile
@@ -14,6 +14,9 @@ unit-test:
 image: ../uv.lock ../pyproject.toml $(shell find . -type f ! -path "*/output/*" ! -name image ! -name *.pyc) $(shell find ../interfaces -type f)
 	./build.sh
 
+image-dev: ../uv.lock ../pyproject.toml $(shell find . -type f ! -path "*/output/*" ! -name image ! -name *.pyc) $(shell find ../interfaces -type f)
+	./build_dev.sh
+
 .PHONY: test
 test:
 	cd mock_uss && make test

--- a/monitoring/Makefile
+++ b/monitoring/Makefile
@@ -11,10 +11,10 @@ unit-test:
 	cd uss_qualifier && make unit_test
 	cd monitorlib && make unit_test
 
-image: ../uv.lock ../pyproject.toml $(shell find . -type f ! -path "*/output/*" ! -name image ! -name *.pyc) $(shell find ../interfaces -type f)
+image: ../uv.lock ../pyproject.toml $(shell find . -type f ! -path "*/output/*" ! -name image ! -name image-dev ! -name *.pyc) $(shell find ../interfaces -type f)
 	./build.sh
 
-image-dev: ../uv.lock ../pyproject.toml $(shell find . -type f ! -path "*/output/*" ! -name image ! -name *.pyc) $(shell find ../interfaces -type f)
+image-dev: ../uv.lock ../pyproject.toml $(shell find . -type f ! -path "*/output/*" ! -name image ! -name image-dev ! -name *.pyc) $(shell find ../interfaces -type f)
 	./build_dev.sh
 
 .PHONY: test

--- a/monitoring/build_dev.sh
+++ b/monitoring/build_dev.sh
@@ -16,11 +16,11 @@ TAG="${1:-interuss/monitoring}"
 
 docker image build \
     -f monitoring/Dockerfile \
-    -t "${TAG}" \
+    -t "${TAG}-dev" \
     --build-arg version="$(scripts/git/version.sh monitoring --long)" \
     --build-arg commit_hash="$(git rev-parse HEAD)" \
-    --target base \
+    --target with-dev-dependencies \
     . \
   || exit 1
 
-echo "File created by monitoring/build.sh to keep track of the latest normal image build run date time." > monitoring/image
+echo "File created by monitoring/build_dev.sh to keep track of the latest dev image build run date time." > monitoring/image-dev

--- a/monitoring/monitorlib/scripts/run_unit_tests.sh
+++ b/monitoring/monitorlib/scripts/run_unit_tests.sh
@@ -15,7 +15,7 @@ cd "${BASEDIR}/../../.." || exit 1
 
 (
 cd monitoring || exit 1
-make image
+make image-dev
 )
 
 # shellcheck disable=SC2086
@@ -26,4 +26,3 @@ docker run --name monitorlib_unit_test \
   -v /var/run/docker.sock:/var/run/docker.sock \
   interuss/monitoring-dev \
   monitorlib/scripts/in_container/run_unit_tests.sh
-

--- a/monitoring/uss_qualifier/scripts/format_test_documentation.sh
+++ b/monitoring/uss_qualifier/scripts/format_test_documentation.sh
@@ -15,7 +15,7 @@ cd "${BASEDIR}/../../.." || exit 1
 
 (
 cd monitoring || exit 1
-make image
+make image-dev
 )
 
 # shellcheck disable=SC2086

--- a/monitoring/uss_qualifier/scripts/format_test_suite_docs.sh
+++ b/monitoring/uss_qualifier/scripts/format_test_suite_docs.sh
@@ -15,7 +15,7 @@ cd "${BASEDIR}/../../.." || exit 1
 
 (
 cd monitoring || exit 1
-make image
+make image-dev
 )
 
 # shellcheck disable=SC2086

--- a/monitoring/uss_qualifier/scripts/run_unit_tests.sh
+++ b/monitoring/uss_qualifier/scripts/run_unit_tests.sh
@@ -15,7 +15,7 @@ cd "${BASEDIR}/../../.." || exit 1
 
 (
 cd monitoring || exit 1
-make image
+make image-dev
 )
 
 # shellcheck disable=SC2086

--- a/monitoring/uss_qualifier/scripts/validate_test_definitions.sh
+++ b/monitoring/uss_qualifier/scripts/validate_test_definitions.sh
@@ -15,7 +15,7 @@ cd "${BASEDIR}/../../.." || exit 1
 
 (
 cd monitoring || exit 1
-make image
+make image-dev
 )
 
 # shellcheck disable=SC2086

--- a/schemas/manage_type_schemas.sh
+++ b/schemas/manage_type_schemas.sh
@@ -14,7 +14,7 @@ fi
 cd "${BASEDIR}/.." || exit 1
 
 cd monitoring
-make image
+make image-dev
 cd ..
 
 action=${1:?The action must be specified as --check or --generate}
@@ -24,5 +24,5 @@ docker run --name type_schema_manager \
   --rm \
   -u "$(id -u):$(id -g)" \
   -v "$(pwd):/app" \
-  interuss/monitoring \
+  interuss/monitoring-dev \
   uv run /app/schemas/manage_type_schemas.py "${action}"


### PR DESCRIPTION
This PR resolves #1453 by treating the normal image and the dev image separately.

My verification process for the CI side was to check each of the job types and verify that neither the normal image nor the dev image were rebuilt (instead using the images built in "Build monitoring images").  This took some doing to troubleshoot, but I believe these changes also fix a pre-existing problem where images would rebuild after pytests.