### PR TITLE
[uss_qualifier] Add tools to troubleshoot NetRID concurrency test failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ This document contains key context, nuances, and troubleshooting tips specifical
 - **Implicit Types**: Many schema objects inherit from `ImplicitDict`. This means that reading their raw Python class definitions may not reveal all their expected structure. Rely on their `__annotations__` or their OpenAPI documentation.
 - **Hidden Schema Nuances**: Certain F3548 properties intuitively behave differently than standard logic might predict (e.g., F3548's `OperationalIntentReference` does *not* represent 4D `altitude` extents, whereas `Volume4D` details do). Always verify property existence programmatically instead of relying on assumptions.
 - **Datetime Types**: Fields annotated as `StringBasedDateTime` (or generic `Time` structures wrapping it) inherently expose a `.datetime` property mapping directly to Python's built-in `datetime.datetime` type. Always rely on this `.datetime` attribute for date-math instead of manually parsing string strings.
+- **DSS Base URL Suffixes**: When configuring DSS instances, the base URL for ASTM F3411-22a (NetRID v2) requires the `/rid/v2` suffix path (e.g. `http://dss1.uss1.localutm/rid/v2`), whereas F3411-19 and SCD (F3548) typically use the host base URL directly without that suffix.
 
 ## 3. `uss_qualifier` Test Development Rules
 - **Markdown Documentation is Mandatory**: Every check (e.g., `self._scenario.check(...)`) added to a Python test scenario must be meticulously documented in the corresponding Markdown documentation file for that specific test scenario or fragment.

--- a/monitoring/uss_qualifier/configurations/dev/README.md
+++ b/monitoring/uss_qualifier/configurations/dev/README.md
@@ -30,6 +30,9 @@ Demonstration of a test where a list of expected geospatial map feature queries 
 
 Exercise of automated tests for message signing (not well-developed yet).
 
+## [netrid_concurrency](netrid_concurrency.jsonnet)
+
+Exercises a mini NetRID load test scenario.  See comments in configuration for details.
 
 ## [netrid_v19](netrid_v19.yaml)
 

--- a/monitoring/uss_qualifier/configurations/dev/netrid_concurrency.jsonnet
+++ b/monitoring/uss_qualifier/configurations/dev/netrid_concurrency.jsonnet
@@ -1,0 +1,169 @@
+// This configuration is designed to stress-test local DSS deployments in ways perhaps similar to
+// dss#1509 (DSS timeouts during HeavyTrafficConcurrent), and allow partial exploration of dss#1488
+// (question regarding number of DSS instances in a pool).
+
+// Before running this configuration, choose a DSS pool size for local deployment.  Set NUM_USS and
+// NUM_NODES as both environment variables and below.  Bring up local DSS pool with
+// `make start-locally`.  Verify that all containers are healthy and not restarting (#1480) and
+// force-remove any containers that are not, then return `make start-locally`.  Repeat until all
+// containers are healthy.
+//     export NUM_USS=7
+//     export NUM_NODES=3
+
+// Choose INT**_USS_NETEM_CONF latency profiles for both intra-instance and inter-instance.  For
+// example:
+// Cross-zonal GCP latency:
+//     export INTRA_USS_NETEM_CONF="delay 600us 40us 25% distribution normal loss 0.0005%"
+// 36ms baseline, 280ms tails:
+//     export INTER_USS_NETEM_CONF="delay 36ms 40ms 50% distribution paretonormal loss 0.25% 15%"
+
+// Run this configuration with ./monitoring/uss_qualifier/run_locally.sh configurations.dev.netrid_concurrency
+
+// Summarize results with uss_qualifier/scenarios/astm/netrid/common/dss/summarize_heavy_traffic_concurrent.py
+
+local NUM_USS = 7;
+local NUM_NODES = 3;
+
+{
+  '$content_schema': 'monitoring/uss_qualifier/configurations/configuration/USSQualifierConfiguration.json',
+  v1: {
+    test_run: {
+      action: {
+        action_generator: {
+          generator_type: 'action_generators.astm.f3411.ForEachDSS',
+          resources: {
+            dss_instances: 'dss_instances',
+            id_generator: 'id_generator',
+            service_area: 'service_area',
+          },
+          specification: {
+            dss_instances_source: 'dss_instances',
+            dss_instance_id: 'dss',
+            action_to_repeat: {
+              test_scenario: {
+                scenario_type: 'scenarios.astm.netrid.v22a.dss.HeavyTrafficConcurrent',
+                resources: {
+                  dss: 'dss',
+                  id_generator: 'id_generator',
+                  isa: 'service_area',
+                },
+              },
+            },
+          },
+        },
+      },
+      non_baseline_inputs: [
+        'v1.test_run.resources.resource_declarations.utm_auth',
+        'v1.test_run.resources.resource_declarations.dss_instances',
+      ],
+      resources: {
+        resource_declarations: {
+          utm_auth: {
+            resource_type: 'resources.communications.AuthAdapterResource',
+            specification: {
+              environment_variable_containing_auth_spec: 'AUTH_SPEC',
+              scopes_authorized: [
+                'rid.service_provider',
+                'rid.display_provider',
+              ],
+            },
+          },
+          utm_client_identity: {
+            resource_type: 'resources.communications.ClientIdentityResource',
+            dependencies: {
+              auth_adapter: 'utm_auth',
+            },
+            specification: {
+              whoami_audience: 'localhost',
+              whoami_scope: 'rid.display_provider',
+            },
+          },
+          id_generator: {
+            resource_type: 'resources.interuss.IDGeneratorResource',
+            dependencies: {
+              client_identity: 'utm_client_identity',
+            },
+            specification: {},
+          },
+          service_area_volume: {
+            resource_type: 'resources.VolumeResource',
+            specification: {
+              template: {
+                outline_polygon: {
+                  vertices: [
+                    { lat: 37.1853, lng: -80.6140 },
+                    { lat: 37.2148, lng: -80.6140 },
+                    { lat: 37.2148, lng: -80.5440 },
+                    { lat: 37.1853, lng: -80.5440 },
+                  ],
+                },
+                altitude_lower: {
+                  value: 0,
+                  reference: 'W84',
+                  units: 'M',
+                },
+                altitude_upper: {
+                  value: 3048,
+                  reference: 'W84',
+                  units: 'M',
+                },
+                start_time: {
+                  offset_from: {
+                    starting_from: {
+                      time_during_test: 'TimeOfEvaluation',
+                    },
+                    offset: '1s',
+                  },
+                },
+                end_time: {
+                  offset_from: {
+                    starting_from: {
+                      time_during_test: 'TimeOfEvaluation',
+                    },
+                    offset: '1h0m1s',
+                  },
+                },
+              },
+            },
+          },
+          service_area: {
+            resource_type: 'resources.netrid.ServiceAreaResource',
+            dependencies: {
+              volume: 'service_area_volume',
+            },
+            specification: {
+              base_url: 'https://testdummy.interuss.org/interuss/monitoring/uss_qualifier/configurations/dev/library/resources/kentland_service_area',
+            },
+          },
+          dss_instances: {
+            resource_type: 'resources.astm.f3411.DSSInstancesResource',
+            dependencies: {
+              auth_adapter: 'utm_auth',
+            },
+            specification: {
+              dss_instances: [
+                {
+                  participant_id: 'uss' + i + '_dss' + j,
+                  rid_version: 'F3411-22a',
+                  base_url: 'http://dss' + j + '.uss' + i + '.localutm/rid/v2',
+                }
+                for i in std.range(1, NUM_USS)
+                for j in std.range(1, NUM_NODES)
+              ],
+            },
+          },
+        },
+      },
+      execution: {
+        stop_fast: false,
+      },
+    },
+    artifacts: {
+      raw_report: {},
+      sequence_view: {},
+      timing_report: {
+        percentage_of_time_to_break_down: 95,
+      },
+    },
+  },
+}

--- a/monitoring/uss_qualifier/configurations/dev/netrid_concurrency.jsonnet
+++ b/monitoring/uss_qualifier/configurations/dev/netrid_concurrency.jsonnet
@@ -132,7 +132,7 @@ local NUM_NODES = 3;
               volume: 'service_area_volume',
             },
             specification: {
-              base_url: 'https://testdummy.interuss.org/interuss/monitoring/uss_qualifier/configurations/dev/library/resources/kentland_service_area',
+              base_url: 'https://testdummy.interuss.org/interuss/monitoring/uss_qualifier/configurations/dev/netrid_concurrency/resources/service_area',
             },
           },
           dss_instances: {

--- a/monitoring/uss_qualifier/reports/templates/heavy_traffic_concurrent/summary.html
+++ b/monitoring/uss_qualifier/reports/templates/heavy_traffic_concurrent/summary.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>HeavyTrafficConcurrent Performance Summary</title>
+  <style>
+    body {
+      margin: 2em;
+      color: #24292f;
+      background-color: #ffffff;
+      font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans",Helvetica,Arial,sans-serif;
+      font-size: 14px;
+      line-height: 1.5;
+    }
+    h1 {
+      margin-bottom: 0.5em;
+    }
+    table {
+      border-spacing: 0;
+      border-collapse: collapse;
+      width: 100%;
+      margin-top: 1em;
+    }
+    th {
+      padding: 10px;
+      text-align: left;
+      background-color: #f6f8fa;
+      border: 1px solid #d0d7de;
+      font-weight: 600;
+    }
+    td {
+      padding: 10px;
+      vertical-align: middle;
+      border: 1px solid #d0d7de;
+    }
+    tr:nth-child(2n) {
+      background-color: #fafbfc;
+    }
+    .metric-group {
+      font-size: 13px;
+    }
+    .metric-label {
+      color: #57606a;
+      font-size: 11px;
+      text-transform: uppercase;
+      font-weight: 500;
+    }
+    .metric-value {
+      font-weight: 500;
+      color: #0969da;
+    }
+    .latency-stats {
+      font-family: monospace;
+      color: #24292f;
+    }
+    .success-rate-good {
+      color: #1a7f37;
+      font-weight: bold;
+    }
+    .success-rate-bad {
+      color: #cf222e;
+      font-weight: bold;
+    }
+    .no-data {
+      color: #57606a;
+      font-style: italic;
+    }
+  </style>
+</head>
+<body>
+  <h1>HeavyTrafficConcurrent Performance Summary</h1>
+  <p>This report summarizes the performance metrics of <code>HeavyTrafficConcurrent</code> test scenario instances extracted from the test run report.</p>
+
+  <table>
+    <thead>
+      <tr>
+        <th rowspan="2">DSS Participant ID</th>
+        <th rowspan="2">Scenario Details</th>
+        <th colspan="4" style="text-align: center;">Operation Types (Metrics: QPS, Latency Min/Med/Max, Success Rate)</th>
+      </tr>
+      <tr>
+        <th>ISA Creation</th>
+        <th>Created ISA Query</th>
+        <th>ISA Deletion</th>
+        <th>Deleted ISA Query</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for row in rows %}
+      <tr>
+        <td><strong>{{ row.participant_id }}</strong></td>
+        <td>
+          <div>{{ row.scenario_name }}</div>
+          <div style="font-size: 11px; color: #57606a;">Started: {{ row.start_time }}</div>
+        </td>
+        {% for op in ['isa_creation', 'created_isa_query', 'isa_deletion', 'deleted_isa_query'] %}
+        <td>
+          {% if row.metrics[op] %}
+            {% set m = row.metrics[op] %}
+            <div class="metric-group">
+              <div><span class="metric-label">QPS:</span> <span class="metric-value">{{ "%.2f"|format(m.qps) }}</span></div>
+              <div>
+                <span class="metric-label">Latency:</span>
+                <span class="latency-stats">{{ "%.0f"|format(m.min_ms) }}/{{ "%.0f"|format(m.median_ms) }}/{{ "%.0f"|format(m.max_ms) }} ms</span>
+              </div>
+              <div>
+                <span class="metric-label">Success:</span>
+                <span class="{% if m.success_rate >= 100 %}success-rate-good{% else %}success-rate-bad{% endif %}">
+                  {{ m.success_count }}/{{ m.total_count }} ({{ "%.1f"|format(m.success_rate) }}%)
+                </span>
+              </div>
+            </div>
+          {% else %}
+            <span class="no-data">No data</span>
+          {% endif %}
+        </td>
+        {% endfor %}
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</body>
+</html>

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/summarize_heavy_traffic_concurrent.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/summarize_heavy_traffic_concurrent.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""
+Summarizes the performance of HeavyTrafficConcurrent scenarios from a TestRunReport.
+
+Example command to run this script (from the repo root):
+PYTHONPATH=. uv run python monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/summarize_heavy_traffic_concurrent.py --report monitoring/uss_qualifier/output/netrid_concurrency/report.json --output monitoring/uss_qualifier/output/netrid_concurrency/summary.html
+"""
+
+import argparse
+import json
+import os
+import statistics
+from typing import List
+
+from implicitdict import ImplicitDict
+from monitoring.uss_qualifier.reports import jinja_env
+from monitoring.uss_qualifier.reports.report import (
+    TestRunReport,
+    TestScenarioReport,
+    TestSuiteActionReport,
+)
+
+
+def find_heavy_traffic_concurrent_scenarios(
+    action_report: TestSuiteActionReport,
+) -> List[TestScenarioReport]:
+    """Recursively search for HeavyTrafficConcurrent scenarios in the action report."""
+    scenarios = []
+    if "test_scenario" in action_report and action_report.test_scenario:
+        if action_report.test_scenario.scenario_type.endswith(
+            ".HeavyTrafficConcurrent"
+        ):
+            scenarios.append(action_report.test_scenario)
+    elif "test_suite" in action_report and action_report.test_suite:
+        for action in action_report.test_suite.actions:
+            scenarios.extend(find_heavy_traffic_concurrent_scenarios(action))
+    elif "action_generator" in action_report and action_report.action_generator:
+        for action in action_report.action_generator.actions:
+            scenarios.extend(find_heavy_traffic_concurrent_scenarios(action))
+    return scenarios
+
+
+def get_dss_participant_id(scenario: TestScenarioReport) -> str:
+    """Extract participant_id of the DSS under test in the scenario."""
+    # Attempt to extract participant ID from recorded queries
+    for case in scenario.cases:
+        for step in case.steps:
+            queries = step.queries if ("queries" in step and step.queries is not None) else []
+
+            for q in queries:
+                if q.participant_id:
+                    return q.participant_id
+
+    # Fallback to resource_origins if queries not available
+    if (
+        "resource_origins" in scenario
+        and scenario.resource_origins
+        and "dss" in scenario.resource_origins
+    ):
+        return f"dss ({scenario.resource_origins['dss']})"
+
+    return "unknown"
+
+
+def extract_metrics(scenario: TestScenarioReport) -> dict:
+    """Extract and calculate QPS, latency, and success statistics for the key steps."""
+    metrics = {}
+
+    step_mapping = {
+        "Create ISA concurrently": "isa_creation",
+        "Get ISAs concurrently": "created_isa_query",
+        "Delete ISAs concurrently": "isa_deletion",
+        "Access Deleted ISAs": "deleted_isa_query",
+    }
+
+    success_codes = {
+        "isa_creation": {200, 201},
+        "created_isa_query": {200},
+        "isa_deletion": {200},
+        "deleted_isa_query": {404},
+    }
+
+    for case in scenario.cases:
+        for step in case.steps:
+            if step.name in step_mapping:
+                op = step_mapping[step.name]
+                queries = step.queries if ("queries" in step and step.queries is not None) else []
+                if not queries:
+                    continue
+
+                t_start = step.start_time.datetime
+                t_end = step.end_time.datetime if step.end_time else t_start
+                duration_s = (t_end - t_start).total_seconds()
+
+                total_count = len(queries)
+                success_count = sum(
+                    1 for q in queries if q.status_code in success_codes[op]
+                )
+
+                qps = total_count / duration_s if duration_s > 0 else 0.0
+
+                latencies = [
+                    q.response.elapsed_s
+                    for q in queries
+                    if q.response.elapsed_s is not None
+                ]
+                if latencies:
+                    min_ms = min(latencies) * 1000
+                    max_ms = max(latencies) * 1000
+                    median_ms = statistics.median(latencies) * 1000
+                else:
+                    min_ms = median_ms = max_ms = 0.0
+
+                success_rate = (
+                    (success_count / total_count * 100) if total_count > 0 else 0.0
+                )
+
+                metrics[op] = {
+                    "qps": qps,
+                    "min_ms": min_ms,
+                    "median_ms": median_ms,
+                    "max_ms": max_ms,
+                    "success_count": success_count,
+                    "total_count": total_count,
+                    "success_rate": success_rate,
+                }
+    return metrics
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Summarize HeavyTrafficConcurrent performance from report.json"
+    )
+    parser.add_argument(
+        "--report",
+        required=True,
+        help="Path to raw report.json (TestRunReport)",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Path to generate the HTML summary file",
+    )
+    args = parser.parse_args()
+
+    print(f"Loading report from: {args.report}")
+    with open(args.report, "r") as f:
+        raw_report = json.load(f)
+    report = ImplicitDict.parse(raw_report, TestRunReport)
+
+    scenarios = find_heavy_traffic_concurrent_scenarios(report.report)
+    print(f"Found {len(scenarios)} HeavyTrafficConcurrent scenario(s)")
+
+    rows = []
+    for scenario in scenarios:
+        part_id = get_dss_participant_id(scenario)
+        metrics = extract_metrics(scenario)
+        rows.append(
+            {
+                "participant_id": part_id,
+                "scenario_name": scenario.name,
+                "start_time": scenario.start_time,
+                "metrics": metrics,
+            }
+        )
+
+    # Render template using Jinja2
+    template = jinja_env.get_template("heavy_traffic_concurrent/summary.html")
+    rendered_html = template.render(rows=rows)
+
+    os.makedirs(os.path.dirname(os.path.abspath(args.output)), exist_ok=True)
+    with open(args.output, "w") as f:
+        f.write(rendered_html)
+
+    print(f"Summary HTML generated successfully at: {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/summarize_heavy_traffic_concurrent.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/summarize_heavy_traffic_concurrent.py
@@ -10,9 +10,9 @@ import argparse
 import json
 import os
 import statistics
-from typing import List
 
 from implicitdict import ImplicitDict
+
 from monitoring.uss_qualifier.reports import jinja_env
 from monitoring.uss_qualifier.reports.report import (
     TestRunReport,
@@ -23,7 +23,7 @@ from monitoring.uss_qualifier.reports.report import (
 
 def find_heavy_traffic_concurrent_scenarios(
     action_report: TestSuiteActionReport,
-) -> List[TestScenarioReport]:
+) -> list[TestScenarioReport]:
     """Recursively search for HeavyTrafficConcurrent scenarios in the action report."""
     scenarios = []
     if "test_scenario" in action_report and action_report.test_scenario:
@@ -45,7 +45,9 @@ def get_dss_participant_id(scenario: TestScenarioReport) -> str:
     # Attempt to extract participant ID from recorded queries
     for case in scenario.cases:
         for step in case.steps:
-            queries = step.queries if ("queries" in step and step.queries is not None) else []
+            queries = (
+                step.queries if ("queries" in step and step.queries is not None) else []
+            )
 
             for q in queries:
                 if q.participant_id:
@@ -84,7 +86,11 @@ def extract_metrics(scenario: TestScenarioReport) -> dict:
         for step in case.steps:
             if step.name in step_mapping:
                 op = step_mapping[step.name]
-                queries = step.queries if ("queries" in step and step.queries is not None) else []
+                queries = (
+                    step.queries
+                    if ("queries" in step and step.queries is not None)
+                    else []
+                )
                 if not queries:
                     continue
 
@@ -144,7 +150,7 @@ def main():
     args = parser.parse_args()
 
     print(f"Loading report from: {args.report}")
-    with open(args.report, "r") as f:
+    with open(args.report) as f:
         raw_report = json.load(f)
     report = ImplicitDict.parse(raw_report, TestRunReport)
 


### PR DESCRIPTION
This PR introduces two tools to work on [dss#1509](https://github.com/interuss/dss/issues/1509): a test configuration that runs the NetRID HeavyTrafficConcurrent scenario on each DSS instance of a N USS * M nodes-per-USS local deployment, and a summarization tool that looks at performance statistics during runs of this test scenario.

When I ran this test configuration with N=7, M=3 (matching description in 1509), GCP-level intra-USS latency/loss, and [36ms/280ms](https://github.com/interuss/dss/issues/1488) inter-USS latency/loss (some parameters advised by AI), I got the following output:

[netrid_concurrency.zip](https://github.com/user-attachments/files/28675484/netrid_concurrency.zip)

(no failures, ~4.5 QPS/3-4 second latency when handling a dump of 100 ISA requests)

Note that it took a number of tries to set up the mock DSS instances because of #1480, but then once established I don't think I've seen any failures.  I've run it twice now, so 42/42 runs of that test scenario have succeeded with the setup described in this PR.