### PR TITLE
Use https rather than SSH for ED-318 submodule retrieval

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,4 +12,4 @@
 	url = https://github.com/interuss/automated_testing_interfaces
 [submodule "interfaces/ed318"]
 	path = interfaces/ed318
-	url = git@github.com:UASGeoZones/ED-318.git
+	url = https://github.com/UASGeoZones/ED-318


### PR DESCRIPTION
Using SSH rather than https to retrieve the ED-318 submodule triggers a warning in multiple git clients that the host is not recognized.  This PR fixes that problem by retrieving the submodule via https similar to other existing submodules.