### PR TITLE
[benchmarker] Add configuration and report schemas

### DIFF
--- a/schemas/manage_type_schemas.py
+++ b/schemas/manage_type_schemas.py
@@ -15,6 +15,8 @@ from loguru import logger
 import monitoring
 import monitoring.uss_qualifier.action_generators
 import monitoring.uss_qualifier.resources
+from monitoring.benchmarker.configurations.configuration import BenchmarkConfiguration
+from monitoring.benchmarker.reports.report import BenchmarkRunReport
 from monitoring.monitorlib.inspection import fullname, import_submodules
 from monitoring.uss_qualifier.action_generators.action_generator import ActionGenerator
 from monitoring.uss_qualifier.configurations.configuration import (
@@ -185,6 +187,8 @@ def main() -> int:
     schemas = {}
     _make_type_schemas(TestRunReport, schema_vars_resolver, schemas)
     _make_type_schemas(USSQualifierConfiguration, schema_vars_resolver, schemas)
+    _make_type_schemas(BenchmarkRunReport, schema_vars_resolver, schemas)
+    _make_type_schemas(BenchmarkConfiguration, schema_vars_resolver, schemas)
 
     repo = {}
     import_submodules(monitoring.uss_qualifier.resources)

--- a/schemas/monitoring/benchmarker/configurations/actions/BenchmarkActionSpecification.json
+++ b/schemas/monitoring/benchmarker/configurations/actions/BenchmarkActionSpecification.json
@@ -1,0 +1,28 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/configurations/actions/BenchmarkActionSpecification.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "monitoring.benchmarker.configurations.actions.BenchmarkActionSpecification, as defined in monitoring/benchmarker/configurations/actions.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "run_command": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "RunCommandActionSpecification.json"
+        }
+      ]
+    }
+  },
+  "required": [
+    "name"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/benchmarker/configurations/actions/RunCommandActionSpecification.json
+++ b/schemas/monitoring/benchmarker/configurations/actions/RunCommandActionSpecification.json
@@ -1,0 +1,38 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/configurations/actions/RunCommandActionSpecification.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Shell command to run as a benchmark action.\n\nmonitoring.benchmarker.configurations.actions.RunCommandActionSpecification, as defined in monitoring/benchmarker/configurations/actions.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "command": {
+      "description": "Shell command to run.",
+      "type": "string"
+    },
+    "env": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Override each environment variable key with the specified value before running the command.",
+      "properties": {
+        "$ref": {
+          "description": "Path to content that replaces the $ref",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "path": {
+      "description": "Working folder in which to run the command.  `$REPO_ROOT` will be replaced with the root folder of the repo.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "command",
+    "env",
+    "path"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/benchmarker/configurations/artifacts/artifact/ArtifactSpecification.json
+++ b/schemas/monitoring/benchmarker/configurations/artifacts/artifact/ArtifactSpecification.json
@@ -1,0 +1,32 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/configurations/artifacts/artifact/ArtifactSpecification.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "monitoring.benchmarker.configurations.artifacts.artifact.ArtifactSpecification, as defined in monitoring/benchmarker/configurations/artifacts/artifact.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "matplotlib_figure": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "../matplotlib_figure/MatplotlibFigureSpecification.json"
+        }
+      ]
+    },
+    "raw_report": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "../raw_report/RawReportSpecification.json"
+        }
+      ]
+    }
+  },
+  "type": "object"
+}

--- a/schemas/monitoring/benchmarker/configurations/artifacts/matplotlib_figure/AxisSpecification.json
+++ b/schemas/monitoring/benchmarker/configurations/artifacts/matplotlib_figure/AxisSpecification.json
@@ -1,0 +1,18 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/configurations/artifacts/matplotlib_figure/AxisSpecification.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "monitoring.benchmarker.configurations.artifacts.matplotlib_figure.AxisSpecification, as defined in monitoring/benchmarker/configurations/artifacts/matplotlib_figure.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "label": {
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "type": "object"
+}

