### PR TITLE
[benchmarker] Implement flight planner user with ASTM NetRID

### DIFF
--- a/monitoring/benchmarker/configurations/users.py
+++ b/monitoring/benchmarker/configurations/users.py
@@ -91,7 +91,7 @@ class ASTMNetRIDBehaviorSpecification(ImplicitDict):
 
     dss_selection_strategy: Optional[ASTMDSSSelectionStrategy]
 
-    isa_strategy: Optional[ASTMNetRIDISAStrategySpecification]
+    isa_strategy: ASTMNetRIDISAStrategySpecification
 
 
 class FlightPlannerSpecification(ImplicitDict):

--- a/monitoring/benchmarker/engine/users/flight_planner/astm_net_rid.py
+++ b/monitoring/benchmarker/engine/users/flight_planner/astm_net_rid.py
@@ -20,7 +20,6 @@ from monitoring.benchmarker.engine.users.framework import VirtualUser
 from monitoring.monitorlib.fetch.rid import ISA
 from monitoring.monitorlib.geo import get_latlngrect_vertices
 from monitoring.monitorlib.mutate.rid import ISAChange, delete_isa, put_isa
-from monitoring.monitorlib.rid import RIDVersion
 from monitoring.monitorlib.testing import make_fake_url
 from monitoring.uss_qualifier.resources.astm.f3411.dss import (
     DSSInstance,
@@ -70,10 +69,7 @@ class ASTMNetRIDHandler:
             )
 
         if len(self.dss_instances) > 1:
