### PR TITLE
[loadtest] Improve FlightsInSub and SCD Locust Load Tests

### DIFF
--- a/monitoring/loadtest/README.md
+++ b/monitoring/loadtest/README.md
@@ -49,6 +49,9 @@ Clusters are shifted by approimatly 2*Radius on the latitude axe.
 
 There will be one subscriptions per area per client.
 
+Note: One locust user will create subscriptions, the rest create operational
+intents.
+
 Parameters:
 
 * `--uss-base-url`: Base URL of the USS, used to create subscriptions.

--- a/monitoring/loadtest/README.md
+++ b/monitoring/loadtest/README.md
@@ -38,6 +38,7 @@ Parameters:
 * `--area-lng`: Longitude of the center of the area in which to create flights
 * `--area-radius`: Radius (in meters) of the area in which to create flights
 * `--area-lat`: Maximum distance to cover for an individual flight
+* `--oi-duration`: Duration (in seconds) of the operational intent
 
 ### FlightsInSub.py
 
@@ -56,6 +57,7 @@ Parameters:
 * `--base-lng`: Longitude of the center of the first cluster
 * `--area-radius`: Radius (in meters) of the area in which to create flights
 * `--area-lat`: Maximum distance to cover for an individual flight
+* `--oi-duration`: Duration (in seconds) of the operational intent
 
 ## Adjusting workload ratio
 For `ISA.py` and `Sub.py`, every action has a weight declared in the `@task(n)` decorator. You can adjust the value of `n` to suite your needs

--- a/monitoring/loadtest/locust_files/FlightsInSub.py
+++ b/monitoring/loadtest/locust_files/FlightsInSub.py
@@ -6,13 +6,14 @@ from collections import namedtuple
 
 import client
 import locust
+import gevent
 from geo_utils import create_random_flight_path_volume
 from utils import format_time
 
 from monitoring.monitorlib.testing import make_fake_url
 
 Cluster = namedtuple("Cluster", ["lng", "lat", "uuid", "version"])
-
+clusters = []
 
 @locust.events.init_command_line_parser.add_listener
 def init_parser(parser: argparse.ArgumentParser):
@@ -61,80 +62,89 @@ def init_parser(parser: argparse.ArgumentParser):
       default=10,
     )
 
+class Subscriber(client.USS):
+  # Only create subscriptions once at the beginning of the test.
+  fixed_count = 1
+  wait_time = locust.constant(3600)
+
+  @locust.task
+  def create_subscriptions(self):
+    lat = self.environment.parsed_options.base_lat
+    lng = self.environment.parsed_options.base_lng
+    radius = self.environment.parsed_options.area_radius
+
+    time_start = datetime.datetime.now(datetime.UTC)
+    time_end = time_start + datetime.timedelta(minutes=60)
+    for _ in range(self.environment.parsed_options.cluster_count):
+      sub_uuid = str(uuid.uuid4())
+      response = self.client.put(
+          f"/dss/v1/subscriptions/{sub_uuid}",
+          json={
+              "extents": {
+                  "volume": {
+                      "outline_circle": {
+                          "center": {"lng": lng, "lat": lat},
+                          "radius": {"value": radius, "units": "M"},
+                      },
+                      "altitude_lower": {
+                          "value": 0,
+                          "reference": "W84",
+                          "units": "M",
+                      },
+                      "altitude_upper": {
+                          "value": 10000,
+                          "reference": "W84",
+                          "units": "M",
+                      },
+                  },
+                  "time_start": {
+                      "value": format_time(time_start),
+                      "format": "RFC3339",
+                  },
+                  "time_end": {
+                      "value": format_time(time_end),
+                      "format": "RFC3339",
+                  },
+              },
+              "uss_base_url": make_fake_url(),
+              "notify_for_operational_intents": True,
+          },
+          name="/dss/v1/subscriptions/[id]",
+      )
+
+      if response.status_code == 200:
+        clusters.append(
+            Cluster(
+                lng=lng,
+                lat=lat,
+                uuid=sub_uuid,
+                version=response.json()["subscription"]["version"],
+            )
+        )
+      # Move latitude approtimatly
+      lat += (radius * 2) / 111111
+
+  def on_stop(self):
+    # Clean up long lasting subscriptions
+    for cluster in clusters:
+      resp = self.client.delete(
+          f"/dss/v1/subscriptions/{cluster.uuid}/{cluster.version}",
+          name="/dss/v1/subscriptions/[id]/[version]",
+      )
 
 class SCD(client.USS):
     wait_time = locust.between(0.01, 0.1)
 
     def on_start(self):
