### PR TITLE
[infrastructure] Fix local dss pool

### DIFF
--- a/build/dev/README.md
+++ b/build/dev/README.md
@@ -4,11 +4,11 @@ This directory contains scripts to deploy a local UTM interoperability ecosystem
 
 ## Overview
 
-The `run_locally.sh` script deploys a choice of DSS instances and databases using Docker Compose. All components are accessible on the shared `interop_ecosystem_network`.
+The `run_locally.sh` script deploys a choice of DSS instances and databases using `docker compose`. All components are accessible on the shared `interop_ecosystem_network`.
 
 ## Usage
 
-Run the following command from this directory:
+Run the following command from this directory (also via `make start-locally` at the repo root):
 ```bash
 ./run_locally.sh up
 ```
@@ -16,7 +16,7 @@ To run in debug mode:
 ```bash
 ./run_locally.sh debug
 ```
-To tear down the deployment and clean up networks:
+To tear down the deployment and clean up networks (also via `make down-locally` at the repo root):
 ```bash
 ./run_locally.sh down
 ```
@@ -35,39 +35,32 @@ The following environment variables can be configured to customize the simulated
 
 ---
 
-## Scaling Limitations & Node Estimations
+## Scaling Limits
 
 When scaling up the local ecosystem by increasing `NUM_USS` or `NUM_NODES`, there are physical and configuration-based limits to keep in mind.
 
-### 1. Host Port Mapping Limit (Max 99 Total Nodes)
-The script maps container ports to host ports using a two-digit padded index (`PADDED_NODE_IDX` from `01` to `99`).
-* Example: `81${PADDED_NODE_IDX}:8080` for CockroachDB Admin UI.
-* **Why it's a limit:** If the total number of nodes (`NUM_USS * NUM_NODES`) reaches **100**, the formatted port (e.g. `81100:8080`) will exceed the maximum TCP port number of **65535**, causing Docker Compose to throw an invalid port error and fail to start.
-* **Estimation:** `NUM_USS * NUM_NODES <= 99`
+### Host Port Mapping Limit (Max 99 Total Nodes)
+The script maps container ports to host ports using a two-digit padded index (`PADDED_NODE_IDX` from `01` to `99`).  So, NUM_USS*NUM_NODES may not exceed 99 without adjusting run_locally.sh.
 
-### 2. Dynamic IP Limit (Max ~250 Total Nodes)
-The `dss_internal_network` is created with a dynamic IP pool range of `172.27.0.0/24`.
-* **Why it's a limit:** All DSS containers, bootstrap, and init containers are assigned dynamic IPs from this pool. Since `/24` has **253** usable host IPs (with `172.27.0.1` as gateway), starting more than ~250 containers requiring dynamic IPs will cause Docker to run out of IPs.
-* **Estimation:** `(NUM_USS * NUM_NODES) + (bootstrap containers) <= 250`
+### Dynamic IP Limit (Max ~250 Total Nodes)
+The `dss_internal_network` is created with a dynamic IP pool range of `172.27.0.0/24`.  All DSS containers, bootstrap, and init containers are assigned dynamic IPs from this pool. Since `/24` has **253** usable host IPs (with `172.27.0.1` as gateway), starting more than ~250 containers requiring dynamic IPs will cause Docker to run out of IPs.  In addition to 2 containers per node, there are also bootstrap containers.
 