--- a/schemas/monitoring/benchmarker/configurations/artifacts/matplotlib_figure/MatplotlibFigureSpecification.json
+++ b/schemas/monitoring/benchmarker/configurations/artifacts/matplotlib_figure/MatplotlibFigureSpecification.json
@@ -1,0 +1,42 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/configurations/artifacts/matplotlib_figure/MatplotlibFigureSpecification.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "monitoring.benchmarker.configurations.artifacts.matplotlib_figure.MatplotlibFigureSpecification, as defined in monitoring/benchmarker/configurations/artifacts/matplotlib_figure.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "evaluation_context": {
+      "description": "Symbols available to other expressions in this figure specification.",
+      "items": {
+        "$ref": "../../../../monitorlib/expressions/types/SymbolExpression.json"
+      },
+      "type": [
+        "array",
+        "null"
+      ]
+    },
+    "n_subfigure_cols": {
+      "type": "integer"
+    },
+    "n_subfigure_rows": {
+      "type": "integer"
+    },
+    "name": {
+      "description": "Machine-level name for this figure.  Used as the output file name.",
+      "type": "string"
+    },
+    "subfigures": {
+      "items": {
+        "$ref": "SubfigureSpecification.json"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "name",
+    "subfigures"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/benchmarker/configurations/artifacts/matplotlib_figure/SubfigureSpecification.json
+++ b/schemas/monitoring/benchmarker/configurations/artifacts/matplotlib_figure/SubfigureSpecification.json
@@ -1,0 +1,43 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/configurations/artifacts/matplotlib_figure/SubfigureSpecification.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "monitoring.benchmarker.configurations.artifacts.matplotlib_figure.SubfigureSpecification, as defined in monitoring/benchmarker/configurations/artifacts/matplotlib_figure.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "evaluation_context": {
+      "description": "Symbols available to other expressions in this subfigure specification.",
+      "items": {
+        "$ref": "../../../../monitorlib/expressions/types/SymbolExpression.json"
+      },
+      "type": [
+        "array",
+        "null"
+      ]
+    },
+    "n_subplot_cols": {
+      "type": "integer"
+    },
+    "n_subplot_rows": {
+      "type": "integer"
+    },
+    "subplots": {
+      "items": {
+        "$ref": "SubplotSpecification.json"
+      },
+      "type": "array"
+    },
+    "title": {
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "required": [
+    "subplots"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/benchmarker/configurations/artifacts/matplotlib_figure/SubplotSpecification.json
+++ b/schemas/monitoring/benchmarker/configurations/artifacts/matplotlib_figure/SubplotSpecification.json
@@ -1,0 +1,57 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/configurations/artifacts/matplotlib_figure/SubplotSpecification.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "monitoring.benchmarker.configurations.artifacts.matplotlib_figure.SubplotSpecification, as defined in monitoring/benchmarker/configurations/artifacts/matplotlib_figure.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "evaluation_context": {
+      "description": "Symbols available to other expressions in this subplot specification.",
+      "items": {
+        "$ref": "../../../../monitorlib/expressions/types/SymbolExpression.json"
+      },
+      "type": [
+        "array",
+        "null"
+      ]
+    },
+    "title": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "x_axis": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "AxisSpecification.json"
+        }
+      ]
+    },
+    "xy_plots": {
+      "items": {
+        "$ref": "XYPlotSpecification.json"
+      },
+      "type": "array"
+    },
+    "y_axis": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "AxisSpecification.json"
+        }
+      ]
+    }
+  },
+  "required": [
+    "xy_plots"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/benchmarker/configurations/artifacts/matplotlib_figure/XYPlotSpecification.json
+++ b/schemas/monitoring/benchmarker/configurations/artifacts/matplotlib_figure/XYPlotSpecification.json
@@ -1,0 +1,50 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/configurations/artifacts/matplotlib_figure/XYPlotSpecification.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Specification for a plot (artist) to show on a matplotlib Axes.\n\nWhen evaluating expressions, the BenchmarkRunReport will be available as the `report` symbol.\n\nmonitoring.benchmarker.configurations.artifacts.matplotlib_figure.XYPlotSpecification, as defined in monitoring/benchmarker/configurations/artifacts/matplotlib_figure.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "evaluation_context": {
+      "description": "Symbols available to other expressions in this plot specification.",
+      "items": {
+        "$ref": "../../../../monitorlib/expressions/types/SymbolExpression.json"
+      },
+      "type": [
+        "array",
+        "null"
+      ]
+    },
+    "render_expr": {
+      "description": "If specified, whether this plot should be rendered (boolean).  Default true.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "type": {
+      "enum": [
+        "Scatter"
+      ],
+      "type": "string"
+    },
+    "x_data_expr": {
+      "description": "List of X data values for XY points.\n\nMust have the same number of entries as y_data.\nDefaults to 1, 2, 3, ..., N for N y_data values.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "y_data_expr": {
+      "description": "List of Y data values for XY points.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "type",
+    "y_data_expr"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/benchmarker/configurations/artifacts/raw_report/RawReportSpecification.json
+++ b/schemas/monitoring/benchmarker/configurations/artifacts/raw_report/RawReportSpecification.json
@@ -1,0 +1,19 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/configurations/artifacts/raw_report/RawReportSpecification.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "monitoring.benchmarker.configurations.artifacts.raw_report.RawReportSpecification, as defined in monitoring/benchmarker/configurations/artifacts/raw_report.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "name": {
+      "description": "Machine-level name for this report.  Used as the output file name.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "name"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/benchmarker/configurations/configuration/BenchmarkConfiguration.json
+++ b/schemas/monitoring/benchmarker/configurations/configuration/BenchmarkConfiguration.json
@@ -1,0 +1,69 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/configurations/configuration/BenchmarkConfiguration.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "monitoring.benchmarker.configurations.configuration.BenchmarkConfiguration, as defined in monitoring/benchmarker/configurations/configuration.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "actions": {
+      "description": "Actions available to be performed during the benchmarker run.",
+      "items": {
+        "$ref": "../actions/BenchmarkActionSpecification.json"
+      },
+      "type": [
+        "array",
+        "null"
+      ]
+    },
+    "artifacts": {
+      "description": "Artifacts to produce from the data collected during the benchmarker run.",
+      "items": {
+        "$ref": "../artifacts/artifact/ArtifactSpecification.json"
+      },
+      "type": [
+        "array",
+        "null"
+      ]
+    },
+    "loads": {
+      "description": "Loads that can be applied to the system under test during the benchmarker run.",
+      "items": {
+        "$ref": "../loads/BenchmarkLoadSpecification.json"
+      },
+      "type": "array"
+    },
+    "resources": {
+      "description": "Pool of uss_qualifier resources available for use by other resources in this benchmark configuration.",
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "../../../uss_qualifier/resources/definitions/ResourceCollection.json"
+        }
+      ]
+    },
+    "scenarios": {
+      "description": "The sequential list of scenarios to perform in the benchmarker run.",
+      "items": {
+        "$ref": "../scenarios/BenchmarkScenarioSpecification.json"
+      },
+      "type": "array"
+    },
+    "user_types": {
+      "description": "Types of users available to load the system under test during the benchmarker run.",
+      "items": {
+        "$ref": "../users/BenchmarkUserSpecification.json"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "loads",
+    "scenarios",
+    "user_types"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/benchmarker/configurations/loads/BenchmarkLoadSpecification.json
+++ b/schemas/monitoring/benchmarker/configurations/loads/BenchmarkLoadSpecification.json
@@ -1,0 +1,29 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/configurations/loads/BenchmarkLoadSpecification.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Specification of how load will be applied.\n\nmonitoring.benchmarker.configurations.loads.BenchmarkLoadSpecification, as defined in monitoring/benchmarker/configurations/loads.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "user_ramp": {
+      "description": "Load will be provided by ramping up the number of virtual users of a particular type/behavior.",
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "UserRampLoad.json"
+        }
+      ]
+    }
+  },
+  "required": [
+    "name"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/benchmarker/configurations/loads/LoadCompletionCriteria.json
+++ b/schemas/monitoring/benchmarker/configurations/loads/LoadCompletionCriteria.json
@@ -1,0 +1,54 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/configurations/loads/LoadCompletionCriteria.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Completion criteria for an entire load.\n\nAny specified field that evaluates to false will cause this criterion to evaluate to false.\n\nmonitoring.benchmarker.configurations.loads.LoadCompletionCriteria, as defined in monitoring/benchmarker/configurations/loads.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "any_of": {
+      "items": {
+        "$ref": "LoadCompletionCriteria.json"
+      },
+      "type": [
+        "array",
+        "null"
+      ]
+    },
+    "failures_more_than": {
+      "description": "Evaluates true when the number of failures for the specified operations exceeds the specified number.",
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "OperationCount.json"
+        }
+      ]
+    },
+    "most_recent_step": {
+      "description": "Evaluates true when the most recently completed step meets these criteria.",
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "StepCompletionCriteria.json"
+        }
+      ]
+    },
+    "throughput_lower_than_peak": {
+      "description": "Evaluates true when the throughput of the specified operations for the most recently-completed step drops below the specified fraction of the maximum throughput of all prior steps.",
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "ThroughputPastPeak.json"
+        }
+      ]
+    }
+  },
+  "type": "object"
+}