-        self.uss_base_url = self.environment.parsed_options.uss_base_url
-        self.radius = self.environment.parsed_options.area_radius
-        self.max_flight_distance = self.environment.parsed_options.max_flight_distance
-        self.oi_duration = self.environment.parsed_options.oi_duration
+      self.uss_base_url = self.environment.parsed_options.uss_base_url
+      self.radius = self.environment.parsed_options.area_radius
+      self.max_flight_distance = self.environment.parsed_options.max_flight_distance
+      self.oi_duration = self.environment.parsed_options.oi_duration
 
-        self.clusters = []
+      # Wait for subscriptions to be created and clusters to be initialized.
+      gevent.sleep(10)
 
-        lat = self.environment.parsed_options.base_lat
-        lng = self.environment.parsed_options.base_lng
-
-        time_start = datetime.datetime.now(datetime.UTC)
-        time_end = time_start + datetime.timedelta(minutes=60)
-
-        for _ in range(self.environment.parsed_options.cluster_count):
-            sub_uuid = str(uuid.uuid4())
-
-            resp = self.client.put(
-                f"/dss/v1/subscriptions/{sub_uuid}",
-                json={
-                    "extents": {
-                        "volume": {
-                            "outline_circle": {
-                                "center": {"lng": lng, "lat": lat},
-                                "radius": {"value": self.radius, "units": "M"},
-                            },
-                            "altitude_lower": {
-                                "value": 0,
-                                "reference": "W84",
-                                "units": "M",
-                            },
-                            "altitude_upper": {
-                                "value": 10000,
-                                "reference": "W84",
-                                "units": "M",
-                            },
-                        },
-                        "time_start": {
-                            "value": format_time(time_start),
-                            "format": "RFC3339",
-                        },
-                        "time_end": {
-                            "value": format_time(time_end),
-                            "format": "RFC3339",
-                        },
-                    },
-                    "uss_base_url": make_fake_url(),
-                    "notify_for_operational_intents": True,
-                },
-                name="/subscriptions/[sub_uuid]",
-            )
-
-            if resp.status_code == 200:
-                self.clusters.append(
-                    Cluster(
-                        lng=lng,
-                        lat=lat,
-                        uuid=sub_uuid,
-                        version=resp.json()["subscription"]["version"],
-                    )
-                )
-
-            # Move latitude approtimatly
-            lat += (self.radius * 2) / 111111
-
-    def on_stop(self):
-        for cluster in self.clusters:
-            self.client.delete(
-                f"/dss/v1/subscriptions/{cluster.uuid}/{cluster.version}"
-            )
+      self.clusters = clusters
 
     @locust.task
     def task_put_intent(self):

--- a/monitoring/loadtest/locust_files/FlightsInSub.py
+++ b/monitoring/loadtest/locust_files/FlightsInSub.py
@@ -54,6 +54,12 @@ def init_parser(parser: argparse.ArgumentParser):
         help="Maximum distance to cover for an individual flight",
         required=True,
     )
+    parser.add_argument(
+      "--oi-duration",
+      type=int,
+      help="Duration (in seconds) of the operational intent",
+      default=10,
+    )
 
 
 class SCD(client.USS):
