### PR TITLE
[local deployment/crdb] Ensure that each USS has at least a replica of the tables

### DIFF
--- a/build/dev/docker-compose.yaml
+++ b/build/dev/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
     image: cockroachdb/cockroach:v24.1.3
     entrypoint: /db-entrypoint.sh
     # 128MB limits allow larger numbers of nodes on a single machine
-    command: /cockroach/cockroach.sh start --insecure --join=db1.uss1.localutm --cache=128MiB --max-sql-memory=128MiB
+    command: /cockroach/cockroach.sh start --insecure --join=db1.uss1.localutm --cache=128MiB --max-sql-memory=128MiB --locality=uss=${USS_IDX:?},node=${USS_IDX:?}-${USS_NODE_IDX:?}
     volumes:
       - $PWD/startup/db-entrypoint.sh:/db-entrypoint.sh:ro
     profiles: [crdb]
@@ -66,11 +66,12 @@ services:
     image: cockroachdb/cockroach:v24.1.3
     profiles: [bootstrap-crdb]
     depends_on: [crdb]
-    entrypoint: >
+    entrypoint: > # note that this sets the CRDB zones to have as many replicas as there are USSs (for all tables), combined with the fact that CRDB will try to distribute replicas uniformly over zones (which are defined by locality), this ensures that each USS has at least a replica
       sh -c "
         out=$$(/cockroach/cockroach.sh init --insecure --host=db1.uss1.localutm 2>&1);
         if [ $$? -eq 0 ]; then
           echo "$$out";
+          /cockroach/cockroach.sh sql --insecure --host=db1.uss1.localutm -e 'ALTER RANGE default CONFIGURE ZONE USING num_replicas = ${NUM_USS:?};';
           exit 0;
         fi;
         echo "$$out";

--- a/build/dev/docker-compose.yaml
+++ b/build/dev/docker-compose.yaml
@@ -66,7 +66,9 @@ services:
     image: cockroachdb/cockroach:v24.1.3
     profiles: [bootstrap-crdb]
     depends_on: [crdb]
-    entrypoint: > # note that this sets the CRDB zones to have as many replicas as there are USSs (for all tables), combined with the fact that CRDB will try to distribute replicas uniformly over zones (which are defined by locality), this ensures that each USS has at least a replica
+    # The entrypoint below sets the CRDB zones to have as many replicas as there are USSs (for all tables), combined with the fact that CRDB will try to distribute replicas uniformly over zones (which are defined by locality), this ensures that each USS has at least a replica.
+    # On a real production deployment such a configuration would be made to meet the survivability objectives (https://interuss.github.io/dss/latest/architecture/#survivability), either manually or automatically (https://github.com/interuss/dss/issues/482).
+    entrypoint: > 
       sh -c "
         out=$$(/cockroach/cockroach.sh init --insecure --host=db1.uss1.localutm 2>&1);
         if [ $$? -eq 0 ]; then

--- a/build/dev/docker-compose.yaml
+++ b/build/dev/docker-compose.yaml
@@ -67,8 +67,8 @@ services:
     profiles: [bootstrap-crdb]
     depends_on: [crdb]
     # The entrypoint below sets the CRDB zones to have as many replicas as there are USSs (for all tables), combined with the fact that CRDB will try to distribute replicas uniformly over zones (which are defined by locality), this ensures that each USS has at least a replica.
-    # On a real production deployment such a configuration would be made to meet the survivability objectives (https://interuss.github.io/dss/latest/architecture/#survivability), either manually or automatically (https://github.com/interuss/dss/issues/482).
-    entrypoint: > 
+    # On a real production deployment such a configuration would be made to meet the survivability objectives (https://interuss.github.io/dss/latest/operations/survivability-crdb).
+    entrypoint: >
       sh -c "
         out=$$(/cockroach/cockroach.sh init --insecure --host=db1.uss1.localutm 2>&1);
         if [ $$? -eq 0 ]; then

--- a/build/dev/run_locally.sh
+++ b/build/dev/run_locally.sh
@@ -20,7 +20,7 @@ fi
 
 cd "${BASEDIR}" || exit 1
 
-NUM_USS=${NUM_USS:-2}
+export NUM_USS=${NUM_USS:-2}
 NUM_NODES=${NUM_NODES:-1}
 DB_TYPE=${DB_TYPE:-crdb}
 


### PR DESCRIPTION
- sets the locality of each CRDB nodes to its USS, which defines zones for CRDB
- configure the default behavior (applying to all tables) to have as many replicas as there are USSs, and because CRDB will distribute replicas over zones, each USS will get a replica

We do this to produce more consistent results when testing performances of the DSS.
This should address https://github.com/interuss/dss/issues/1559