### PR TITLE
Add third Kentland NetRID flight

### DIFF
--- a/monitoring/uss_qualifier/test_data/usa/kentland/rid.kml
+++ b/monitoring/uss_qualifier/test_data/usa/kentland/rid.kml
@@ -547,6 +547,79 @@ accuracy_v: VAUnknown</description>
 				</Point>
 			</Placemark>
 		</Folder>
+		<Folder>
+			<name>flight: eastern transit</name>
+			<open>1</open>
+			<description>serial_number: MNFR5FAKE3
+operation_description: Eastbound transit north of takeoff
+operator_id: EXAMPLE_OPERATOR3
+registration_number: N.654321
+aircraft_type: Helicopter
+operator_name: Participant 3
+timestamp_accuracy: 1.0
+speed_accuracy: SA3mps
+sample_rate: 1.0
+accuracy_h: HAUnknown
+accuracy_v: VAUnknown</description>
+			<Placemark>
+				<name>Eastern transit</name>
+				<styleUrl>#msn_ylw-pushpin10</styleUrl>
+				<LineString>
+					<tessellate>1</tessellate>
+					<coordinates>
+						-80.57350,37.199,0 -80.57342,37.199,0 -80.57334,37.199,0 -80.57326,37.199,0 -80.57318,37.199,0 -80.57310,37.199,0 -80.57302,37.199,0 -80.57294,37.199,0 -80.57286,37.199,0 -80.57278,37.199,0 -80.57270,37.199,0 -80.57262,37.199,0 -80.57254,37.199,0 -80.57246,37.199,0 -80.57238,37.199,0 -80.57230,37.199,0 -80.57222,37.199,0 -80.57214,37.199,0 -80.57206,37.199,0 -80.57198,37.199,0 -80.57190,37.199,0 -80.57182,37.199,0 -80.57174,37.199,0 -80.57166,37.199,0 -80.57158,37.199,0 -80.57150,37.199,0 -80.57142,37.199,0 -80.57134,37.199,0 -80.57126,37.199,0 -80.57118,37.199,0 -80.57110,37.199,0 -80.57102,37.199,0 -80.57094,37.199,0 -80.57086,37.199,0 -80.57078,37.199,0 -80.57070,37.199,0 -80.57062,37.199,0 -80.57054,37.199,0 -80.57046,37.199,0 -80.57038,37.199,0 -80.57030,37.199,0 -80.57022,37.199,0 -80.57014,37.199,0 -80.57006,37.199,0 -80.56998,37.199,0 -80.56990,37.199,0 -80.56982,37.199,0 -80.56974,37.199,0 -80.56966,37.199,0 -80.56958,37.199,0 -80.56950,37.199,0 -80.56942,37.199,0 -80.56934,37.199,0 -80.56926,37.199,0 -80.56918,37.199,0 -80.56910,37.199,0 -80.56902,37.199,0 -80.56894,37.199,0 -80.56886,37.199,0 -80.56878,37.199,0 -80.56870,37.199,0 -80.56862,37.199,0 -80.56854,37.199,0 -80.56846,37.199,0 -80.56838,37.199,0 -80.56830,37.199,0 -80.56822,37.199,0 -80.56814,37.199,0 -80.56806,37.199,0 -80.56798,37.199,0 -80.56790,37.199,0 -80.56782,37.199,0 -80.56774,37.199,0 -80.56766,37.199,0 -80.56758,37.199,0 -80.56750,37.199,0 -80.56742,37.199,0 -80.56734,37.199,0 -80.56726,37.199,0 -80.56718,37.199,0 -80.56710,37.199,0 -80.56702,37.199,0 -80.56694,37.199,0 -80.56686,37.199,0 -80.56678,37.199,0 -80.56670,37.199,0 -80.56662,37.199,0 -80.56654,37.199,0 -80.56646,37.199,0 -80.56638,37.199,0
+					</coordinates>
+				</LineString>
+			</Placemark>
+			<Placemark>
+				<name>alt: Cruise</name>
+				<styleUrl>#msn_ylw-pushpin3</styleUrl>
+				<Polygon>
+					<extrude>1</extrude>
+					<tessellate>1</tessellate>
+					<altitudeMode>absolute</altitudeMode>
+					<outerBoundaryIs>
+						<LinearRing>
+							<coordinates>
+								-80.574,37.1985,610 -80.5655,37.1985,610 -80.5655,37.1995,610 -80.574,37.1995,610 -80.574,37.1985,610
+							</coordinates>
+						</LinearRing>
+					</outerBoundaryIs>
+				</Polygon>
+			</Placemark>
+			<Placemark>
+				<name>speed: Transit (5)</name>
+				<styleUrl>#msn_ylw-pushpin2</styleUrl>
+				<Polygon>
+					<tessellate>1</tessellate>
+					<outerBoundaryIs>
+						<LinearRing>
+							<coordinates>
+								-80.574,37.1985,0 -80.5655,37.1985,0 -80.5655,37.1995,0 -80.574,37.1995,0 -80.574,37.1985,0
+							</coordinates>
+						</LinearRing>
+					</outerBoundaryIs>
+				</Polygon>
+			</Placemark>
+			<Placemark>
+				<name>operator_location</name>
+				<LookAt>
+					<longitude>-80.5737</longitude>
+					<latitude>37.1988</latitude>
+					<altitude>0</altitude>
+					<heading>80</heading>
+					<tilt>10</tilt>
+					<range>250</range>
+					<gx:altitudeMode>relativeToSeaFloor</gx:altitudeMode>
+				</LookAt>
+				<styleUrl>#m_ylw-pushpin</styleUrl>
+				<Point>
+					<gx:drawOrder>1</gx:drawOrder>
+					<coordinates>-80.5737,37.1988,526.1</coordinates>
+					<altitudeMode>absolute</altitudeMode>
+				</Point>
+			</Placemark>
+		</Folder>
 	</Folder>
 </Document>
 </kml>


### PR DESCRIPTION
## Summary
- add a third nominal flight to the Kentland NetRID KML fixture
- give the new flight unique operator and aircraft metadata
- keep the existing Kentland resource and suite wiring unchanged

## Motivation
Fixes #1533. The slow-update scenario requires one nominal flight per SP under test, but the Kentland fixture only provided two flights. A 3-SP run therefore failed before reaching scenario checks.

I recognize this is not a long-term solution but need immediate unlock so here it is. I will open another PR with something more future-proof.

## Validation
- Parsed the Kentland KML through FlightDataResource: 3 flights with telemetry counts [65, 67, 89]
- Checked injected_flights_errors for the first 3 generated test flights: 0 errors
- PYTHONPATH=../.. ../../.venv/bin/pytest resources/netrid/flight_data_resources_test.py