### PR TITLE
[uss_qualifier] Use monitoring image for format/validate test definition

### DIFF
--- a/monitoring/uss_qualifier/scripts/format_test_documentation.sh
+++ b/monitoring/uss_qualifier/scripts/format_test_documentation.sh
@@ -24,5 +24,5 @@ docker run --name test_documentation_formatter \
   -u "$(id -u):$(id -g)" \
   -v "$(pwd):/app" \
   -e MONITORING_GITHUB_ROOT=${MONITORING_GITHUB_ROOT:-} \
-  interuss/monitoring \
+  interuss/monitoring-dev \
   uss_qualifier/scripts/in_container/format_test_documentation.sh

--- a/monitoring/uss_qualifier/scripts/format_test_suite_docs.sh
+++ b/monitoring/uss_qualifier/scripts/format_test_suite_docs.sh
@@ -23,5 +23,5 @@ docker run --name test_suite_docs_formatter \
   --rm \
   -v "$(pwd):/app" \
   -e MONITORING_GITHUB_ROOT=${MONITORING_GITHUB_ROOT:-} \
-  interuss/monitoring \
+  interuss/monitoring-dev \
   uss_qualifier/scripts/in_container/format_test_suite_docs.sh "$@"

--- a/monitoring/uss_qualifier/scripts/validate_test_definitions.sh
+++ b/monitoring/uss_qualifier/scripts/validate_test_definitions.sh
@@ -22,5 +22,5 @@ make image-dev
 docker run --name test_definition_validator \
   --rm \
   -e MONITORING_GITHUB_ROOT=${MONITORING_GITHUB_ROOT:-} \
-  interuss/monitoring \
+  interuss/monitoring-dev \
   uss_qualifier/scripts/in_container/validate_test_definitions.sh


### PR DESCRIPTION
The make command for those scripts has been switched to `image-dev but still use the base docker, image this PR fixes it.

It leaded to various issues, like a right error with uv trying to remove the venv in the image, as the pyproject.toml is not updated between the repo and the image should the base docker image not beeing up-to-date.