### PR TITLE
[prober] Fix scope issues in delete_subscription_if_exists

### DIFF
--- a/monitoring/prober/scd/actions.py
+++ b/monitoring/prober/scd/actions.py
@@ -5,7 +5,7 @@ from monitoring.monitorlib.scd import SCOPE_CM, SCOPE_CP, SCOPE_SC
 
 def _read_both_scope(scd_api: str) -> str:
     if scd_api == scd.API_0_3_17:
-        return f"{str(SCOPE_SC)} {str(SCOPE_CP)}"
+        return f"{SCOPE_SC.value} {SCOPE_CP.value}"
     else:
         raise NotImplementedError(f"Unsupported API version {scd_api}")
 


### PR DESCRIPTION
Working on https://github.com/interuss/dss/pull/1618, I noticed an unrelated error occurring only when there have been errors and delete_subscription_if_exists is called.

`E           AssertionError: b'{"message":"Access token missing scopes (AuthOption[0]: utm.constraint_processing ; AuthOption[1]: utm.strategic_coordination) while expecting [Authority: (utm.constraint_processing)] OR [Authority: (utm.strategic_coordination)] and got Scope.StrategicCoordination, Scope.ConstraintProcessing (E:de1646ce-134a-491b-b779-b6fecf5c97e2)"}\n'`

This PR fix the helper to get scope values and not their description.