-            if (
-                "dss_selection_strategy" in behavior
-                and behavior.dss_selection_strategy
-            ):
+            if "dss_selection_strategy" in behavior and behavior.dss_selection_strategy:
                 self.dss_selection_strategy = behavior.dss_selection_strategy
             else:
                 raise ValueError(

--- a/monitoring/benchmarker/engine/users/flight_planner/astm_net_rid.py
+++ b/monitoring/benchmarker/engine/users/flight_planner/astm_net_rid.py
@@ -1,0 +1,222 @@
+import uuid
+from collections.abc import Iterable
+from datetime import UTC, datetime
+from functools import partial
+from random import Random
+from typing import Any
+
+from monitoring.benchmarker.configurations.users import (
+    ASTMDSSSelectionStrategy,
+    ASTMNetRIDBehaviorSpecification,
+    ASTMNetRIDISAPerFlightStrategySpecification,
+)
+from monitoring.benchmarker.engine.users.flight_planner.framework import (
+    CompletedFlightAction,
+    Flight,
+    FlightAction,
+    FlightActionType,
+)
+from monitoring.benchmarker.engine.users.framework import VirtualUser
+from monitoring.monitorlib.fetch.rid import ISA
+from monitoring.monitorlib.geo import get_latlngrect_vertices
+from monitoring.monitorlib.mutate.rid import ISAChange, delete_isa, put_isa
+from monitoring.monitorlib.rid import RIDVersion
+from monitoring.monitorlib.testing import make_fake_url
+from monitoring.uss_qualifier.resources.astm.f3411.dss import (
+    DSSInstance,
+    DSSInstanceResource,
+    DSSInstancesResource,
+)
+from monitoring.uss_qualifier.resources.definitions import ResourceID
+
+
+class ASTMNetRIDHandler:
+    user: VirtualUser
+
+    dss_instances: list[DSSInstance]
+    dss_selection_strategy: ASTMDSSSelectionStrategy
+
+    isa_per_flight: ASTMNetRIDISAPerFlightStrategySpecification | None = None
+
+    random: Random
+
+    def __init__(
+        self,
+        behavior: ASTMNetRIDBehaviorSpecification,
+        resource_pool: dict[ResourceID, Any],
+        user: VirtualUser,
+    ):
+        self.user = user
+
+        self.dss_instances = []
+        for res_id in behavior.dss_pool:
+            if res_id not in resource_pool:
+                raise ValueError(
+                    f"Resource '{res_id}' in astm_netrid_behavior.dss_pool not found in resource pool"
+                )
+            res = resource_pool[res_id]
+            if isinstance(res, DSSInstancesResource):
+                self.dss_instances.extend(res.dss_instances)
+            elif isinstance(res, DSSInstanceResource):
+                self.dss_instances.append(res.dss_instance)
+            else:
+                raise ValueError(
+                    f"Resource '{res_id}' is not a uss_qualifier.resources.astm.f3411.dss.DSSInstanceResource nor uss_qualifier.resources.astm.f3411.dss.DSSInstancesResource"
+                )
+
+        if not self.dss_instances:
+            raise ValueError(
+                f"No NetRID DSS instances resolved from astm_netrid_behavior.dss_pool for user '{user.user_id}'"
+            )
+
+        if len(self.dss_instances) > 1:
+            if (
+                "dss_selection_strategy" in behavior
+                and behavior.dss_selection_strategy
+            ):
+                self.dss_selection_strategy = behavior.dss_selection_strategy
+            else:
+                raise ValueError(
+                    f"User `{user.user_id}` specified {len(self.dss_instances)} DSS instances but no dss_selection strategy"
+                )
+        else:
+            self.dss_selection_strategy = ASTMDSSSelectionStrategy.First
+
+        if self.dss_selection_strategy not in (
+            ASTMDSSSelectionStrategy.First,
+            ASTMDSSSelectionStrategy.Random,
+        ):
+            raise NotImplementedError(
+                f"DSS selection strategy '{self.dss_selection_strategy}' not implemented"
+            )
+
+        if (
+            "isa_per_flight" in behavior.isa_strategy
+            and behavior.isa_strategy.isa_per_flight
+        ):
+            self.isa_per_flight = ASTMNetRIDISAPerFlightStrategySpecification(
+                **behavior.isa_strategy.isa_per_flight
+            )
+            if "after_flight_end" not in self.isa_per_flight:
+                self.isa_per_flight.after_flight_end = None
+        else:
+            raise NotImplementedError(
+                f"No supported ISA strategy was specified in user `{user.user_id}` specification for astm_netrid_behavior.isa_strategy"
+            )
+
+        self.random = Random()
+
+    def select_dss_instance(self) -> DSSInstance:
+        if self.dss_selection_strategy == ASTMDSSSelectionStrategy.First:
+            return self.dss_instances[0]
+        elif self.dss_selection_strategy == ASTMDSSSelectionStrategy.Random:
+            return self.random.choice(self.dss_instances)
+        else:
+            raise NotImplementedError(
+                f"Unsupported DSS selection strategy `{self.dss_selection_strategy}`"
+            )
+
+    async def create_isa(self, flight: Flight, isa_id: str) -> list[FlightAction]:
+        assert self.isa_per_flight  # This method is only called in this case
+
+        new_actions: list[FlightAction] = []
+        t0 = datetime.now(UTC)
+
+        dss_instance = self.select_dss_instance()
+        uss_base_url = make_fake_url()
+
+        altitude_lower = flight.volumes.altitude_lower
+        altitude_upper = flight.volumes.altitude_upper
+        if not altitude_lower or not altitude_upper:
+            raise ValueError("Altitude bounds for flight were not fully defined")
+
+        # TODO: create ISA asynchronously
+        isa_change: ISAChange = await self.user.run_sync_client_call(
+            put_isa,
+            area_vertices=get_latlngrect_vertices(flight.volumes.rect_bounds),
+            alt_lo=altitude_lower.to_w84_m(),
+            alt_hi=altitude_upper.to_w84_m(),
+            start_time=flight.start_time,
+            end_time=flight.end_time,
+            uss_base_url=uss_base_url,
+            isa_id=isa_id,
+            rid_version=dss_instance.rid_version,
+            utm_client=dss_instance.client,
+            isa_version=None,
+            participant_id=dss_instance.participant_id,
+        )
+
+        isa_success = isa_change.dss_query.success
+        self.user.record_query(isa_change.dss_query.query, successful=isa_success)
+        for notif in isa_change.notifications.values():
+            self.user.record_query(notif.query)
+        flight.completed_actions.append(
+            CompletedFlightAction(
+                type=FlightActionType.CreateISA,
+                initiated_at=t0,
+                success=isa_success,
+            )
+        )
+
+        if isa_success and self.isa_per_flight.after_flight_end:
+            new_actions.append(
+                FlightAction(
+                    timestamp=flight.end_time
+                    + self.isa_per_flight.after_flight_end.timedelta,
+                    flight_id=flight.id,
+                    start=partial(
+                        self.delete_isa,
+                        flight,
+                        isa_change.dss_query.isa,
+                    ),
+                    run_on_shutdown=True,
+                )
+            )
+
+        return new_actions
+
+    async def delete_isa(self, flight: Flight, isa: ISA) -> list[FlightAction]:
+        t0 = datetime.now(UTC)
+        dss_instance = self.select_dss_instance()
+
+        del_success = False
+
+        if isa:
+            # TODO: delete ISA asynchronously
+            del_change: ISAChange = await self.user.run_sync_client_call(
+                delete_isa,
+                isa_id=isa.id,
+                isa_version=isa.version,
+                rid_version=dss_instance.rid_version,
+                utm_client=dss_instance.client,
+                participant_id=dss_instance.participant_id,
+            )
+
+            del_success = del_change.dss_query.success
+            self.user.record_query(del_change.dss_query.query, successful=del_success)
+            for notif in del_change.notifications.values():
+                self.user.record_query(notif.query)
+            flight.completed_actions.append(
+                CompletedFlightAction(
+                    type=FlightActionType.DeleteISA,
+                    initiated_at=t0,
+                    success=del_success,
+                )
+            )
+
+        return []
+
+    def get_utm_actions(self, flight: Flight) -> Iterable[FlightAction]:
+        if self.isa_per_flight:
+            isa_id = str(uuid.uuid4())
+            yield FlightAction(
+                timestamp=flight.start_time
+                - self.isa_per_flight.before_flight_start.timedelta,
+                flight_id=flight.id,
+                start=partial(
+                    self.create_isa,
+                    flight,
+                    isa_id,
+                ),
+                run_on_shutdown=False,
+            )

--- a/monitoring/benchmarker/engine/users/flight_planner/flight_generation.py
+++ b/monitoring/benchmarker/engine/users/flight_planner/flight_generation.py
@@ -1,0 +1,127 @@
+import uuid
+from datetime import datetime
+
+from monitoring.benchmarker.configurations.users import (
+    FlightGenerationSpecification,
+    IndependentComponentsFlightGenerationSpecification,
+)
+from monitoring.benchmarker.engine.users.flight_planner.framework import (
+    Flight,
+    FlightGenerator,
+    FlightID,
+)
+from monitoring.monitorlib.geo import (
+    AltitudeDatum,
+    DistanceUnits,
+    RelativeTranslation,
+    Transformation,
+)
+from monitoring.monitorlib.geotemporal import Volume4DCollection
+
+
+class IndependentTimeLocationShape(FlightGenerator):
+    spec: IndependentComponentsFlightGenerationSpecification
+
+    def __init__(
+        self, spec: IndependentComponentsFlightGenerationSpecification, user_id: str
+    ):
+        self.spec = spec
+
+        if "fixed_spacing" in spec.time and spec.time.fixed_spacing:
+            pass
+        else:
+            raise NotImplementedError(
+                f"No supported time component is specified in independent_time_location_shape.time for user `{user_id}`"
+            )
+
+        if "fixed_location" in spec.location and spec.location.fixed_location:
+            pass
+        else:
+            raise NotImplementedError(
+                "No supported location component is specified in independent_time_location_shape.location for user `user_id`"
+            )
+
+        if "fixed_volumes" in spec.shape and spec.shape.fixed_volumes:
+            pass
+        else:
+            raise NotImplementedError(
+                "No supported shape component specified in independent_time_location_shape.shape for user `user_id`"
+            )
+
+        if spec.shape.fixed_volumes and spec.location.fixed_location:
+            # Check unit/reference match between fixed_location and fixed_volumes
+            fixed_vols = spec.shape.fixed_volumes
+            fixed_loc = spec.location.fixed_location
+            origin_vert = fixed_vols.origin_vertical
+            if (
+                fixed_loc.vertical.reference != origin_vert.reference
+                or fixed_loc.vertical.units != origin_vert.units
+            ):
+                raise NotImplementedError(
+                    "Combining vertical location and shape with different reference or units is not supported"
+                )
+
+    def generate_flight(self, previous_flight_end: datetime) -> Flight:
+        if self.spec.time.fixed_spacing:
+            t0 = previous_flight_end + self.spec.time.fixed_spacing.timedelta
+        else:
+            raise NotImplementedError("Specified time component not implemented")
+
+        if self.spec.location.fixed_location:
+            xy = self.spec.location.fixed_location.horizontal
+            z = self.spec.location.fixed_location.vertical
+            if z.units != DistanceUnits.M:
+                raise NotImplementedError(
+                    "Only meters are supported for fixed_location altitude"
+                )
+            if z.reference != AltitudeDatum.W84:
+                raise NotImplementedError(
+                    "Only W84 is supported for fixed_location altitude"
+                )
+        else:
+            raise NotImplementedError("Specified location component not implemented")
+
+        if self.spec.shape.fixed_volumes:
+            origin_h = self.spec.shape.fixed_volumes.origin_horizontal
+            origin_v = self.spec.shape.fixed_volumes.origin_vertical
+            if origin_v.units != DistanceUnits.M:
+                raise NotImplementedError(
+                    "Only meters are supported for fixed_volumes vertical origin"
+                )
+            if origin_v.reference != AltitudeDatum.W84:
+                raise NotImplementedError(
+                    "Only W84 is supported for fixed_volumes vertical origin"
+                )
+            transformation = Transformation(
+                relative_translation=RelativeTranslation(
+                    degrees_east=xy.lng - origin_h.lng,
+                    degrees_north=xy.lat - origin_h.lat,
+                    meters_up=z.value - origin_v.value,
+                    reference_center=origin_h,
+                )
+            )
+            dt = t0 - self.spec.shape.fixed_volumes.origin_time.datetime
+            volumes = Volume4DCollection()
+            for fixed_volume in self.spec.shape.fixed_volumes.volumes:
+                volumes.append(fixed_volume.offset_time(dt).transform(transformation))
+        else:
+            raise NotImplementedError("Specified shape component not implemented")
+
+        return Flight(id=FlightID(uuid.uuid4()), volumes=volumes)
+
+
+def make_flight_generator(
+    flight_generation: FlightGenerationSpecification, user_id: str
+) -> FlightGenerator:
+    if (
+        "independent_time_location_shape" in flight_generation
+        and flight_generation.independent_time_location_shape
+    ):
+        return IndependentTimeLocationShape(
+            flight_generation.independent_time_location_shape,
+            user_id,
+        )
+    else:
+        raise ValueError(
+            f"No supported flight_generation method specified for user `{user_id}`"
+        )

--- a/monitoring/benchmarker/engine/users/flight_planner/flight_planner.py
+++ b/monitoring/benchmarker/engine/users/flight_planner/flight_planner.py
@@ -1,22 +1,48 @@
 import asyncio
+import heapq
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
 from typing import Any
 
 from implicitdict import StringBasedDateTime
+from loguru import logger
 
 from monitoring.benchmarker.configurations.loads import OperationType, WorkflowType
 from monitoring.benchmarker.configurations.users import (
     BenchmarkUserSpecification,
 )
 from monitoring.benchmarker.engine.operations import ExecutedOperation
+from monitoring.benchmarker.engine.users.flight_planner.astm_net_rid import (
+    ASTMNetRIDHandler,
+)
+from monitoring.benchmarker.engine.users.flight_planner.flight_generation import (
+    FlightGenerator,
+    make_flight_generator,
+)
+from monitoring.benchmarker.engine.users.flight_planner.framework import (
+    Flight,
+    FlightAction,
+    FlightID,
+)
 from monitoring.benchmarker.engine.users.framework import VirtualUser
 from monitoring.uss_qualifier.resources.definitions import ResourceID
 
 
 class FlightPlannerUser(VirtualUser):
     """Virtual user performing flight planning."""
+
+    flight_generator: FlightGenerator
+    """Means by which this user generates flights."""
+
+    net_rid: ASTMNetRIDHandler | None = None
+    """Means by which this user performs ASTM network remote ID (if any)."""
+
+    flights: dict[FlightID, Flight]
+    """Flights originating from this user with outstanding actions."""
+
+    most_recent_flight: Flight | None = None
+    """Most recent flight created by this user."""
 
     def __init__(
         self,
@@ -27,41 +53,112 @@ class FlightPlannerUser(VirtualUser):
         record_operation: Callable[[ExecutedOperation], None],
     ):
         super().__init__(user_id, user_spec.name, executor, record_operation)
-
-        self.record_operation = record_operation
-
-        # TODO: Implement
-
-    async def _sleep_interruptible(
-        self, seconds: float, stop_event: asyncio.Event
-    ) -> None:
-        """Sleep in short intervals to wake up quickly if stop_event is set."""
-        elapsed = 0.0
-        while elapsed < seconds and not stop_event.is_set():
-            slice_dur = min(0.5, seconds - elapsed)
-            await asyncio.sleep(slice_dur)
-            elapsed += slice_dur
-
-    async def run_workflow(self, stop_event: asyncio.Event) -> None:
-        duration_ms = 200
-        duration_ms_dt = 200
-        while not stop_event.is_set():
-            t_start = datetime.now(UTC)
-
-            # TODO: Perform real flight planning work
-            await self._sleep_interruptible(duration_ms * 0.001, stop_event)
-            duration_ms += duration_ms_dt
-
-            t_end = datetime.now(UTC)
-
-            flight_op = ExecutedOperation(
-                type=OperationType(WorkflowType.FlightPlannerFlight),
-                origin=self.user_id,
-                initiated_at=StringBasedDateTime(t_start),
-                completed_at=StringBasedDateTime(t_end),
-                successful=True,
+        if "flight_planner" not in user_spec or not user_spec.flight_planner:
+            raise ValueError(
+                f"User specification '{user_spec.name}' has no flight_planner definition"
             )
-            self.record_operation(flight_op)
 
-            if stop_event.is_set():
-                break
+        self.flight_generator = make_flight_generator(
+            user_spec.flight_planner.flight_generation, user_id
+        )
+
+        if (
+            "astm_netrid_behavior" in user_spec.flight_planner
+            and user_spec.flight_planner.astm_netrid_behavior
+        ):
+            self.net_rid = ASTMNetRIDHandler(
+                user_spec.flight_planner.astm_netrid_behavior, resource_pool, self
+            )
+
+        self.flights = {}
+
+    async def _make_next_flight(self) -> list[FlightAction]:
+        if not self.most_recent_flight:
+            t_prev_flight = datetime.now(UTC)
+        else:
+            t_prev_flight = self.most_recent_flight.end_time
+
+        flight = self.flight_generator.generate_flight(t_prev_flight)
+
+        new_actions: list[FlightAction] = [
+            FlightAction(
+                timestamp=flight.end_time,
+                flight_id=flight.id,
+                start=flight.complete,
+                run_on_shutdown=False,
+            ),
+            FlightAction(
+                timestamp=flight.end_time,
+                start=self._make_next_flight,
+                run_on_shutdown=False,
+            ),
+        ]
+
+        if self.net_rid:
+            new_actions.extend(self.net_rid.get_utm_actions(flight))
+
+        self.flights[flight.id] = flight
+        self.most_recent_flight = flight
+
+        return new_actions
+
+    async def run_custom_workflow(self, stop_event: asyncio.Event) -> None:
+        action_queue: list[FlightAction] = [
+            FlightAction(
+                timestamp=datetime.now(UTC),
+                start=self._make_next_flight,
+                run_on_shutdown=False,
+            )
+        ]
+
+        while action_queue and not stop_event.is_set():
+            # Grab the next-soonest action from the queue
+            next_action = heapq.heappop(action_queue)
+
+            # If the action is scheduled for the future, wait until then
+            dt = next_action.timestamp - datetime.now(UTC)
+            if dt.total_seconds() > 0:
+                await self.sleep_interruptible(dt.total_seconds(), stop_event)
+                if stop_event.is_set():
+                    heapq.heappush(action_queue, next_action)
+                    break
+
+            # Perform the action
+            new_actions = await next_action.start()
+            t_action_complete = datetime.now(UTC)
+
+            # Queue up any follow-up actions
+            for action in new_actions:
+                heapq.heappush(action_queue, action)
+
+            if next_action.flight_id and not any(
+                action.flight_id == next_action.flight_id for action in action_queue
+            ):
+                # This was the last action for this flight
+                flight = self.flights.pop(next_action.flight_id)
+                flight_op = ExecutedOperation(
+                    type=OperationType(WorkflowType.FlightPlannerFlight),
+                    origin=self.user_id,
+                    initiated_at=StringBasedDateTime(
+                        flight.earliest_action_initiated_at or flight.start_time
+                    ),
+                    completed_at=StringBasedDateTime(t_action_complete),
+                    successful=flight.successful,
+                    query=None,
+                )
+                self.record_operation(flight_op)
+
+        if not stop_event.is_set():
+            if not action_queue:
+                reason = "no more actions were queued"
+            else:
+                reason = "of an unknown reason"
+            logger.warning(
+                f"Flight planner user {self.user_id} stopped early because {reason}"
+            )
+
+        # Run any outstanding actions that should run on shutdown
+        while action_queue:
+            next_action = heapq.heappop(action_queue)
+            if next_action.run_on_shutdown:
+                await next_action.start()

--- a/monitoring/benchmarker/engine/users/flight_planner/framework.py
+++ b/monitoring/benchmarker/engine/users/flight_planner/framework.py
@@ -1,0 +1,80 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import StrEnum
+
+from monitoring.benchmarker.engine.users.framework import Action
+from monitoring.monitorlib.geotemporal import Volume4DCollection
+
+
+class FlightID(str):
+    pass
+
+
+@dataclass(order=True, kw_only=True)
+class FlightAction(Action):
+    flight_id: FlightID | None = field(default=None, compare=False)
+
+
+class FlightActionType(StrEnum):
+    CompleteFlight = "complete_flight"
+    """The virtual user finished flying the virtual physical flight.
+    
+    Success for this action does not necessarily imply UTM actions were all successful."""
+
+    CreateISA = "astm_netrid_behavior.create_isa"
+    DeleteISA = "astm_netrid_behavior.delete_isa"
+
+
+@dataclass
+class CompletedFlightAction:
+    type: FlightActionType
+    initiated_at: datetime
+    success: bool
+
+
+@dataclass
+class Flight:
+    id: FlightID
+    volumes: Volume4DCollection
+    completed_actions: list[CompletedFlightAction] = field(default_factory=lambda: [])
+
+    @property
+    def earliest_action_initiated_at(self) -> datetime | None:
+        if not self.completed_actions:
+            return None
+        return min(action.initiated_at for action in self.completed_actions)
+
+    @property
+    def start_time(self) -> datetime:
+        t = self.volumes.time_start
+        if not t:
+            raise ValueError(f"The volumes of flight {id} do not have a start time")
+        return t.datetime
+
+    @property
+    def end_time(self) -> datetime:
+        t = self.volumes.time_end
+        if not t:
+            raise ValueError(f"The volumes of flight {id} do not have an end time")
+        return t.datetime
+
+    @property
+    def successful(self) -> bool:
+        return all(action.success for action in self.completed_actions)
+
+    async def complete(self) -> list[FlightAction]:
+        self.completed_actions.append(
+            CompletedFlightAction(
+                type=FlightActionType.CompleteFlight,
+                initiated_at=self.start_time,
+                success=True,
+            )
+        )
+        return []
+
+
+class FlightGenerator(ABC):
+    @abstractmethod
+    def generate_flight(self, previous_flight_end: datetime) -> Flight:
+        raise NotImplementedError()

--- a/monitoring/benchmarker/engine/users/framework.py
+++ b/monitoring/benchmarker/engine/users/framework.py
@@ -1,12 +1,20 @@
 import asyncio
 from abc import ABC, abstractmethod
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Self
 
+from implicitdict import StringBasedDateTime
+from loguru import logger
+
+from monitoring.benchmarker.configurations.loads import OperationType
 from monitoring.benchmarker.configurations.users import (
     BenchmarkUserName,
 )
 from monitoring.benchmarker.engine.operations import ExecutedOperation
+from monitoring.monitorlib.fetch import Query
 
 
 class VirtualUser(ABC):
@@ -35,6 +43,52 @@ class VirtualUser(ABC):
         self.executor = executor
         self.record_operation = record_operation
 
-    @abstractmethod
+    async def run_sync_client_call(
+        self, func: Callable[..., Any], *args: Any, **kwargs: Any
+    ) -> Any:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(self.executor, lambda: func(*args, **kwargs))
+
+    async def sleep_interruptible(
+        self, seconds: float, stop_event: asyncio.Event
+    ) -> None:
+        """Sleep in short intervals to wake up quickly if stop_event is set."""
+        elapsed = 0.0
+        while elapsed < seconds and not stop_event.is_set():
+            slice_dur = min(0.1, seconds - elapsed)
+            await asyncio.sleep(slice_dur)
+            elapsed += slice_dur
+
+    def record_query(self, query: Query, successful: bool | None = None) -> None:
+        if query.query_type is None:
+            raise NotImplementedError(
+                f"Query type not specified for {query.request.method} query to {query.request.url}"
+            )
+        if successful is None:
+            successful = query.status_code in (200, 201, 204)
+        op = ExecutedOperation(
+            type=OperationType(query.query_type),
+            origin=self.user_id,
+            initiated_at=StringBasedDateTime(query.request.timestamp),
+            completed_at=StringBasedDateTime(query.response.reported.datetime),
+            successful=successful,
+            query=query,
+        )
+        self.record_operation(op)
+
     async def run_workflow(self, stop_event: asyncio.Event) -> None:
+        try:
+            await self.run_custom_workflow(stop_event)
+        except Exception as e:
+            logger.error(f"Error during user {self.user_id} workflow: {e}")
+    
+    @abstractmethod
+    async def run_custom_workflow(self, stop_event: asyncio.Event) -> None:
         raise NotImplementedError()
+
+
+@dataclass(order=True, kw_only=True)
+class Action:
+    timestamp: datetime
+    start: Callable[[], Awaitable[list[Self]]] = field(compare=False)
+    run_on_shutdown: bool

--- a/monitoring/benchmarker/engine/users/framework.py
+++ b/monitoring/benchmarker/engine/users/framework.py
@@ -81,7 +81,7 @@ class VirtualUser(ABC):
             await self.run_custom_workflow(stop_event)
         except Exception as e:
             logger.error(f"Error during user {self.user_id} workflow: {e}")
-    
+
     @abstractmethod
     async def run_custom_workflow(self, stop_event: asyncio.Event) -> None:
         raise NotImplementedError()

--- a/monitoring/monitorlib/mutate/rid.py
+++ b/monitoring/monitorlib/mutate/rid.py
@@ -557,9 +557,9 @@ def put_isa(
     (op, url) = build_isa_url(rid_version, isa_id, isa_version)
     if rid_version == RIDVersion.f3411_19:
         query_type = (
-            QueryType.F3411v19DSSUpdateIdentificationServiceArea
+            QueryType.F3411v19DSSCreateIdentificationServiceArea
             if is_creation
-            else QueryType.F3411v19DSSCreateIdentificationServiceArea
+            else QueryType.F3411v19DSSUpdateIdentificationServiceArea
         )
         dss_response = ChangedISA(
             mutation=mutation,
@@ -575,9 +575,9 @@ def put_isa(
         )
     elif rid_version == RIDVersion.f3411_22a:
         query_type = (
-            QueryType.F3411v22aDSSUpdateIdentificationServiceArea
+            QueryType.F3411v22aDSSCreateIdentificationServiceArea
             if is_creation
-            else QueryType.F3411v22aDSSCreateIdentificationServiceArea
+            else QueryType.F3411v22aDSSUpdateIdentificationServiceArea
         )
         dss_response = ChangedISA(
             mutation=mutation,


### PR DESCRIPTION
This PR provides a substantive implementation of benchmarker's FlightPlannerUser including ASTM NetRID operations (not including strategic coordination yet).

The implementation approach is to have an action queue with timestamped FlightActions (some of which relate to specific flights) that FlightPlannerUser executes, each of which potentially spawns more FlightActions.  This decouples identifying stuff that needs to be done from the order in which that stuff needs to be done.  An abstract FlightGenerator generates a flight, and then an ASTMNetRIDHandler queues NetRID UTM operations necessary for that flight (when NetRID behavior is specified).

Verified with an abbreviated variation of isas_uncontended:

<img width="782" height="486" alt="Screenshot 2026-07-15 at 12 02 08 PM" src="https://github.com/user-attachments/assets/fd8e3f39-5261-438a-bfc4-e6ef91dce802" />
