### PR TITLE
[benchmarker] Add random flight locations

### DIFF
--- a/monitoring/benchmarker/configurations/interuss/scd/single_s2_cell.jsonnet
+++ b/monitoring/benchmarker/configurations/interuss/scd/single_s2_cell.jsonnet
@@ -5,7 +5,7 @@ local dss_config_names = ['Existing local DSS deployment'];
 local users_per_step = 3;
 
 local location = {
-  horizontal: {lat: 34, lng: -118},
+  uniform_box: {lat_min: 34, lat_max: 34.001, lng_max: -118, lng_min: -118.001},
   vertical: {value: 300, reference: 'W84', units: 'M'},
 };
 
@@ -85,7 +85,7 @@ local shape = {
               uniform_random_spacing: '2s',
             },
             location: {
-              fixed_location: location,
+              random_location: location,
             },
             shape: {
                 fixed_volumes: shape,

--- a/monitoring/benchmarker/configurations/users.py
+++ b/monitoring/benchmarker/configurations/users.py
@@ -4,7 +4,7 @@ from implicitdict import ImplicitDict, StringBasedDateTime, StringBasedTimeDelta
 
 from monitoring.benchmarker.configurations.user.astm import scd
 from monitoring.benchmarker.configurations.user.astm.dss import ASTMDSSSelectionStrategy
-from monitoring.monitorlib.geo import Altitude, LatLngPoint
+from monitoring.monitorlib.geo import Altitude, LatLngBoundingBox, LatLngPoint
 from monitoring.monitorlib.geotemporal import Volume4D
 from monitoring.monitorlib.rid import RIDVersion
 from monitoring.uss_qualifier.resources.definitions import ResourceID
@@ -19,6 +19,14 @@ class FixedLocationSpecification(ImplicitDict):
     vertical: Altitude
 
 
+class RandomLocationSpecification(ImplicitDict):
+    uniform_box: LatLngBoundingBox
+    """Selected flight location will be drawn uniformly from this box."""
+
+    vertical: Altitude
+    """Selected flight location will be at exactly this altitude."""
+
+
 class FlightTimeGenerationSpecification(ImplicitDict):
     fixed_spacing: Optional[StringBasedTimeDelta]
     """Add this fixed delay between the end of the previous flight and the start of the next flight."""
@@ -30,6 +38,9 @@ class FlightTimeGenerationSpecification(ImplicitDict):
 class FlightLocationGenerationSpecification(ImplicitDict):
     fixed_location: Optional[FixedLocationSpecification]
     """Always choose the same flight location."""
+
+    random_location: Optional[RandomLocationSpecification]
+    """Choose a flight location at random."""
 
 
 class FixedVolumesSpecification(ImplicitDict):

--- a/monitoring/benchmarker/engine/users/flight_planner/flight_generation.py
+++ b/monitoring/benchmarker/engine/users/flight_planner/flight_generation.py
@@ -15,6 +15,7 @@ from monitoring.benchmarker.engine.users.flight_planner.framework import (
 from monitoring.monitorlib.geo import (
     AltitudeDatum,
     DistanceUnits,
+    LatLngPoint,
     RelativeTranslation,
     Transformation,
 )
@@ -41,28 +42,44 @@ class IndependentTimeLocationShape(FlightGenerator):
         if "execution" in spec and spec.execution:
             self.execution = spec.execution
 
-        if "fixed_location" in self.spec.location and self.spec.location.fixed_location:
+        if (
+            "fixed_location" in self.spec.location and self.spec.location.fixed_location
+        ) or (
+            "random_location" in self.spec.location
+            and self.spec.location.random_location
+        ):
             pass
         else:
             raise NotImplementedError(
-                "No supported location component is specified in independent_time_location_shape.location for user `user_id`"
+                f"No supported location component is specified in independent_time_location_shape.location for user `{user_id}`"
             )
 
         if "fixed_volumes" in self.spec.shape and self.spec.shape.fixed_volumes:
             pass
         else:
             raise NotImplementedError(
-                "No supported shape component specified in independent_time_location_shape.shape for user `user_id`"
+                f"No supported shape component specified in independent_time_location_shape.shape for user `{user_id}`"
             )
 
-        if self.spec.shape.fixed_volumes and self.spec.location.fixed_location:
-            # Check unit/reference match between fixed_location and fixed_volumes
+        if self.spec.shape.fixed_volumes:
+            # Check unit/reference match between location and fixed_volumes
             fixed_vols = self.spec.shape.fixed_volumes
-            fixed_loc = self.spec.location.fixed_location
             origin_vert = fixed_vols.origin_vertical
             if (
-                fixed_loc.vertical.reference != origin_vert.reference
-                or fixed_loc.vertical.units != origin_vert.units
+                "fixed_location" in self.spec.location
+                and self.spec.location.fixed_location
+            ):
+                loc_vert = self.spec.location.fixed_location.vertical
+            elif (
+                "random_location" in self.spec.location
+                and self.spec.location.random_location
+            ):
+                loc_vert = self.spec.location.random_location.vertical
+            else:
+                loc_vert = None
+            if loc_vert and (
+                loc_vert.reference != origin_vert.reference
+                or loc_vert.units != origin_vert.units
             ):
                 raise NotImplementedError(
                     "Combining vertical location and shape with different reference or units is not supported"
@@ -81,7 +98,7 @@ class IndependentTimeLocationShape(FlightGenerator):
             dt += self.spec.time.uniform_random_spacing.timedelta * self.random.random()
         t0 = previous_flight_end + dt
 
-        if self.spec.location.fixed_location:
+        if "fixed_location" in self.spec.location and self.spec.location.fixed_location:
             xy = self.spec.location.fixed_location.horizontal
             z = self.spec.location.fixed_location.vertical
             if z.units != DistanceUnits.M:
@@ -91,6 +108,24 @@ class IndependentTimeLocationShape(FlightGenerator):
             if z.reference != AltitudeDatum.W84:
                 raise NotImplementedError(
                     "Only W84 is supported for fixed_location altitude"
+                )
+        elif (
+            "random_location" in self.spec.location
+            and self.spec.location.random_location
+        ):
+            box = self.spec.location.random_location.uniform_box
+            xy = LatLngPoint(
+                lat=self.random.uniform(box.lat_min, box.lat_max),
+                lng=self.random.uniform(box.lng_min, box.lng_max),
+            )
+            z = self.spec.location.random_location.vertical
+            if z.units != DistanceUnits.M:
+                raise NotImplementedError(
+                    "Only meters are supported for random_location altitude"
+                )
+            if z.reference != AltitudeDatum.W84:
+                raise NotImplementedError(
+                    "Only W84 is supported for random_location altitude"
                 )
         else:
             raise NotImplementedError("Specified location component not implemented")

--- a/schemas/monitoring/benchmarker/configurations/users/FlightLocationGenerationSpecification.json
+++ b/schemas/monitoring/benchmarker/configurations/users/FlightLocationGenerationSpecification.json
@@ -17,6 +17,17 @@
           "$ref": "FixedLocationSpecification.json"
         }
       ]
+    },
+    "random_location": {
+      "description": "Choose a flight location at random.",
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "RandomLocationSpecification.json"
+        }
+      ]
     }
   },
   "type": "object"

--- a/schemas/monitoring/benchmarker/configurations/users/RandomLocationSpecification.json
+++ b/schemas/monitoring/benchmarker/configurations/users/RandomLocationSpecification.json
@@ -1,0 +1,24 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/configurations/users/RandomLocationSpecification.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "monitoring.benchmarker.configurations.users.RandomLocationSpecification, as defined in monitoring/benchmarker/configurations/users.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "uniform_box": {
+      "$ref": "../../../monitorlib/geo/LatLngBoundingBox.json",
+      "description": "Selected flight location will be drawn uniformly from this box."
+    },
+    "vertical": {
+      "$ref": "../../../monitorlib/geo/Altitude.json",
+      "description": "Selected flight location will be at exactly this altitude."
+    }
+  },
+  "required": [
+    "uniform_box",
+    "vertical"
+  ],
+  "type": "object"
+}


### PR DESCRIPTION
This PR adds the ability to generate simple random flight locations in a horizontal lat/lng box.

Results from single_s2_cell.jsonnet:

<img width="2566" height="407" alt="scalability_curve" src="https://github.com/user-attachments/assets/1d4b0ccb-0b9e-4ba0-a4eb-c80b8ed9c04d" />