@@ -63,6 +69,7 @@ class SCD(client.USS):
         self.uss_base_url = self.environment.parsed_options.uss_base_url
         self.radius = self.environment.parsed_options.area_radius
         self.max_flight_distance = self.environment.parsed_options.max_flight_distance
+        self.oi_duration = self.environment.parsed_options.oi_duration
 
         self.clusters = []
 
@@ -142,7 +149,7 @@ class SCD(client.USS):
                 "uss_base_url": self.uss_base_url,
             },
             "extents": create_random_flight_path_volume(
-                cluster.lat, cluster.lng, self.radius, self.max_flight_distance
+                cluster.lat, cluster.lng, self.radius, self.max_flight_distance, self.oi_duration
             ),
         }
         self.client.put(

--- a/monitoring/loadtest/locust_files/FlightsInSub.py
+++ b/monitoring/loadtest/locust_files/FlightsInSub.py
@@ -5,8 +5,8 @@ import uuid
 from collections import namedtuple
 
 import client
-import locust
 import gevent
+import locust
 from geo_utils import create_random_flight_path_volume
 from utils import format_time
 
@@ -14,6 +14,7 @@ from monitoring.monitorlib.testing import make_fake_url
 
 Cluster = namedtuple("Cluster", ["lng", "lat", "uuid", "version"])
 clusters = []
+
 
 @locust.events.init_command_line_parser.add_listener
 def init_parser(parser: argparse.ArgumentParser):
@@ -56,95 +57,97 @@ def init_parser(parser: argparse.ArgumentParser):
         required=True,
     )
     parser.add_argument(
-      "--oi-duration",
-      type=int,
-      help="Duration (in seconds) of the operational intent",
-      default=10,
+        "--oi-duration",
+        type=int,
+        help="Duration (in seconds) of the operational intent",
+        default=10,
     )
 
+
 class Subscriber(client.USS):
-  # Only create subscriptions once at the beginning of the test.
-  fixed_count = 1
-  wait_time = locust.constant(3600)
+    # Only create subscriptions once at the beginning of the test.
+    fixed_count = 1
+    wait_time = locust.constant(3600)
 
-  @locust.task
-  def create_subscriptions(self):
-    lat = self.environment.parsed_options.base_lat
-    lng = self.environment.parsed_options.base_lng
-    radius = self.environment.parsed_options.area_radius
+    @locust.task
+    def create_subscriptions(self):
+        lat = self.environment.parsed_options.base_lat
+        lng = self.environment.parsed_options.base_lng
+        radius = self.environment.parsed_options.area_radius
 
