### PR TITLE
[reporting] Improve error handling on failed templated report download

### DIFF
--- a/monitoring/uss_qualifier/reports/artifacts.py
+++ b/monitoring/uss_qualifier/reports/artifacts.py
@@ -94,9 +94,7 @@ def generate_artifacts(
             artifacts.templated_reports,
             redacted_report,
         )
-        logger.info(
-            f"Wrote templated report in {time.monotonic() - t0:.1f}s"
-        )
+        logger.info(f"Wrote templated report in {time.monotonic() - t0:.1f}s")
 
     def make_tested_requirements() -> None:
         if not artifacts.tested_requirements:

--- a/monitoring/uss_qualifier/reports/artifacts.py
+++ b/monitoring/uss_qualifier/reports/artifacts.py
@@ -87,10 +87,15 @@ def generate_artifacts(
     def make_templated_reports() -> None:
         if not artifacts.templated_reports:
             return
+        logger.info(f"Writing templated report to {output_path}")
+        t0 = time.monotonic()
         render_templates(
             output_path,
             artifacts.templated_reports,
             redacted_report,
+        )
+        logger.info(
+            f"Wrote templated report in {time.monotonic() - t0:.1f}s"
         )
 
     def make_tested_requirements() -> None:

--- a/monitoring/uss_qualifier/reports/templates.py
+++ b/monitoring/uss_qualifier/reports/templates.py
@@ -54,7 +54,9 @@ class TemplateRenderer:
                 req = requests.get(url)
                 req.raise_for_status()
             except Exception as e:
-                raise RuntimeError(f"Failed to download template from {url}: {e}") from e
+                raise RuntimeError(
+                    f"Failed to download template from {url}: {e}"
+                ) from e
             z = zipfile.ZipFile(io.BytesIO(req.content))
             z.extractall(path)
             logger.debug(f"{url} extracted to {path}")

--- a/monitoring/uss_qualifier/reports/templates.py
+++ b/monitoring/uss_qualifier/reports/templates.py
@@ -50,7 +50,11 @@ class TemplateRenderer:
         if path.exists():
             logger.debug(f"{url} already in cache ({path}). Skip download.")
         else:
-            req = requests.get(url)
+            try:
+                req = requests.get(url)
+                req.raise_for_status()
+            except Exception as e:
+                raise RuntimeError(f"Failed to download template from {url}: {e}") from e
             z = zipfile.ZipFile(io.BytesIO(req.content))
             z.extractall(path)
             logger.debug(f"{url} extracted to {path}")


### PR DESCRIPTION
When the uss qualifier renders a templated report, it downloads a zip file.
Failure to download was not handled gracefully. This PR fixes it and aligns logging strategy with other reports.