### PR TITLE
[tooling] Add support for raft and custom image in local run

### DIFF
--- a/build/dev/README.md
+++ b/build/dev/README.md
@@ -20,7 +20,7 @@ To tear down the deployment and clean up networks (also via `make down-locally` 
 ```bash
 ./run_locally.sh down
 ```
-Note that to ensure a proper cleanup, the same environment variables used for the `up` should be used for the `down`. 
+Note that to ensure a proper cleanup, the same environment variables used for the `up` should be used for the `down`.
 
 ## Environment Variables
 
@@ -28,7 +28,8 @@ The following environment variables can be configured to customize the simulated
 
 * `NUM_USS`: Number of simulated USS instances (default: `2`). Note that the standard mock ecosystem requires at least 2 USSs.
 * `NUM_NODES`: Number of nodes per USS database/DSS cluster (default: `1`).
-* `DB_TYPE`: Datastore backend type. Options are `crdb` (CockroachDB) or `ybdb` (Yugabyte) (default: `crdb`).
+* `DB_TYPE`: Datastore backend type. Options are `crdb` (CockroachDB), `ybdb` (Yugabyte), or `raft` (built-in raft store, no separate database container) (default: `crdb`).
+* `DSS_IMAGE`: Docker image used for the DSS core service and bootstrappers (default: `interuss/dss:v0.22.0`). Override to test a locally built image, e.g. `interuss-local/dss`.
 * `INTRA_USS_NETEM_CONF`: `tc netem` configuration rules applied to traffic between database nodes of the *same* USS (default: `<none>`).
   * *Sensible values (low latency/jitter, very low loss):* `"delay 250us 25us 25% distribution normal loss 0.0025% 10%"`
 * `INTER_USS_NETEM_CONF`: `tc netem` configuration rules applied to traffic between database nodes of *different* USSs (default: `<none>`).

--- a/build/dev/docker-compose.yaml
+++ b/build/dev/docker-compose.yaml
@@ -82,7 +82,7 @@ services:
     networks: [dss_internal_network]
 
   rid_bootstrapper:
-    image: interuss/dss:v0.22.0
+    image: ${DSS_IMAGE:-interuss/dss:v0.22.0}
     profiles: [bootstrap-crdb]
     entrypoint: sh -c "/usr/bin/db-manager migrate --schemas_dir=/db-schemas/rid --db_version latest --cockroach_host db1.uss1.localutm"
     depends_on:
@@ -93,7 +93,7 @@ services:
       disable: true
 
   scd_bootstrapper:
-    image: interuss/dss:v0.22.0
+    image: ${DSS_IMAGE:-interuss/dss:v0.22.0}
     profiles: [bootstrap-crdb]
     entrypoint: sh -c "/usr/bin/db-manager migrate --schemas_dir=/db-schemas/scd --db_version latest --cockroach_host db1.uss1.localutm"
     depends_on:
@@ -104,7 +104,7 @@ services:
       disable: true
 
   aux_bootstrapper:
-    image: interuss/dss:v0.22.0
+    image: ${DSS_IMAGE:-interuss/dss:v0.22.0}
     profiles: [bootstrap-crdb]
     entrypoint: sh -c "/usr/bin/db-manager migrate --schemas_dir=/db-schemas/aux_ --db_version latest --cockroach_host db1.uss1.localutm"
     depends_on:
@@ -115,7 +115,7 @@ services:
       disable: true
 
   rid_bootstrapper-ybdb:
-    image: interuss/dss:v0.22.0
+    image: ${DSS_IMAGE:-interuss/dss:v0.22.0}
     profiles: [bootstrap-ybdb]
     entrypoint: sh -c "/usr/bin/db-manager migrate --schemas_dir=/db-schemas/yugabyte/rid --db_version latest --datastore_host db1.uss1.localutm --datastore_user yugabyte --datastore_port 5433"
     restart: on-failure
@@ -124,7 +124,7 @@ services:
       disable: true
 
   scd_bootstrapper-ybdb:
-    image: interuss/dss:v0.22.0
+    image: ${DSS_IMAGE:-interuss/dss:v0.22.0}
     profiles: [bootstrap-ybdb]
     entrypoint: sh -c "/usr/bin/db-manager migrate --schemas_dir=/db-schemas/yugabyte/scd --db_version latest --datastore_host db1.uss1.localutm --datastore_user yugabyte --datastore_port 5433"
     restart: on-failure
@@ -133,7 +133,7 @@ services:
       disable: true
 
   aux_bootstrapper-ybdb:
-    image: interuss/dss:v0.22.0
+    image: ${DSS_IMAGE:-interuss/dss:v0.22.0}
     profiles: [bootstrap-ybdb]
     entrypoint: sh -c "/usr/bin/db-manager migrate --schemas_dir=/db-schemas/yugabyte/aux_ --db_version latest --datastore_host db1.uss1.localutm --datastore_user yugabyte --datastore_port 5433"
     restart: on-failure
@@ -142,10 +142,11 @@ services:
       disable: true
 
   dss:
-    image: interuss/dss:v0.22.0
+    image: ${DSS_IMAGE:-interuss/dss:v0.22.0}
     command: /startup/core_service.sh ${DEBUG_ON:-0}
-    profiles: [ crdb, ybdb ]
+    profiles: [ crdb, ybdb, raft ]
     restart: always
+    cap_add: [ NET_ADMIN ]
     volumes:
       - $PWD/../test-certs:/var/test-certs:ro
       - $PWD/startup/core_service.sh:/startup/core_service.sh:ro
@@ -175,10 +176,17 @@ services:
     ports:
       - "40${PADDED_NODE_IDX:?}:4000"
       - "80${PADDED_NODE_IDX:?}:80"
+      - "97${PADDED_NODE_IDX:?}:97${PADDED_NODE_IDX:?}"
     environment:
       COMPOSE_PROFILES: ${COMPOSE_PROFILES}
       JWT_AUDIENCES: dss${USS_NODE_IDX:?}.uss${USS_IDX:?}.localutm
       DATASTORE_HOST: db${USS_NODE_IDX:?}.uss${USS_IDX:?}.localutm
+      INTRA_USS_SUBNET: 172.27.${USS_IDX:?}.0/24
+      INTER_USS_SUBNET: 172.27.0.0/16
+      INTRA_USS_NETEM_CONF: ${INTRA_USS_NETEM_CONF-}
+      INTER_USS_NETEM_CONF: ${INTER_USS_NETEM_CONF-}
+      RAFT_ID: ${RAFT_ID:-1}
+      RAFT_NODES: ${RAFT_NODES-}
     healthcheck:
       test: wget -O - 'http://localhost/healthy' || exit 1
       start_period: 120s # yugabyte may be slow to be ready, and the dss service needs the ybdb service live in order to be healthy

--- a/build/dev/run_locally.sh
+++ b/build/dev/run_locally.sh
@@ -51,18 +51,32 @@ if [[ "$DC_COMMAND" == up* ]]; then
   echo "Starting containers..."
 fi
 
+if [[ "$DB_TYPE" == "raft" ]]; then
+  RAFT_NODES=""
+  for ((i=1; i<=NUM_USS; i++)); do
+    for ((j=1; j<=NUM_NODES; j++)); do
+      NODE_IDX=$(( (i-1) * NUM_NODES + j ))
+      PADDED_NODE_IDX=$(printf "%02d" "$NODE_IDX")
+      RAFT_NODES="${RAFT_NODES},${NODE_IDX}=http://dss${j}.uss${i}.localutm:97${PADDED_NODE_IDX}"
+    done
+  done
+  export RAFT_NODES=${RAFT_NODES#,}
+fi
+
 for ((i=1; i<=NUM_USS; i++)); do
   for ((j=1; j<=NUM_NODES; j++)); do
     export USS_IDX=$i
     export USS_NODE_IDX=$j
-    PADDED_NODE_IDX=$(printf "%02d" $(( (i-1) * NUM_NODES + j)))
+    NODE_IDX=$(( (i-1) * NUM_NODES + j ))
+    export RAFT_ID=$NODE_IDX
+    PADDED_NODE_IDX=$(printf "%02d" "$NODE_IDX")
     export PADDED_NODE_IDX
 
     export COMPOSE_PROFILES=${DB_TYPE}
     if [ "$i" -eq 1 ] && [ "$j" -eq 1 ]; then
       export COMPOSE_PROFILES=${COMPOSE_PROFILES},oauth
     fi
-    if [ "$i" -eq "$NUM_USS" ] && [ "$j" -eq "$NUM_NODES" ]; then
+    if [ "$i" -eq "$NUM_USS" ] && [ "$j" -eq "$NUM_NODES" ] && [ "$DB_TYPE" != "raft" ]; then
       export COMPOSE_PROFILES=${COMPOSE_PROFILES},bootstrap-${DB_TYPE}
     fi
 
@@ -91,7 +105,9 @@ if [[ "$DC_COMMAND" == up* ]]; then
     for ((j=1; j<=NUM_NODES; j++)); do
       check_and_connect "local_infra_${i}-${j}-dss-1" "dss_internal_network"
       check_and_connect "local_infra_${i}-${j}-dss-1" "interop_ecosystem_network"
-      check_and_connect "local_infra_${i}-${j}-${DB_TYPE}-1" "dss_internal_network"
+      if [ "$DB_TYPE" != "raft" ]; then
+        check_and_connect "local_infra_${i}-${j}-${DB_TYPE}-1" "dss_internal_network"
+      fi
     done
   done
 
@@ -127,7 +143,9 @@ if [[ "$DC_COMMAND" == up* ]]; then
     for ((i=1; i<=NUM_USS; i++)); do
       for ((j=1; j<=NUM_NODES; j++)); do
         check_container_health "local_infra_${i}-${j}-dss-1"
-        check_container_health "local_infra_${i}-${j}-${DB_TYPE}-1"
+        if [ "$DB_TYPE" != "raft" ]; then
+          check_container_health "local_infra_${i}-${j}-${DB_TYPE}-1"
+        fi
       done
     done
     check_container_health "local_infra_1-1-oauth-1"

--- a/build/dev/startup/core_service.sh
+++ b/build/dev/startup/core_service.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# shellcheck disable=SC2086
 
 set -e
 
@@ -8,23 +9,48 @@ set -e
 DEBUG_ON=${1:-0}
 JWT_AUDIENCES="localhost,host.docker.internal,${JWT_AUDIENCES}"
 
-# POSIX compliant test to check if ybdb profile is enabled.
+# apply netem config for intra/inter-USS subnets, if requested
+if [ -n "$INTRA_USS_NETEM_CONF" ] || [ -n "$INTER_USS_NETEM_CONF" ]; then
+  apk add iproute2-tc
+
+  # create handle on default interface
+  tc qdisc add dev eth0 root handle 1: prio
+
+  if [ -n "$INTRA_USS_NETEM_CONF" ]; then
+    tc qdisc add dev eth0 parent 1:2 handle 30: netem $INTRA_USS_NETEM_CONF
+    tc filter add dev eth0 parent 1:0 protocol ip prio 1 u32 match ip dst "$INTRA_USS_SUBNET" flowid 1:2
+  fi
+
+  if [ -n "$INTER_USS_NETEM_CONF" ]; then
+    tc qdisc add dev eth0 parent 1:3 handle 31: netem $INTER_USS_NETEM_CONF
+    tc filter add dev eth0 parent 1:0 protocol ip prio 2 u32 match ip dst "$INTER_USS_SUBNET" flowid 1:3
+  fi
+fi
+
+# POSIX compliant tests to select the datastore backend.
 if [ "${COMPOSE_PROFILES#*"ybdb"}" != "${COMPOSE_PROFILES}" ]; then
   echo "Using Yugabyte"
   DATASTORE_CONNECTION="-datastore_host ${DATASTORE_HOST} -datastore_user yugabyte --datastore_port 5433"
   DB_PORT=5433
+elif [ "${COMPOSE_PROFILES#*"raft"}" != "${COMPOSE_PROFILES}" ]; then
+  echo "Using raft"
+  DATASTORE_CONNECTION="-store_type raft -raft_node_id=${RAFT_ID} -raft_peers=${RAFT_NODES} -raft_datadir /raftdata"
+  DB_PORT=
 else
   echo "Using CockroachDB"
   DATASTORE_CONNECTION="-datastore_host ${DATASTORE_HOST}"
   DB_PORT=26257
 fi
 
-echo "Waiting for datastore ${DATASTORE_HOST}:${DB_PORT}..."
-until nc -z -w 2 "${DATASTORE_HOST}" "${DB_PORT}" 2>/dev/null; do
-  echo "Datastore ${DATASTORE_HOST}:${DB_PORT} is not available yet, sleeping..."
-  sleep 2
-done
-echo "Datastore ${DATASTORE_HOST}:${DB_PORT} is online!"
+# raft has no external datastore to wait for.
+if [ -n "$DB_PORT" ]; then
+  echo "Waiting for datastore ${DATASTORE_HOST}:${DB_PORT}..."
+  until nc -z -w 2 "${DATASTORE_HOST}" "${DB_PORT}" 2>/dev/null; do
+    echo "Datastore ${DATASTORE_HOST}:${DB_PORT} is not available yet, sleeping..."
+    sleep 2
+  done
+  echo "Datastore ${DATASTORE_HOST}:${DB_PORT} is online!"
+fi
 
 if [ "$DEBUG_ON" = "1" ]; then
   echo "Debug Mode: on"


### PR DESCRIPTION
This PR add support for raft in local dev system.

It also add support for a custom DSS_IMAGE to allow simpler debugging.

As with raft datastore is directly with the DSS service, network latency has been added in the DSS container as well.