### PR TITLE
[uss_qualifier] Add pre-existing subscription to NetRID HeavyTrafficConcurrent

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -5650,14 +5650,6 @@
         ],
         "./monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/heavy_traffic_concurrent.py": [
             {
-                "code": "reportGeneralTypeIssues",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportRedeclaration",
                 "range": {
                     "startColumn": 4,

--- a/.gitmodules
+++ b/.gitmodules
@@ -12,4 +12,4 @@
 	url = https://github.com/interuss/automated_testing_interfaces
 [submodule "interfaces/ed318"]
 	path = interfaces/ed318
-	url = git@github.com:UASGeoZones/ED-318.git
+	url = https://github.com/UASGeoZones/ED-318

--- a/monitoring/prober/infrastructure.py
+++ b/monitoring/prober/infrastructure.py
@@ -96,7 +96,7 @@ ResourceType = int
 resource_type_code_descriptions: dict[ResourceType, str] = {}
 
 
-# Next code: 405
+# Next code: 406
 def register_resource_type(code: int, description: str) -> ResourceType:
     """Register that the specified code refers to the described resource.
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/heavy_traffic_concurrent.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/common/dss/heavy_traffic_concurrent.py
@@ -1,5 +1,8 @@
 import asyncio
+from datetime import datetime
 
+import s2sphere
+from implicitdict import ImplicitDict
 from uas_standards.astm.f3411 import v19, v22a
 
 from monitoring.monitorlib.fetch import (
@@ -12,6 +15,7 @@ from monitoring.monitorlib.infrastructure import AsyncUTMTestSession
 from monitoring.monitorlib.mutate import rid as mutate
 from monitoring.monitorlib.mutate.rid import ChangedISA
 from monitoring.monitorlib.rid import RIDVersion
+from monitoring.monitorlib.testing import make_fake_url
 from monitoring.prober.infrastructure import register_resource_type
 from monitoring.uss_qualifier.resources.astm.f3411.dss import DSSInstanceResource
 from monitoring.uss_qualifier.resources.interuss.id_generator import IDGeneratorResource
@@ -33,14 +37,28 @@ THREAD_COUNT = 10
 CREATE_ISAS_COUNT = 100
 
 
+class ISAParams(ImplicitDict):
+    area_vertices: list[s2sphere.LatLng]
+    start_time: datetime | None
+    end_time: datetime | None
+    uss_base_url: str
+    alt_lo: float
+    alt_hi: float
+
+
 class HeavyTrafficConcurrent(GenericTestScenario):
     """Based on prober/rid/v1/test_isa_simple_heavy_traffic_concurrent.py from the legacy prober tool."""
 
     ISA_TYPE = register_resource_type(374, "ISA")
+    SUB_TYPE = register_resource_type(405, "Background subscription")
+
+    _sub_id: str
 
     _isa_ids: list[str]
 
-    _isa_params: dict[str, any]
+    _isa_area: list[s2sphere.LatLng]
+
+    _isa_params: ISAParams
 
     _isa_versions: dict[str, str]
 
@@ -67,13 +85,15 @@ class HeavyTrafficConcurrent(GenericTestScenario):
             self._dss.base_url, self._dss.client.auth_adapter
         )
 
+        self._sub_id = id_generator.id_factory.make_id(HeavyTrafficConcurrent.SUB_TYPE)
+
         isa_base_id = id_generator.id_factory.make_id(HeavyTrafficConcurrent.ISA_TYPE)
         # The base ID ends in 000: we simply increment it to generate the other IDs
         self._isa_ids = [f"{isa_base_id[:-3]}{i:03d}" for i in range(CREATE_ISAS_COUNT)]
 
         # currently all params are the same:
         # we could improve the test by having unique parameters per ISA
-        self._isa_params = dict(
+        self._isa_params = ISAParams(
             area_vertices=self._isa_area,
             start_time=None,
             end_time=None,
@@ -90,6 +110,9 @@ class HeavyTrafficConcurrent(GenericTestScenario):
         self.begin_test_case("Setup")
         self.begin_test_step("Ensure clean workspace")
         self._delete_isas_if_exists()
+        self.end_test_step()
+        self.begin_test_step("Emplace subscription")
+        self._create_subscription()
         self.end_test_step()
         self.end_test_case()
 
@@ -124,8 +147,30 @@ class HeavyTrafficConcurrent(GenericTestScenario):
 
     def _resolve_isa_time_bounds(self):
         start, end = self._isa.resolved_time_bounds(self.time_context.evaluate_now())
-        self._isa_params["start_time"] = start
-        self._isa_params["end_time"] = end
+        self._isa_params.start_time = start
+        self._isa_params.end_time = end
+
+    def _create_subscription(self):
+        with self.check(
+            "Subscription creation succeeds", self._dss_wrapper.participant_id
+        ) as check:
+            cs = self._dss_wrapper.put_sub(
+                check,
+                self._isa_params.area_vertices,
+                self._isa_params.alt_lo,
+                self._isa_params.alt_hi,
+                self._isa_params.start_time,
+                self._isa_params.end_time,
+                make_fake_url("preexisting_sub"),
+                self._sub_id,
+                None,
+            )
+            if not cs.success:
+                check.record_failed(
+                    summary="Error while creating a Subscription in the DSS",
+                    details=f"Error message: {cs.errors}",
+                    query_timestamps=cs.query_timestamps,
+                )
 
     def _delete_isas_if_exists(self):
         """Delete test ISAs if they exist. Done sequentially."""
@@ -407,6 +452,7 @@ class HeavyTrafficConcurrent(GenericTestScenario):
     def cleanup(self):
         self.begin_cleanup()
 
+        self._dss_wrapper.cleanup_sub(self._sub_id)
         self._delete_isas_if_exists()
         self._async_session.close()
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/heavy_traffic_concurrent.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss/heavy_traffic_concurrent.md
@@ -24,6 +24,14 @@ Create, query and delete ISAs on the DSS, concurrently.
 
 This scenario creates ISA's with known IDs. This step ensures that no ISA with a known ID is present in the DSS before proceeding with the test.
 
+### Emplace subscription test step
+
+ISA manipulation can be much more resource-intensive when a subscription is present than when it isn't.  Add a subscription covering the area to make sure we're sufficiently stressing the system.
+
+#### 🛑 Subscription creation succeeds check
+
+If the DSS did not create the subscription according to the valid request, the DSS provider does not comply with **[astm.f3411.v19.DSS0030,c](../../../../../requirements/astm/f3411/v19.md)**.
+
 ## Concurrent Requests test case
 
 This test case will:
@@ -93,7 +101,15 @@ The ISA search area parameter cover the resource ISA, but it has been previously
 
 ## Cleanup
 
-The cleanup phase of this test scenario attempts to remove any created ISA if the test ended prematurely.
+The cleanup phase of this test scenario attempts to remove the subscription and any created ISA if the test ended prematurely.
+
+### ⚠️ Subscription can be queried by ID check
+
+If the DSS cannot be queried for the existing test ID, the DSS is likely not implementing **[astm.f3411.v19.DSS0030,e](../../../../../requirements/astm/f3411/v19.md)** correctly.
+
+### ⚠️ Subscription can be deleted check
+
+An attempt to delete a subscription when the correct version is provided should succeed, otherwise the DSS is in violation of **[astm.f3411.v19.DSS0030,d](../../../../../requirements/astm/f3411/v19.md)**.
 
 ### ⚠️ Successful ISA query check
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/heavy_traffic_concurrent.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/v22a/dss/heavy_traffic_concurrent.md
@@ -24,6 +24,14 @@ Create, query and delete ISAs on the DSS, concurrently.
 
 This scenario creates ISA's with known IDs. This step ensures that no ISA with a known ID is present in the DSS before proceeding with the test.
 
+### Emplace subscription test step
+
+ISA manipulation can be much more resource-intensive when a subscription is present than when it isn't.  Add a subscription covering the area to make sure we're sufficiently stressing the system.
+
+#### 🛑 Subscription creation succeeds check
+
+If the DSS did not create the subscription according to the valid request, the DSS provider does not comply with **[astm.f3411.v22a.DSS0030,c](../../../../../requirements/astm/f3411/v22a.md)**.
+
 ## Concurrent Requests test case
 
 This test case will:
@@ -93,7 +101,15 @@ The ISA search area parameter cover the resource ISA, but it has been previously
 
 ## Cleanup
 
-The cleanup phase of this test scenario attempts to remove any created ISA if the test ended prematurely.
+The cleanup phase of this test scenario attempts to remove the subscription and any created ISA if the test ended prematurely.
+
+### ⚠️ Subscription can be queried by ID check
+
+If the DSS cannot be queried for the existing test ID, the DSS is likely not implementing **[astm.f3411.v22a.DSS0030,e](../../../../../requirements/astm/f3411/v22a.md)** correctly.
+
+### ⚠️ Subscription can be deleted check
+
+An attempt to delete a subscription when the correct version is provided should succeed, otherwise the DSS is in violation of **[astm.f3411.v22a.DSS0030,d](../../../../../requirements/astm/f3411/v22a.md)**.
 
 ### ⚠️ Successful ISA query check
 

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_19.md
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_19.md
@@ -48,7 +48,7 @@
   <tr>
     <td><a href="../../../requirements/astm/f3411/v19.md">DSS0030,c</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/netrid/v19/dss/isa_subscription_interactions.md">ASTM NetRID DSS: ISA Subscription Interactions</a><br><a href="../../../scenarios/astm/netrid/v19/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/netrid/v19/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/netrid/v19/sp_notification_behavior.md">ASTM NetRID Service Provider notification behavior</a></td>
+    <td><a href="../../../scenarios/astm/netrid/v19/dss/heavy_traffic_concurrent.md">ASTM NetRID DSS: Concurrent Requests</a><br><a href="../../../scenarios/astm/netrid/v19/dss/isa_subscription_interactions.md">ASTM NetRID DSS: ISA Subscription Interactions</a><br><a href="../../../scenarios/astm/netrid/v19/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/netrid/v19/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/netrid/v19/sp_notification_behavior.md">ASTM NetRID Service Provider notification behavior</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3411/v19.md">DSS0030,d</a></td>

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_19/dss_probing.md
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_19/dss_probing.md
@@ -49,7 +49,7 @@
   <tr>
     <td><a href="../../../../requirements/astm/f3411/v19.md">DSS0030,c</a></td>
     <td>Implemented</td>
-    <td><a href="../../../../scenarios/astm/netrid/v19/dss/isa_subscription_interactions.md">ASTM NetRID DSS: ISA Subscription Interactions</a><br><a href="../../../../scenarios/astm/netrid/v19/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a><br><a href="../../../../scenarios/astm/netrid/v19/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a></td>
+    <td><a href="../../../../scenarios/astm/netrid/v19/dss/heavy_traffic_concurrent.md">ASTM NetRID DSS: Concurrent Requests</a><br><a href="../../../../scenarios/astm/netrid/v19/dss/isa_subscription_interactions.md">ASTM NetRID DSS: ISA Subscription Interactions</a><br><a href="../../../../scenarios/astm/netrid/v19/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a><br><a href="../../../../scenarios/astm/netrid/v19/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a></td>
   </tr>
   <tr>
     <td><a href="../../../../requirements/astm/f3411/v19.md">DSS0030,d</a></td>

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a.md
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a.md
@@ -54,7 +54,7 @@
   <tr>
     <td><a href="../../../requirements/astm/f3411/v22a.md">DSS0030,c</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/netrid/v22a/dss/isa_subscription_interactions.md">ASTM NetRID DSS: ISA Subscription Interactions</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/netrid/v22a/sp_notification_behavior.md">ASTM NetRID Service Provider notification behavior</a></td>
+    <td><a href="../../../scenarios/astm/netrid/v22a/dss/heavy_traffic_concurrent.md">ASTM NetRID DSS: Concurrent Requests</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/isa_subscription_interactions.md">ASTM NetRID DSS: ISA Subscription Interactions</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a><br><a href="../../../scenarios/astm/netrid/v22a/sp_notification_behavior.md">ASTM NetRID Service Provider notification behavior</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3411/v22a.md">DSS0030,d</a></td>

--- a/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a/dss_probing.md
+++ b/monitoring/uss_qualifier/suites/astm/netrid/f3411_22a/dss_probing.md
@@ -54,7 +54,7 @@
   <tr>
     <td><a href="../../../../requirements/astm/f3411/v22a.md">DSS0030,c</a></td>
     <td>Implemented</td>
-    <td><a href="../../../../scenarios/astm/netrid/v22a/dss/isa_subscription_interactions.md">ASTM NetRID DSS: ISA Subscription Interactions</a><br><a href="../../../../scenarios/astm/netrid/v22a/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a><br><a href="../../../../scenarios/astm/netrid/v22a/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a></td>
+    <td><a href="../../../../scenarios/astm/netrid/v22a/dss/heavy_traffic_concurrent.md">ASTM NetRID DSS: Concurrent Requests</a><br><a href="../../../../scenarios/astm/netrid/v22a/dss/isa_subscription_interactions.md">ASTM NetRID DSS: ISA Subscription Interactions</a><br><a href="../../../../scenarios/astm/netrid/v22a/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a><br><a href="../../../../scenarios/astm/netrid/v22a/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a></td>
   </tr>
   <tr>
     <td><a href="../../../../requirements/astm/f3411/v22a.md">DSS0030,d</a></td>

--- a/monitoring/uss_qualifier/suites/interuss/dss/all_tests.md
+++ b/monitoring/uss_qualifier/suites/interuss/dss/all_tests.md
@@ -44,7 +44,7 @@
   <tr>
     <td><a href="../../../requirements/astm/f3411/v19.md">DSS0030,c</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/netrid/v19/dss/isa_subscription_interactions.md">ASTM NetRID DSS: ISA Subscription Interactions</a><br><a href="../../../scenarios/astm/netrid/v19/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/netrid/v19/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a></td>
+    <td><a href="../../../scenarios/astm/netrid/v19/dss/heavy_traffic_concurrent.md">ASTM NetRID DSS: Concurrent Requests</a><br><a href="../../../scenarios/astm/netrid/v19/dss/isa_subscription_interactions.md">ASTM NetRID DSS: ISA Subscription Interactions</a><br><a href="../../../scenarios/astm/netrid/v19/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/netrid/v19/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3411/v19.md">DSS0030,d</a></td>

--- a/monitoring/uss_qualifier/suites/interuss/dss/all_tests.md
+++ b/monitoring/uss_qualifier/suites/interuss/dss/all_tests.md
@@ -255,7 +255,7 @@
   <tr>
     <td><a href="../../../requirements/astm/f3411/v22a.md">DSS0030,c</a></td>
     <td>Implemented</td>
-    <td><a href="../../../scenarios/astm/netrid/v22a/dss/isa_subscription_interactions.md">ASTM NetRID DSS: ISA Subscription Interactions</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a></td>
+    <td><a href="../../../scenarios/astm/netrid/v22a/dss/heavy_traffic_concurrent.md">ASTM NetRID DSS: Concurrent Requests</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/isa_subscription_interactions.md">ASTM NetRID DSS: ISA Subscription Interactions</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a><br><a href="../../../scenarios/astm/netrid/v22a/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a></td>
   </tr>
   <tr>
     <td><a href="../../../requirements/astm/f3411/v22a.md">DSS0030,d</a></td>

--- a/monitoring/uss_qualifier/suites/uspace/network_identification.md
+++ b/monitoring/uss_qualifier/suites/uspace/network_identification.md
@@ -45,7 +45,7 @@
   <tr>
     <td><a href="../../requirements/astm/f3411/v22a.md">DSS0030,c</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/netrid/v22a/dss/isa_subscription_interactions.md">ASTM NetRID DSS: ISA Subscription Interactions</a><br><a href="../../scenarios/astm/netrid/v22a/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a><br><a href="../../scenarios/astm/netrid/v22a/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a><br><a href="../../scenarios/astm/netrid/v22a/sp_notification_behavior.md">ASTM NetRID Service Provider notification behavior</a></td>
+    <td><a href="../../scenarios/astm/netrid/v22a/dss/heavy_traffic_concurrent.md">ASTM NetRID DSS: Concurrent Requests</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_subscription_interactions.md">ASTM NetRID DSS: ISA Subscription Interactions</a><br><a href="../../scenarios/astm/netrid/v22a/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a><br><a href="../../scenarios/astm/netrid/v22a/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a><br><a href="../../scenarios/astm/netrid/v22a/sp_notification_behavior.md">ASTM NetRID Service Provider notification behavior</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3411/v22a.md">DSS0030,d</a></td>

--- a/monitoring/uss_qualifier/suites/uspace/required_services.md
+++ b/monitoring/uss_qualifier/suites/uspace/required_services.md
@@ -46,7 +46,7 @@
   <tr>
     <td><a href="../../requirements/astm/f3411/v22a.md">DSS0030,c</a></td>
     <td>Implemented</td>
-    <td><a href="../../scenarios/astm/netrid/v22a/dss/isa_subscription_interactions.md">ASTM NetRID DSS: ISA Subscription Interactions</a><br><a href="../../scenarios/astm/netrid/v22a/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a><br><a href="../../scenarios/astm/netrid/v22a/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a><br><a href="../../scenarios/astm/netrid/v22a/sp_notification_behavior.md">ASTM NetRID Service Provider notification behavior</a></td>
+    <td><a href="../../scenarios/astm/netrid/v22a/dss/heavy_traffic_concurrent.md">ASTM NetRID DSS: Concurrent Requests</a><br><a href="../../scenarios/astm/netrid/v22a/dss/isa_subscription_interactions.md">ASTM NetRID DSS: ISA Subscription Interactions</a><br><a href="../../scenarios/astm/netrid/v22a/dss/subscription_simple.md">ASTM NetRID DSS: Subscription Simple</a><br><a href="../../scenarios/astm/netrid/v22a/dss/subscription_validation.md">ASTM NetRID DSS: Subscription Validation</a><br><a href="../../scenarios/astm/netrid/v22a/sp_notification_behavior.md">ASTM NetRID Service Provider notification behavior</a></td>
   </tr>
   <tr>
     <td><a href="../../requirements/astm/f3411/v22a.md">DSS0030,d</a></td>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,3 +124,5 @@ namespaces = true
 
 [tool.setuptools_scm]
 write_to = "monitoring/_version.py"
+tag_regex = "^interuss/monitoring/v(?P<version>\\d+\\.\\d+\\.\\d+)"
+


### PR DESCRIPTION
(includes fix from #1490)

Exploring [dss#1509](https://github.com/interuss/dss/issues/1509), I was unable to reproduce the TimeoutError even with very pessimistic network behavior.  However, I realized that creating ISAs is far easier when there is no subscription serializing their creation.  This PR, therefore, adds a pre-existing subscription to make the HeavyTrafficConcurrent scenario more realistic.  In my tests, the scenario still passes with ideal local DSS deployments like we use in most of our CI, but I observed 1-3 TimeoutErrors per scenario with `export INTER_USS_NETEM_CONF="delay 5ms 1ms 50% distribution paretonormal loss 0.02% 5%"` + 3 instances x 3 nodes, and many more with more pessimistic network configurations.  Therefore, I think subscription presence explains the different results under controlled circumstances in the "in the field" for dss#1509, and this change will allow us to reproduce the problems seen in the field.

The tag_regex change in pyproject.toml was suggested as a way to make uv build more stable under certain tag observability circumstances.