--- a/schemas/monitoring/benchmarker/configurations/loads/OperationCount.json
+++ b/schemas/monitoring/benchmarker/configurations/loads/OperationCount.json
@@ -1,0 +1,27 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/configurations/loads/OperationCount.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "monitoring.benchmarker.configurations.loads.OperationCount, as defined in monitoring/benchmarker/configurations/loads.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "count": {
+      "description": "Number of matching operations.",
+      "type": "integer"
+    },
+    "operations": {
+      "description": "Particular operations to look for.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "count",
+    "operations"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/benchmarker/configurations/loads/OperationLatency.json
+++ b/schemas/monitoring/benchmarker/configurations/loads/OperationLatency.json
@@ -1,0 +1,28 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/configurations/loads/OperationLatency.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "monitoring.benchmarker.configurations.loads.OperationLatency, as defined in monitoring/benchmarker/configurations/loads.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "duration": {
+      "description": "Duration of relevant operations.",
+      "format": "duration",
+      "type": "string"
+    },
+    "operations": {
+      "description": "Particular operations to look for.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "duration",
+    "operations"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/benchmarker/configurations/loads/StepCompletionCriteria.json
+++ b/schemas/monitoring/benchmarker/configurations/loads/StepCompletionCriteria.json
@@ -1,0 +1,59 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/configurations/loads/StepCompletionCriteria.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Completion criteria based on a load step.\n\nAny specified field that evaluates to false will cause this criteria to evaluate to false.\n\nmonitoring.benchmarker.configurations.loads.StepCompletionCriteria, as defined in monitoring/benchmarker/configurations/loads.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "any_of": {
+      "items": {
+        "$ref": "StepCompletionCriteria.json"
+      },
+      "type": [
+        "array",
+        "null"
+      ]
+    },
+    "average_duration_more_than": {
+      "description": "Evaluates true when the average duration of operations completed during the step exceeds the specified value.",
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "OperationLatency.json"
+        }
+      ]
+    },
+    "completed_at_least": {
+      "description": "Evaluates true when at least this many operations have completed while the step was collecting valid throughput data.",
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "OperationCount.json"
+        }
+      ]
+    },
+    "sampling_duration_at_least": {
+      "description": "Evaluates true when the step has been collecting valid throughput data for at least this long.",
+      "format": "duration",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "throughput_stability_took_longer_than": {
+      "description": "Evaluates true when reaching throughput stability took longer than this amount of time since the start of the step.",
+      "format": "duration",
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "type": "object"
+}

--- a/schemas/monitoring/benchmarker/configurations/loads/ThroughputPastPeak.json
+++ b/schemas/monitoring/benchmarker/configurations/loads/ThroughputPastPeak.json
@@ -1,0 +1,27 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/configurations/loads/ThroughputPastPeak.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "monitoring.benchmarker.configurations.loads.ThroughputPastPeak, as defined in monitoring/benchmarker/configurations/loads.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "fraction_of_peak": {
+      "description": "Trigger this threshold when throughput drops below this fraction of the peak throughput measured for any past step. [0, 1]",
+      "type": "number"
+    },
+    "operations": {
+      "description": "Operations for which throughput should be calculated.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "fraction_of_peak",
+    "operations"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/benchmarker/configurations/loads/ThroughputStabilityCriteria.json
+++ b/schemas/monitoring/benchmarker/configurations/loads/ThroughputStabilityCriteria.json
@@ -1,0 +1,23 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/configurations/loads/ThroughputStabilityCriteria.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Criteria used to determine when it is valid to start collecting throughput data in a step.\n\nAny specified field that evaluates to false will cause this criteria to evaluate to false\n\nmonitoring.benchmarker.configurations.loads.ThroughputStabilityCriteria, as defined in monitoring/benchmarker/configurations/loads.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "each_user_completed_at_least": {
+      "description": "Evaluates true when each user has completed at least this many operations since the step started.",
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "OperationCount.json"
+        }
+      ]
+    }
+  },
+  "type": "object"
+}

