### PR TITLE
[prober] Add flag to avoid direct value testing on notification_index for -enable_time_based_notification_index

### DIFF
--- a/monitoring/prober/conftest.py
+++ b/monitoring/prober/conftest.py
@@ -100,6 +100,15 @@ def pytest_addoption(parser):
         dest="scd_api_version",
     )
 
+    parser.addoption(
+        "--scd-time-based-notification-index",
+        help="True if the DSS under test computes subscription notification indices from time rather than incrementing them",
+        type=str2bool,
+        nargs="?",
+        default=False,
+        dest="scd_time_based_notification_index",
+    )
+
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
 def pytest_runtest_makereport(item, call):
@@ -259,3 +268,8 @@ def no_auth_session_ridv2(pytestconfig) -> UTMClientSession:
 def scd_api(pytestconfig) -> str:
     api = pytestconfig.getoption("scd_api_version")
     return VersionString(api)
+
+
+@pytest.fixture(scope="session")
+def time_based_notification_index(pytestconfig) -> bool:
+    return pytestconfig.getoption("scd_time_based_notification_index")

--- a/monitoring/prober/scd/test_constraints_with_subscriptions.py
+++ b/monitoring/prober/scd/test_constraints_with_subscriptions.py
@@ -157,7 +157,9 @@ def test_constraint_does_not_exist(ids, scd_api, scd_session, scd_session2):
 # Mutations: Constraint ids(CONSTRAINT_ID) created by scd_session user
 @for_api_versions(scd.API_0_3_17)
 @default_scope(SCOPE_CM)
-def test_create_constraint(ids, scd_api, scd_session, scd_session2):
+def test_create_constraint(
+    ids, scd_api, scd_session, scd_session2, time_based_notification_index
+):
     req = _make_c1_request()
     resp = scd_session.put(f"/constraint_references/{ids(CONSTRAINT_TYPE)}", json=req)
     assert resp.status_code == 201, resp.content
@@ -185,13 +187,15 @@ def test_create_constraint(ids, scd_api, scd_session, scd_session2):
         for subscription in subscriberb["subscriptions"]
         if subscription["subscription_id"] == ids(SUB2_TYPE)
     ][0]
-    assert sub2_index == 1, subscriberb
+    if not time_based_notification_index:
+        assert sub2_index == 1, subscriberb
     sub3_index = [
         subscription["notification_index"]
         for subscription in subscriberb["subscriptions"]
         if subscription["subscription_id"] == ids(SUB3_TYPE)
     ][0]
-    assert sub3_index == 1, subscriberb
+    if not time_based_notification_index:
+        assert sub3_index == 1, subscriberb
 
 
 # Preconditions:
@@ -200,7 +204,9 @@ def test_create_constraint(ids, scd_api, scd_session, scd_session2):
 #   * Constraint ids(CONSTRAINT_ID) created by scd_session user
 # Mutations: Constraint ids(CONSTRAINT_ID) mutated to second version
 @for_api_versions(scd.API_0_3_17)
-def test_mutate_constraint(ids, scd_api, scd_session, scd_session2):
+def test_mutate_constraint(
+    ids, scd_api, scd_session, scd_session2, time_based_notification_index
+):
     # GET current constraint
     resp = scd_session.get(
         f"/constraint_references/{ids(CONSTRAINT_TYPE)}",
@@ -253,13 +259,15 @@ def test_mutate_constraint(ids, scd_api, scd_session, scd_session2):
         for subscription in subscriberb["subscriptions"]
         if subscription["subscription_id"] == ids(SUB2_TYPE)
     ][0]
-    assert sub2_index == 2, subscriberb
+    if not time_based_notification_index:
+        assert sub2_index == 2, subscriberb
     sub3_index = [
         subscription["notification_index"]
         for subscription in subscriberb["subscriptions"]
         if subscription["subscription_id"] == ids(SUB3_TYPE)
     ][0]
