### PR TITLE
[benchmarker/scd] Improve SCD flight logic

### DIFF
--- a/monitoring/benchmarker/configurations/interuss/scd/single_s2_cell.jsonnet
+++ b/monitoring/benchmarker/configurations/interuss/scd/single_s2_cell.jsonnet
@@ -121,8 +121,8 @@ local shape = {
       name: 'Flight planner ramp for USS %d' % uss,
       user_ramp: {
         user_type: 'FPU%d' % uss,
-        initial_users: 10,
-        additional_users_per_step: 10,
+        initial_users: 5,
+        additional_users_per_step: 5,
         random_seed: 1234,
         throughput_stability_criteria: {
           each_user_completed_at_least: {

--- a/monitoring/benchmarker/configurations/interuss/scd/single_s2_cell.jsonnet
+++ b/monitoring/benchmarker/configurations/interuss/scd/single_s2_cell.jsonnet
@@ -69,7 +69,7 @@ local shape = {
         flight_generation: {
           independent_time_location_shape: {
             time: {
-              fixed_spacing: '19s',
+              fixed_spacing: '29s',
               uniform_random_spacing: '2s',
             },
             location: {
@@ -104,8 +104,9 @@ local shape = {
             ovn_coordination_group: 'cluster1',
             coordinate_requested_ovns: true,
             retries: 2,
-            accept_before_flight_start: '5s',
-            activate_before_flight_start: null,
+            accept_before_flight_start: '20s',
+            activate_before_flight_start: '10s',
+            expect_timely_clearance: true,
           },
           op_intent_ref_cleanup_strategy: {
             after_actual_flight_end: '1s',
@@ -120,8 +121,8 @@ local shape = {
       name: 'Flight planner ramp for USS %d' % uss,
       user_ramp: {
         user_type: 'FPU%d' % uss,
-        initial_users: 2,
-        additional_users_per_step: 2,
+        initial_users: 10,
+        additional_users_per_step: 10,
         random_seed: 1234,
         throughput_stability_criteria: {
           each_user_completed_at_least: {

--- a/monitoring/benchmarker/configurations/user/astm/scd.py
+++ b/monitoring/benchmarker/configurations/user/astm/scd.py
@@ -54,6 +54,9 @@ class OpIntentRefCreationStrategy(ImplicitDict):
     activate_before_flight_start: Optional[StringBasedTimeDelta]
     """Create or update an operational intent to the Activated state this long before the flight starts (start of first volume)."""
 
+    expect_timely_clearance: Optional[bool]
+    """If true, fail the flight if acceptance and activation (when specified) are not complete by the start time of the flight."""
+
 
 class OpIntentRefCleanupStrategy(ImplicitDict):
     after_actual_flight_end: Optional[StringBasedTimeDelta]

--- a/monitoring/benchmarker/engine/operations.py
+++ b/monitoring/benchmarker/engine/operations.py
@@ -104,8 +104,8 @@ def record_operation(
                 or op.query.response.failure
                 or f"HTTP {op.query.status_code}"
             )
-            logger.warning(
+            logger.debug(
                 f"Operation '{op.type}' from origin '{op.origin}' failed on {op.query.request.method} {op.query.request.url} ({op.query.status_code}): {details}"
             )
         else:
-            logger.warning(f"Operation '{op.type}' from origin '{op.origin}' failed.")
+            logger.debug(f"Operation '{op.type}' from origin '{op.origin}' failed.")

--- a/monitoring/benchmarker/engine/users/flight_planner/flight_planner.py
+++ b/monitoring/benchmarker/engine/users/flight_planner/flight_planner.py
@@ -158,6 +158,15 @@ class FlightPlannerUser(VirtualUser):
             ):
                 # This was the last action for this flight
                 flight = self.flights.pop(next_action.flight_id)
+                if not flight.successful:
+                    logger.warning(
+                        f"Flight {flight.id} from {self.user_id} failed "
+                        + ", ".join(
+                            a.type
+                            for a in flight.completed_actions
+                            if a.causes_flight_failure
+                        )
+                    )
                 flight_op = ExecutedOperation(
                     type=OperationType(WorkflowType.FlightPlannerFlight),
                     origin=self.user_id,

--- a/monitoring/benchmarker/engine/users/flight_planner/framework.py
+++ b/monitoring/benchmarker/engine/users/flight_planner/framework.py
@@ -30,6 +30,9 @@ class FlightActionType(StrEnum):
     UpsertOpIntent = "scd_behavior.upsert_op_intent"
     DeleteOpIntent = "scd_behavior.delete_op_intent"
 
+    SCDTakeoffClearance = "scd_behavior.takeoff_clearance"
+    """The required SCD actions were completed before the start time of the flight (earliest volume start time)."""
+
 
 @dataclass
 class CompletedFlightAction:

--- a/monitoring/benchmarker/engine/users/flight_planner/scd.py
+++ b/monitoring/benchmarker/engine/users/flight_planner/scd.py
@@ -276,6 +276,9 @@ class SCDHandler(CoordinationSubscriber):
                 run_on_shutdown=False,
             )
 
+    def get_activate_actions(
+        self, flight: Flight, op_intent_id: api.EntityID
+    ) -> Iterable[FlightAction]:
         if (
             "activate_before_flight_start" in self.op_intent_ref_creation_strategy
             and self.op_intent_ref_creation_strategy.activate_before_flight_start
@@ -461,7 +464,14 @@ class SCDHandler(CoordinationSubscriber):
                     )
                 )
 
-        return list(self.get_delete_actions(flight, op_intent_id))
+        if (
+            state == api.OperationalIntentState.Accepted
+            and "activate_before_flight_start" in self.op_intent_ref_creation_strategy
+            and self.op_intent_ref_creation_strategy.activate_before_flight_start
+        ):
+            return list(self.get_activate_actions(flight, op_intent_id))
+        else:
+            return list(self.get_delete_actions(flight, op_intent_id))
 
     def get_delete_actions(
         self, flight: Flight, op_intent_id: api.EntityID

--- a/monitoring/benchmarker/engine/users/flight_planner/scd.py
+++ b/monitoring/benchmarker/engine/users/flight_planner/scd.py
@@ -320,6 +320,17 @@ class SCDHandler(CoordinationSubscriber):
         ):
             raise NotImplementedError(f"Cannot transition op intent to state {state}")
 
+        if self.timely_clearance_expected and t0 >= flight.start_time:
+            # The start time of the flight has already passed; no point in establishing an operational intent because we're already too late to fly on time
+            flight.completed_actions.append(
+                CompletedFlightAction(
+                    type=FlightActionType.SCDTakeoffClearance,
+                    initiated_at=t0,
+                    causes_flight_failure=True,
+                )
+            )
+            return []
+
         dss_instance = self.select_dss_instance()
         uss_base_url = make_fake_url()
         coordination_group = (

--- a/monitoring/benchmarker/engine/users/flight_planner/scd.py
+++ b/monitoring/benchmarker/engine/users/flight_planner/scd.py
@@ -320,8 +320,12 @@ class SCDHandler(CoordinationSubscriber):
         ):
             raise NotImplementedError(f"Cannot transition op intent to state {state}")
 
-        if self.timely_clearance_expected and t0 >= flight.start_time:
+        dt_s = (t0 - flight.start_time).total_seconds()
+        if self.timely_clearance_expected and dt_s > 0:
             # The start time of the flight has already passed; no point in establishing an operational intent because we're already too late to fly on time
+            logger.debug(
+                f"Transition to {state.value} not attempted for flight {flight.id} because start time already passed {dt_s:.1f}s ago"
+            )
             flight.completed_actions.append(
                 CompletedFlightAction(
                     type=FlightActionType.SCDTakeoffClearance,
@@ -406,7 +410,7 @@ class SCDHandler(CoordinationSubscriber):
                             "missing_operational_intents"
                         )
                         if missing_op_intents:
-                            logger.warning(
+                            logger.debug(
                                 f"{self.user.user_id} missing OVNs for OI {op_intent_id}:\n"
                                 + "\n".join(
                                     f"OI {oi.get('id', None)}: OVN {oi.get('ovn', None)}"
@@ -464,7 +468,7 @@ class SCDHandler(CoordinationSubscriber):
                     old_ovn,
                 )
             if requested_ovn and op_intent_ref.ovn != requested_ovn:
-                logger.warning(
+                logger.debug(
                     f"Requested OVN {requested_ovn} was not accepted; returned {op_intent_ref.ovn} instead for user {self.user.user_id}"
                 )
                 self.user.coordinator.publish(
@@ -495,11 +499,12 @@ class SCDHandler(CoordinationSubscriber):
             and "activate_before_flight_start" in self.op_intent_ref_creation_strategy
             and self.op_intent_ref_creation_strategy.activate_before_flight_start
         ):
-            if (
-                self.timely_clearance_expected
-                and datetime.now(UTC) >= flight.start_time
-            ):
+            dt_s = (datetime.now(UTC) - flight.start_time).total_seconds()
+            if self.timely_clearance_expected and dt_s > 0:
                 # Acceptance was already too late; no reason to try to activate
+                logger.debug(
+                    f"Transition to {state.value} for flight {flight.id} completed {dt_s:.1f}s too late; aborting rather than activating"
+                )
                 flight.completed_actions.append(
                     CompletedFlightAction(
                         type=FlightActionType.SCDTakeoffClearance,
@@ -514,15 +519,21 @@ class SCDHandler(CoordinationSubscriber):
             # Check to see if SCD actions were completed too late
             flight_aborted = False
             if self.timely_clearance_expected:
-                timely_clearance = query.response.reported.datetime <= flight.start_time
+                dt_s = (
+                    query.response.reported.datetime - flight.start_time
+                ).total_seconds()
+                flight_aborted = dt_s > 0
                 flight.completed_actions.append(
                     CompletedFlightAction(
                         type=FlightActionType.SCDTakeoffClearance,
                         initiated_at=t0,
-                        causes_flight_failure=timely_clearance,
+                        causes_flight_failure=flight_aborted,
                     )
                 )
-                flight_aborted = not timely_clearance
+                if flight_aborted:
+                    logger.debug(
+                        f"Transition to {state.value} for flight {flight.id} completed {dt_s:.1f}s too late; removing op intent early"
+                    )
 
             # Queue op intent deletion action
             return list(self.get_delete_actions(flight, op_intent_id, flight_aborted))

--- a/monitoring/benchmarker/engine/users/flight_planner/scd.py
+++ b/monitoring/benchmarker/engine/users/flight_planner/scd.py
@@ -55,6 +55,9 @@ class SCDHandler(CoordinationSubscriber):
     op_intent_ref_creation_strategy: OpIntentRefCreationStrategy
     """All fields guaranteed to be present."""
 
+    timely_clearance_expected: bool
+    """Whether op intent actions are expected to be completed before the start of the flight."""
+
     op_intent_ref_cleanup_strategy: OpIntentRefCleanupStrategy
     """All fields guaranteed to be present."""
 
@@ -133,7 +136,14 @@ class SCDHandler(CoordinationSubscriber):
         if "implicit_subscription" not in self.subscription_strategy:
             self.subscription_strategy.implicit_subscription = None
 
-        self.op_intent_ref_creation_strategy = behavior.op_intent_ref_creation_strategy
+        strategy = behavior.op_intent_ref_creation_strategy
+        self.op_intent_ref_creation_strategy = strategy
+        self.timely_clearance_expected = (
+            True
+            if "expect_timely_clearance" in strategy
+            and strategy.expect_timely_clearance
+            else False
+        )
 
         self.op_intent_ref_cleanup_strategy = behavior.op_intent_ref_cleanup_strategy
 
@@ -335,6 +345,7 @@ class SCDHandler(CoordinationSubscriber):
         old_ovn = op_intent_ref.ovn if op_intent_ref else None
         ovn_suffix = None
         requested_ovn = None
+        query = None
 
         attempts = 1
         if (
@@ -413,6 +424,10 @@ class SCDHandler(CoordinationSubscriber):
             raise RuntimeError(
                 "op_intent_ref cannot be None upon successful op intent ref upsertion"
             )
+        if query is None:
+            raise RuntimeError(
+                "query cannot be None upon successful op intent ref upsertion"
+            )
 
         flight.completed_actions.append(
             CompletedFlightAction(
@@ -469,33 +484,64 @@ class SCDHandler(CoordinationSubscriber):
             and "activate_before_flight_start" in self.op_intent_ref_creation_strategy
             and self.op_intent_ref_creation_strategy.activate_before_flight_start
         ):
-            return list(self.get_activate_actions(flight, op_intent_id))
+            if (
+                self.timely_clearance_expected
+                and datetime.now(UTC) >= flight.start_time
+            ):
+                # Acceptance was already too late; no reason to try to activate
+                flight.completed_actions.append(
+                    CompletedFlightAction(
+                        type=FlightActionType.SCDTakeoffClearance,
+                        initiated_at=t0,
+                        causes_flight_failure=True,
+                    )
+                )
+                return list(self.get_delete_actions(flight, op_intent_id, True))
+            else:
+                return list(self.get_activate_actions(flight, op_intent_id))
         else:
-            return list(self.get_delete_actions(flight, op_intent_id))
+            # Check to see if SCD actions were completed too late
+            flight_aborted = False
+            if self.timely_clearance_expected:
+                timely_clearance = query.response.reported.datetime <= flight.start_time
+                flight.completed_actions.append(
+                    CompletedFlightAction(
+                        type=FlightActionType.SCDTakeoffClearance,
+                        initiated_at=t0,
+                        causes_flight_failure=timely_clearance,
+                    )
+                )
+                flight_aborted = not timely_clearance
+
+            # Queue op intent deletion action
+            return list(self.get_delete_actions(flight, op_intent_id, flight_aborted))
 
     def get_delete_actions(
-        self, flight: Flight, op_intent_id: api.EntityID
+        self, flight: Flight, op_intent_id: api.EntityID, delete_now: bool
     ) -> Iterable[FlightAction]:
         deletion_time = None
-        if (
-            "after_actual_flight_end" in self.op_intent_ref_cleanup_strategy
-            and self.op_intent_ref_cleanup_strategy.after_actual_flight_end
-        ):
-            deletion_time = (
-                flight.actual_end_time
-                + self.op_intent_ref_cleanup_strategy.after_actual_flight_end.timedelta
-            )
-        if (
-            "after_planned_flight_end" in self.op_intent_ref_cleanup_strategy
-            and self.op_intent_ref_cleanup_strategy.after_planned_flight_end
-        ):
-            new_time = (
-                flight.volumes.time_end_not_none.datetime
-                + self.op_intent_ref_cleanup_strategy.after_planned_flight_end.timedelta
-            )
-            deletion_time = (
-                new_time if deletion_time is None else max(deletion_time, new_time)
-            )
+        if delete_now:
+            deletion_time = datetime.now(UTC)
+        else:
+            if (
+                "after_actual_flight_end" in self.op_intent_ref_cleanup_strategy
+                and self.op_intent_ref_cleanup_strategy.after_actual_flight_end
+            ):
+                deletion_time = (
+                    flight.actual_end_time
+                    + self.op_intent_ref_cleanup_strategy.after_actual_flight_end.timedelta
+                )
+            if (
+                "after_planned_flight_end" in self.op_intent_ref_cleanup_strategy
+                and self.op_intent_ref_cleanup_strategy.after_planned_flight_end
+            ):
+                new_time = (
+                    flight.volumes.time_end_not_none.datetime
+                    + self.op_intent_ref_cleanup_strategy.after_planned_flight_end.timedelta
+                )
+                deletion_time = (
+                    new_time if deletion_time is None else max(deletion_time, new_time)
+                )
         if deletion_time is not None:
             yield FlightAction(
                 timestamp=deletion_time,

--- a/schemas/monitoring/benchmarker/configurations/user/astm/scd/OpIntentRefCreationStrategy.json
+++ b/schemas/monitoring/benchmarker/configurations/user/astm/scd/OpIntentRefCreationStrategy.json
@@ -30,6 +30,13 @@
         "null"
       ]
     },
+    "expect_timely_clearance": {
+      "description": "If true, fail the flight if acceptance and activation (when specified) are not complete by the start time of the flight.",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
     "ovn_coordination_group": {
       "description": "If specified, exchange OVNs directly between other virtual users using this coordination group to exchange OVNs.",
       "type": [


### PR DESCRIPTION
I noticed that flights sometimes attempted to activate even though acceptance failed.  This was because the acceptance and activation of the flight for SCD were queued at the same time without respecting the serial nature of the actions.  This PR fixes this by only running activation after successful acceptance.

Also, I noticed flights failing because the requested op intent references had end times in the past.  That means the op intent was being established past the time the flight was planned for and this doesn't make sense as an operational practice.  This PR also fixes this logic by introducing timely_clearance_expected where op intents will not be established when it's already too late, and the flight will fail if the necessary op intent transitions have not been completed by the time the flight is scheduled to start.

<img width="2481" height="407" alt="single_s2_cell (1)" src="https://github.com/user-attachments/assets/1a7f1c8d-63cc-40a4-b3eb-c70bb0812e57" />