### PR TITLE
Revert "Bump setuptools from 82.0.1 to 84.0.0"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ exclude = [
 
 [build-system]
 requires = [
-  "setuptools>=84.0.0",
+  "setuptools>=83.0.0",
   "wheel",               # for bdist package distribution
   "setuptools_scm>=10.2.1", # for automated versioning
 ]


### PR DESCRIPTION
Reverts interuss/monitoring#1628

This update is too recent for uv, who reject it when running uv commands:

```
  × Failed to build `monitoring @ file:///.../interuss/monitoring`
  ├─▶ Failed to resolve requirements from `build-system.requires`
  ├─▶ No solution found when resolving: `setuptools>=84.0.0`, `wheel`, `setuptools-scm>=10.2.1`
  ╰─▶ Because only setuptools<=83.0.0 is available and you require setuptools>=84.0.0, we can conclude that your requirements are unsatisfiable.

hint: `setuptools` was filtered by `exclude-newer` to only include packages uploaded before 2026-08-07T15:18:33.897173528Z. The latest version satisfying the requirement is v84.0.0, published at 2026-08-08T18:27:56.719Z. Consider using `exclude-newer-package` to override the cutoff for this package
```

I tracked the original issue in #1631 