-    assert sub3_index == 2, subscriberb
+    if not time_based_notification_index:
+        assert sub3_index == 2, subscriberb
 
 
 # Preconditions: {Sub1, Sub2, Sub3} created by scd_session2 user
@@ -328,7 +336,9 @@ def test_mutate_subs(ids, scd_api, scd_session2, scd_session):
 # Mutations: Constraint ids(CONSTRAINT_ID) mutated to third version
 @for_api_versions(scd.API_0_3_17)
 @default_scope(SCOPE_CM)
-def test_mutate_constraint2(ids, scd_api, scd_session, scd_session2):
+def test_mutate_constraint2(
+    ids, scd_api, scd_session, scd_session2, time_based_notification_index
+):
     # GET current constraint
     resp = scd_session.get(f"/constraint_references/{ids(CONSTRAINT_TYPE)}")
     assert resp.status_code == 200, resp.content
@@ -376,7 +386,8 @@ def test_mutate_constraint2(ids, scd_api, scd_session, scd_session2):
         for subscription in subscribera["subscriptions"]
         if subscription["subscription_id"] == ids(SUB1_TYPE)
     ][0]
-    assert sub1_index == 1, subscribera
+    if not time_based_notification_index:
+        assert sub1_index == 1, subscribera
 
     subscriberb = [
         subscriber
@@ -396,7 +407,8 @@ def test_mutate_constraint2(ids, scd_api, scd_session, scd_session2):
         for subscription in subscriberb["subscriptions"]
         if subscription["subscription_id"] == ids(SUB2_TYPE)
     ][0]
-    assert sub2_index == 3, subscriberb
+    if not time_based_notification_index:
+        assert sub2_index == 3, subscriberb
 
 
 # Preconditions: Constraint ids(CONSTRAINT_ID) mutated to second version

--- a/monitoring/prober/scd/test_operations_simple.py
+++ b/monitoring/prober/scd/test_operations_simple.py
@@ -260,7 +260,9 @@ def test_create_op2_no_ovn(ids, scd_api, scd_session, scd_session2):
 # Mutations: Subscription Sub2 created by scd_session2 user
 @for_api_versions(scd.API_0_3_17)
 @default_scope(SCOPE_SC)
-def test_create_op2sub(ids, scd_api, scd_session, scd_session2):
+def test_create_op2sub(
+    ids, scd_api, scd_session, scd_session2, time_based_notification_index
+):
     if scd_session2 is None:
         return
     time_start = datetime.datetime.now(datetime.UTC)
@@ -284,7 +286,8 @@ def test_create_op2sub(ids, scd_api, scd_session, scd_session2):
     op = [op for op in ops if op["id"] == ids(OP1_TYPE)][0]
     assert op.get("ovn", "") in scd.NO_OVN_PHRASES
 
-    assert data["subscription"]["notification_index"] == 0
+    if not time_based_notification_index:
+        assert data["subscription"]["notification_index"] == 0
 
     resp = scd_session2.get(f"/subscriptions/{ids(SUB2_TYPE)}")
     assert resp.status_code == 200, resp.content
@@ -318,7 +321,9 @@ def test_create_op2_no_key(ids, scd_api, scd_session, scd_session2):
 # Mutations: Operation Op2 created by scd_session2 user
 @for_api_versions(scd.API_0_3_17)
 @default_scope(SCOPE_SC)
-def test_create_op2(ids, scd_api, scd_session, scd_session2):
+def test_create_op2(
+    ids, scd_api, scd_session, scd_session2, time_based_notification_index
+):
     req = _make_op2_request()
     req["subscription_id"] = ids(SUB2_TYPE)
     req["key"] = [op1_ovn]
@@ -352,7 +357,8 @@ def test_create_op2(ids, scd_api, scd_session, scd_session2):
     # USS2 should also be instructed to notify USS2's explicit Subscription of the new Operation
     assert URL_SUB2 in subscribers, subscribers
     assert ids(SUB2_TYPE) in subscribers[URL_SUB2], subscribers[URL_SUB2]
