### PR TITLE
[deployment] Fix DSS nodes in compose deployment: enforce IP to use correct subnet

### DIFF
--- a/build/dev/run_locally.sh
+++ b/build/dev/run_locally.sh
@@ -59,10 +59,10 @@ if [[ "$DB_TYPE" == "raft" ]]; then
     for ((j=1; j<=NUM_NODES; j++)); do
       NODE_IDX=$(( (i-1) * NUM_NODES + j ))
       PADDED_NODE_IDX=$(printf "%02d" "$NODE_IDX")
-      HOST="dss${j}.uss${i}.localutm"
-      RID_RAFT_NODES="${RID_RAFT_NODES},${NODE_IDX}=http://${HOST}:95${PADDED_NODE_IDX}"
-      SCD_RAFT_NODES="${SCD_RAFT_NODES},${NODE_IDX}=http://${HOST}:96${PADDED_NODE_IDX}"
-      AUX_RAFT_NODES="${AUX_RAFT_NODES},${NODE_IDX}=http://${HOST}:97${PADDED_NODE_IDX}"
+      NODE_IP="172.27.${i}.${j}"
+      RID_RAFT_NODES="${RID_RAFT_NODES},${NODE_IDX}=http://${NODE_IP}:95${PADDED_NODE_IDX}"
+      SCD_RAFT_NODES="${SCD_RAFT_NODES},${NODE_IDX}=http://${NODE_IP}:96${PADDED_NODE_IDX}"
+      AUX_RAFT_NODES="${AUX_RAFT_NODES},${NODE_IDX}=http://${NODE_IP}:97${PADDED_NODE_IDX}"
     done
   done
   export RID_RAFT_NODES=${RID_RAFT_NODES#,}


### PR DESCRIPTION
This PR follow #1528 and #1548

It does enforce usage of correct subnet for raft communication between nodes by using IP. As DSS container are on both network, it's not guaranteed that the DNS return the IP we want to use.

