### PR TITLE
[benchmarker] Add intermediate artifact generation

### DIFF
--- a/monitoring/benchmarker/artifacts/matplotlib/matplotlib_figure.py
+++ b/monitoring/benchmarker/artifacts/matplotlib/matplotlib_figure.py
@@ -121,7 +121,7 @@ def generate_matplotlib_figure(
         name: obj for name, obj in inspect.getmembers(analysis, inspect.isclass)
     }
 
-    figure_symbols, _ = get_updated_context(
+    figure_symbols, figure_interpreter = get_updated_context(
         {
             "report": report,
         }
@@ -138,7 +138,14 @@ def generate_matplotlib_figure(
                 f"More subfigures defined than grid capacity ({len(subfigs)})"
             )
 
-        subfig_symbols, _ = get_updated_context(
+        if "render_expr" in subfig_spec and subfig_spec.render_expr:
+            render = evaluate_expression(
+                subfig_spec.render_expr, "render_expr", figure_interpreter
+            )
+            if not render:
+                continue
+
+        subfig_symbols, subfig_interpreter = get_updated_context(
             figure_symbols,
             subfig_spec.evaluation_context
             if "evaluation_context" in subfig_spec and subfig_spec.evaluation_context
@@ -164,6 +171,13 @@ def generate_matplotlib_figure(
                 raise ValueError(
                     f"More subplots defined than subfigure capacity ({len(axes)})"
                 )
+
+            if "render_expr" in subplot_spec and subplot_spec.render_expr:
+                render = evaluate_expression(
+                    subplot_spec.render_expr, "render_expr", subfig_interpreter
+                )
+                if not render:
+                    continue
 
             subplot_symbols, subplot_interpreter = get_updated_context(
                 subfig_symbols,

--- a/monitoring/benchmarker/benchmark.py
+++ b/monitoring/benchmarker/benchmark.py
@@ -45,7 +45,7 @@ def run_config(
 ) -> int:
     config = load_config(config_name, skip_validation)
 
-    run_report = run_benchmark(config)
+    run_report = run_benchmark(config, output_dir)
 
     if "artifacts" in config and config.artifacts:
         logger.info("Generating configured artifacts...")

--- a/monitoring/benchmarker/configurations/actions.py
+++ b/monitoring/benchmarker/configurations/actions.py
@@ -2,6 +2,11 @@ from typing import Optional
 
 from implicitdict import ImplicitDict
 
+from monitoring.benchmarker.configurations.artifacts.artifact import (
+    ArtifactSpecification,
+)
+from monitoring.monitorlib.expressions.types import ASTExpression
+
 
 class BenchmarkActionName(str):
     """Unique (within benchmark configuration) name for an action to perform, for instance at setup and/or teardown of one or more scenarios."""
@@ -22,7 +27,26 @@ class RunCommandActionSpecification(ImplicitDict):
     """Override each environment variable key with the specified value before running the command."""
 
 
+class GenerateArtifactsActionSpecification(ImplicitDict):
+    """Generate an intermediate artifact (prior to final artifact generation) during benchmarker execution."""
+
+    subfolder: Optional[ASTExpression]
+    """If specified, place artifacts in a subfolder (relative to where normal artifacts will be generated) of this name.
+    
+    If not specified, artifacts will be generated in the same location as the normal artifacts (and may be overwritten).
+    The variable `action_invocation` will be a 0-based integer indicating the index of the invocation of this action
+    and will be available during the evaluation of this expression."""
+
+    custom_artifacts: Optional[list[ArtifactSpecification]]
+    """Generate these custom artifacts when this action is run."""
+
+    defined_artifact_indices: Optional[list[int]]
+    """Generate the artifacts from the main configuration having the indices listed here when this action is run."""
+
+
 class BenchmarkActionSpecification(ImplicitDict):
     name: BenchmarkActionName
 
     run_command: Optional[RunCommandActionSpecification]
+
+    generate_artifacts: Optional[GenerateArtifactsActionSpecification]

--- a/monitoring/benchmarker/configurations/artifacts/matplotlib_figure.py
+++ b/monitoring/benchmarker/configurations/artifacts/matplotlib_figure.py
@@ -111,6 +111,9 @@ class SubplotSpecification(ImplicitDict):
     title: Optional[str]
     """Title of this subplot."""
 
+    render_expr: Optional[ASTExpression]
+    """If specified and this expression evaluates to false, skip rendering this subplot."""
+
     evaluation_context: Optional[list[SymbolExpression]]
     """Symbols available to other expressions in this subplot specification."""
 
@@ -135,6 +138,9 @@ class SubfigureSpecification(ImplicitDict):
 
     n_subplot_rows: int = 1
     n_subplot_cols: int = 1
+
+    render_expr: Optional[ASTExpression]
+    """If specified and this expression evaluates to false, skip rendering this subfigure."""
 
     evaluation_context: Optional[list[SymbolExpression]]
     """Symbols available to other expressions in this subfigure specification."""

--- a/monitoring/benchmarker/configurations/interuss/scd/single_s2_cell.jsonnet
+++ b/monitoring/benchmarker/configurations/interuss/scd/single_s2_cell.jsonnet
@@ -64,6 +64,16 @@ local shape = {
     },
   },
 
+  actions: [
+    {
+      name: 'Generate intermediate artifacts',
+      generate_artifacts: {
+        subfolder: 'f"intermediate{action_invocation}"',
+        defined_artifact_indices: [0, 1],
+      },
+    },
+  ],
+
   user_types: [
     {
       name: 'FPU%d' % uss, // Flight planner user using DSS instance from uss
@@ -195,6 +205,7 @@ local shape = {
       {
         name: '%s: %s for USS %d' % [dss_config_names[dss_config - 1], test_name,  uss],
         load: 'Flight planner ramp for USS %d' % uss,
+        [if uss < num_uss || dss_config < std.length(dss_config_names) then "teardown"]: ['Generate intermediate artifacts'],
       } for uss in std.range(1, num_uss)
     ] for dss_config in std.range(1, std.length(dss_config_names))
   ]),
@@ -231,6 +242,7 @@ local shape = {
               title: '%s\nDSS instance %d' % [dss_config_names[dss_config - 1], uss],
               subplots: [
                 {
+                  render_expr: '%d < len(report.report.scenarios)' % (uss - 1),
                   evaluation_context: [
                     {
                       name: 'scenario_index',

--- a/monitoring/benchmarker/engine/actions/actions.py
+++ b/monitoring/benchmarker/engine/actions/actions.py
@@ -2,12 +2,23 @@ from monitoring.benchmarker.configurations.actions import (
     BenchmarkActionName,
     BenchmarkActionSpecification,
 )
+from monitoring.benchmarker.configurations.configuration import BenchmarkConfiguration
+from monitoring.benchmarker.engine.actions.generate_artifacts import (
+    generate_intermediate_artifacts,
+)
 from monitoring.benchmarker.engine.actions.run_command import run_command
+from monitoring.benchmarker.reports.report import BenchmarkScenarioReport
 
 
 def run_scenario_actions(
     action_names: list[BenchmarkActionName] | None,
     action_specs: dict[BenchmarkActionName, BenchmarkActionSpecification],
+    action_invocations: dict[BenchmarkActionName, int],
+    config: BenchmarkConfiguration,
+    scenarios_reports: list[BenchmarkScenarioReport],
+    output_dir: str,
+    codebase_version: str,
+    commit_hash: str,
 ) -> None:
     """Run a sequence of scenario setup or teardown actions by name."""
     if not action_names:
@@ -19,10 +30,31 @@ def run_scenario_actions(
                 f"Scenario action '{action_name}' not defined in configuration.actions"
             )
         action_spec = action_specs[action_name]
+        invocation = action_invocations.get(action_name, 0)
+        action_performed = False
 
         if "run_command" in action_spec and action_spec.run_command is not None:
             run_command(action_spec.run_command)
-        else:
+            action_performed = True
+        if (
+            "generate_artifacts" in action_spec
+            and action_spec.generate_artifacts is not None
+        ):
+            generate_intermediate_artifacts(
+                action_spec.generate_artifacts,
+                action_name,
+                invocation,
+                config,
+                scenarios_reports,
+                output_dir,
+                codebase_version,
+                commit_hash,
+            )
+            action_performed = True
+
+        if not action_performed:
             raise NotImplementedError(
                 f"Action '{action_name}' has no recognized action specification implemented in this version of benchmarker"
             )
+
+        action_invocations[action_name] = invocation + 1

--- a/monitoring/benchmarker/engine/actions/generate_artifacts.py
+++ b/monitoring/benchmarker/engine/actions/generate_artifacts.py
@@ -1,0 +1,75 @@
+import os
+
+from asteval import Interpreter
+from loguru import logger
+
+from monitoring.benchmarker.artifacts.generation import generate_artifacts
+from monitoring.benchmarker.configurations.actions import (
+    BenchmarkActionName,
+    GenerateArtifactsActionSpecification,
+)
+from monitoring.benchmarker.configurations.artifacts.artifact import (
+    ArtifactSpecification,
+)
+from monitoring.benchmarker.configurations.configuration import BenchmarkConfiguration
+from monitoring.benchmarker.reports.report import (
+    BenchmarkReport,
+    BenchmarkRunReport,
+    BenchmarkScenarioReport,
+)
+from monitoring.monitorlib.expressions.evaluation import evaluate_expression
+
+
+def generate_intermediate_artifacts(
+    gen_spec: GenerateArtifactsActionSpecification,
+    action_name: BenchmarkActionName,
+    invocation: int,
+    config: BenchmarkConfiguration,
+    scenarios_reports: list[BenchmarkScenarioReport],
+    output_dir: str,
+    codebase_version: str,
+    commit_hash: str,
+) -> None:
+    target_dir = output_dir
+    if "subfolder" in gen_spec and gen_spec.subfolder is not None:
+        interpreter = Interpreter(user_symbols={"action_invocation": invocation})
+        subfolder_val = evaluate_expression(
+            gen_spec.subfolder, f"action.{action_name}.subfolder", interpreter
+        )
+        if subfolder_val is not None and str(subfolder_val).strip():
+            target_dir = os.path.join(output_dir, str(subfolder_val))
+
+    artifacts_to_generate: list[ArtifactSpecification] = []
+    if "custom_artifacts" in gen_spec and gen_spec.custom_artifacts:
+        artifacts_to_generate.extend(gen_spec.custom_artifacts)
+
+    if "defined_artifact_indices" in gen_spec and gen_spec.defined_artifact_indices:
+        if "artifacts" not in config or not config.artifacts:
+            raise ValueError(
+                f"Action '{action_name}' specifies defined_artifact_indices, but no artifacts are defined in the main configuration"
+            )
+        for idx in gen_spec.defined_artifact_indices:
+            if idx < 0 or idx >= len(config.artifacts):
+                raise ValueError(
+                    f"Action '{action_name}' references defined_artifact_indices [{idx}], which is out of range (configuration defined {len(config.artifacts)} artifacts)"
+                )
+            artifacts_to_generate.append(config.artifacts[idx])
+
+    if not artifacts_to_generate:
+        logger.warning(
+            f"Action '{action_name}' generate_artifacts specified no artifacts to generate"
+        )
+        return
+
+    logger.info(
+        f"Action '{action_name}' (invocation {invocation}): generating {len(artifacts_to_generate)} artifact(s) in {target_dir}"
+    )
+
+    current_report = BenchmarkRunReport(
+        codebase_version=codebase_version,
+        commit_hash=commit_hash,
+        configuration=config,
+        report=BenchmarkReport(scenarios=list(scenarios_reports)),
+    )
+
+    generate_artifacts(artifacts_to_generate, current_report, target_dir)

--- a/monitoring/benchmarker/engine/engine.py
+++ b/monitoring/benchmarker/engine/engine.py
@@ -3,6 +3,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 from loguru import logger
 
+from monitoring.benchmarker.configurations.actions import BenchmarkActionName
 from monitoring.benchmarker.configurations.configuration import BenchmarkConfiguration
 from monitoring.benchmarker.engine.actions.actions import run_scenario_actions
 from monitoring.benchmarker.engine.coordination import Coordinator
@@ -24,6 +25,7 @@ async def _run_benchmark_async(
     config: BenchmarkConfiguration,
     codebase_version: str,
     commit_hash: str,
+    output_dir: str = "output",
 ) -> BenchmarkRunReport:
     logger.info("Instantiating declared resources...")
     resource_pool = instantiate_resources(config)
@@ -40,6 +42,7 @@ async def _run_benchmark_async(
 
     action_list = config.actions if "actions" in config and config.actions else []
     action_specs = {action_spec.name: action_spec for action_spec in action_list}
+    action_invocations: dict[BenchmarkActionName, int] = {}
 
     coordination_groups = list(enumerate_coordination_groups(config.user_types))
     coordinator = Coordinator(coordination_groups)
@@ -52,7 +55,16 @@ async def _run_benchmark_async(
 
             # Run setup actions
             setup_actions = scenario_spec.setup if "setup" in scenario_spec else None
-            run_scenario_actions(setup_actions, action_specs)
+            run_scenario_actions(
+                setup_actions,
+                action_specs,
+                action_invocations,
+                config,
+                scenarios_reports,
+                output_dir,
+                codebase_version,
+                commit_hash,
+            )
 
             # Run load
             if scenario_spec.load not in loads_map:
@@ -69,12 +81,6 @@ async def _run_benchmark_async(
                 scenario_spec.name,
             )
 
-            # Run teardown actions
-            teardown_actions = (
-                scenario_spec.teardown if "teardown" in scenario_spec else None
-            )
-            run_scenario_actions(teardown_actions, action_specs)
-
             # Generate and record scenario report
             scenario_report = BenchmarkScenarioReport(
                 operations=group_operations(scenario_ops),
@@ -87,6 +93,21 @@ async def _run_benchmark_async(
                     else None
                 )
             scenarios_reports.append(scenario_report)
+
+            # Run teardown actions
+            teardown_actions = (
+                scenario_spec.teardown if "teardown" in scenario_spec else None
+            )
+            run_scenario_actions(
+                teardown_actions,
+                action_specs,
+                action_invocations,
+                config,
+                scenarios_reports,
+                output_dir,
+                codebase_version,
+                commit_hash,
+            )
 
             logger.info(
                 f"========== Completed Scenario '{scenario_spec.name}' =========="
@@ -104,8 +125,12 @@ async def _run_benchmark_async(
     return run_report
 
 
-def run_benchmark(config: BenchmarkConfiguration) -> BenchmarkRunReport:
+def run_benchmark(
+    config: BenchmarkConfiguration, output_dir: str = "output"
+) -> BenchmarkRunReport:
     """Execute the benchmarker engine for the provided configuration and return the resulting report."""
     codebase_version = get_code_version()
     commit_hash = get_commit_hash()
-    return asyncio.run(_run_benchmark_async(config, codebase_version, commit_hash))
+    return asyncio.run(
+        _run_benchmark_async(config, codebase_version, commit_hash, output_dir)
+    )

--- a/schemas/monitoring/benchmarker/configurations/actions/BenchmarkActionSpecification.json
+++ b/schemas/monitoring/benchmarker/configurations/actions/BenchmarkActionSpecification.json
@@ -7,6 +7,16 @@
       "description": "Path to content that replaces the $ref",
       "type": "string"
     },
+    "generate_artifacts": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "GenerateArtifactsActionSpecification.json"
+        }
+      ]
+    },
     "name": {
       "type": "string"
     },

--- a/schemas/monitoring/benchmarker/configurations/actions/GenerateArtifactsActionSpecification.json
+++ b/schemas/monitoring/benchmarker/configurations/actions/GenerateArtifactsActionSpecification.json
@@ -1,0 +1,39 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/configurations/actions/GenerateArtifactsActionSpecification.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Generate an intermediate artifact (prior to final artifact generation) during benchmarker execution.\n\nmonitoring.benchmarker.configurations.actions.GenerateArtifactsActionSpecification, as defined in monitoring/benchmarker/configurations/actions.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "custom_artifacts": {
+      "description": "Generate these custom artifacts when this action is run.",
+      "items": {
+        "$ref": "../artifacts/artifact/ArtifactSpecification.json"
+      },
+      "type": [
+        "array",
+        "null"
+      ]
+    },
+    "defined_artifact_indices": {
+      "description": "Generate the artifacts from the main configuration having the indices listed here when this action is run.",
+      "items": {
+        "type": "integer"
+      },
+      "type": [
+        "array",
+        "null"
+      ]
+    },
+    "subfolder": {
+      "description": "If specified, place artifacts in a subfolder (relative to where normal artifacts will be generated) of this name.\n\nIf not specified, artifacts will be generated in the same location as the normal artifacts (and may be overwritten).\nThe variable `action_invocation` will be a 0-based integer indicating the index of the invocation of this action\nand will be available during the evaluation of this expression.",
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "type": "object"
+}

--- a/schemas/monitoring/benchmarker/configurations/artifacts/matplotlib_figure/SubfigureSpecification.json
+++ b/schemas/monitoring/benchmarker/configurations/artifacts/matplotlib_figure/SubfigureSpecification.json
@@ -23,6 +23,13 @@
     "n_subplot_rows": {
       "type": "integer"
     },
+    "render_expr": {
+      "description": "If specified and this expression evaluates to false, skip rendering this subfigure.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "subplots": {
       "items": {
         "$ref": "SubplotSpecification.json"

--- a/schemas/monitoring/benchmarker/configurations/artifacts/matplotlib_figure/SubplotSpecification.json
+++ b/schemas/monitoring/benchmarker/configurations/artifacts/matplotlib_figure/SubplotSpecification.json
@@ -28,6 +28,13 @@
         }
       ]
     },
+    "render_expr": {
+      "description": "If specified and this expression evaluates to false, skip rendering this subplot.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "title": {
       "description": "Title of this subplot.",
       "type": [


### PR DESCRIPTION
This PR follows #1566 to add the ability to create intermediate artifacts (artifacts generated while the run is happening).

Tested by expanding single_s2_cell.jsonnet to write intermediate artifacts.