### PR TITLE
[deployment] Add a loadbalancer to perform better load tests

### DIFF
--- a/build/dev/README.md
+++ b/build/dev/README.md
@@ -37,6 +37,12 @@ The following environment variables can be configured to customize the simulated
 * `INTER_USS_NETEM_CONF`: `tc netem` configuration rules applied to traffic between database nodes of *different* USSs (default: `<none>`).
   * *Sensible values (higher latency/jitter, moderate loss):* `"delay 25ms 7.5ms 50% distribution paretonormal loss 0.025% 25%"`
 
+## Load Balancer
+
+A load balancer (powered by HAProxy) is deployed and is available at `http://dss.lb.localutm` within internal networks, or externally at `http://127.0.0.1:8090`.
+
+It targets all DSS instances and can be used to perform balanced load testing.
+
 ---
 
 ## Scaling Limits

--- a/build/dev/docker-compose.yaml
+++ b/build/dev/docker-compose.yaml
@@ -211,6 +211,21 @@ services:
       start_period: 30s
       start_interval: 5s
 
+  dss_loadbalancer:
+    image: haproxy:2.9-alpine
+    profiles: [lb]
+    entrypoint: /startup/lb-entrypoint.sh
+    hostname: dss.lb.localutm
+    volumes:
+      - $PWD/startup/lb-entrypoint.sh:/startup/lb-entrypoint.sh:ro
+    networks:
+      - interop_ecosystem_network
+    ports:
+      - "8090:80"
+    environment:
+      NUM_USS: ${NUM_USS:-1}
+      NUM_NODES: ${NUM_NODES:-1}
+
 networks:
   dss_internal_network:
     name: dss_internal_network

--- a/build/dev/run_locally.sh
+++ b/build/dev/run_locally.sh
@@ -74,7 +74,7 @@ for ((i=1; i<=NUM_USS; i++)); do
 
     export COMPOSE_PROFILES=${DB_TYPE}
     if [ "$i" -eq 1 ] && [ "$j" -eq 1 ]; then
-      export COMPOSE_PROFILES=${COMPOSE_PROFILES},oauth
+      export COMPOSE_PROFILES=${COMPOSE_PROFILES},oauth,lb
     fi
     if [ "$i" -eq "$NUM_USS" ] && [ "$j" -eq "$NUM_NODES" ] && [ "$DB_TYPE" != "raft" ]; then
       export COMPOSE_PROFILES=${COMPOSE_PROFILES},bootstrap-${DB_TYPE}

--- a/build/dev/startup/core_service.sh
+++ b/build/dev/startup/core_service.sh
@@ -7,7 +7,7 @@ set -e
 # started by docker-compose.yaml, not on a local system.
 
 DEBUG_ON=${1:-0}
-JWT_AUDIENCES="localhost,host.docker.internal,${JWT_AUDIENCES}"
+JWT_AUDIENCES="localhost,host.docker.internal,dss.lb.localutm,${JWT_AUDIENCES}"
 
 # apply netem config for intra/inter-USS subnets, if requested
 if [ -n "$INTRA_USS_NETEM_CONF" ] || [ -n "$INTER_USS_NETEM_CONF" ]; then

--- a/build/dev/startup/lb-entrypoint.sh
+++ b/build/dev/startup/lb-entrypoint.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+set -e
+
+cat > /tmp/haproxy.cfg <<'EOF'
+global
+    maxconn 1024
+
+defaults
+    mode http
+    timeout connect 5s
+    timeout client 30s
+    timeout server 30s
+
+resolvers docker
+    nameserver dns1 127.0.0.11:53
+
+frontend dss_in
+    bind *:80
+    default_backend dss_pool
+
+backend dss_pool
+    balance roundrobin
+EOF
+
+i=1
+while [ "$i" -le "$NUM_USS" ]; do
+  j=1
+  while [ "$j" -le "$NUM_NODES" ]; do
+    echo "    server dss${j}_${i} dss${j}.uss${i}.localutm:80 check resolvers docker init-addr none"
+    j=$((j+1))
+  done
+  i=$((i+1))
+done >> /tmp/haproxy.cfg
+
+exec haproxy -f /tmp/haproxy.cfg

--- a/monitoring/loadtest/README.md
+++ b/monitoring/loadtest/README.md
@@ -83,7 +83,7 @@ Simply build the Docker container with the Dockerfile from the root directory. A
 ## Use
 1. Navigate to http://127.0.0.1:8089
 1. Start new test with number of Users to spawn and the rate to spawn them.
