### PR TITLE
[uss_qualifier] Fix shallow-copy problem for $refs in fileio

### DIFF
--- a/monitoring/uss_qualifier/fileio.py
+++ b/monitoring/uss_qualifier/fileio.py
@@ -1,4 +1,5 @@
 import base64
+import copy
 import json
 import os
 import re
@@ -160,7 +161,7 @@ def load_dict_with_references(data_file: FileReference) -> dict:
     removed.  This $ref convention is generally compatible with OpenAPI, except
     that other keys may co-exist with $ref.  Multiple $refs may be used when
     enclosed in an allOf key (with an array as a value), again similar to
-    OpenAPI.
+    OpenAPI (nested dictionaries are recursively merged and lists are concatenated).
     """
     base_file_name, anchor = _split_anchor(data_file)
     base_file_name = resolve_filename(base_file_name)
@@ -324,6 +325,19 @@ def _find_refs(content: dict | list, root: str = "$") -> dict[str, str]:
     return paths
 
 
+def _merge_dict(target: dict, source: dict) -> None:
+    for k, v in source.items():
+        if k in target:
+            if isinstance(target[k], dict) and isinstance(v, dict):
+                _merge_dict(target[k], v)
+            elif isinstance(target[k], list) and isinstance(v, list):
+                target[k].extend(copy.deepcopy(v))
+            else:
+                target[k] = copy.deepcopy(v)
+        else:
+            target[k] = copy.deepcopy(v)
+
+
 def _replace_refs(
     content: dict,
     context_file_name: str,
@@ -368,15 +382,14 @@ def _replace_refs(
                 ]
                 if len(allof_parent_content) != 1:
                     raise RuntimeError(
-                        f'Unexpectedly found {len(ref_content)} matches for allOf parent path "{ref_path}"'
+                        f'Unexpectedly found {len(allof_parent_content)} matches for allOf parent path "{allof_parent_path}"'
                     )
                 allof_parent_content = allof_parent_content[0]
                 if all("$ref" not in s for s in allof_parent_content["allOf"]):
                     # This allOf is complete and can be resolved
                     schemas = allof_parent_content.pop("allOf")
                     for schema in schemas:
-                        for k, v in schema.items():
-                            allof_parent_content[k] = v
+                        _merge_dict(allof_parent_content, schema)
 
 
 def _select_path(content: dict, path: str) -> dict:

--- a/monitoring/uss_qualifier/fileio_test.py
+++ b/monitoring/uss_qualifier/fileio_test.py
@@ -1,0 +1,183 @@
+import json
+import tempfile
+from pathlib import Path
+
+import yaml
+
+from monitoring.uss_qualifier.fileio import load_dict_with_references
+
+
+def test_allof_list_concatenation_issue_1661():
+    """Verify that allOf concatenates lists when referenced blocks share identical keys,
+    fixing the bug described in https://github.com/interuss/monitoring/issues/1661."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+
+        definitions_file = tmp_path / "definitions.yaml"
+        definitions_file.write_text(
+            yaml.dump(
+                {
+                    "set_a": {
+                        "requirement_collections": [
+                            {"requirements": ["REQ_001", "REQ_002"]}
+                        ]
+                    },
+                    "set_b": {
+                        "requirement_collections": [
+                            {"requirements": ["REQ_003", "REQ_004"]}
+                        ]
+                    },
+                }
+            )
+        )
+
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            yaml.dump(
+                {
+                    "tested_requirements": [
+                        {
+                            "report_name": "my_results",
+                            "requirement_collections": {
+                                "CombinedRequirements": {
+                                    "allOf": [
+                                        {"$ref": f"{definitions_file}#/set_a"},
+                                        {"$ref": f"{definitions_file}#/set_b"},
+                                    ]
+                                }
+                            },
+                        }
+                    ]
+                }
+            )
+        )
+
+        result = load_dict_with_references(f"file://{config_file}")
+        combined = result["tested_requirements"][0]["requirement_collections"][
+            "CombinedRequirements"
+        ]
+        assert "allOf" not in combined
+        assert combined == {
+            "requirement_collections": [
+                {"requirements": ["REQ_001", "REQ_002"]},
+                {"requirements": ["REQ_003", "REQ_004"]},
+            ]
+        }
+
+
+def test_allof_readme_example():
+    """Verify that allOf reproduces the example documented in configurations/README.md."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+
+        r_file = tmp_path / "r.json"
+        r_file.write_text(json.dumps({"b": 5, "c": 6, "e": 7}))
+
+        s_file = tmp_path / "s.json"
+        s_file.write_text(json.dumps({"b": 8, "d": 9, "f": 10}))
+
+        q_file = tmp_path / "q.json"
+        q_file.write_text(
+            json.dumps(
+                {
+                    "a": 1,
+                    "b": 2,
+                    "allOf": [{"$ref": str(r_file)}, {"$ref": str(s_file)}],
+                    "c": 3,
+                    "d": 4,
+                }
+            )
+        )
+
+        result = load_dict_with_references(f"file://{q_file}")
+        assert result == {"a": 1, "b": 8, "c": 6, "d": 9, "e": 7, "f": 10}
+
+
+def test_allof_deep_merge_nested_dicts_and_lists():
+    """Verify recursive merging of nested dictionaries and concatenation of nested lists."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+
+        part_a = tmp_path / "a.yaml"
+        part_a.write_text(
+            yaml.dump(
+                {
+                    "nested": {
+                        "key1": "val1",
+                        "list1": [1, 2],
+                        "inner_dict": {"x": 10, "y": 20},
+                    }
+                }
+            )
+        )
+
+        part_b = tmp_path / "b.yaml"
+        part_b.write_text(
+            yaml.dump(
+                {
+                    "nested": {
+                        "key2": "val2",
+                        "list1": [3, 4],
+                        "inner_dict": {"y": 30, "z": 40},
+                    }
+                }
+            )
+        )
+
+        main_file = tmp_path / "main.yaml"
+        main_file.write_text(
+            yaml.dump(
+                {
+                    "container": {
+                        "nested": {"list1": [0]},
+                        "allOf": [
+                            {"$ref": str(part_a)},
+                            {"$ref": str(part_b)},
+                        ],
+                    }
+                }
+            )
+        )
+
+        result = load_dict_with_references(f"file://{main_file}")
+        assert result == {
+            "container": {
+                "nested": {
+                    "key1": "val1",
+                    "key2": "val2",
+                    "list1": [0, 1, 2, 3, 4],
+                    "inner_dict": {"x": 10, "y": 30, "z": 40},
+                }
+            }
+        }
+
+
+def test_allof_internal_references():
+    """Verify that allOf works with internal document references (#)."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+
+        doc_file = tmp_path / "doc.yaml"
+        doc_file.write_text(
+            yaml.dump(
+                {
+                    "definitions": {
+                        "part_a": {"features": ["feat_1", "feat_2"], "score": 10},
+                        "part_b": {"features": ["feat_3"], "score": 20, "extra": "yes"},
+                    },
+                    "combined": {
+                        "allOf": [
+                            {"$ref": "#/definitions/part_a"},
+                            {"$ref": "#/definitions/part_b"},
+                        ]
+                    },
+                }
+            )
+        )
+
+        result = load_dict_with_references(f"file://{doc_file}")
+        assert result["combined"] == {
+            "features": ["feat_1", "feat_2", "feat_3"],
+            "score": 20,
+            "extra": "yes",
+        }


### PR DESCRIPTION
This PR was generated by Gemini to fix #1661 using the prompt:

> Please fix the bug described here: https://github.com/interuss/monitoring/issues/1661 (in the local monitoring repo/folder).

(I think this indicates a very well-reported bug)

Gemini summarized the changes as:

<hr>

The issue reported in [Issue #1661](https://github.com/interuss/monitoring/issues/1661) has been resolved.

### Root Cause
When flattening configurations containing `allOf` blocks, [`fileio.py`](file:///usr/local/google/home/pelletierb/IdeaProjects/OpenSource/monitoring/monitoring/uss_qualifier/fileio.py#L380-L393) performed a shallow key assignment (`allof_parent_content[k] = v`), causing schemas with shared keys (such as `requirement_collections`) to overwrite previous entries instead of merging them.

### Changes Made
1. **Deep Merge & List Concatenation in [`fileio.py`](file:///usr/local/google/home/pelletierb/IdeaProjects/OpenSource/monitoring/monitoring/uss_qualifier/fileio.py#L328-L340)**:
   - Added [`_merge_dict`](file:///usr/local/google/home/pelletierb/IdeaProjects/OpenSource/monitoring/monitoring/uss_qualifier/fileio.py#L328-L338) to recursively merge dictionary values, concatenate list values, and overwrite scalar values when resolving `allOf` schemas.
   - Updated `_replace_refs` to use `_merge_dict` when resolving all complete `allOf` blocks into the parent object.
   - Clarified `load_dict_with_references` documentation to explicitly state the merging and list-concatenation behavior.
2. **Added Unit Tests in [`fileio_test.py`](file:///usr/local/google/home/pelletierb/IdeaProjects/OpenSource/monitoring/monitoring/uss_qualifier/fileio_test.py)**:
   - Tested the exact reproduction case from #1661 (`requirement_collections` list merging).
   - Tested the scalar override behavior from `configurations/README.md`.
   - Tested nested dictionary merging and list concatenation.
   - Tested local internal references (`#`) combined with `allOf`.