### PR TITLE
[uss_qualifier] Fix checks assuming perfect clock sync

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -18820,14 +18820,6 @@
         ],
         "./monitoring/uss_qualifier/scenarios/interuss/mock_uss/test_steps.py": [
             {
-                "code": "reportInvalidTypeVarUse",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportPossiblyUnboundVariable",
                 "range": {
                     "startColumn": 31,

--- a/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md
@@ -30,9 +30,9 @@ DSSInstanceResource that provides access to a DSS instance where flight creation
 
 ### mock_uss plans flight 2 test step
 
-#### 🛑 mock_uss clock time retrievable check
+#### [Note mock_uss clock](../../../interuss/mock_uss/get_clock.md)
 
-We need to know mock_uss's clock time to later request observed interactions after the planning time. If mock_uss's current time isn't retrievable, the mock_uss provider's mock_uss does not meet **[interuss.mock_uss.hosted_instance.ExposeInterface](../../../../requirements/interuss/mock_uss/hosted_instance.md)**.
+We need to know mock_uss's clock time to later request observed interactions after the planning time.
 
 #### [Plan successfully](../../../flight_planning/plan_flight_intent.md)
 
@@ -42,9 +42,9 @@ Flight 2 should be successfully planned by mock_uss.
 
 ### tested_uss plans flight 1 test step
 
-#### 🛑 mock_uss clock time retrievable check
+#### [Note mock_uss clock](../../../interuss/mock_uss/get_clock.md)
 
-We need to know mock_uss's clock time to later request observed interactions after the planning time. If mock_uss's current time isn't retrievable, the mock_uss provider's mock_uss does not meet **[interuss.mock_uss.hosted_instance.ExposeInterface](../../../../requirements/interuss/mock_uss/hosted_instance.md)**.
+We need to know mock_uss's clock time to later request observed interactions after the planning time.
 
 #### [Plan successfully](../../../flight_planning/plan_flight_intent.md)
 
@@ -75,9 +75,9 @@ In this test case, mock_uss is manipulated to share invalid operational intent d
 
 ### mock_uss plans flight 2, sharing invalid operational intent data test step
 
-#### 🛑 mock_uss clock time retrievable check
+#### [Note mock_uss clock](../../../interuss/mock_uss/get_clock.md)
 
-We need to know mock_uss's clock time to later request observed interactions after the planning time. If mock_uss's current time isn't retrievable, the mock_uss provider's mock_uss does not meet **[interuss.mock_uss.hosted_instance.ExposeInterface](../../../../requirements/interuss/mock_uss/hosted_instance.md)**.
+We need to know mock_uss's clock time to later request observed interactions after the planning time.
 
 #### [Plan successfully](../../../flight_planning/plan_flight_intent.md)
 
@@ -89,9 +89,9 @@ The mock_uss is instructed to share invalid data with other USS, for negative te
 
 ### tested_uss attempts to plan flight 1, expect failure test step
 
-#### 🛑 mock_uss clock time retrievable check
+#### [Note mock_uss clock](../../../interuss/mock_uss/get_clock.md)
 
-We need to know mock_uss's clock time to later request observed interactions after the planning time. If mock_uss's current time isn't retrievable, the mock_uss provider's mock_uss does not meet **[interuss.mock_uss.hosted_instance.ExposeInterface](../../../../requirements/interuss/mock_uss/hosted_instance.md)**.
+We need to know mock_uss's clock time to later request observed interactions after the planning time.
 
 #### [Plan unsuccessfully](test_steps/plan_flight_intent_expect_failed.md)
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/get_op_data_validation.md
@@ -30,6 +30,10 @@ DSSInstanceResource that provides access to a DSS instance where flight creation
 
 ### mock_uss plans flight 2 test step
 
+#### 🛑 mock_uss clock time retrievable check
+
+We need to know mock_uss's clock time to later request observed interactions after the planning time. If mock_uss's current time isn't retrievable, the mock_uss provider's mock_uss does not meet **[interuss.mock_uss.hosted_instance.ExposeInterface](../../../../requirements/interuss/mock_uss/hosted_instance.md)**.
+
 #### [Plan successfully](../../../flight_planning/plan_flight_intent.md)
 
 Flight 2 should be successfully planned by mock_uss.
@@ -37,6 +41,10 @@ Flight 2 should be successfully planned by mock_uss.
 #### [Validate operational intent is shared](../validate_shared_operational_intent.md)
 
 ### tested_uss plans flight 1 test step
+
+#### 🛑 mock_uss clock time retrievable check
+
+We need to know mock_uss's clock time to later request observed interactions after the planning time. If mock_uss's current time isn't retrievable, the mock_uss provider's mock_uss does not meet **[interuss.mock_uss.hosted_instance.ExposeInterface](../../../../requirements/interuss/mock_uss/hosted_instance.md)**.
 
 #### [Plan successfully](../../../flight_planning/plan_flight_intent.md)
 
@@ -67,6 +75,10 @@ In this test case, mock_uss is manipulated to share invalid operational intent d
 
 ### mock_uss plans flight 2, sharing invalid operational intent data test step
 
+#### 🛑 mock_uss clock time retrievable check
+
+We need to know mock_uss's clock time to later request observed interactions after the planning time. If mock_uss's current time isn't retrievable, the mock_uss provider's mock_uss does not meet **[interuss.mock_uss.hosted_instance.ExposeInterface](../../../../requirements/interuss/mock_uss/hosted_instance.md)**.
+
 #### [Plan successfully](../../../flight_planning/plan_flight_intent.md)
 
 Flight 2 should be successfully planned by the mock_uss.
@@ -76,6 +88,10 @@ Flight 2 should be successfully planned by the mock_uss.
 The mock_uss is instructed to share invalid data with other USS, for negative test.
 
 ### tested_uss attempts to plan flight 1, expect failure test step
+
+#### 🛑 mock_uss clock time retrievable check
+
+We need to know mock_uss's clock time to later request observed interactions after the planning time. If mock_uss's current time isn't retrievable, the mock_uss provider's mock_uss does not meet **[interuss.mock_uss.hosted_instance.ExposeInterface](../../../../requirements/interuss/mock_uss/hosted_instance.md)**.
 
 #### [Plan unsuccessfully](test_steps/plan_flight_intent_expect_failed.md)
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/get_op_data_validation.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/get_op_data_validation.py
@@ -49,9 +49,9 @@ from monitoring.uss_qualifier.scenarios.flight_planning.test_steps import (
     plan_flight,
     submit_flight,
 )
+from monitoring.uss_qualifier.scenarios.interuss.mock_uss.test_steps import get_clock
 from monitoring.uss_qualifier.scenarios.scenario import (
     ScenarioCannotContinueError,
-    ScenarioDidNotStopError,
     TestScenario,
 )
 from monitoring.uss_qualifier.suites.suite import ExecutionContext
@@ -148,19 +148,7 @@ class GetOpResponseDataValidationByUSS(TestScenario):
         flight_2 = self.flight_2.resolve(self.time_context.evaluate_now())
 
         self.begin_test_step("mock_uss plans flight 2")
-        t0, query = self.mock_uss.get_clock()
-        self.record_query(query)
-        with self.check(
-            "mock_uss clock time retrievable", self.mock_uss.participant_id
-        ) as check:
-            if t0 is None:
-                check.record_failed(
-                    "mock_uss clock time was not retrievable",
-                    f"mock_uss responded {query.response.status_code} without a valid clock time; is mock_uss running the latest version of `monitoring`?",
-                    queries=query,
-                )
-                raise ScenarioDidNotStopError(check)
-        flight_2_planning_time = Time(t0)
+        flight_2_planning_time = Time(get_clock(self, self.mock_uss))
         with OpIntentValidator(
             self,
             self.mock_uss_client,
@@ -182,19 +170,7 @@ class GetOpResponseDataValidationByUSS(TestScenario):
         flight_1 = self.flight_1.resolve(self.time_context.evaluate_now())
 
         self.begin_test_step("tested_uss plans flight 1")
-        t1, query = self.mock_uss.get_clock()
-        self.record_query(query)
-        with self.check(
-            "mock_uss clock time retrievable", self.mock_uss.participant_id
-        ) as check:
-            if t1 is None:
-                check.record_failed(
-                    "mock_uss clock time was not retrievable",
-                    f"mock_uss responded {query.response.status_code} without a valid clock time; is mock_uss running the latest version of `monitoring`?",
-                    queries=query,
-                )
-                raise ScenarioDidNotStopError(check)
-        flight_1_planning_time = Time(t1)
+        flight_1_planning_time = Time(get_clock(self, self.mock_uss))
         with OpIntentValidator(
             self,
             self.tested_uss_client,
@@ -263,19 +239,7 @@ class GetOpResponseDataValidationByUSS(TestScenario):
         self.begin_test_step(
             "mock_uss plans flight 2, sharing invalid operational intent data"
         )
-        t2, query = self.mock_uss.get_clock()
-        self.record_query(query)
-        with self.check(
-            "mock_uss clock time retrievable", self.mock_uss.participant_id
-        ) as check:
-            if t2 is None:
-                check.record_failed(
-                    "mock_uss clock time was not retrievable",
-                    f"mock_uss responded {query.response.status_code} without a valid clock time; is mock_uss running the latest version of `monitoring`?",
-                    queries=query,
-                )
-                raise ScenarioDidNotStopError(check)
-        flight_2_planning_time = Time(t2)
+        flight_2_planning_time = Time(get_clock(self, self.mock_uss))
         with OpIntentValidator(
             self,
             self.mock_uss_client,
@@ -300,19 +264,7 @@ class GetOpResponseDataValidationByUSS(TestScenario):
 
         flight_1 = self.flight_1.resolve(self.time_context.evaluate_now())
         self.begin_test_step("tested_uss attempts to plan flight 1, expect failure")
-        t3, query = self.mock_uss.get_clock()
-        self.record_query(query)
-        with self.check(
-            "mock_uss clock time retrievable", self.mock_uss.participant_id
-        ) as check:
-            if t3 is None:
-                check.record_failed(
-                    "mock_uss clock time was not retrievable",
-                    f"mock_uss responded {query.response.status_code} without a valid clock time; is mock_uss running the latest version of `monitoring`?",
-                    queries=query,
-                )
-                raise ScenarioDidNotStopError(check)
-        flight_1_planning_time = Time(t3)
+        flight_1_planning_time = Time(get_clock(self, self.mock_uss))
         with OpIntentValidator(
             self,
             self.tested_uss_client,

--- a/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/get_op_data_validation.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/data_exchange_validation/get_op_data_validation.py
@@ -1,4 +1,3 @@
-import arrow
 from uas_standards.astm.f3548.v21.api import EntityID
 from uas_standards.astm.f3548.v21.constants import Scope
 
@@ -52,6 +51,7 @@ from monitoring.uss_qualifier.scenarios.flight_planning.test_steps import (
 )
 from monitoring.uss_qualifier.scenarios.scenario import (
     ScenarioCannotContinueError,
+    ScenarioDidNotStopError,
     TestScenario,
 )
 from monitoring.uss_qualifier.suites.suite import ExecutionContext
@@ -148,13 +148,25 @@ class GetOpResponseDataValidationByUSS(TestScenario):
         flight_2 = self.flight_2.resolve(self.time_context.evaluate_now())
 
         self.begin_test_step("mock_uss plans flight 2")
+        t0, query = self.mock_uss.get_clock()
+        self.record_query(query)
+        with self.check(
+            "mock_uss clock time retrievable", self.mock_uss.participant_id
+        ) as check:
+            if t0 is None:
+                check.record_failed(
+                    "mock_uss clock time was not retrievable",
+                    f"mock_uss responded {query.response.status_code} without a valid clock time; is mock_uss running the latest version of `monitoring`?",
+                    queries=query,
+                )
+                raise ScenarioDidNotStopError(check)
+        flight_2_planning_time = Time(t0)
         with OpIntentValidator(
             self,
             self.mock_uss_client,
             self.dss,
             flight_2.basic_information.area.bounding_volume.to_f3548v21(),
         ) as validator:
-            flight_2_planning_time = Time(arrow.utcnow().datetime)
             _, self.flight_2_id, as_planned = plan_flight(
                 self,
                 self.mock_uss_client,
@@ -170,13 +182,25 @@ class GetOpResponseDataValidationByUSS(TestScenario):
         flight_1 = self.flight_1.resolve(self.time_context.evaluate_now())
 
         self.begin_test_step("tested_uss plans flight 1")
+        t1, query = self.mock_uss.get_clock()
+        self.record_query(query)
+        with self.check(
+            "mock_uss clock time retrievable", self.mock_uss.participant_id
+        ) as check:
+            if t1 is None:
+                check.record_failed(
+                    "mock_uss clock time was not retrievable",
+                    f"mock_uss responded {query.response.status_code} without a valid clock time; is mock_uss running the latest version of `monitoring`?",
+                    queries=query,
+                )
+                raise ScenarioDidNotStopError(check)
+        flight_1_planning_time = Time(t1)
         with OpIntentValidator(
             self,
             self.tested_uss_client,
             self.dss,
             flight_1.basic_information.area.bounding_volume.to_f3548v21(),
         ) as validator:
-            flight_1_planning_time = Time(arrow.utcnow().datetime)
             plan_res, self.flight_1_id, as_planned = plan_flight(
                 self,
                 self.tested_uss_client,
@@ -239,13 +263,25 @@ class GetOpResponseDataValidationByUSS(TestScenario):
         self.begin_test_step(
             "mock_uss plans flight 2, sharing invalid operational intent data"
         )
+        t2, query = self.mock_uss.get_clock()
+        self.record_query(query)
+        with self.check(
+            "mock_uss clock time retrievable", self.mock_uss.participant_id
+        ) as check:
+            if t2 is None:
+                check.record_failed(
+                    "mock_uss clock time was not retrievable",
+                    f"mock_uss responded {query.response.status_code} without a valid clock time; is mock_uss running the latest version of `monitoring`?",
+                    queries=query,
+                )
+                raise ScenarioDidNotStopError(check)
+        flight_2_planning_time = Time(t2)
         with OpIntentValidator(
             self,
             self.mock_uss_client,
             self.dss,
             flight_info.basic_information.area.bounding_volume.to_f3548v21(),
         ) as validator:
-            flight_2_planning_time = Time(arrow.utcnow().datetime)
             _, self.flight_2_id, as_planned = plan_flight(
                 self,
                 self.mock_uss_client,
@@ -264,13 +300,25 @@ class GetOpResponseDataValidationByUSS(TestScenario):
 
         flight_1 = self.flight_1.resolve(self.time_context.evaluate_now())
         self.begin_test_step("tested_uss attempts to plan flight 1, expect failure")
+        t3, query = self.mock_uss.get_clock()
+        self.record_query(query)
+        with self.check(
+            "mock_uss clock time retrievable", self.mock_uss.participant_id
+        ) as check:
+            if t3 is None:
+                check.record_failed(
+                    "mock_uss clock time was not retrievable",
+                    f"mock_uss responded {query.response.status_code} without a valid clock time; is mock_uss running the latest version of `monitoring`?",
+                    queries=query,
+                )
+                raise ScenarioDidNotStopError(check)
+        flight_1_planning_time = Time(t3)
         with OpIntentValidator(
             self,
             self.tested_uss_client,
             self.dss,
             flight_1.basic_information.area.bounding_volume.to_f3548v21(),
         ) as validator:
-            flight_1_planning_time = Time(arrow.utcnow().datetime)
             _, self.flight_1_id, _ = submit_flight(
                 self,
                 "Plan should fail",

--- a/monitoring/uss_qualifier/scenarios/astm/utm/subscription_notifications/receive_notifications_for_awareness/receive_notifications_for_awareness.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/subscription_notifications/receive_notifications_for_awareness/receive_notifications_for_awareness.md
@@ -89,6 +89,10 @@ Notifications of relevant flights will be sent to tested_uss using this subscrip
 
 ### Mock_uss plans Flight 2 test step
 
+#### 🛑 mock_uss clock time retrievable check
+
+We need to know mock_uss's clock time to later request observed interactions after the planning time. If mock_uss's current time isn't retrievable, the mock_uss provider's mock_uss does not meet **[interuss.mock_uss.hosted_instance.ExposeInterface](../../../../../requirements/interuss/mock_uss/hosted_instance.md)**.
+
 #### [Plan Flight 2](../../../../flight_planning/plan_flight_intent.md)
 
 The test driver successfully plans Flight 2 via the mock uss, as there is no conflict with Flight 1.
@@ -105,6 +109,10 @@ Check a notification was received by tested_uss for Flight 2, with Flight 1's su
 This test case verifies that relevant notifications for modified operational intents are received through subscription of an operational intent in Activated state.
 
 ### Mock_uss modifies planned Flight 2 test step
+
+#### 🛑 mock_uss clock time retrievable check
+
+We need to know mock_uss's clock time to later request observed interactions after the planning time. If mock_uss's current time isn't retrievable, the mock_uss provider's mock_uss does not meet **[interuss.mock_uss.hosted_instance.ExposeInterface](../../../../../requirements/interuss/mock_uss/hosted_instance.md)**.
 
 #### [Modify Flight 2](../../../../flight_planning/modify_planned_flight_intent.md)
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/subscription_notifications/receive_notifications_for_awareness/receive_notifications_for_awareness.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/subscription_notifications/receive_notifications_for_awareness/receive_notifications_for_awareness.md
@@ -89,9 +89,9 @@ Notifications of relevant flights will be sent to tested_uss using this subscrip
 
 ### Mock_uss plans Flight 2 test step
 
-#### 🛑 mock_uss clock time retrievable check
+#### [Note mock_uss clock](../../../../interuss/mock_uss/get_clock.md)
 
-We need to know mock_uss's clock time to later request observed interactions after the planning time. If mock_uss's current time isn't retrievable, the mock_uss provider's mock_uss does not meet **[interuss.mock_uss.hosted_instance.ExposeInterface](../../../../../requirements/interuss/mock_uss/hosted_instance.md)**.
+We need to know mock_uss's clock time to later request observed interactions after the planning time.
 
 #### [Plan Flight 2](../../../../flight_planning/plan_flight_intent.md)
 
@@ -110,9 +110,9 @@ This test case verifies that relevant notifications for modified operational int
 
 ### Mock_uss modifies planned Flight 2 test step
 
-#### 🛑 mock_uss clock time retrievable check
+#### [Note mock_uss clock](../../../../interuss/mock_uss/get_clock.md)
 
-We need to know mock_uss's clock time to later request observed interactions after the planning time. If mock_uss's current time isn't retrievable, the mock_uss provider's mock_uss does not meet **[interuss.mock_uss.hosted_instance.ExposeInterface](../../../../../requirements/interuss/mock_uss/hosted_instance.md)**.
+We need to know mock_uss's clock time to later request observed interactions after the planning time.
 
 #### [Modify Flight 2](../../../../flight_planning/modify_planned_flight_intent.md)
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/subscription_notifications/receive_notifications_for_awareness/receive_notifications_for_awareness.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/subscription_notifications/receive_notifications_for_awareness/receive_notifications_for_awareness.py
@@ -34,8 +34,8 @@ from monitoring.uss_qualifier.scenarios.flight_planning.test_steps import (
     modify_planned_flight,
     plan_flight,
 )
+from monitoring.uss_qualifier.scenarios.interuss.mock_uss.test_steps import get_clock
 from monitoring.uss_qualifier.scenarios.scenario import (
-    ScenarioDidNotStopError,
     TestScenario,
 )
 from monitoring.uss_qualifier.suites.suite import ExecutionContext
@@ -187,19 +187,7 @@ class ReceiveNotificationsForAwareness(TestScenario):
         self.end_test_step()
 
         self.begin_test_step("Mock_uss plans Flight 2")
-        t0, query = self.mock_uss.get_clock()
-        self.record_query(query)
-        with self.check(
-            "mock_uss clock time retrievable", self.mock_uss.participant_id
-        ) as check:
-            if t0 is None:
-                check.record_failed(
-                    "mock_uss clock time was not retrievable",
-                    f"mock_uss responded {query.response.status_code} without a valid clock time; is mock_uss running the latest version of `monitoring`?",
-                    queries=query,
-                )
-                raise ScenarioDidNotStopError(check)
-        flight_2_planning_time = t0
+        flight_2_planning_time = get_clock(self, self.mock_uss)
         with OpIntentValidator(
             self,
             self.mock_uss_client,
@@ -236,19 +224,7 @@ class ReceiveNotificationsForAwareness(TestScenario):
         )
 
         self.begin_test_step("Mock_uss modifies planned Flight 2")
-        t1, query = self.mock_uss.get_clock()
-        self.record_query(query)
-        with self.check(
-            "mock_uss clock time retrievable", self.mock_uss.participant_id
-        ) as check:
-            if t1 is None:
-                check.record_failed(
-                    "mock_uss clock time was not retrievable",
-                    f"mock_uss responded {query.response.status_code} without a valid clock time; is mock_uss running the latest version of `monitoring`?",
-                    queries=query,
-                )
-                raise ScenarioDidNotStopError(check)
-        flight_2_modif_time = t1
+        flight_2_modif_time = get_clock(self, self.mock_uss)
         with OpIntentValidator(
             self,
             self.mock_uss_client,

--- a/monitoring/uss_qualifier/scenarios/astm/utm/subscription_notifications/receive_notifications_for_awareness/receive_notifications_for_awareness.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/subscription_notifications/receive_notifications_for_awareness/receive_notifications_for_awareness.py
@@ -1,4 +1,3 @@
-import arrow
 from uas_standards.astm.f3548.v21.api import OperationalIntentReference
 from uas_standards.astm.f3548.v21.constants import Scope
 
@@ -35,7 +34,10 @@ from monitoring.uss_qualifier.scenarios.flight_planning.test_steps import (
     modify_planned_flight,
     plan_flight,
 )
-from monitoring.uss_qualifier.scenarios.scenario import TestScenario
+from monitoring.uss_qualifier.scenarios.scenario import (
+    ScenarioDidNotStopError,
+    TestScenario,
+)
 from monitoring.uss_qualifier.suites.suite import ExecutionContext
 
 
@@ -185,13 +187,25 @@ class ReceiveNotificationsForAwareness(TestScenario):
         self.end_test_step()
 
         self.begin_test_step("Mock_uss plans Flight 2")
+        t0, query = self.mock_uss.get_clock()
+        self.record_query(query)
+        with self.check(
+            "mock_uss clock time retrievable", self.mock_uss.participant_id
+        ) as check:
+            if t0 is None:
+                check.record_failed(
+                    "mock_uss clock time was not retrievable",
+                    f"mock_uss responded {query.response.status_code} without a valid clock time; is mock_uss running the latest version of `monitoring`?",
+                    queries=query,
+                )
+                raise ScenarioDidNotStopError(check)
+        flight_2_planning_time = t0
         with OpIntentValidator(
             self,
             self.mock_uss_client,
             self.dss,
             resolved_extents,
         ) as validator:
-            flight_2_planning_time = arrow.utcnow().datetime
             _, self.flight_2_id, as_planned = plan_flight(
                 self,
                 self.mock_uss_client,
@@ -222,6 +236,19 @@ class ReceiveNotificationsForAwareness(TestScenario):
         )
 
         self.begin_test_step("Mock_uss modifies planned Flight 2")
+        t1, query = self.mock_uss.get_clock()
+        self.record_query(query)
+        with self.check(
+            "mock_uss clock time retrievable", self.mock_uss.participant_id
+        ) as check:
+            if t1 is None:
+                check.record_failed(
+                    "mock_uss clock time was not retrievable",
+                    f"mock_uss responded {query.response.status_code} without a valid clock time; is mock_uss running the latest version of `monitoring`?",
+                    queries=query,
+                )
+                raise ScenarioDidNotStopError(check)
+        flight_2_modif_time = t1
         with OpIntentValidator(
             self,
             self.mock_uss_client,
@@ -229,7 +256,6 @@ class ReceiveNotificationsForAwareness(TestScenario):
             flight_2_planned_modified.basic_information.area.bounding_volume.to_f3548v21(),
             self.flight_2_oi_ref,
         ) as validator:
-            flight_2_modif_time = arrow.utcnow().datetime
             _, as_planned = modify_planned_flight(
                 self,
                 self.mock_uss_client,

--- a/monitoring/uss_qualifier/scenarios/flight_planning/injection_evaluation.py
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/injection_evaluation.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable, Iterable
+from datetime import timedelta
 from numbers import Number
 from types import NoneType
 from typing import Any
@@ -6,6 +7,9 @@ from typing import Any
 import arrow
 import bc_jsonpath_ng
 from implicitdict import StringBasedDateTime
+from uas_standards.astm.f3548.v21.constants import (
+    TimeSyncMaxDifferentialSeconds,
+)
 
 from monitoring.monitorlib.clients.flight_planning.flight_info import FlightInfo
 from monitoring.monitorlib.dicts import JSONAddress, JSONPath
@@ -79,7 +83,10 @@ def times_not_later_than_specified_or_now(
         return
     now = arrow.utcnow().datetime
     latest = now if as_requested.datetime < now else as_requested.datetime
-    if as_planned.datetime > latest:
+    # Different servers can have different clocks.  Use max time skew from ASTM F3548-21.
+    if as_planned.datetime > latest + timedelta(
+        seconds=2 * TimeSyncMaxDifferentialSeconds
+    ):
         check.record_failed(
             f"Planned time {as_planned} is too late",
             details=f"Requested time no later than {as_requested} (or now, at {now}) for {address}, but planned time was {as_planned} which is later than the latest time allowed of {latest}",

--- a/monitoring/uss_qualifier/scenarios/interuss/mock_uss/get_clock.md
+++ b/monitoring/uss_qualifier/scenarios/interuss/mock_uss/get_clock.md
@@ -1,0 +1,6 @@
+# Get mock_uss clock test step fragment
+This step obtains the current clock time from mock_uss to synchronize a sequence of actions across servers.
+
+#### 🛑 mock_uss clock time retrievable check
+
+If mock_uss's current time isn't retrievable, the mock_uss provider's mock_uss does not meet **[interuss.mock_uss.hosted_instance.ExposeInterface](../../../requirements/interuss/mock_uss/hosted_instance.md)**.

--- a/monitoring/uss_qualifier/scenarios/interuss/mock_uss/test_steps.py
+++ b/monitoring/uss_qualifier/scenarios/interuss/mock_uss/test_steps.py
@@ -1,5 +1,6 @@
 import re
 from collections.abc import Callable, Iterable
+from datetime import datetime
 
 from implicitdict import StringBasedDateTime
 from uas_standards.astm.f3548.v21 import api
@@ -11,11 +12,30 @@ from monitoring.monitorlib.clients.mock_uss.interactions import (
 )
 from monitoring.monitorlib.fetch import Query, QueryError, QueryType
 from monitoring.uss_qualifier.resources.interuss.mock_uss.client import MockUSSClient
-from monitoring.uss_qualifier.scenarios.scenario import TestScenarioType
+from monitoring.uss_qualifier.scenarios.scenario import (
+    ScenarioDidNotStopError,
+    TestScenario,
+)
+
+
+def get_clock(scenario: TestScenario, mock_uss: MockUSSClient) -> datetime:
+    t0, query = mock_uss.get_clock()
+    scenario.record_query(query)
+    with scenario.check(
+        "mock_uss clock time retrievable", mock_uss.participant_id
+    ) as check:
+        if t0 is None:
+            check.record_failed(
+                "mock_uss clock time was not retrievable",
+                f"mock_uss responded {query.response.status_code} without a valid clock time; is mock_uss running the latest version of `monitoring`?",
+                queries=query,
+            )
+            raise ScenarioDidNotStopError(check)
+    return t0
 
 
 def get_mock_uss_interactions(
-    scenario: TestScenarioType,
+    scenario: TestScenario,
     mock_uss: MockUSSClient,
     since: StringBasedDateTime,
     *is_applicable: Callable[[Interaction], bool],


### PR DESCRIPTION
This PR attempts to follow up on #1459 with an AI-assisted scan through the codebase.  The two categories of checks found and fixed were mock_uss interaction retrievals (found by AI) and flight injection validation (found as a problem by a user).