### PR TITLE
[Dockerfile] Specify uv version in docker base image

### DIFF
--- a/monitoring/Dockerfile
+++ b/monitoring/Dockerfile
@@ -9,7 +9,7 @@
 #
 # This image is intended to be built from the repository root context/folder.
 
-FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim AS base
+FROM ghcr.io/astral-sh/uv:0.11.15-python3.11-trixie-slim AS base
 # Not -alpine because: https://stackoverflow.com/a/58028091/651139
 
 # Install system tools

--- a/monitoring/Dockerfile
+++ b/monitoring/Dockerfile
@@ -9,7 +9,7 @@
 #
 # This image is intended to be built from the repository root context/folder.
 
-FROM ghcr.io/astral-sh/uv:0.11.15-python3.11-trixie-slim AS base
+FROM ghcr.io/astral-sh/uv:0.11.15-python3.13-trixie-slim AS base
 # Not -alpine because: https://stackoverflow.com/a/58028091/651139
 
 # Install system tools


### PR DESCRIPTION
Allows to pin more specifically the docker image used. This avoids the recent issue where a UV option was introduced but some users had locally cached an older version of the image where the UV version did not support the option. 