-### 3. Kernel Neighbor Table / ARP Cache Limit (Max ~30-40 Total Nodes)
-Each container network connection spawns a virtual network interface (`veth` pair) on the host machine.
-* **Why it's a limit:** Linux hosts track virtual endpoints in the kernel's neighbor table (ARP cache). By default, Linux has a hard limit (`gc_thresh3`) of **1024** entries. With a large number of containers, the combined ARP tables, loopbacks, and network interfaces easily exceed this limit, causing the kernel to throw `No buffer space available (ENOBUFS)` and break networking entirely.
-* **Estimation:** Without kernel tuning, the host might start throwing `ENOBUFS` when total containers approach **60-80** (around `NUM_USS * NUM_NODES >= 30` to `40`).
+### Kernel Neighbor Table / ARP Cache Limit (Max ~30-40 Total Nodes)
+Each container network connection spawns a virtual network interface (`veth` pair) on the host machine.  Linux hosts track virtual endpoints in the kernel's neighbor table (ARP cache). By default, Linux has a hard limit (`gc_thresh3`) of **1024** entries. With a large number of containers, the combined ARP tables, loopbacks, and network interfaces easily exceed this limit, causing the kernel to throw `No buffer space available (ENOBUFS)` and break networking entirely.  Without kernel tuning, the host might start throwing `ENOBUFS` when total containers approach **60-80**.
 
 ---
 
-## Troubleshooting: Kernel Neighbor Table Fix
+## Troubleshooting: Kernel Neighbor Table Adjustment
 
 If you experience container startup timeouts and see errors like `ping: sendmsg: No buffer space available` or `replica unavailable` in database logs, you have hit the Linux neighbor table limit.
 
-### What the Fix Does
+### What the Adjustment Does
 It increases the garbage collection (GC) thresholds of the IPv4 and IPv6 ARP tables in the Linux kernel:
 * **`gc_thresh1`**: Threshold at which garbage collection starts (if neighbor entries stay unused).
 * **`gc_thresh2`**: Threshold at which garbage collection becomes aggressive.
 * **`gc_thresh3`**: The absolute hard limit. The kernel will refuse to create new neighbor entries above this, returning `ENOBUFS`.
 
-### How to Apply the Fix
+### How to Apply the Adjustment
 Run these commands in your host terminal to raise the thresholds:
 ```bash
 sudo sysctl -w \
@@ -82,7 +75,7 @@ sudo sysctl -w \
 ### Why it Works
 By raising `gc_thresh3` from 1024 to 4096, the kernel gains the capacity to track up to 4096 network endpoints concurrently, allowing the 90+ virtual interfaces used in large-scale deployments to resolve ARP addresses without buffer exhaustion.
 
-### How to Reverse the Fix
+### How to Reverse the Adjustment
 To revert the settings to default Linux values, run:
 ```bash
 sudo sysctl -w \

