### PR TITLE
[tooling] Improve reliability of `make start-locally`

### DIFF
--- a/build/dev/run_locally.sh
+++ b/build/dev/run_locally.sh
@@ -105,10 +105,18 @@ if [[ "$DC_COMMAND" == up* ]]; then
   check_and_connect() {
     local container=$1
     local network=$2
-    if docker ps --format '{{.Names}}' | grep -q "^${container}$"; then
+    if docker ps -a --format '{{.Names}}' | grep -q "^${container}$"; then
       if ! docker inspect "${container}" --format '{{json .NetworkSettings.Networks}}' | grep -q "\"${network}\""; then
         echo "Warning: Container ${container} is not connected to ${network}. Reconnecting and restarting so the entrypoint reapplies traffic shaping..."
-        docker network connect "${network}" "${container}"
+        local status
+        status=$(docker inspect --format '{{.State.Status}}' "${container}" 2>/dev/null || true)
+        if [ "$status" = "restarting" ] || [ "$status" = "running" ]; then
+          docker stop -t 2 "${container}" >/dev/null 2>&1 || true
+        fi
+        docker network connect "${network}" "${container}" || {
+          docker stop -t 2 "${container}" >/dev/null 2>&1 || true
+          docker network connect "${network}" "${container}"
+        }
         docker restart "${container}"
       fi
     fi

--- a/build/dev/run_locally.sh
+++ b/build/dev/run_locally.sh
@@ -108,11 +108,6 @@ if [[ "$DC_COMMAND" == up* ]]; then
     if docker ps -a --format '{{.Names}}' | grep -q "^${container}$"; then
       if ! docker inspect "${container}" --format '{{json .NetworkSettings.Networks}}' | grep -q "\"${network}\""; then
         echo "Warning: Container ${container} is not connected to ${network}. Reconnecting and restarting so the entrypoint reapplies traffic shaping..."
-        local status
-        status=$(docker inspect --format '{{.State.Status}}' "${container}" 2>/dev/null || true)
-        if [ "$status" = "restarting" ] || [ "$status" = "running" ]; then
-          docker stop -t 2 "${container}" >/dev/null 2>&1 || true
-        fi
         docker network connect "${network}" "${container}" || {
           docker stop -t 2 "${container}" >/dev/null 2>&1 || true
           docker network connect "${network}" "${container}"


### PR DESCRIPTION
While working on benchmarking, I noticed that `make start-locally` often failed with messages like:

```
Warning: Container local_infra_1-3-dss-1 is not connected to dss_internal_network. Reconnecting and restarting so the entrypoint reapplies traffic shaping...
Error response from daemon: network sandbox for container 8d2716de57f3ea398f586380c88f3457b09af8d79a5c1b0ccdcb092a33e2cb79 not found
```

Gemini identified that this was probably happening when a container was restarting at the moment check_and_connect was called and suggested ensuring a known state when attempting `docker network connect`.  This seems to have fixed the issue as I haven't seen this type of failure since making this fix.