### PR TITLE
[tooling] Add clean-locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@ UPSTREAM_OWNER := $(shell scripts/git/upstream_owner.sh)
 COMMIT := $(shell scripts/git/commit.sh)
 
 ifeq ($(OS),Windows_NT)
-  detected_OS := Windows
+	detected_OS := Windows
 else
-  detected_OS := $(shell uname -s)
+	detected_OS := $(shell uname -s)
 endif
 
 .PHONY: format
@@ -97,6 +97,11 @@ stop-locally:
 .PHONY: down-locally
 down-locally:
 	build/dev/run_locally.sh down
+
+.PHONY: clean-locally
+clean-locally: down-locally
+	-docker ps -aq --filter network=interop_ecosystem_network | xargs -r docker rm -f
+	-docker ps -aq --filter network=dss_internal_network | xargs -r docker rm -f
 
 .PHONY: check-monitoring
 check-monitoring:

--- a/build/dev/README.md
+++ b/build/dev/README.md
@@ -22,6 +22,8 @@ To tear down the deployment and clean up networks (also via `make down-locally` 
 ```
 Note that to ensure a proper cleanup, the same environment variables used for the `up` should be used for the `down`.
 
+You can use `make cleanup-locally` to remove all containers. Notice this will perform a very large clean, using network to remove containers, external containers (e.g. locust test runner) will be removed as well: proceed with caution.
+
 ## Environment Variables
 
 The following environment variables can be configured to customize the simulated conditions:

--- a/build/dev/README.md
+++ b/build/dev/README.md
@@ -22,7 +22,7 @@ To tear down the deployment and clean up networks (also via `make down-locally` 
 ```
 Note that to ensure a proper cleanup, the same environment variables used for the `up` should be used for the `down`.
 
-You can use `make cleanup-locally` to remove all containers. Notice this will perform a very large clean, using network to remove containers, external containers (e.g. locust test runner) will be removed as well: proceed with caution.
+You can use `make cleanup-locally` to remove all containers connected to the `dss_internal_network` and/or `interop_ecosystem_network`.  This can include DSS instances, dummy auth server, mock USS instances, locust load test, etc.
 
 ## Environment Variables
 


### PR DESCRIPTION
This PR introduce a new helper that perform extensive cleanup of containers that may be used locally.

Useful to remove leftover, e.g. for automatic tests and when exact parameters used for dss instances have been forgotten.