-    assert subscribers[URL_SUB2][ids(SUB2_TYPE)] == 1
+    if not time_based_notification_index:
+        assert subscribers[URL_SUB2][ids(SUB2_TYPE)] == 1
 
     global op2_ovn
     op2_ovn = op["ovn"]
@@ -471,7 +477,9 @@ def test_mutate_op1_bad_key(ids, scd_api, scd_session, scd_session2):
 # Mutations: Operation Op1 mutated to second version
 @for_api_versions(scd.API_0_3_17)
 @default_scope(SCOPE_SC)
-def test_mutate_op1(ids, scd_api, scd_session, scd_session2):
+def test_mutate_op1(
+    ids, scd_api, scd_session, scd_session2, time_based_notification_index
+):
     resp = scd_session.get(f"/operational_intent_references/{ids(OP1_TYPE)}")
     assert resp.status_code == 200, resp.content
     existing_op = resp.json().get("operational_intent_reference", None)
@@ -506,7 +514,8 @@ def test_mutate_op1(ids, scd_api, scd_session, scd_session2):
     subscribers = _parse_subscribers(data.get("subscribers", []))
     assert URL_SUB2 in subscribers, subscribers
     assert ids(SUB2_TYPE) in subscribers[URL_SUB2], subscribers[URL_SUB2]
-    assert subscribers[URL_SUB2][ids(SUB2_TYPE)] == 2
+    if not time_based_notification_index:
+        assert subscribers[URL_SUB2][ids(SUB2_TYPE)] == 2
 
     op1_ovn = op["ovn"]
 
@@ -533,7 +542,9 @@ def test_delete_dependent_sub(ids, scd_api, scd_session, scd_session2):
 # Mutations: Subscription Sub2 mutated
 @for_api_versions(scd.API_0_3_17)
 @default_scope(SCOPE_SC)
-def test_mutate_sub2(ids, scd_api, scd_session, scd_session2):
+def test_mutate_sub2(
+    ids, scd_api, scd_session, scd_session2, time_based_notification_index
+):
     if scd_session2 is None:
         return
     time_now = datetime.datetime.now(datetime.UTC)
@@ -602,7 +613,8 @@ def test_mutate_sub2(ids, scd_api, scd_session, scd_session2):
     assert ops[ids(OP1_TYPE)].get("ovn", "") in scd.NO_OVN_PHRASES
     assert ops[ids(OP2_TYPE)].get("ovn", "") not in scd.NO_OVN_PHRASES
 
-    assert data["subscription"]["notification_index"] == 2
+    if not time_based_notification_index:
+        assert data["subscription"]["notification_index"] == 2
 
     # Make sure the Subscription is still retrievable specifically
     resp = scd_session2.get(f"/subscriptions/{ids(SUB2_TYPE)}")
@@ -618,7 +630,9 @@ def test_mutate_sub2(ids, scd_api, scd_session, scd_session2):
 # Mutations: Operation Op1 deleted
 @for_api_versions(scd.API_0_3_17)
 @default_scope(SCOPE_SC)
-def test_delete_op1(ids, scd_api, scd_session, scd_session2):
+def test_delete_op1(
+    ids, scd_api, scd_session, scd_session2, time_based_notification_index
+):
     resp = scd_session.delete(
         f"/operational_intent_references/{ids(OP1_TYPE)}/{op1_ovn}"
     )
@@ -631,7 +645,8 @@ def test_delete_op1(ids, scd_api, scd_session, scd_session2):
     subscribers = _parse_subscribers(data.get("subscribers", []))
     assert URL_SUB2 in subscribers, subscribers
     assert ids(SUB2_TYPE) in subscribers[URL_SUB2], subscribers[URL_SUB2]
-    assert subscribers[URL_SUB2][ids(SUB2_TYPE)] == 3
+    if not time_based_notification_index:
+        assert subscribers[URL_SUB2][ids(SUB2_TYPE)] == 3
 
     resp = scd_session.get("/subscriptions/{}".format(op["subscription_id"]))
     print(resp.content)