-1. For the Host, provide the DSS root endpoint used for testing. An example of such url is: http://dss1.uss1.localutm/ in case local environment is setup with `make start-locally`
+1. For the Host, provide the DSS root endpoint used for testing. An example of such url is: http://dss.lb.localutm/ in case local environment is setup with `make start-locally`
 
 ## Examples to run tests locally
 
@@ -94,16 +94,16 @@ Before running all examples:
 
 ### ISA.py
 
-`docker run -e AUTH_SPEC="DummyOAuth(http://oauth.authority.localutm:8085/token,uss1)" --network="interop_ecosystem_network" -p 8089:8089 -v .:/app/ interuss/monitoring-dev uv run locust -f loadtest/locust_files/ISA.py -H http://dss1.uss1.localutm -u 10 --uss-base-url http://dss1.uss1.localutm`
+`docker run -e AUTH_SPEC="DummyOAuth(http://oauth.authority.localutm:8085/token,uss1)" --network="interop_ecosystem_network" -p 8089:8089 -v .:/app/ interuss/monitoring-dev uv run locust -f loadtest/locust_files/ISA.py -H http://dss.lb.localutm -u 10 --uss-base-url http://dss.lb.localutm`
 
 ### Sub.py
 
-`docker run -e AUTH_SPEC="DummyOAuth(http://oauth.authority.localutm:8085/token,uss1)" --network="interop_ecosystem_network" -p 8089:8089 -v .:/app/ interuss/monitoring-dev uv run locust -f loadtest/locust_files/Sub.py -H http://dss1.uss1.localutm -u 10 --uss-base-url http://dss1.uss1.localutm`
+`docker run -e AUTH_SPEC="DummyOAuth(http://oauth.authority.localutm:8085/token,uss1)" --network="interop_ecosystem_network" -p 8089:8089 -v .:/app/ interuss/monitoring-dev uv run locust -f loadtest/locust_files/Sub.py -H http://dss.lb.localutm -u 10 --uss-base-url http://dss.lb.localutm`
 
 ### SCD.py
 
-`docker run -e AUTH_SPEC="DummyOAuth(http://oauth.authority.localutm:8085/token,uss1)" --network="interop_ecosystem_network" -p 8089:8089 -v .:/app/ interuss/monitoring-dev uv run locust -f loadtest/locust_files/SCD.py -H http://dss1.uss1.localutm -u 10 --area-lat -34.93 --area-lng 138.6 --area-radius 1000 --max-flight-distance 12000 --uss-base-url http://dss1.uss1.localutm`
+`docker run -e AUTH_SPEC="DummyOAuth(http://oauth.authority.localutm:8085/token,uss1)" --network="interop_ecosystem_network" -p 8089:8089 -v .:/app/ interuss/monitoring-dev uv run locust -f loadtest/locust_files/SCD.py -H http://dss.lb.localutm -u 10 --area-lat -34.93 --area-lng 138.6 --area-radius 1000 --max-flight-distance 12000 --uss-base-url http://dss.lb.localutm`
 
 ### FlightsInSub.py
 
-`docker run -e AUTH_SPEC="DummyOAuth(http://oauth.authority.localutm:8085/token,uss1)" --network="interop_ecosystem_network" -p 8089:8089 -v .:/app/ interuss/monitoring-dev uv run locust -f loadtest/locust_files/FlightsInSub.py -H http://dss1.uss1.localutm -u 10 --cluster-count 3 --base-lat -34.93 --base-lng 138.6 --area-radius 1000 --max-flight-distance 1000 --uss-base-url http://dss1.uss1.localutm`
+`docker run -e AUTH_SPEC="DummyOAuth(http://oauth.authority.localutm:8085/token,uss1)" --network="interop_ecosystem_network" -p 8089:8089 -v .:/app/ interuss/monitoring-dev uv run locust -f loadtest/locust_files/FlightsInSub.py -H http://dss.lb.localutm -u 10 --cluster-count 3 --base-lat -34.93 --base-lng 138.6 --area-radius 1000 --max-flight-distance 1000 --uss-base-url http://dss.lb.localutm`


### PR DESCRIPTION
This PR add a load balancer to the local testing stack, fixing one issue described in  https://github.com/interuss/dss/issues/1559

A DSS may have different q/s depending on CockroachDB spread data. In the 3 node scenario described in https://github.com/interuss/dss/issues/1559, there is usually one DSS faster that others ones, but in average, q/s are the same.

Tested with the 3 node scenario: across multiple restart, average q/s are the same, and with same number of clients, results are the sum of what has been measured in the issue (second graph).