### PR TITLE
[dependabot] Set cooldown to 7 days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,23 +3,35 @@ version: 2
 updates:
   - package-ecosystem: "uv"
     directory: "/"
+    cooldown:
+      default-days: 7
     schedule:
       interval: "daily"
+
   - package-ecosystem: "uv"
     directory: "/test/repo_hygiene/"
+    cooldown:
+      default-days: 7
     schedule:
       interval: "daily"
 
   - package-ecosystem: "docker"
     directory: "/monitoring/"
+    cooldown:
+      default-days: 7
     schedule:
       interval: "daily"
+
   - package-ecosystem: "docker"
     directory: "/test/repo_hygiene/"
+    cooldown:
+      default-days: 7
     schedule:
       interval: "daily"
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    cooldown:
+      default-days: 7
     schedule:
       interval: "daily"


### PR DESCRIPTION
This PR configures Dependabot with a 7-day cooldown.

The goal is to help prevent supply chain attacks by delaying update proposals, while matching UV parameters that already use a cooldown to avoid lock file update issues.

Fixes #1631