--- a/schemas/monitoring/benchmarker/configurations/loads/UserRampLoad.json
+++ b/schemas/monitoring/benchmarker/configurations/loads/UserRampLoad.json
@@ -1,0 +1,42 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/configurations/loads/UserRampLoad.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Ramps up users of a specified type, observing resulting throughput.\n\nmonitoring.benchmarker.configurations.loads.UserRampLoad, as defined in monitoring/benchmarker/configurations/loads.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "additional_users_per_step": {
+      "description": "Additional users to add at each step along the ramp.",
+      "type": "integer"
+    },
+    "initial_users": {
+      "description": "Number of users to start with.",
+      "type": "integer"
+    },
+    "load_completion_criteria": {
+      "$ref": "LoadCompletionCriteria.json",
+      "description": "The load is considered complete if these criteria are met."
+    },
+    "step_completion_criteria": {
+      "$ref": "StepCompletionCriteria.json",
+      "description": "The current step is considered complete once these criteria are met."
+    },
+    "throughput_stability_criteria": {
+      "$ref": "ThroughputStabilityCriteria.json",
+      "description": "Throughput of the current step is considered stable once these criteria are met."
+    },
+    "user_type": {
+      "description": "Type of user to instantiate.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "load_completion_criteria",
+    "step_completion_criteria",
+    "throughput_stability_criteria",
+    "user_type"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/benchmarker/configurations/scenarios/BenchmarkScenarioSpecification.json
+++ b/schemas/monitoring/benchmarker/configurations/scenarios/BenchmarkScenarioSpecification.json
@@ -1,0 +1,52 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/configurations/scenarios/BenchmarkScenarioSpecification.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "monitoring.benchmarker.configurations.scenarios.BenchmarkScenarioSpecification, as defined in monitoring/benchmarker/configurations/scenarios.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "load": {
+      "description": "How and when to generate load in this scenario.",
+      "type": "string"
+    },
+    "metadata": {
+      "description": "Arbitrary data that may be relevant to the scenario.",
+      "type": "object"
+    },
+    "name": {
+      "type": "string"
+    },
+    "record_query_details": {
+      "description": "When true, include full details in the report for queries made during this scenario.",
+      "type": "boolean"
+    },
+    "setup": {
+      "description": "Actions to perform before beginning load testing in this scenario.",
+      "items": {
+        "type": "string"
+      },
+      "type": [
+        "array",
+        "null"
+      ]
+    },
+    "teardown": {
+      "description": "Actions to perform after completing load testing in this scenario.",
+      "items": {
+        "type": "string"
+      },
+      "type": [
+        "array",
+        "null"
+      ]
+    }
+  },
+  "required": [
+    "load",
+    "metadata",
+    "name"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/benchmarker/configurations/users/ASTMNetRIDBehaviorSpecification.json
+++ b/schemas/monitoring/benchmarker/configurations/users/ASTMNetRIDBehaviorSpecification.json
@@ -1,0 +1,50 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/configurations/users/ASTMNetRIDBehaviorSpecification.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "monitoring.benchmarker.configurations.users.ASTMNetRIDBehaviorSpecification, as defined in monitoring/benchmarker/configurations/users.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "dss_pool": {
+      "description": "Means to interact with the ASTM DSS.\n\nBenchmark configuration must contain a `resources.astm.f3411.DSSInstanceResource` resource with each of these names.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "dss_selection_strategy": {
+      "enum": [
+        "First",
+        "Random"
+      ],
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "isa_strategy": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "ASTMNetRIDISAStrategySpecification.json"
+        }
+      ]
+    },
+    "rid_version": {
+      "enum": [
+        "F3411-19",
+        "F3411-22a"
+      ],
+      "type": "string"
+    }
+  },
+  "required": [
+    "dss_pool",
+    "rid_version"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/benchmarker/configurations/users/ASTMNetRIDISAPerFlightStrategySpecification.json
+++ b/schemas/monitoring/benchmarker/configurations/users/ASTMNetRIDISAPerFlightStrategySpecification.json
@@ -1,0 +1,28 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/configurations/users/ASTMNetRIDISAPerFlightStrategySpecification.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Create an ISA per flight.\n\nmonitoring.benchmarker.configurations.users.ASTMNetRIDISAPerFlightStrategySpecification, as defined in monitoring/benchmarker/configurations/users.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "after_flight_end": {
+      "description": "Delete the ISA this amount of time after the end of this flight.",
+      "format": "duration",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "before_flight_start": {
+      "description": "Create the ISA this amount of time before the start of the flight.",
+      "format": "duration",
+      "type": "string"
+    }
+  },
+  "required": [
+    "before_flight_start"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/benchmarker/configurations/users/ASTMNetRIDISAStrategySpecification.json
+++ b/schemas/monitoring/benchmarker/configurations/users/ASTMNetRIDISAStrategySpecification.json
@@ -1,0 +1,22 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/configurations/users/ASTMNetRIDISAStrategySpecification.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Strategy used to ensure at least one ISA covers every flight.\n\nmonitoring.benchmarker.configurations.users.ASTMNetRIDISAStrategySpecification, as defined in monitoring/benchmarker/configurations/users.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "isa_per_flight": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "ASTMNetRIDISAPerFlightStrategySpecification.json"
+        }
+      ]
+    }
+  },
+  "type": "object"
+}