-    time_start = datetime.datetime.now(datetime.UTC)
-    time_end = time_start + datetime.timedelta(minutes=60)
-    for _ in range(self.environment.parsed_options.cluster_count):
-      sub_uuid = str(uuid.uuid4())
-      response = self.client.put(
-          f"/dss/v1/subscriptions/{sub_uuid}",
-          json={
-              "extents": {
-                  "volume": {
-                      "outline_circle": {
-                          "center": {"lng": lng, "lat": lat},
-                          "radius": {"value": radius, "units": "M"},
-                      },
-                      "altitude_lower": {
-                          "value": 0,
-                          "reference": "W84",
-                          "units": "M",
-                      },
-                      "altitude_upper": {
-                          "value": 10000,
-                          "reference": "W84",
-                          "units": "M",
-                      },
-                  },
-                  "time_start": {
-                      "value": format_time(time_start),
-                      "format": "RFC3339",
-                  },
-                  "time_end": {
-                      "value": format_time(time_end),
-                      "format": "RFC3339",
-                  },
-              },
-              "uss_base_url": make_fake_url(),
-              "notify_for_operational_intents": True,
-          },
-          name="/dss/v1/subscriptions/[id]",
-      )
-
-      if response.status_code == 200:
-        clusters.append(
-            Cluster(
-                lng=lng,
-                lat=lat,
-                uuid=sub_uuid,
-                version=response.json()["subscription"]["version"],
+        time_start = datetime.datetime.now(datetime.UTC)
+        time_end = time_start + datetime.timedelta(minutes=60)
+        for _ in range(self.environment.parsed_options.cluster_count):
+            sub_uuid = str(uuid.uuid4())
+            response = self.client.put(
+                f"/dss/v1/subscriptions/{sub_uuid}",
+                json={
+                    "extents": {
+                        "volume": {
+                            "outline_circle": {
+                                "center": {"lng": lng, "lat": lat},
+                                "radius": {"value": radius, "units": "M"},
+                            },
+                            "altitude_lower": {
+                                "value": 0,
+                                "reference": "W84",
+                                "units": "M",
+                            },
+                            "altitude_upper": {
+                                "value": 10000,
+                                "reference": "W84",
+                                "units": "M",
+                            },
+                        },
+                        "time_start": {
+                            "value": format_time(time_start),
+                            "format": "RFC3339",
+                        },
+                        "time_end": {
+                            "value": format_time(time_end),
+                            "format": "RFC3339",
+                        },
+                    },
+                    "uss_base_url": make_fake_url(),
+                    "notify_for_operational_intents": True,
+                },
+                name="/dss/v1/subscriptions/[id]",
             )
-        )
-      # Move latitude approtimatly
-      lat += (radius * 2) / 111111
 
-  def on_stop(self):
-    # Clean up long lasting subscriptions
-    for cluster in clusters:
-      resp = self.client.delete(
-          f"/dss/v1/subscriptions/{cluster.uuid}/{cluster.version}",
-          name="/dss/v1/subscriptions/[id]/[version]",
-      )
+            if response.status_code == 200:
+                clusters.append(
+                    Cluster(
+                        lng=lng,
+                        lat=lat,
+                        uuid=sub_uuid,
+                        version=response.json()["subscription"]["version"],
+                    )
+                )
+            # Move latitude approtimatly
+            lat += (radius * 2) / 111111
+
+    def on_stop(self):
+        # Clean up long lasting subscriptions
+        for cluster in clusters:
+            self.client.delete(
+                f"/dss/v1/subscriptions/{cluster.uuid}/{cluster.version}",
+                name="/dss/v1/subscriptions/[id]/[version]",
+            )
+
 
 class SCD(client.USS):
     wait_time = locust.between(0.01, 0.1)
 
     def on_start(self):
-      self.uss_base_url = self.environment.parsed_options.uss_base_url
-      self.radius = self.environment.parsed_options.area_radius
-      self.max_flight_distance = self.environment.parsed_options.max_flight_distance
-      self.oi_duration = self.environment.parsed_options.oi_duration
+        self.uss_base_url = self.environment.parsed_options.uss_base_url
+        self.radius = self.environment.parsed_options.area_radius
+        self.max_flight_distance = self.environment.parsed_options.max_flight_distance
+        self.oi_duration = self.environment.parsed_options.oi_duration
 
-      # Wait for subscriptions to be created and clusters to be initialized.
-      gevent.sleep(10)
+        # Wait for subscriptions to be created and clusters to be initialized.
+        gevent.sleep(10)
 
-      self.clusters = clusters
+        self.clusters = clusters
 
     @locust.task
     def task_put_intent(self):
@@ -152,7 +155,7 @@ class SCD(client.USS):
 
         entity_id = uuid.uuid4().hex
         with self.lock:
-          key = list(self.oi_dict.values())
+            key = list(self.oi_dict.values())
 
         body = {
             "state": "Accepted",
@@ -161,7 +164,11 @@ class SCD(client.USS):
                 "uss_base_url": self.uss_base_url,
             },
             "extents": create_random_flight_path_volume(
-                cluster.lat, cluster.lng, self.radius, self.max_flight_distance, self.oi_duration
+                cluster.lat,
+                cluster.lng,
+                self.radius,
+                self.max_flight_distance,
+                self.oi_duration,
             ),
             "key": key,
         }
