### PR TITLE
[loadtest/FlightsInSub] Do not account for creation/deletion of subscriptions in locust stats

### DIFF
--- a/monitoring/loadtest/locust_files/FlightsInSub.py
+++ b/monitoring/loadtest/locust_files/FlightsInSub.py
@@ -5,8 +5,8 @@ import uuid
 from collections import namedtuple
 
 import client
-import gevent
 import locust
+import requests
 from geo_utils import create_random_flight_path_volume
 from utils import format_time
 
@@ -64,75 +64,77 @@ def init_parser(parser: argparse.ArgumentParser):
     )
 
 
-class Subscriber(client.USS):
-    # Only create subscriptions once at the beginning of the test.
-    fixed_count = 1
-    wait_time = locust.constant(3600)
+@locust.events.test_start.add_listener
+def create_subscriptions(environment):
+    print("Creating subscriptions...")
 
-    @locust.task
-    def create_subscriptions(self):
-        lat = self.environment.parsed_options.base_lat
-        lng = self.environment.parsed_options.base_lng
-        radius = self.environment.parsed_options.area_radius
+    lat = environment.parsed_options.base_lat
+    lng = environment.parsed_options.base_lng
+    radius = environment.parsed_options.area_radius
 
-        time_start = datetime.datetime.now(datetime.UTC)
-        time_end = time_start + datetime.timedelta(minutes=60)
-        for _ in range(self.environment.parsed_options.cluster_count):
-            sub_uuid = str(uuid.uuid4())
-            response = self.client.put(
-                f"/dss/v1/subscriptions/{sub_uuid}",
-                json={
-                    "extents": {
-                        "volume": {
-                            "outline_circle": {
-                                "center": {"lng": lng, "lat": lat},
-                                "radius": {"value": radius, "units": "M"},
-                            },
-                            "altitude_lower": {
-                                "value": 0,
-                                "reference": "W84",
-                                "units": "M",
-                            },
-                            "altitude_upper": {
-                                "value": 10000,
-                                "reference": "W84",
-                                "units": "M",
-                            },
+    time_start = datetime.datetime.now(datetime.UTC)
+    time_end = time_start + datetime.timedelta(minutes=60)
+
+    for _ in range(environment.parsed_options.cluster_count):
+        sub_uuid = str(uuid.uuid4())
+        response = requests.put(
+            f"{environment.host}/dss/v1/subscriptions/{sub_uuid}",
+            auth=client.get_auth_from_env(),
+            json={
+                "extents": {
+                    "volume": {
+                        "outline_circle": {
+                            "center": {"lng": lng, "lat": lat},
+                            "radius": {"value": radius, "units": "M"},
                         },
-                        "time_start": {
-                            "value": format_time(time_start),
-                            "format": "RFC3339",
+                        "altitude_lower": {
+                            "value": 0,
+                            "reference": "W84",
+                            "units": "M",
                         },
-                        "time_end": {
-                            "value": format_time(time_end),
-                            "format": "RFC3339",
+                        "altitude_upper": {
+                            "value": 10000,
+                            "reference": "W84",
+                            "units": "M",
                         },
                     },
-                    "uss_base_url": make_fake_url(),
-                    "notify_for_operational_intents": True,
+                    "time_start": {
+                        "value": format_time(time_start),
+                        "format": "RFC3339",
+                    },
+                    "time_end": {
+                        "value": format_time(time_end),
+                        "format": "RFC3339",
+                    },
                 },
-                name="/dss/v1/subscriptions/[id]",
-            )
+                "uss_base_url": make_fake_url(),
+                "notify_for_operational_intents": True,
+            },
+        )
 
-            if response.status_code == 200:
-                clusters.append(
-                    Cluster(
-                        lng=lng,
-                        lat=lat,
-                        uuid=sub_uuid,
-                        version=response.json()["subscription"]["version"],
-                    )
+        if response.status_code == 200:
+            clusters.append(
+                Cluster(
+                    lng=lng,
+                    lat=lat,
+                    uuid=sub_uuid,
+                    version=response.json()["subscription"]["version"],
                 )
-            # Move latitude approtimatly
-            lat += (radius * 2) / 111111
-
-    def on_stop(self):
-        # Clean up long lasting subscriptions
-        for cluster in clusters:
-            self.client.delete(
-                f"/dss/v1/subscriptions/{cluster.uuid}/{cluster.version}",
-                name="/dss/v1/subscriptions/[id]/[version]",
             )
+        # Move latitude approximately
+        lat += (radius * 2) / 111111
+    print(f"Created {len(clusters)} subscriptions.")
+
+
+@locust.events.test_stop.add_listener
+def cleanup_subscriptions(environment):
+    print("Cleaning up subscriptions...")
+
+    for cluster in clusters:
+        requests.delete(
+            f"{environment.host}/dss/v1/subscriptions/{cluster.uuid}/{cluster.version}",
+            auth=client.get_auth_from_env(),
+        )
 
 
 class SCD(client.USS):
@@ -143,9 +145,6 @@ class SCD(client.USS):
         self.radius = self.environment.parsed_options.area_radius
         self.max_flight_distance = self.environment.parsed_options.max_flight_distance
         self.oi_duration = self.environment.parsed_options.oi_duration
-
-        # Wait for subscriptions to be created and clusters to be initialized.
-        gevent.sleep(10)
 
         self.clusters = clusters
 

--- a/monitoring/loadtest/locust_files/client.py
+++ b/monitoring/loadtest/locust_files/client.py
@@ -2,6 +2,7 @@
 
 import os
 import threading
+from collections.abc import Callable
 
 import requests
 from locust import HttpUser
@@ -9,6 +10,33 @@ from uas_standards.astm.f3411.v19.constants import Scope as f3411_scope
 from uas_standards.astm.f3548.v21.constants import Scope as f3548_scope
 
 from monitoring.monitorlib import auth
+
+
+def get_auth_from_env() -> Callable[
+    [requests.PreparedRequest], requests.PreparedRequest
+]:
+    auth_spec = os.environ.get("AUTH_SPEC")
+    if not auth_spec:
+        raise Exception("Missing AUTH_SPEC environment variable, please check README")
+
+    # This is a load tester its acceptable to have all the scopes required to operate anything.
+    # We are not testing if the scope is incorrect. We are testing if it can handle the load.
+    scopes = [
+        f3411_scope.Read,
+        f3411_scope.Write,
+        f3548_scope.StrategicCoordination,
+        "rid.display_provider",
+        "rid.service_provider",
+    ]
+    oauth_adapter = auth.make_auth_adapter(auth_spec)
+
+    def _auth(
+        prepared_request: requests.PreparedRequest,
+    ) -> requests.PreparedRequest:
+        oauth_adapter.add_headers(prepared_request, scopes)
+        return prepared_request
+
+    return _auth
 
 
 class USS(HttpUser):
@@ -21,28 +49,5 @@ class USS(HttpUser):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        auth_spec = os.environ.get("AUTH_SPEC")
 
-        if not auth_spec:
-            raise Exception(
-                "Missing AUTH_SPEC environment variable, please check README"
-            )
-
-        # This is a load tester its acceptable to have all the scopes required to operate anything.
-        # We are not testing if the scope is incorrect. We are testing if it can handle the load.
-        scopes = [
-            f3411_scope.Read,
-            f3411_scope.Write,
-            f3548_scope.StrategicCoordination,
-            "rid.display_provider",
-            "rid.service_provider",
-        ]
-        oauth_adapter = auth.make_auth_adapter(auth_spec)
-
-        def _auth(
-            prepared_request: requests.PreparedRequest,
-        ) -> requests.PreparedRequest:
-            oauth_adapter.add_headers(prepared_request, scopes)
-            return prepared_request
-
-        self.client.auth = _auth
+        self.client.auth = get_auth_from_env()


### PR DESCRIPTION
- use the 'test_start' and 'test_stop' locust listener to perform creation / cleanup of subscriptions
- use `requests` package and not the locust client to perform those operations in order to exclude them from the statistics