--- a/schemas/monitoring/benchmarker/configurations/users/BenchmarkUserSpecification.json
+++ b/schemas/monitoring/benchmarker/configurations/users/BenchmarkUserSpecification.json
@@ -1,0 +1,29 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/configurations/users/BenchmarkUserSpecification.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "monitoring.benchmarker.configurations.users.BenchmarkUserSpecification, as defined in monitoring/benchmarker/configurations/users.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "flight_planner": {
+      "description": "User is a USS client that plans flights coordinated with UTM technologies.",
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "FlightPlannerSpecification.json"
+        }
+      ]
+    },
+    "name": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "name"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/benchmarker/configurations/users/FixedLocationSpecification.json
+++ b/schemas/monitoring/benchmarker/configurations/users/FixedLocationSpecification.json
@@ -1,0 +1,22 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/configurations/users/FixedLocationSpecification.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "monitoring.benchmarker.configurations.users.FixedLocationSpecification, as defined in monitoring/benchmarker/configurations/users.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "horizontal": {
+      "$ref": "../../../monitorlib/geo/LatLngPoint.json"
+    },
+    "vertical": {
+      "$ref": "../../../monitorlib/geo/Altitude.json"
+    }
+  },
+  "required": [
+    "horizontal",
+    "vertical"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/benchmarker/configurations/users/FixedVolumesSpecification.json
+++ b/schemas/monitoring/benchmarker/configurations/users/FixedVolumesSpecification.json
@@ -1,0 +1,34 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/configurations/users/FixedVolumesSpecification.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "monitoring.benchmarker.configurations.users.FixedVolumesSpecification, as defined in monitoring/benchmarker/configurations/users.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "origin_horizontal": {
+      "$ref": "../../../monitorlib/geo/LatLngPoint.json"
+    },
+    "origin_time": {
+      "format": "date-time",
+      "type": "string"
+    },
+    "origin_vertical": {
+      "$ref": "../../../monitorlib/geo/Altitude.json"
+    },
+    "volumes": {
+      "items": {
+        "$ref": "../../../monitorlib/geotemporal/Volume4D.json"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "origin_horizontal",
+    "origin_time",
+    "origin_vertical",
+    "volumes"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/benchmarker/configurations/users/FlightGenerationSpecification.json
+++ b/schemas/monitoring/benchmarker/configurations/users/FlightGenerationSpecification.json
@@ -1,0 +1,22 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/configurations/users/FlightGenerationSpecification.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "monitoring.benchmarker.configurations.users.FlightGenerationSpecification, as defined in monitoring/benchmarker/configurations/users.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "independent_time_location_shape": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "IndependentComponentsFlightGenerationSpecification.json"
+        }
+      ]
+    }
+  },
+  "type": "object"
+}

