### PR TITLE
[benchmarker] Add universal scalability law fit

### DIFF
--- a/monitoring/benchmarker/artifacts/matplotlib/matplotlib_figure.py
+++ b/monitoring/benchmarker/artifacts/matplotlib/matplotlib_figure.py
@@ -47,12 +47,16 @@ def generate_matplotlib_figure(
     analysis_functions = {
         name: obj for name, obj in inspect.getmembers(analysis, inspect.isfunction)
     }
+    analysis_classes = {
+        name: obj for name, obj in inspect.getmembers(analysis, inspect.isclass)
+    }
 
     figure_symbols, _ = get_updated_context(
         {
             "report": report,
         }
-        | analysis_functions,
+        | analysis_functions
+        | analysis_classes,
         fig_spec.evaluation_context
         if "evaluation_context" in fig_spec and fig_spec.evaluation_context
         else [],
@@ -153,8 +157,16 @@ def generate_matplotlib_figure(
                     if label_val is not None:
                         label = str(label_val)
 
+                kwargs = {"label": label}
+                if "color" in xy_plot and xy_plot.color:
+                    kwargs["color"] = xy_plot.color
+                if "kwargs" in xy_plot and xy_plot.kwargs:
+                    kwargs = kwargs | xy_plot.kwargs
+
                 if xy_plot.type == XYPlotType.Scatter:
-                    ax.scatter(x_vals, y_vals, label=label)
+                    ax.scatter(x_vals, y_vals, **kwargs)
+                elif xy_plot.type == XYPlotType.Line:
+                    ax.plot(x_vals, y_vals, **kwargs)
                 else:
                     raise NotImplementedError(
                         f"XYPlotType '{xy_plot.type}' not implemented"

--- a/monitoring/benchmarker/configurations/artifacts/matplotlib_figure.py
+++ b/monitoring/benchmarker/configurations/artifacts/matplotlib_figure.py
@@ -12,6 +12,7 @@ class AxisSpecification(ImplicitDict):
 
 class XYPlotType(StrEnum):
     Scatter = "Scatter"
+    Line = "Line"
 
 
 class XYPlotSpecification(ImplicitDict):
@@ -23,6 +24,11 @@ class XYPlotSpecification(ImplicitDict):
 
     label_expr: Optional[ASTExpression]
     """Expression for the label of this plot/artist (string), primarily used in the plot legend."""
+
+    color: Optional[str]
+    """Matplotlib color string for this plot.
+    
+    See https://matplotlib.org/stable/users/explain/colors/colors.html#colors-def"""
 
     evaluation_context: Optional[list[SymbolExpression]]
     """Symbols available to other expressions in this plot specification."""
@@ -38,6 +44,9 @@ class XYPlotSpecification(ImplicitDict):
 
     render_expr: Optional[ASTExpression]
     """If specified, whether this plot should be rendered (boolean).  Default true."""
+
+    kwargs: Optional[dict]
+    """If specified, pass these additional keyword arguments to the plot function."""
 
 
 class LegendLocation(StrEnum):

--- a/monitoring/benchmarker/configurations/interuss/scd/single_s2_cell.jsonnet
+++ b/monitoring/benchmarker/configurations/interuss/scd/single_s2_cell.jsonnet
@@ -148,7 +148,7 @@ local shape = {
             },
             {
               failures_more_than: {
-                count: 100,
+                count: 30,
                 operations: ['workflow.flight_planner.flight'],
               },
             },
@@ -169,7 +169,7 @@ local shape = {
             },
             {
               failures_more_than: {
-                count: 400,
+                count: 75,
                 operations: ['workflow.flight_planner.flight'],
               }
             },
@@ -228,6 +228,10 @@ local shape = {
                     value: '[throughput_of_step(scenario, s, types=["workflow.flight_planner.flight"], outcomes=[False])' +
                            ' for s in range(len(scenario.steps))]',
                   },
+                  {
+                    name: 'usl',
+                    value: 'USLFit.from_data(scale, throughput)',
+                  },
                 ],
                 x_axis: {
                   label: 'Flight planners',
@@ -236,6 +240,16 @@ local shape = {
                   label: 'Throughput\n(Flights/s)',
                 },
                 xy_plots: [
+                  {
+                    type: 'Line',
+                    color: 'lightgray',
+                    label_expr: 'f"USL: $\\\\gamma$={usl.parameters.scaling_factor:.2g} $\\\\alpha$={usl.parameters.contention_factor:.2g} $\\\\beta$={usl.parameters.coherency_factor:.2g}"',
+                    x_data_expr: 'scale',
+                    y_data_expr: 'list(usl.compute_throughput(scale))',
+                    kwargs: {
+                      zorder: -1,
+                    },
+                  },
                   {
                     type: 'Scatter',
                     label_expr: '"Successes"',

--- a/monitoring/benchmarker/reports/analysis.py
+++ b/monitoring/benchmarker/reports/analysis.py
@@ -1,6 +1,11 @@
 from collections.abc import Iterable, Sequence
 from datetime import datetime
 
+import numpy as np
+import scipy.optimize
+import scipy.stats
+from implicitdict import ImplicitDict
+
 from monitoring.benchmarker.configurations.loads import OperationType
 from monitoring.benchmarker.reports.report import (
     BenchmarkOperation,
@@ -112,3 +117,160 @@ def throughput_of_step(
         step.end_time.datetime,
         **kwargs,
     )
+
+
+class USLParameters(ImplicitDict):
+    """Parameters describing a fit of measured data to the Universal Scalability Law model.
+
+    X(N) = 𝛾N/[1 + 𝛼(N-1) + 𝛽N(N-1)]
+
+    𝛾 is the scaling factor (how quickly throughput scales as load increases)
+    𝛼 is the contention factor (how much throughput increases slow down as load increases)
+    𝛽 is the coherency/crosstalk factor (how quickly throughput decreases as load increases)
+
+    See:
+    https://www.graphiumlabs.com/blog/part2-gunthers-universal-scalability-law
+    https://raw.githubusercontent.com/VividCortex/ebooks/master/scalability.pdf"""
+
+    scaling_factor: float
+    contention_factor: float
+    coherency_factor: float
+
+
+class USLFit:
+    parameters: USLParameters
+    inlier_mask: list[bool] | None
+
+    def __init__(
+        self,
+        parameters: USLParameters,
+        inlier_mask: Sequence[bool] | None = None,
+    ):
+        self.parameters = parameters
+        self.inlier_mask = list(inlier_mask) if inlier_mask is not None else None
+
+    def compute_throughput(self, scale: Sequence[float]) -> Iterable[float]:
+        gamma = self.parameters.scaling_factor
+        alpha = self.parameters.contention_factor
+        beta = self.parameters.coherency_factor
+        for n in scale:
+            yield gamma * n / (1 + alpha * (n - 1) + beta * n * (n - 1))
+
+    @staticmethod
+    def _fit_single(x: np.ndarray, y: np.ndarray) -> USLParameters:
+        if (x == 0).any():
+            raise ValueError("USL load factor may never be zero")
+        if (y < 0).any():
+            raise ValueError("USL throughput may never be negative")
+
+        def rmse(params: Sequence[float]) -> float:
+            gamma, alpha, beta = params
+            alpha = pow(10, alpha)
+            beta = pow(10, beta)
+            denom = np.maximum(1.0 + alpha * (x - 1.0) + beta * x * (x - 1.0), 1e-12)
+            y_pred = gamma * x / denom
+            return float(np.sqrt(np.mean((y - y_pred) ** 2)))
+
+        gamma_guess = np.max(y / x)
+
+        bounds = [(0.0, None), (None, None), (None, None)]
+        best_result: Sequence[float] | None = None
+        best_score = float("inf")
+
+        for a, b in ((-3, -5), (-5, -3), (-1, -1), (-7, -7)):
+            res = scipy.optimize.minimize(
+                rmse,
+                x0=[gamma_guess, a, b],
+                method="Nelder-Mead",
+                bounds=bounds,
+                options={"xatol": 1e-9, "fatol": 1e-9, "maxiter": 5000},
+            )
+            score = rmse(res.x)
+            if score < best_score:
+                best_score = score
+                best_result = res.x
+
+        if best_result is None:
+            raise RuntimeError("No solution found to fit USL")
+
+        gamma, alpha, beta = best_result
+        return USLParameters(
+            scaling_factor=float(gamma),
+            contention_factor=pow(10, alpha),
+            coherency_factor=pow(10, beta),
+        )
+
+    @staticmethod
+    def from_data(
+        x_data: Sequence[float],
+        y_data: Sequence[float],
+        discard_probability: float | None = 0.05,
+    ) -> "USLFit":
+        x_arr = np.array(x_data, dtype=float)
+        y_arr = np.array(y_data, dtype=float)
+        if len(x_arr) != len(y_arr):
+            raise ValueError("x_data and y_data must have the same length")
+        if len(x_arr) == 0:
+            raise ValueError("Cannot fit USL model with no data points")
+
+        inlier_mask = np.ones(len(x_arr), dtype=bool)
+
+        while True:
+            # Fit USL to all inlier data
+            x_in = x_arr[inlier_mask]
+            y_in = y_arr[inlier_mask]
+
+            params = USLFit._fit_single(x_in, y_in)
+
+            # Decide if any data should be discarded as outliers
+            if (
+                discard_probability is None
+                or discard_probability <= 0.0
+                or discard_probability >= 1.0
+                or len(x_in) <= 3
+            ):
+                break
+
+            denom = np.maximum(
+                1.0
+                + params.contention_factor * (x_in - 1.0)
+                + params.coherency_factor * x_in * (x_in - 1.0),
+                1e-12,
+            )
+            y_pred = params.scaling_factor * x_in / denom
+            residuals = y_in - y_pred
+
+            # Estimate standard deviation via median absolute deviation (MAD) to avoid outlier masking from RMS estimate
+            med_res = np.median(residuals)
+            mad = np.median(np.abs(residuals - med_res))
+            sigma_mad = 1.4826 * mad
+
+            if sigma_mad > 1e-12:
+                sigma = float(sigma_mad)
+            else:
+                ddof = min(3, len(residuals) - 1)
+                sigma = float(np.std(residuals, ddof=ddof))
+
+            if sigma < 1e-12:
+                break
+
+            # Apply Dunn–Šidák correction
+            m = len(x_in)
+            prob_threshold = (1.0 + (1.0 - discard_probability) ** (1.0 / m)) / 2.0
+
+            # Check for outliers exceeding the threshold
+            k = float(scipy.stats.norm.ppf(prob_threshold))
+            min_practical_error = max(1e-6, 1e-3 * float(np.max(np.abs(y_in))))
+            max_error = max(k * sigma, min_practical_error)
+            outliers_in_subset = np.abs(residuals) > max_error
+
+            if not np.any(outliers_in_subset):
+                # No outliers; we're done
+                break
+
+            # Remove the single worst outlier and iterate
+            inlier_indices = np.where(inlier_mask)[0]
+            worst_idx = int(np.argmax(np.abs(residuals)))
+            inlier_mask[inlier_indices[worst_idx]] = False
+
+        return USLFit(parameters=params, inlier_mask=inlier_mask.tolist())

--- a/monitoring/benchmarker/reports/test_analysis.py
+++ b/monitoring/benchmarker/reports/test_analysis.py
@@ -1,0 +1,106 @@
+import pytest
+
+from monitoring.benchmarker.reports.analysis import USLFit
+
+
+def test_usl_fit_exact():
+    gamma = 100.0
+    alpha = 0.05
+    beta = 0.001
+
+    scale = [1.0, 2.0, 5.0, 10.0, 20.0, 40.0, 60.0]
+    throughput = [
+        gamma * n / (1.0 + alpha * (n - 1.0) + beta * n * (n - 1.0)) for n in scale
+    ]
+
+    fit = USLFit.from_data(scale, throughput)
+    assert fit.parameters.scaling_factor == pytest.approx(gamma, rel=1e-3)
+    assert fit.parameters.contention_factor == pytest.approx(alpha, rel=1e-3)
+    assert fit.parameters.coherency_factor == pytest.approx(beta, rel=1e-3)
+
+    assert fit.inlier_mask is not None
+    assert all(fit.inlier_mask)
+
+    computed_throughput = list(fit.compute_throughput(scale))
+    assert len(computed_throughput) == len(throughput)
+    for expected, actual in zip(throughput, computed_throughput, strict=True):
+        assert actual == pytest.approx(expected, rel=1e-3)
+
+
+def test_usl_fit_with_outlier():
+    gamma = 100.0
+    alpha = 0.05
+    beta = 0.001
+
+    scale = [1.0, 2.0, 4.0, 6.0, 8.0, 10.0, 12.0, 15.0, 20.0, 30.0]
+    throughput = [
+        gamma * n / (1.0 + alpha * (n - 1.0) + beta * n * (n - 1.0)) for n in scale
+    ]
+
+    # Inject a severe outlier at index 4 (N=8.0)
+    outlier_idx = 4
+    throughput[outlier_idx] = 2500.0  # Far above the true model value
+
+    fit = USLFit.from_data(scale, throughput, discard_probability=0.05)
+    assert fit.inlier_mask is not None
+    assert not fit.inlier_mask[outlier_idx]
+    assert sum(fit.inlier_mask) == len(scale) - 1
+
+    # Parameters should still recover closely to true values despite the outlier
+    assert fit.parameters.scaling_factor == pytest.approx(gamma, rel=1e-2)
+    assert fit.parameters.contention_factor == pytest.approx(alpha, rel=1e-2)
+    assert fit.parameters.coherency_factor == pytest.approx(beta, rel=1e-2)
+
+
+def test_usl_fit_no_outlier_discarding():
+    scale = [1.0, 2.0, 3.0, 4.0, 5.0]
+    throughput = [10.0, 18.0, 1000.0, 22.0, 24.0]
+
+    # Disable outlier discarding
+    fit = USLFit.from_data(scale, throughput, discard_probability=None)
+    assert fit.inlier_mask is not None
+    assert all(fit.inlier_mask)
+
+
+def test_usl_fit_invalid_input():
+    with pytest.raises(ValueError, match="x_data and y_data must have the same length"):
+        USLFit.from_data([1.0, 2.0], [10.0])
+
+    with pytest.raises(ValueError, match="Cannot fit USL model with no data points"):
+        USLFit.from_data([], [])
+
+
+def test_usl_outlier_rejection_invariant_with_scale():
+    """Verify that adding more non-outlier points does not appreciably increase
+    or decrease the likelihood of discarding a specific outlier of identical magnitude,
+    and that false positives remain controlled."""
+    gamma = 50.0
+    alpha = 0.02
+    beta = 0.0005
+
+    # Small dataset (10 points) vs larger dataset (50 points)
+    scale_small = [1.0, 2.0, 3.0, 4.0, 5.0, 7.0, 10.0, 15.0, 20.0, 25.0]
+    scale_large = [float(i) for i in range(1, 51)]
+
+    def generate_throughput(scale_vals, outlier_idx):
+        tp = []
+        for i, n in enumerate(scale_vals):
+            base = gamma * n / (1.0 + alpha * (n - 1.0) + beta * n * (n - 1.0))
+            if i == outlier_idx:
+                # Add fixed massive anomaly
+                base += 500.0
+            tp.append(base)
+        return tp
+
+    tp_small = generate_throughput(scale_small, outlier_idx=3)
+    tp_large = generate_throughput(scale_large, outlier_idx=3)
+
+    fit_small = USLFit.from_data(scale_small, tp_small, discard_probability=0.05)
+    fit_large = USLFit.from_data(scale_large, tp_large, discard_probability=0.05)
+
+    assert fit_small.inlier_mask is not None and not fit_small.inlier_mask[3]
+    assert fit_large.inlier_mask is not None and not fit_large.inlier_mask[3]
+
+    # In both small and large sets, only the true outlier is rejected
+    assert sum(fit_small.inlier_mask) == len(scale_small) - 1
+    assert sum(fit_large.inlier_mask) == len(scale_large) - 1

--- a/schemas/monitoring/benchmarker/configurations/artifacts/matplotlib_figure/XYPlotSpecification.json
+++ b/schemas/monitoring/benchmarker/configurations/artifacts/matplotlib_figure/XYPlotSpecification.json
@@ -7,6 +7,13 @@
       "description": "Path to content that replaces the $ref",
       "type": "string"
     },
+    "color": {
+      "description": "Matplotlib color string for this plot.\n\nSee https://matplotlib.org/stable/users/explain/colors/colors.html#colors-def",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "evaluation_context": {
       "description": "Symbols available to other expressions in this plot specification.",
       "items": {
@@ -14,6 +21,13 @@
       },
       "type": [
         "array",
+        "null"
+      ]
+    },
+    "kwargs": {
+      "description": "If specified, pass these additional keyword arguments to the plot function.",
+      "type": [
+        "object",
         "null"
       ]
     },
@@ -33,7 +47,8 @@
     },
     "type": {
       "enum": [
-        "Scatter"
+        "Scatter",
+        "Line"
       ],
       "type": "string"
     },


### PR DESCRIPTION
This PR works toward #1566 by adding an analysis utility to fit data to the universal scalability law model and allow easy display of that fit on graphs.  The updated single_s2_cell.jsonnet benchmarker configuration yielded this result when run:

<img width="2496" height="407" alt="single_s2_cell_5x3" src="https://github.com/user-attachments/assets/3bdc9acc-c4bc-4288-a0c8-339f88904d71" />

The shape of the data in that run is a bit confusing, but the USL fits seem good.  I also ran the fit against other data and that seemed reasonable as well.  For instance:

<img width="790" height="495" alt="single_s2_cell" src="https://github.com/user-attachments/assets/3193ed72-0657-4788-b2d0-862aef79377f" />