### PR TITLE
Fix local ecosystem configuration defaults

### DIFF
--- a/build/dev/README.md
+++ b/build/dev/README.md
@@ -31,7 +31,7 @@ The following environment variables can be configured to customize the simulated
 * `NUM_USS`: Number of simulated USS instances (default: `2`). Note that the standard mock ecosystem requires at least 2 USSs.
 * `NUM_NODES`: Number of nodes per USS database/DSS cluster (default: `1`).
 * `DB_TYPE`: Datastore backend type. Options are `crdb` (CockroachDB), `ybdb` (Yugabyte), or `raft` (built-in raft store, no separate database container) (default: `crdb`).
-* `DSS_IMAGE`: Docker image used for the DSS core service and bootstrappers (default: `interuss/dss:v0.22.0`). Override to test a locally built image, e.g. `interuss-local/dss`.
+* `DSS_IMAGE`: Docker image used for the DSS core service and bootstrappers. Override to test a locally built image, e.g. `interuss-local/dss`.
 * `INTRA_USS_NETEM_CONF`: `tc netem` configuration rules applied to traffic between database nodes of the *same* USS (default: `<none>`).
   * *Sensible values (low latency/jitter, very low loss):* `"delay 250us 25us 25% distribution normal loss 0.0025% 10%"`
 * `INTER_USS_NETEM_CONF`: `tc netem` configuration rules applied to traffic between database nodes of *different* USSs (default: `<none>`).

--- a/build/dev/docker-compose.yaml
+++ b/build/dev/docker-compose.yaml
@@ -1,4 +1,4 @@
-# This Docker Compose file must be used through `./run_locally.sh`.
+# This Docker Compose file is intended to be used through `./run_locally.sh` to supply all required environment variables.
 
 services:
 
@@ -85,7 +85,7 @@ services:
     networks: [dss_internal_network]
 
   rid_bootstrapper:
-    image: ${DSS_IMAGE:-interuss/dss:v0.22.0}
+    image: ${DSS_IMAGE:?}
     profiles: [bootstrap-crdb]
     entrypoint: sh -c "/usr/bin/db-manager migrate --schemas_dir=/db-schemas/rid --db_version latest --cockroach_host db1.uss1.localutm"
     depends_on:
@@ -96,7 +96,7 @@ services:
       disable: true
 
   scd_bootstrapper:
-    image: ${DSS_IMAGE:-interuss/dss:v0.22.0}
+    image: ${DSS_IMAGE:?}
     profiles: [bootstrap-crdb]
     entrypoint: sh -c "/usr/bin/db-manager migrate --schemas_dir=/db-schemas/scd --db_version latest --cockroach_host db1.uss1.localutm"
     depends_on:
@@ -107,7 +107,7 @@ services:
       disable: true
 
   aux_bootstrapper:
-    image: ${DSS_IMAGE:-interuss/dss:v0.22.0}
+    image: ${DSS_IMAGE:?}
     profiles: [bootstrap-crdb]
     entrypoint: sh -c "/usr/bin/db-manager migrate --schemas_dir=/db-schemas/aux_ --db_version latest --cockroach_host db1.uss1.localutm"
     depends_on:
@@ -118,7 +118,7 @@ services:
       disable: true
 
   rid_bootstrapper-ybdb:
-    image: ${DSS_IMAGE:-interuss/dss:v0.22.0}
+    image: ${DSS_IMAGE:?}
     profiles: [bootstrap-ybdb]
     entrypoint: sh -c "/usr/bin/db-manager migrate --schemas_dir=/db-schemas/yugabyte/rid --db_version latest --datastore_host db1.uss1.localutm --datastore_user yugabyte --datastore_port 5433"
     restart: on-failure
@@ -127,7 +127,7 @@ services:
       disable: true
 
   scd_bootstrapper-ybdb:
-    image: ${DSS_IMAGE:-interuss/dss:v0.22.0}
+    image: ${DSS_IMAGE:?}
     profiles: [bootstrap-ybdb]
     entrypoint: sh -c "/usr/bin/db-manager migrate --schemas_dir=/db-schemas/yugabyte/scd --db_version latest --datastore_host db1.uss1.localutm --datastore_user yugabyte --datastore_port 5433"
     restart: on-failure
@@ -136,7 +136,7 @@ services:
       disable: true
 
   aux_bootstrapper-ybdb:
-    image: ${DSS_IMAGE:-interuss/dss:v0.22.0}
+    image: ${DSS_IMAGE:?}
     profiles: [bootstrap-ybdb]
     entrypoint: sh -c "/usr/bin/db-manager migrate --schemas_dir=/db-schemas/yugabyte/aux_ --db_version latest --datastore_host db1.uss1.localutm --datastore_user yugabyte --datastore_port 5433"
     restart: on-failure
@@ -145,7 +145,7 @@ services:
       disable: true
 
   dss:
-    image: ${DSS_IMAGE:-interuss/dss:v0.22.0}
+    image: ${DSS_IMAGE:?}
     command: /startup/core_service.sh ${DEBUG_ON:-0}
     profiles: [ crdb, ybdb, raft ]
     restart: always

--- a/build/dev/run_locally.sh
+++ b/build/dev/run_locally.sh
@@ -24,6 +24,9 @@ export NUM_USS=${NUM_USS:-2}
 NUM_NODES=${NUM_NODES:-1}
 DB_TYPE=${DB_TYPE:-crdb}
 
+export DSS_IMAGE="${DSS_IMAGE:-interuss/dss:v0.23.0-rc5}"
+export CORE_SERVICE_EXTRA_FLAGS="${CORE_SERVICE_EXTRA_FLAGS:---enable_time_based_notification_index}"
+
 DC_COMMAND=$*
 
 if [[ ! "$DC_COMMAND" ]]; then

--- a/monitoring/prober/run_locally.sh
+++ b/monitoring/prober/run_locally.sh
@@ -47,6 +47,7 @@ if ! docker run --rm \
 	--dss-endpoint http://dss1.uss1.localutm \
 	--rid-auth "DummyOAuth(http://oauth.authority.localutm:8085/token,sub=fake_uss)" \
 	--rid-v2-auth "DummyOAuth(http://oauth.authority.localutm:8085/token,sub=fake_uss)" \
+	--scd-time-based-notification-index True \
 	--scd-auth1 "DummyOAuth(http://oauth.authority.localutm:8085/token,sub=fake_uss)" \
 	--scd-auth2 "DummyOAuth(http://oauth.authority.localutm:8085/token,sub=fake_uss2)"	\
 	--scd-api-version 1.0.0; then

--- a/monitoring/uss_qualifier/scripts/test_docker_fully_mocked.sh
+++ b/monitoring/uss_qualifier/scripts/test_docker_fully_mocked.sh
@@ -47,8 +47,6 @@ trap on_sigint SIGINT
 
 echo "Start mock system"
 echo "============="
-export DSS_IMAGE="${DSS_IMAGE:-interuss/dss:v0.23.0-rc4}"
-export CORE_SERVICE_EXTRA_FLAGS="${CORE_SERVICE_EXTRA_FLAGS:---enable_time_based_notification_index}"
 make start-locally
 make start-uss-mocks
 


### PR DESCRIPTION
In #1652, I changed test_docker_fully_mocked.sh to use the newest DSS image with expected flags, but this results in the local ecosystem used for CI tests being different from the local ecosystem that a developer would bring up by default on their system.  This PR attempts to fix the difference by making run_locally.sh the sole location for default ecosystem options.  It also removes a value from documentation so that it won't fall out of sync with the implementation, nor need maintenance when the implementation changes.