--- a/schemas/monitoring/benchmarker/configurations/users/FlightLocationGenerationSpecification.json
+++ b/schemas/monitoring/benchmarker/configurations/users/FlightLocationGenerationSpecification.json
@@ -1,0 +1,23 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/configurations/users/FlightLocationGenerationSpecification.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "monitoring.benchmarker.configurations.users.FlightLocationGenerationSpecification, as defined in monitoring/benchmarker/configurations/users.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "fixed_location": {
+      "description": "Always choose the same flight location.",
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "FixedLocationSpecification.json"
+        }
+      ]
+    }
+  },
+  "type": "object"
+}

--- a/schemas/monitoring/benchmarker/configurations/users/FlightPlannerSpecification.json
+++ b/schemas/monitoring/benchmarker/configurations/users/FlightPlannerSpecification.json
@@ -1,0 +1,30 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/configurations/users/FlightPlannerSpecification.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "User planning flights coordinated via UTM standards.\n\nmonitoring.benchmarker.configurations.users.FlightPlannerSpecification, as defined in monitoring/benchmarker/configurations/users.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "astm_netrid_behavior": {
+      "description": "How flight planner provides ASTM NetRID service for their flights.",
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "ASTMNetRIDBehaviorSpecification.json"
+        }
+      ]
+    },
+    "flight_generation": {
+      "$ref": "FlightGenerationSpecification.json",
+      "description": "How flight planner generates their flights."
+    }
+  },
+  "required": [
+    "flight_generation"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/benchmarker/configurations/users/FlightShapeGenerationSpecification.json
+++ b/schemas/monitoring/benchmarker/configurations/users/FlightShapeGenerationSpecification.json
@@ -1,0 +1,22 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/configurations/users/FlightShapeGenerationSpecification.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "monitoring.benchmarker.configurations.users.FlightShapeGenerationSpecification, as defined in monitoring/benchmarker/configurations/users.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "fixed_volumes": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "FixedVolumesSpecification.json"
+        }
+      ]
+    }
+  },
+  "type": "object"
+}

--- a/schemas/monitoring/benchmarker/configurations/users/FlightTimeGenerationSpecification.json
+++ b/schemas/monitoring/benchmarker/configurations/users/FlightTimeGenerationSpecification.json
@@ -1,0 +1,20 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/configurations/users/FlightTimeGenerationSpecification.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "monitoring.benchmarker.configurations.users.FlightTimeGenerationSpecification, as defined in monitoring/benchmarker/configurations/users.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "fixed_spacing": {
+      "description": "Set delay between the end of the previous flight and the start of the next flight to this value.",
+      "format": "duration",
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "type": "object"
+}

