### PR TITLE
Rename pyproject from 'monitoring' to 'interuss-monitoring'

### DIFF
--- a/monitoring/Dockerfile
+++ b/monitoring/Dockerfile
@@ -39,7 +39,7 @@ ENV GIT_COMMIT_HASH=$commit_hash
 ENV UV_LINK_MODE=copy
 ENV UV_PROJECT_ENVIRONMENT=/venv/
 ENV VIRTUAL_ENV=/venv/
-ENV SETUPTOOLS_SCM_PRETEND_VERSION_FOR_MONITORING=$version
+ENV SETUPTOOLS_SCM_PRETEND_VERSION_FOR_INTERUSS_MONITORING=$version
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=./uv.lock,target=/app/uv.lock \
     --mount=type=bind,source=./pyproject.toml,target=/app/pyproject.toml \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "monitoring"
+name = "interuss-monitoring"
 dynamic = ["version"]
 authors = [
   { name="InterUSS Platform", email="tsc@lists.interussplatform.org" },


### PR DESCRIPTION
With the newly-introduced ability to publish on PyPI, the name of this project needs to be globally available in PyPI.  This PR changes the taken `monitoring` name to `interuss-monitoring`.