@@ -171,6 +178,6 @@ class SCD(client.USS):
             name="/dss/v1/operational_intent_references/[id]",
         )
         if resp.status_code in (200, 201):
-          ovn = resp.json()["operational_intent_reference"]["ovn"]
-          with self.lock:
-            self.oi_dict[entity_id] = ovn
+            ovn = resp.json()["operational_intent_reference"]["ovn"]
+            with self.lock:
+                self.oi_dict[entity_id] = ovn

--- a/monitoring/loadtest/locust_files/FlightsInSub.py
+++ b/monitoring/loadtest/locust_files/FlightsInSub.py
@@ -141,6 +141,8 @@ class SCD(client.USS):
         cluster = random.choice(self.clusters)
 
         entity_id = uuid.uuid4().hex
+        with self.lock:
+          key = list(self.oi_dict.values())
 
         body = {
             "state": "Accepted",
@@ -151,9 +153,14 @@ class SCD(client.USS):
             "extents": create_random_flight_path_volume(
                 cluster.lat, cluster.lng, self.radius, self.max_flight_distance, self.oi_duration
             ),
+            "key": key,
         }
-        self.client.put(
+        resp = self.client.put(
             f"/dss/v1/operational_intent_references/{entity_id}",
             json=body,
             name="/dss/v1/operational_intent_references/[id]",
         )
+        if resp.status_code in (200, 201):
+          ovn = resp.json()["operational_intent_reference"]["ovn"]
+          with self.lock:
+            self.oi_dict[entity_id] = ovn

--- a/monitoring/loadtest/locust_files/SCD.py
+++ b/monitoring/loadtest/locust_files/SCD.py
@@ -62,6 +62,8 @@ class SCD(client.USS):
     @locust.task
     def task_put_intent(self):
         entity_id = uuid.uuid4().hex
+        with self.lock:
+          key = list(self.oi_dict.values())
 
         body = {
             "state": "Accepted",
@@ -72,9 +74,14 @@ class SCD(client.USS):
             "extents": create_random_flight_path_volume(
                 self.lat, self.lng, self.radius, self.max_flight_distance, self.oi_duration,
             ),
+            "key": key,
         }
-        self.client.put(
+        resp = self.client.put(
             f"/dss/v1/operational_intent_references/{entity_id}",
             json=body,
             name="/dss/v1/operational_intent_references/[id]",
         )
+        if resp.status_code in (200, 201):
+          ovn = resp.json()["operational_intent_reference"]["ovn"]
+          with self.lock:
+            self.oi_dict[entity_id] = ovn

--- a/monitoring/loadtest/locust_files/SCD.py
+++ b/monitoring/loadtest/locust_files/SCD.py
@@ -41,10 +41,10 @@ def init_parser(parser: argparse.ArgumentParser):
         required=True,
     )
     parser.add_argument(
-      "--oi-duration",
-      type=int,
-      help="Duration (in seconds) of the operational intent",
-      default=10,
+        "--oi-duration",
+        type=int,
+        help="Duration (in seconds) of the operational intent",
+        default=10,
     )
 
 
@@ -63,7 +63,7 @@ class SCD(client.USS):
     def task_put_intent(self):
         entity_id = uuid.uuid4().hex
         with self.lock:
-          key = list(self.oi_dict.values())
+            key = list(self.oi_dict.values())
 
         body = {
             "state": "Accepted",
@@ -72,7 +72,11 @@ class SCD(client.USS):
                 "uss_base_url": self.uss_base_url,
             },
             "extents": create_random_flight_path_volume(
-                self.lat, self.lng, self.radius, self.max_flight_distance, self.oi_duration,
+                self.lat,
+                self.lng,
+                self.radius,
+                self.max_flight_distance,
+                self.oi_duration,
             ),
             "key": key,
         }
@@ -82,6 +86,6 @@ class SCD(client.USS):
             name="/dss/v1/operational_intent_references/[id]",
         )
         if resp.status_code in (200, 201):