@@ -646,7 +661,9 @@ def test_delete_op1(ids, scd_api, scd_session, scd_session2):
 # Mutations: Operation Op2 deleted
 @for_api_versions(scd.API_0_3_17)
 @default_scope(SCOPE_SC)
-def test_delete_op2(ids, scd_api, scd_session, scd_session2):
+def test_delete_op2(
+    ids, scd_api, scd_session, scd_session2, time_based_notification_index
+):
     resp = scd_session2.delete(
         f"/operational_intent_references/{ids(OP2_TYPE)}/{op2_ovn}"
     )
@@ -660,7 +677,8 @@ def test_delete_op2(ids, scd_api, scd_session, scd_session2):
     subscribers = _parse_subscribers(data.get("subscribers", []))
     assert URL_SUB2 in subscribers, subscribers
     assert ids(SUB2_TYPE) in subscribers[URL_SUB2], subscribers[URL_SUB2]
-    assert subscribers[URL_SUB2][ids(SUB2_TYPE)] == 4
+    if not time_based_notification_index:
+        assert subscribers[URL_SUB2][ids(SUB2_TYPE)] == 4
 
     resp = scd_session2.get(f"/subscriptions/{ids(SUB2_TYPE)}")
     assert resp.status_code == 200, resp.content

--- a/monitoring/prober/scd/test_subscription_simple.py
+++ b/monitoring/prober/scd/test_subscription_simple.py
@@ -47,11 +47,12 @@ def _make_sub1_req(scd_api):
     return req
 
 
-def _check_sub1(data, sub_id, scd_api):
+def _check_sub1(data, sub_id, scd_api, time_based_notification_index):
     assert data["subscription"]["id"] == sub_id
-    assert ("notification_index" not in data["subscription"]) or (
-        data["subscription"]["notification_index"] == 0
-    )
+    if not time_based_notification_index:
+        assert ("notification_index" not in data["subscription"]) or (
+            data["subscription"]["notification_index"] == 0
+        )
     assert data["subscription"]["uss_base_url"] == make_fake_url()
     assert data["subscription"]["time_start"]["format"] == api.TimeFormat.RFC3339
     assert data["subscription"]["time_end"]["format"] == api.TimeFormat.RFC3339
@@ -109,7 +110,7 @@ def test_create_sub_time_start_after_time_end(ids, scd_api, scd_session):
 
 @for_api_versions(scd.API_0_3_17)
 @default_scope(SCOPE_SC)
-def test_create_sub(ids, scd_api, scd_session):
+def test_create_sub(ids, scd_api, scd_session, time_based_notification_index):
     if scd_session is None:
         return
     req = _make_sub1_req(scd_api)
@@ -124,21 +125,21 @@ def test_create_sub(ids, scd_api, scd_session):
     assert_datetimes_are_equal(
         data["subscription"]["time_end"]["value"], req["extents"]["time_end"]["value"]
     )
-    _check_sub1(data, ids(SUB_TYPE), scd_api)
+    _check_sub1(data, ids(SUB_TYPE), scd_api, time_based_notification_index)
     assert "constraint_references" not in data
     assert isinstance(data["operational_intent_references"], list)
 
 
 @for_api_versions(scd.API_0_3_17)
 @default_scope(SCOPE_SC)
-def test_get_sub_by_id(ids, scd_api, scd_session):
+def test_get_sub_by_id(ids, scd_api, scd_session, time_based_notification_index):
     if scd_session is None:
         return
     resp = scd_session.get(f"/subscriptions/{ids(SUB_TYPE)}")
     assert resp.status_code == 200, resp.content
 
     data = resp.json()
-    _check_sub1(data, ids(SUB_TYPE), scd_api)
+    _check_sub1(data, ids(SUB_TYPE), scd_api, time_based_notification_index)
 
 
 @for_api_versions(scd.API_0_3_17)


### PR DESCRIPTION
This PR add a flag to avoid testing for specific values on notification_index in the prober, allowing the prober to be run against a DSS with enable_time_based_notification_index set.