--- a/build/dev/README.md
+++ b/build/dev/README.md
@@ -1,0 +1,96 @@
+# Local Interoperability Ecosystem Deployment
+
+This directory contains scripts to deploy a local UTM interoperability ecosystem consisting of multiple DSS instances and a dummy OAuth server.
+
+## Overview
+
+The `run_locally.sh` script deploys a choice of DSS instances and databases using Docker Compose. All components are accessible on the shared `interop_ecosystem_network`.
+
+## Usage
+
+Run the following command from this directory:
+```bash
+./run_locally.sh up
+```
+To run in debug mode:
+```bash
+./run_locally.sh debug
+```
+To tear down the deployment and clean up networks:
+```bash
+./run_locally.sh down
+```
+
+## Environment Variables
+
+The following environment variables can be configured to customize the simulated conditions:
+
+* `NUM_USS`: Number of simulated USS instances (default: `2`). Note that the standard mock ecosystem requires at least 2 USSs.
+* `NUM_NODES`: Number of nodes per USS database/DSS cluster (default: `1`).
+* `DB_TYPE`: Datastore backend type. Options are `crdb` (CockroachDB) or `ybdb` (Yugabyte) (default: `crdb`).
+* `INTRA_USS_NETEM_CONF`: `tc netem` configuration rules applied to traffic between database nodes of the *same* USS (default: `<none>`).
+  * *Sensible values (low latency/jitter, very low loss):* `"delay 250us 25us 25% distribution normal loss 0.0025% 10%"`
+* `INTER_USS_NETEM_CONF`: `tc netem` configuration rules applied to traffic between database nodes of *different* USSs (default: `<none>`).
+  * *Sensible values (higher latency/jitter, moderate loss):* `"delay 25ms 7.5ms 50% distribution paretonormal loss 0.025% 25%"`
+
+---
+
+## Scaling Limitations & Node Estimations
+
+When scaling up the local ecosystem by increasing `NUM_USS` or `NUM_NODES`, there are physical and configuration-based limits to keep in mind.
+
+### 1. Host Port Mapping Limit (Max 99 Total Nodes)
+The script maps container ports to host ports using a two-digit padded index (`PADDED_NODE_IDX` from `01` to `99`).
+* Example: `81${PADDED_NODE_IDX}:8080` for CockroachDB Admin UI.
+* **Why it's a limit:** If the total number of nodes (`NUM_USS * NUM_NODES`) reaches **100**, the formatted port (e.g. `81100:8080`) will exceed the maximum TCP port number of **65535**, causing Docker Compose to throw an invalid port error and fail to start.
+* **Estimation:** `NUM_USS * NUM_NODES <= 99`
+
+### 2. Dynamic IP Limit (Max ~250 Total Nodes)
+The `dss_internal_network` is created with a dynamic IP pool range of `172.27.0.0/24`.
+* **Why it's a limit:** All DSS containers, bootstrap, and init containers are assigned dynamic IPs from this pool. Since `/24` has **253** usable host IPs (with `172.27.0.1` as gateway), starting more than ~250 containers requiring dynamic IPs will cause Docker to run out of IPs.
+* **Estimation:** `(NUM_USS * NUM_NODES) + (bootstrap containers) <= 250`
+
+### 3. Kernel Neighbor Table / ARP Cache Limit (Max ~30-40 Total Nodes)
+Each container network connection spawns a virtual network interface (`veth` pair) on the host machine.
+* **Why it's a limit:** Linux hosts track virtual endpoints in the kernel's neighbor table (ARP cache). By default, Linux has a hard limit (`gc_thresh3`) of **1024** entries. With a large number of containers, the combined ARP tables, loopbacks, and network interfaces easily exceed this limit, causing the kernel to throw `No buffer space available (ENOBUFS)` and break networking entirely.
+* **Estimation:** Without kernel tuning, the host might start throwing `ENOBUFS` when total containers approach **60-80** (around `NUM_USS * NUM_NODES >= 30` to `40`).
+
+---
+
+## Troubleshooting: Kernel Neighbor Table Fix
+
+If you experience container startup timeouts and see errors like `ping: sendmsg: No buffer space available` or `replica unavailable` in database logs, you have hit the Linux neighbor table limit.
+
+### What the Fix Does
+It increases the garbage collection (GC) thresholds of the IPv4 and IPv6 ARP tables in the Linux kernel:
+* **`gc_thresh1`**: Threshold at which garbage collection starts (if neighbor entries stay unused).
+* **`gc_thresh2`**: Threshold at which garbage collection becomes aggressive.
+* **`gc_thresh3`**: The absolute hard limit. The kernel will refuse to create new neighbor entries above this, returning `ENOBUFS`.
+
+### How to Apply the Fix
+Run these commands in your host terminal to raise the thresholds:
+```bash
+sudo sysctl -w \
+  net.ipv4.neigh.default.gc_thresh1=1024 \
+  net.ipv4.neigh.default.gc_thresh2=2048 \
+  net.ipv4.neigh.default.gc_thresh3=4096 \
+  net.ipv6.neigh.default.gc_thresh1=1024 \
+  net.ipv6.neigh.default.gc_thresh2=2048 \
+  net.ipv6.neigh.default.gc_thresh3=4096
+```
+
+### Why it Works
+By raising `gc_thresh3` from 1024 to 4096, the kernel gains the capacity to track up to 4096 network endpoints concurrently, allowing the 90+ virtual interfaces used in large-scale deployments to resolve ARP addresses without buffer exhaustion.
+
+### How to Reverse the Fix
+To revert the settings to default Linux values, run:
+```bash
+sudo sysctl -w \
+  net.ipv4.neigh.default.gc_thresh1=128 \
+  net.ipv4.neigh.default.gc_thresh2=512 \
+  net.ipv4.neigh.default.gc_thresh3=1024 \
+  net.ipv6.neigh.default.gc_thresh1=128 \
+  net.ipv6.neigh.default.gc_thresh2=512 \
+  net.ipv6.neigh.default.gc_thresh3=1024
+```
+*(Alternatively, rebooting the host machine will also reset these values to default unless they are persist-configured in `/etc/sysctl.conf`.)*