-          ovn = resp.json()["operational_intent_reference"]["ovn"]
-          with self.lock:
-            self.oi_dict[entity_id] = ovn
+            ovn = resp.json()["operational_intent_reference"]["ovn"]
+            with self.lock:
+                self.oi_dict[entity_id] = ovn

--- a/monitoring/loadtest/locust_files/SCD.py
+++ b/monitoring/loadtest/locust_files/SCD.py
@@ -40,6 +40,12 @@ def init_parser(parser: argparse.ArgumentParser):
         help="Maximum distance to cover for an individual flight",
         required=True,
     )
+    parser.add_argument(
+      "--oi-duration",
+      type=int,
+      help="Duration (in seconds) of the operational intent",
+      default=10,
+    )
 
 
 class SCD(client.USS):
@@ -51,6 +57,7 @@ class SCD(client.USS):
         self.lng = self.environment.parsed_options.area_lng
         self.radius = self.environment.parsed_options.area_radius
         self.max_flight_distance = self.environment.parsed_options.max_flight_distance
+        self.oi_duration = self.environment.parsed_options.oi_duration
 
     @locust.task
     def task_put_intent(self):
@@ -63,7 +70,7 @@ class SCD(client.USS):
                 "uss_base_url": self.uss_base_url,
             },
             "extents": create_random_flight_path_volume(
-                self.lat, self.lng, self.radius, self.max_flight_distance
+                self.lat, self.lng, self.radius, self.max_flight_distance, self.oi_duration,
             ),
         }
         self.client.put(

--- a/monitoring/loadtest/locust_files/client.py
+++ b/monitoring/loadtest/locust_files/client.py
@@ -1,6 +1,7 @@
 #!env/bin/python3
 
 import os
+import threading
 
 import requests
 from locust import HttpUser
@@ -15,6 +16,8 @@ class USS(HttpUser):
     abstract = True
     isa_dict: dict[str, str] = {}
     sub_dict: dict[str, str] = {}
+    oi_dict: dict[str, str] = {}
+    lock = threading.Lock()
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/monitoring/loadtest/locust_files/geo_utils.py
+++ b/monitoring/loadtest/locust_files/geo_utils.py
@@ -100,13 +100,13 @@ def create_random_flight_path(
 
 
 def create_random_flight_path_volume(
-    lat: float, lng: float, radius: int, max_flight_distance_meters: int
+    lat: float, lng: float, radius: int, max_flight_distance_meters: int, duration_seconds: int = 10
 ):
     altitude_lower = random.randint(0, 10000)
     altitude_upper = altitude_lower + 1
 
     start_time = datetime.datetime.now()
-    end_time = start_time + datetime.timedelta(seconds=10)
+    end_time = start_time + datetime.timedelta(seconds=duration_seconds)
 
     rects = create_random_flight_path(lat, lng, radius, max_flight_distance_meters)
     return [

--- a/monitoring/loadtest/locust_files/geo_utils.py
+++ b/monitoring/loadtest/locust_files/geo_utils.py
@@ -100,7 +100,11 @@ def create_random_flight_path(
 
 
 def create_random_flight_path_volume(
-    lat: float, lng: float, radius: int, max_flight_distance_meters: int, duration_seconds: int = 10
+    lat: float,
+    lng: float,
+    radius: int,
+    max_flight_distance_meters: int,
+    duration_seconds: int = 10,
 ):
     altitude_lower = random.randint(0, 10000)
     altitude_upper = altitude_lower + 1


### PR DESCRIPTION
This PR adds a couple of features to the existing SCD locust load tests:
1) makes OI Duration configurable
2) creates an OVN key for PUT requests by storing the OVNs of previously created intents
3) separates the subscription creation in FlightsInSub.py into a separate locust user allowing for a single subscription creation per cluster at the beginning of the test. Number of users can now be increased without creating multiple subscriptions per cluster.