### PR TITLE
[monitorlib/kml] Handle missing OVN and Area of Interest

### DIFF
--- a/monitoring/monitorlib/kml/f3548v21.py
+++ b/monitoring/monitorlib/kml/f3548v21.py
@@ -25,7 +25,7 @@ def full_op_intent(op_intent: OperationalIntent):
     """Render operational intent information into Placemarks in a KML folder."""
     ref = op_intent.reference
     details = op_intent.details
-    name = f"{ref.manager}'s P{priority_of(details)} {ref.state.value} {ref.id}[{ref.version}] @ {ref.ovn}"
+    name = f"{ref.manager}'s P{priority_of(details)} {ref.state.value} {ref.id}[{ref.version}] @ {ref.get('ovn')}"
     folder = kml.Folder(kml.name(name))
     if "volumes" in details:
         for i, v4_f3548 in enumerate(details.volumes or []):
@@ -56,7 +56,7 @@ def op_intent_refs_query(
 ):
     """Render the area of interest and response from an operational intent references query into a KML Placemark."""
 
-    if not req.area_of_interest:
+    if "area_of_interest" not in req or not req.area_of_interest:
         raise ValueError("req.area_of_interest is not defined")
 
     v4 = Volume4D.from_f3548v21(req.area_of_interest)

--- a/monitoring/monitorlib/kml/f3548v21_test.py
+++ b/monitoring/monitorlib/kml/f3548v21_test.py
@@ -1,0 +1,61 @@
+from implicitdict import ImplicitDict
+from uas_standards.astm.f3548.v21.api import (
+    OperationalIntent,
+    QueryOperationalIntentReferenceParameters,
+    QueryOperationalIntentReferenceResponse,
+)
+
+from monitoring.monitorlib.kml.f3548v21 import full_op_intent, op_intent_refs_query
+
+
+def _op_intent(**reference_overrides) -> OperationalIntent:
+    reference = {
+        "id": "",
+        "manager": "",
+        "uss_availability": "Unknown",
+        "version": 0,
+        "state": "Accepted",
+        "time_start": {"value": "2024-01-01T00:00:00Z", "format": "RFC3339"},
+        "time_end": {"value": "2024-01-01T01:00:00Z", "format": "RFC3339"},
+        "uss_base_url": "",
+        "subscription_id": "",
+    }
+    reference.update(reference_overrides)
+    return ImplicitDict.parse(
+        {"reference": reference, "details": {}},
+        OperationalIntent,
+    )
+
+
+def test_full_op_intent_with_ovn():
+    folder = full_op_intent(_op_intent(ovn="abc123"))
+    assert folder.name.text == "'s P0 Accepted [0] @ abc123"
+
+
+def test_full_op_intent_without_ovn():
+    folder = full_op_intent(_op_intent())
+    assert folder.name.text == "'s P0 Accepted [0] @ None"
+
+
+def _expect_value_error(req: QueryOperationalIntentReferenceParameters) -> None:
+    resp = ImplicitDict.parse(
+        {"operational_intent_references": []}, QueryOperationalIntentReferenceResponse
+    )
+    try:
+        op_intent_refs_query(req, resp)
+    except ValueError as e:
+        assert "req.area_of_interest is not defined" == str(e)
+    else:
+        raise AssertionError("Expected ValueError for missing area_of_interest")
+
+
+def test_op_intent_refs_query_without_area_of_interest():
+    _expect_value_error(
+        ImplicitDict.parse({}, QueryOperationalIntentReferenceParameters)
+    )
+
+
+def test_op_intent_refs_query_with_falsy_area_of_interest():
+    req = ImplicitDict.parse({}, QueryOperationalIntentReferenceParameters)
+    req["area_of_interest"] = None
+    _expect_value_error(req)


### PR DESCRIPTION
The HTML report generation would fail if the USS under test responded with a payload that did not include an `ovn` or an `area_of_interest`. This means that users wouldn't be able to use the HTML report to inspect failures until the USS under test began responding with those attributes.

This change adds checks to handle both those missing values gracefully.