--- a/build/dev/README.md
+++ b/build/dev/README.md
@@ -20,6 +20,7 @@ To tear down the deployment and clean up networks (also via `make down-locally` 
 ```bash
 ./run_locally.sh down
 ```
+Note that to ensure a proper cleanup, the same environment variables used for the `up` should be used for the `down`. 
 
 ## Environment Variables
 

--- a/build/dev/docker-compose.yaml
+++ b/build/dev/docker-compose.yaml
@@ -5,6 +5,7 @@ services:
   crdb:
     image: cockroachdb/cockroach:v24.1.3
     entrypoint: /db-entrypoint.sh
+    # 128MB limits allow larger numbers of nodes on a single machine
     command: /cockroach/cockroach.sh start --insecure --join=db1.uss1.localutm --cache=128MiB --max-sql-memory=128MiB
     volumes:
       - $PWD/startup/db-entrypoint.sh:/db-entrypoint.sh:ro

--- a/build/dev/docker-compose.yaml
+++ b/build/dev/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
   crdb:
     image: cockroachdb/cockroach:v24.1.3
     entrypoint: /db-entrypoint.sh
-    command: /cockroach/cockroach.sh start --insecure --join=db1.uss1.localutm
+    command: /cockroach/cockroach.sh start --insecure --join=db1.uss1.localutm --cache=128MiB --max-sql-memory=128MiB
     volumes:
       - $PWD/startup/db-entrypoint.sh:/db-entrypoint.sh:ro
     profiles: [crdb]

--- a/build/dev/run_locally.sh
+++ b/build/dev/run_locally.sh
@@ -76,9 +76,36 @@ for ((i=1; i<=NUM_USS; i++)); do
 
     # shellcheck disable=SC2086
     docker compose -f docker-compose.yaml -p "local_infra_${USS_IDX}-${USS_NODE_IDX}" $DC_COMMAND $DC_OPTIONS &
+    sleep 0.1
   done
 done
 wait
+
+if [[ "$DC_COMMAND" == up* ]]; then
+  echo "Verifying and repairing docker network connections..."
+
+  check_and_connect() {
+    local container=$1
+    local network=$2
+    if docker ps --format '{{.Names}}' | grep -q "^${container}$"; then
+      if ! docker inspect "${container}" --format '{{json .NetworkSettings.Networks}}' | grep -q "\"${network}\""; then
+        echo "Warning: Container ${container} is not connected to ${network}. Reconnecting..."
+        docker network connect "${network}" "${container}"
+      fi
+    fi
+  }
+
+  for ((i=1; i<=NUM_USS; i++)); do
+    for ((j=1; j<=NUM_NODES; j++)); do
+      check_and_connect "local_infra_${i}-${j}-dss-1" "dss_internal_network"
+      check_and_connect "local_infra_${i}-${j}-dss-1" "interop_ecosystem_network"
+      check_and_connect "local_infra_${i}-${j}-${DB_TYPE}-1" "dss_internal_network"
+    done
+  done
+
+  check_and_connect "local_infra_1-1-oauth-1" "interop_ecosystem_network"
+  echo "Network verification complete."
+fi
 
 if [[ "$DC_COMMAND" == "down" ]]; then
   echo "Removing networks..."

--- a/build/dev/run_locally.sh
+++ b/build/dev/run_locally.sh
@@ -2,20 +2,8 @@
 
 set -eo pipefail
 
-# This script will deploy an interoperability ecosystem consisting of a chosen number of DSS instances and a dummy OAuth
-# server (all accessible on the interop_ecosystem_network) with docker compose using the DSS image from Docker Hub.
-# Run `./run_locally.sh up -d` to start two DSS instances using CockroachDB.
-#
-# The following environment variables may be used to simulate different conditions:
-# - NUM_USS: number of USSs (default: 2); note that the standard local mock ecosystem requires at least 2 USSs
-# - NUM_NODES: number of nodes per USS (default: 1)
-# - DB_TYPE: crdb or ybdb (default: crdb)
-# - INTRA_USS_NETEM_CONF: tc netem configuration to apply to traffic between DB nodes of an USS (default: <none>)
-#   sensible value (low latency/jitter, very low loss (e.g., within same availability DC)):
-#   "delay 250us 25us 25% distribution normal loss 0.0025% 10%"
-# - INTER_USS_NETEM_CONF: tc netem configuration to apply to traffic between DB nodes of different USS (default: <none>)
-#   sensible value (higher latency/jitter, moderate loss (e.g., cross-country)):
-#   "delay 25ms 7.5ms 50% distribution paretonormal loss 0.025% 25%"
+# This script deploys a local UTM interoperability ecosystem.
+# For full documentation on parameters, usage, sizing limits, and troubleshooting, please refer to README.md.
 
 if [[ -z $(command -v docker) ]]; then
   echo "docker is required but not installed.  Visit https://docs.docker.com/install/ to install."
@@ -40,16 +28,20 @@ DC_COMMAND=$*
 
 if [[ ! "$DC_COMMAND" ]]; then
   DC_COMMAND="up"
-  DC_OPTIONS="--build --wait"
+  DC_OPTIONS="--build -d"
 elif [[ "$DC_COMMAND" == "down" ]]; then
   DC_OPTIONS="--volumes --remove-orphans"
 elif [[ "$DC_COMMAND" == "debug" ]]; then
   DC_COMMAND=up
-  DC_OPTIONS="--wait"
+  DC_OPTIONS="-d"
   export DEBUG_ON=1
 fi
 
 if [[ "$DC_COMMAND" == up* ]]; then
+  DC_COMMAND=${DC_COMMAND//--wait/}
+  if [[ ! "$DC_COMMAND" =~ "-d" && ! "$DC_OPTIONS" =~ "-d" ]]; then
+    DC_OPTIONS="${DC_OPTIONS} -d"
+  fi
   echo "Creating networks..."
   docker network create --subnet=172.27.0.0/16 \
                         --ip-range=172.27.0.0/24 \
@@ -105,6 +97,58 @@ if [[ "$DC_COMMAND" == up* ]]; then
 
   check_and_connect "local_infra_1-1-oauth-1" "interop_ecosystem_network"
   echo "Network verification complete."
+
+  echo "Waiting for all containers to become healthy..."
+  timeout=240
+  interval=5
+  elapsed=0
+  all_healthy=true
+
+  while [ $elapsed -lt $timeout ]; do
+    all_healthy=true
+    unhealthy_containers=()
+
+    check_container_health() {
+      local container=$1
+      if ! docker ps --format '{{.Names}}' | grep -q "^${container}$"; then
+        all_healthy=false
+        unhealthy_containers+=("$container (not running)")
+        return
+      fi
+
+      local health_status=$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$container")
+      if [[ "$health_status" == "unhealthy" || "$health_status" == "starting" ]]; then
+        all_healthy=false
+        unhealthy_containers+=("$container ($health_status)")
+      fi
+    }
+
+    for ((i=1; i<=NUM_USS; i++)); do
+      for ((j=1; j<=NUM_NODES; j++)); do
+        check_container_health "local_infra_${i}-${j}-dss-1"
+        check_container_health "local_infra_${i}-${j}-${DB_TYPE}-1"
+      done
+    done
+    check_container_health "local_infra_1-1-oauth-1"
+
+    if [ "$all_healthy" = true ]; then
+      echo "All containers are healthy!"
+      break
+    fi
+
+    echo "Still waiting (elapsed ${elapsed}s)... Unhealthy/starting/not-running:"
+    for uc in "${unhealthy_containers[@]}"; do
+      echo "  - $uc"
+    done
+
+    sleep $interval
+    elapsed=$((elapsed + interval))
+  done
+
+  if [ "$all_healthy" != true ]; then
+    echo "Error: Timeout waiting for containers to become healthy."
+    exit 1
+  fi
 fi
 
 if [[ "$DC_COMMAND" == "down" ]]; then

--- a/build/dev/run_locally.sh
+++ b/build/dev/run_locally.sh
@@ -116,7 +116,8 @@ if [[ "$DC_COMMAND" == up* ]]; then
         return
       fi
 
-      local health_status=$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$container")
+      local health_status
+      health_status=$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$container")
       if [[ "$health_status" == "unhealthy" || "$health_status" == "starting" ]]; then
         all_healthy=false
         unhealthy_containers+=("$container ($health_status)")

--- a/build/dev/run_locally.sh
+++ b/build/dev/run_locally.sh
@@ -68,7 +68,7 @@ for ((i=1; i<=NUM_USS; i++)); do
 
     # shellcheck disable=SC2086
     docker compose -f docker-compose.yaml -p "local_infra_${USS_IDX}-${USS_NODE_IDX}" $DC_COMMAND $DC_OPTIONS &
-    sleep 0.1
+    sleep 0.1 # reduce probability of race condition in joining network at container start
   done
 done
 wait

--- a/build/dev/startup/core_service.sh
+++ b/build/dev/startup/core_service.sh
@@ -12,10 +12,19 @@ JWT_AUDIENCES="localhost,host.docker.internal,${JWT_AUDIENCES}"
 if [ "${COMPOSE_PROFILES#*"ybdb"}" != "${COMPOSE_PROFILES}" ]; then
   echo "Using Yugabyte"
   DATASTORE_CONNECTION="-datastore_host ${DATASTORE_HOST} -datastore_user yugabyte --datastore_port 5433"
+  DB_PORT=5433
 else
   echo "Using CockroachDB"
   DATASTORE_CONNECTION="-datastore_host ${DATASTORE_HOST}"
+  DB_PORT=26257
 fi
+
+echo "Waiting for datastore ${DATASTORE_HOST}:${DB_PORT}..."
+until nc -z -w 2 "${DATASTORE_HOST}" "${DB_PORT}" 2>/dev/null; do
+  echo "Datastore ${DATASTORE_HOST}:${DB_PORT} is not available yet, sleeping..."
+  sleep 2
+done
+echo "Datastore ${DATASTORE_HOST}:${DB_PORT} is online!"
 
 if [ "$DEBUG_ON" = "1" ]; then
   echo "Debug Mode: on"


### PR DESCRIPTION
This PR fixes #1480 primarily by redoing silently-failed attempts to connect containers to the network, and waiting for verified success.  If I understand correctly, the issue is likely that racing container initializations may block one of the containers from successfully attaching to the network.  The 0.1s sleep attempts to reduce this a bit, but later repairs (executed by run_locally.sh now) still usually appear to be necessary.

This PR also adds a more involved README for usage of our somewhat-recently enhanced local interoperability ecosystem capabilities, including sizing and one troubleshooting measure.

The troubleshooting measure was surprising to me, but it enabled me to successfully bring up and test NUM_USS=13, NUM_NODES=3 (I ran out of RAM attempting NUM_USS=15).

Made mostly with Gemini; AI-appropriate scrutiny invited during review, though I hope I've already adjusted it into a good state.