--- a/schemas/monitoring/benchmarker/configurations/users/IndependentComponentsFlightGenerationSpecification.json
+++ b/schemas/monitoring/benchmarker/configurations/users/IndependentComponentsFlightGenerationSpecification.json
@@ -1,0 +1,29 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/configurations/users/IndependentComponentsFlightGenerationSpecification.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "monitoring.benchmarker.configurations.users.IndependentComponentsFlightGenerationSpecification, as defined in monitoring/benchmarker/configurations/users.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "location": {
+      "$ref": "FlightLocationGenerationSpecification.json",
+      "description": "Means to generate flight locations."
+    },
+    "shape": {
+      "$ref": "FlightShapeGenerationSpecification.json",
+      "description": "Means to generate flight shapes."
+    },
+    "time": {
+      "$ref": "FlightTimeGenerationSpecification.json",
+      "description": "Means to generate the start times of flights."
+    }
+  },
+  "required": [
+    "location",
+    "shape",
+    "time"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/benchmarker/reports/report/BenchmarkOperation.json
+++ b/schemas/monitoring/benchmarker/reports/report/BenchmarkOperation.json
@@ -1,0 +1,37 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/reports/report/BenchmarkOperation.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Record of an operation of a known type, origin, and outcome executed during a benchmark.\n\nmonitoring.benchmarker.reports.report.BenchmarkOperation, as defined in monitoring/benchmarker/reports/report.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "query": {
+      "description": "The query details for this operation, if this was a query operation and query details are being recorded.",
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "../../../monitorlib/fetch/Query.json"
+        }
+      ]
+    },
+    "t0": {
+      "description": "Time this operation was started/initiated.",
+      "format": "date-time",
+      "type": "string"
+    },
+    "t1": {
+      "description": "Time this operation completed, either successsfully or in failure.",
+      "format": "date-time",
+      "type": "string"
+    }
+  },
+  "required": [
+    "t0",
+    "t1"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/benchmarker/reports/report/BenchmarkReport.json
+++ b/schemas/monitoring/benchmarker/reports/report/BenchmarkReport.json
@@ -1,0 +1,22 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/reports/report/BenchmarkReport.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "monitoring.benchmarker.reports.report.BenchmarkReport, as defined in monitoring/benchmarker/reports/report.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "scenarios": {
+      "description": "Results of scenarios, corresponding to the scenarios defined in the configuration.",
+      "items": {
+        "$ref": "BenchmarkScenarioReport.json"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "scenarios"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/benchmarker/reports/report/BenchmarkRunReport.json
+++ b/schemas/monitoring/benchmarker/reports/report/BenchmarkRunReport.json
@@ -1,0 +1,34 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/reports/report/BenchmarkRunReport.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "monitoring.benchmarker.reports.report.BenchmarkRunReport, as defined in monitoring/benchmarker/reports/report.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "codebase_version": {
+      "description": "Version of codebase used to run benchmarker.",
+      "type": "string"
+    },
+    "commit_hash": {
+      "description": "Full commit hash of codebase used to run benchmarker.",
+      "type": "string"
+    },
+    "configuration": {
+      "$ref": "../../configurations/configuration/BenchmarkConfiguration.json",
+      "description": "Configuration used to run benchmarker."
+    },
+    "report": {
+      "$ref": "BenchmarkReport.json",
+      "description": "Report produced by benchmarker during this run."
+    }
+  },
+  "required": [
+    "codebase_version",
+    "commit_hash",
+    "configuration",
+    "report"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/benchmarker/reports/report/BenchmarkScenarioReport.json
+++ b/schemas/monitoring/benchmarker/reports/report/BenchmarkScenarioReport.json
@@ -1,0 +1,37 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/reports/report/BenchmarkScenarioReport.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "monitoring.benchmarker.reports.report.BenchmarkScenarioReport, as defined in monitoring/benchmarker/reports/report.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "metadata": {
+      "description": "Arbitrary metadata copied from the scenario specification.",
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "operations": {
+      "description": "All operations that occurred during the benchmark run.",
+      "items": {
+        "$ref": "OperationsByType.json"
+      },
+      "type": "array"
+    },
+    "steps": {
+      "description": "Boundaries of steps within this scenario.",
+      "items": {
+        "$ref": "BenchmarkScenarioStepReport.json"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "operations",
+    "steps"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/benchmarker/reports/report/BenchmarkScenarioStepReport.json
+++ b/schemas/monitoring/benchmarker/reports/report/BenchmarkScenarioStepReport.json
@@ -1,0 +1,37 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/reports/report/BenchmarkScenarioStepReport.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "monitoring.benchmarker.reports.report.BenchmarkScenarioStepReport, as defined in monitoring/benchmarker/reports/report.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "end_time": {
+      "description": "Time this step ended.",
+      "format": "date-time",
+      "type": "string"
+    },
+    "load_factor": {
+      "description": "Load factor (e.g., number of users) present during this step.",
+      "type": "number"
+    },
+    "start_time": {
+      "description": "Time this step started.",
+      "format": "date-time",
+      "type": "string"
+    },
+    "throughput_stability_time": {
+      "description": "Time during this step at which activity became sufficiently stable for throughput measurement.",
+      "format": "date-time",
+      "type": "string"
+    }
+  },
+  "required": [
+    "end_time",
+    "load_factor",
+    "start_time",
+    "throughput_stability_time"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/benchmarker/reports/report/OperationsByOrigin.json
+++ b/schemas/monitoring/benchmarker/reports/report/OperationsByOrigin.json
@@ -1,0 +1,27 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/reports/report/OperationsByOrigin.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Record of operations from a particular origin.\n\nmonitoring.benchmarker.reports.report.OperationsByOrigin, as defined in monitoring/benchmarker/reports/report.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "origin": {
+      "description": "Source/originator of the operations in this record; e.g., the user that initiated these operations.",
+      "type": "string"
+    },
+    "outcomes": {
+      "description": "Operations originating from this origin.",
+      "items": {
+        "$ref": "OperationsByOutcome.json"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "origin",
+    "outcomes"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/benchmarker/reports/report/OperationsByOutcome.json
+++ b/schemas/monitoring/benchmarker/reports/report/OperationsByOutcome.json
@@ -1,0 +1,32 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/reports/report/OperationsByOutcome.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Record of operations grouped by whether they were successful.\n\nmonitoring.benchmarker.reports.report.OperationsByOutcome, as defined in monitoring/benchmarker/reports/report.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "successful": {
+      "description": "Operations that were successful (yielded successful user journeys).",
+      "items": {
+        "$ref": "BenchmarkOperation.json"
+      },
+      "type": [
+        "array",
+        "null"
+      ]
+    },
+    "unsuccessful": {
+      "description": "Operations that were unsuccessful (did not yield successful user journeys due to errors, timeouts, aborts, etc)",
+      "items": {
+        "$ref": "BenchmarkOperation.json"
+      },
+      "type": [
+        "array",
+        "null"
+      ]
+    }
+  },
+  "type": "object"
+}

--- a/schemas/monitoring/benchmarker/reports/report/OperationsByType.json
+++ b/schemas/monitoring/benchmarker/reports/report/OperationsByType.json
@@ -1,0 +1,27 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/reports/report/OperationsByType.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Record of operations of a particular type.\n\nmonitoring.benchmarker.reports.report.OperationsByType, as defined in monitoring/benchmarker/reports/report.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "origins": {
+      "description": "Operations of this particular type.",
+      "items": {
+        "$ref": "OperationsByOrigin.json"
+      },
+      "type": "array"
+    },
+    "type": {
+      "description": "The type of the operations in this record.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "origins",
+    "type"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/monitorlib/expressions/types/SymbolExpression.json
+++ b/schemas/monitoring/monitorlib/expressions/types/SymbolExpression.json
@@ -1,0 +1,24 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/monitorlib/expressions/types/SymbolExpression.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "monitoring.monitorlib.expressions.types.SymbolExpression, as defined in monitoring/monitorlib/expressions/types.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "name": {
+      "description": "Name of symbol that will take on the value.",
+      "type": "string"
+    },
+    "value": {
+      "description": "Expression for the untyped value to assign to this symbol.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "name",
+    "value"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/monitorlib/geo/Volume3D.json
+++ b/schemas/monitoring/monitorlib/geo/Volume3D.json
@@ -1,0 +1,52 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/monitorlib/geo/Volume3D.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "monitoring.monitorlib.geo.Volume3D, as defined in monitoring/monitorlib/geo.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "altitude_lower": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "Altitude.json"
+        }
+      ]
+    },
+    "altitude_upper": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "Altitude.json"
+        }
+      ]
+    },
+    "outline_circle": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "Circle.json"
+        }
+      ]
+    },
+    "outline_polygon": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "Polygon.json"
+        }
+      ]
+    }
+  },
+  "type": "object"
+}

--- a/schemas/monitoring/monitorlib/geotemporal/Volume4D.json
+++ b/schemas/monitoring/monitorlib/geotemporal/Volume4D.json
@@ -1,0 +1,32 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/monitorlib/geotemporal/Volume4D.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Generic representation of a 4D volume, usable across multiple standards and formats.\n\nmonitoring.monitorlib.geotemporal.Volume4D, as defined in monitoring/monitorlib/geotemporal.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "time_end": {
+      "format": "date-time",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "time_start": {
+      "format": "date-time",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "volume": {
+      "$ref": "../geo/Volume3D.json"
+    }
+  },
+  "required": [
+    "volume"
+  ],
+  "type": "object"
+}


### PR DESCRIPTION
This PR adds the root configuration (BenchmarkConfiguration) and report (BenchmarkRunReport) schemas to the autogenerated schemas in the main schemas folder of this repository.  The code update to do this is 4 lines in the first commit, and then the rest of this PR is from `make format` following that change.