### PR TITLE
[benchmarker] Add timeline artifact

### DIFF
--- a/monitoring/benchmarker/artifacts/generation.py
+++ b/monitoring/benchmarker/artifacts/generation.py
@@ -56,4 +56,3 @@ def generate_artifacts(
 
         if "timeline" in spec and spec.timeline is not None:
             generate_timeline(report, spec.timeline, output_dir)
-

--- a/monitoring/benchmarker/artifacts/generation.py
+++ b/monitoring/benchmarker/artifacts/generation.py
@@ -4,6 +4,7 @@ from monitoring.benchmarker.artifacts.matplotlib.matplotlib_figure import (
     generate_matplotlib_figure,
 )
 from monitoring.benchmarker.artifacts.raw_report import generate_raw_report
+from monitoring.benchmarker.artifacts.timeline.timeline import generate_timeline
 from monitoring.benchmarker.configurations.artifacts.artifact import (
     ArtifactSpecification,
 )
@@ -52,3 +53,7 @@ def generate_artifacts(
 
         if "matplotlib_figure" in spec and spec.matplotlib_figure is not None:
             generate_matplotlib_figure(report, spec.matplotlib_figure, output_dir)
+
+        if "timeline" in spec and spec.timeline is not None:
+            generate_timeline(report, spec.timeline, output_dir)
+

--- a/monitoring/benchmarker/artifacts/timeline/__init__.py
+++ b/monitoring/benchmarker/artifacts/timeline/__init__.py
@@ -1,0 +1,14 @@
+import os
+
+from jinja2 import Environment, FileSystemLoader
+
+jinja_env = Environment(
+    loader=FileSystemLoader(
+        [
+            os.path.abspath(os.path.join(os.path.dirname(__file__), relpath))
+            for relpath in ("templates", "../../../monitorlib/html/templates")
+        ]
+    ),
+    trim_blocks=True,
+    lstrip_blocks=True,
+)

--- a/monitoring/benchmarker/artifacts/timeline/templates/index.html
+++ b/monitoring/benchmarker/artifacts/timeline/templates/index.html
@@ -1,0 +1,288 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Benchmarker Timeline - {{ spec.name }}</title>
+  <style>
+    :root {
+      --primary: #1976d2;
+      --primary-hover: #1565c0;
+      --bg: #f8fafc;
+      --surface: #ffffff;
+      --border: #e2e8f0;
+      --text: #1e293b;
+      --text-muted: #64748b;
+      --success: #10b981;
+      --danger: #ef4444;
+      --warning: #f59e0b;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      margin: 0;
+      padding: 0;
+      background-color: var(--bg);
+      color: var(--text);
+      line-height: 1.5;
+    }
+
+    .container {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 2rem 1.5rem;
+    }
+
+    header {
+      background-color: var(--surface);
+      border-bottom: 1px solid var(--border);
+      padding: 1.5rem 0;
+      margin-bottom: 2rem;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+    }
+
+    .header-content {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 0 1.5rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 1rem;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: 1.75rem;
+      font-weight: 700;
+      color: var(--text);
+    }
+
+    .meta-badges {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
+
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      padding: 0.25rem 0.75rem;
+      border-radius: 9999px;
+      font-size: 0.8125rem;
+      font-weight: 500;
+      background-color: #f1f5f9;
+      color: var(--text-muted);
+      border: 1px solid var(--border);
+    }
+
+    .card {
+      background-color: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 0.75rem;
+      padding: 1.5rem;
+      margin-bottom: 1.5rem;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+    }
+
+    .card-title {
+      font-size: 1.25rem;
+      font-weight: 600;
+      margin-top: 0;
+      margin-bottom: 1rem;
+      color: var(--text);
+    }
+
+    .legend-grid {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+    }
+
+    .legend-item {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-size: 0.875rem;
+      padding: 0.5rem 0.75rem;
+      background-color: #f8fafc;
+      border: 1px solid var(--border);
+      border-radius: 0.5rem;
+    }
+
+    .legend-color-box {
+      width: 1.25rem;
+      height: 1.25rem;
+      border-radius: 0.25rem;
+      border: 1px solid rgba(0,0,0,0.15);
+      flex-shrink: 0;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      text-align: left;
+    }
+
+    th, td {
+      padding: 0.875rem 1rem;
+      border-bottom: 1px solid var(--border);
+    }
+
+    th {
+      font-weight: 600;
+      font-size: 0.8125rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--text-muted);
+      background-color: #f8fafc;
+    }
+
+    tr:hover td {
+      background-color: #f8fafc;
+    }
+
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 1rem;
+      background-color: var(--primary);
+      color: #ffffff;
+      text-decoration: none;
+      border-radius: 0.375rem;
+      font-weight: 500;
+      font-size: 0.875rem;
+      transition: background-color 0.15s ease-in-out;
+    }
+
+    .btn:hover {
+      background-color: var(--primary-hover);
+    }
+
+    .status-pill {
+      display: inline-block;
+      padding: 0.2rem 0.5rem;
+      border-radius: 0.25rem;
+      font-size: 0.75rem;
+      font-weight: 600;
+      margin-right: 0.25rem;
+      margin-bottom: 0.25rem;
+    }
+
+    .status-completed {
+      background-color: #d1fae5;
+      color: #065f46;
+    }
+
+    .status-stabilitynotachieved {
+      background-color: #fee2e2;
+      color: #991b1b;
+    }
+
+    .status-unstable {
+      background-color: #fef3c7;
+      color: #92400e;
+    }
+
+    .progress-steps {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.25rem;
+      align-items: center;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="header-content">
+      <div>
+        <h1>Timeline Artifact: <code>{{ spec.name }}</code></h1>
+        <div style="color: var(--text-muted); font-size: 0.875rem; margin-top: 0.25rem;">
+          Benchmark Performance Timelines
+        </div>
+      </div>
+      <div class="meta-badges">
+        {% if report.codebase_version %}
+          <span class="badge">Version: {{ report.codebase_version }}</span>
+        {% endif %}
+        {% if report.commit_hash %}
+          <span class="badge">Commit: {{ report.commit_hash[:8] }}</span>
+        {% endif %}
+      </div>
+    </div>
+  </header>
+
+  <div class="container">
+    <div class="card">
+      <h2 class="card-title">Configured Operations of Interest</h2>
+      <div class="legend-grid">
+        {% for op in spec.operations %}
+          <div class="legend-item">
+            <div class="legend-color-box" style="background-color: {{ op.color or '#32aced' }};"></div>
+            <div>
+              <div style="font-weight: 600;">{{ op.type.split('.')[-1] }}</div>
+              <code style="font-size: 0.75rem; color: var(--text-muted);">{{ op.type }}</code>
+            </div>
+          </div>
+        {% endfor %}
+      </div>
+    </div>
+
+    <div class="card" style="padding: 0; overflow: hidden;">
+      <div style="padding: 1.5rem 1.5rem 1rem 1.5rem;">
+        <h2 class="card-title" style="margin: 0;">Benchmark Scenarios</h2>
+      </div>
+      <table>
+        <thead>
+          <tr>
+            <th>Scenario</th>
+            <th>Duration</th>
+            <th>Steps / Progression</th>
+            <th>Origins</th>
+            <th>Operations</th>
+            <th>Action</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for s in scenarios_summary %}
+            <tr>
+              <td>
+                <a href="{{ s.filename }}" style="font-weight: 600; color: var(--primary); text-decoration: none;">
+                  Scenario {{ s.index }}
+                </a>
+              </td>
+              <td>{{ "%.1f"|format(s.duration) }}s</td>
+              <td>
+                <div class="progress-steps">
+                  {% for step in s.steps %}
+                    <span class="status-pill status-{{ step.termination_reason|lower }}" title="Step {{ step.step_index }}: LF {{ step.load_factor }}, {{ step.termination_reason }}">
+                      LF {{ step.load_factor }} {{ step.termination_symbol }}
+                    </span>
+                  {% endfor %}
+                </div>
+              </td>
+              <td>{{ s.origins_count }}</td>
+              <td>
+                <div><b>{{ s.operations_count }}</b> total</div>
+                <div style="font-size: 0.75rem; color: var(--text-muted);">
+                  <span style="color: var(--success); font-weight: 600;">{{ s.successful_operations }} ✔</span>
+                  {% if s.unsuccessful_operations > 0 %}
+                    &nbsp;|&nbsp;<span style="color: var(--danger); font-weight: 600;">{{ s.unsuccessful_operations }} ✖</span>
+                  {% endif %}
+                </div>
+              </td>
+              <td>
+                <a href="{{ s.filename }}" class="btn">
+                  View Timeline &rarr;
+                </a>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</body>
+</html>

--- a/monitoring/benchmarker/artifacts/timeline/templates/index.html
+++ b/monitoring/benchmarker/artifacts/timeline/templates/index.html
@@ -155,6 +155,7 @@
       font-weight: 500;
       font-size: 0.875rem;
       transition: background-color 0.15s ease-in-out;
+      white-space: nowrap;
     }
 
     .btn:hover {
@@ -169,6 +170,7 @@
       font-weight: 600;
       margin-right: 0.25rem;
       margin-bottom: 0.25rem;
+      white-space: nowrap;
     }
 
     .status-completed {
@@ -204,10 +206,10 @@
         </div>
       </div>
       <div class="meta-badges">
-        {% if report.codebase_version %}
+        {% if "codebase_version" in report and report.codebase_version %}
           <span class="badge">Version: {{ report.codebase_version }}</span>
         {% endif %}
-        {% if report.commit_hash %}
+        {% if "commit_hash" in report and report.commit_hash %}
           <span class="badge">Commit: {{ report.commit_hash[:8] }}</span>
         {% endif %}
       </div>
@@ -237,45 +239,45 @@
       <table>
         <thead>
           <tr>
-            <th>Scenario</th>
-            <th>Duration</th>
+            <th style="white-space: nowrap;">Scenario</th>
+            <th style="white-space: nowrap;">Duration</th>
             <th>Steps / Progression</th>
-            <th>Origins</th>
-            <th>Operations</th>
-            <th>Action</th>
+            <th style="white-space: nowrap;">Origins</th>
+            <th style="white-space: nowrap;">Operations</th>
+            <th style="white-space: nowrap;">Action</th>
           </tr>
         </thead>
         <tbody>
           {% for s in scenarios_summary %}
             <tr>
-              <td>
+              <td style="white-space: nowrap;">
                 <a href="{{ s.filename }}" style="font-weight: 600; color: var(--primary); text-decoration: none;">
-                  Scenario {{ s.index }}
+                  Scenario&nbsp;{{ s.index }}
                 </a>
+                <div style="font-size: 0.8125rem; color: var(--text-muted); margin-top: 0.25rem;">
+                  {{ s.name }}
+                </div>
               </td>
-              <td>{{ "%.1f"|format(s.duration) }}s</td>
+              <td style="white-space: nowrap;">{{ s.duration_shorthand }}</td>
               <td>
                 <div class="progress-steps">
                   {% for step in s.steps %}
                     <span class="status-pill status-{{ step.termination_reason|lower }}" title="Step {{ step.step_index }}: LF {{ step.load_factor }}, {{ step.termination_reason }}">
-                      LF {{ step.load_factor }} {{ step.termination_symbol }}
+                      LF&nbsp;{{ step.load_factor }}&nbsp;{{ step.termination_symbol }}
                     </span>
                   {% endfor %}
                 </div>
               </td>
-              <td>{{ s.origins_count }}</td>
-              <td>
-                <div><b>{{ s.operations_count }}</b> total</div>
-                <div style="font-size: 0.75rem; color: var(--text-muted);">
-                  <span style="color: var(--success); font-weight: 600;">{{ s.successful_operations }} ✔</span>
-                  {% if s.unsuccessful_operations > 0 %}
-                    &nbsp;|&nbsp;<span style="color: var(--danger); font-weight: 600;">{{ s.unsuccessful_operations }} ✖</span>
-                  {% endif %}
+              <td style="white-space: nowrap;">{{ s.origins_count }}</td>
+              <td style="white-space: nowrap;">
+                <div><b>{{ s.operations_count }}</b>&nbsp;total</div>
+                <div style="font-size: 0.75rem; color: var(--text-muted); margin-top: 0.15rem;">
+                  <span style="color: var(--success); font-weight: 600;">{{ s.successful_operations }}&nbsp;✔</span>{% if s.unsuccessful_operations > 0 %}&nbsp;|&nbsp;<span style="color: var(--danger); font-weight: 600;">{{ s.unsuccessful_operations }}&nbsp;✖</span>{% endif %}
                 </div>
               </td>
-              <td>
+              <td style="white-space: nowrap;">
                 <a href="{{ s.filename }}" class="btn">
-                  View Timeline &rarr;
+                  View&nbsp;Timeline&nbsp;&rarr;
                 </a>
               </td>
             </tr>

--- a/monitoring/benchmarker/artifacts/timeline/templates/scenario.html
+++ b/monitoring/benchmarker/artifacts/timeline/templates/scenario.html
@@ -1,0 +1,908 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Scenario {{ scenario_index }} Timeline - {{ spec.name }}</title>
+  <style>
+    :root {
+      --primary: #1976d2;
+      --primary-hover: #1565c0;
+      --bg: #f8fafc;
+      --surface: #ffffff;
+      --border: #e2e8f0;
+      --text: #1e293b;
+      --text-muted: #64748b;
+      --success: #10b981;
+      --danger: #ef4444;
+      --warning: #f59e0b;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      margin: 0;
+      padding: 0;
+      background-color: var(--bg);
+      color: var(--text);
+      overflow-x: hidden;
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    header {
+      background-color: var(--surface);
+      border-bottom: 1px solid var(--border);
+      padding: 0.5rem 1.25rem;
+      flex-shrink: 0;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+    }
+
+    .header-content {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+    }
+
+    .title-nav {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: 1.25rem;
+      font-weight: 700;
+      color: var(--text);
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    .nav-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+      color: var(--primary);
+      text-decoration: none;
+      font-size: 0.875rem;
+      font-weight: 500;
+      padding: 0.25rem 0.5rem;
+      border-radius: 0.25rem;
+      border: 1px solid transparent;
+    }
+
+    .nav-link:hover {
+      background-color: #f1f5f9;
+      border-color: var(--border);
+    }
+
+    .controls-bar {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+    }
+
+    .btn-group {
+      display: inline-flex;
+      border-radius: 0.375rem;
+      border: 1px solid var(--border);
+      overflow: hidden;
+      background: var(--surface);
+    }
+
+    .btn-sm {
+      padding: 0.25rem 0.6rem;
+      font-size: 0.8125rem;
+      border: none;
+      background: transparent;
+      color: var(--text);
+      cursor: pointer;
+      border-right: 1px solid var(--border);
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+    }
+
+    .btn-sm:last-child {
+      border-right: none;
+    }
+
+    .btn-sm:hover {
+      background-color: #f1f5f9;
+    }
+
+    .legend-bar {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      background-color: #f8fafc;
+      border: 1px solid var(--border);
+      border-radius: 0.375rem;
+      padding: 0.25rem 0.6rem;
+      font-size: 0.75rem;
+      flex-wrap: wrap;
+    }
+
+    .legend-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+    }
+
+    .legend-color-dot {
+      width: 0.75rem;
+      height: 0.75rem;
+      border-radius: 0.15rem;
+      border: 1px solid rgba(0,0,0,0.2);
+    }
+
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      padding: 0.15rem 0.5rem;
+      border-radius: 9999px;
+      font-size: 0.75rem;
+      font-weight: 500;
+      background-color: #f1f5f9;
+      color: var(--text-muted);
+      border: 1px solid var(--border);
+    }
+
+    #timeline-container {
+      flex: 1;
+      position: relative;
+      width: 100%;
+      background-color: #ffffff;
+      overflow: hidden;
+    }
+
+    #timeline-canvas {
+      display: block;
+      width: 100%;
+      height: 100%;
+      cursor: default;
+    }
+
+    #tooltip {
+      position: absolute;
+      display: none;
+      background: rgba(15, 23, 42, 0.94);
+      color: #ffffff;
+      padding: 0.5rem 0.75rem;
+      border-radius: 0.375rem;
+      font-size: 0.75rem;
+      line-height: 1.45;
+      pointer-events: none;
+      z-index: 1000;
+      box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.2), 0 2px 4px -1px rgba(0, 0, 0, 0.1);
+      max-width: 400px;
+    }
+
+    #tooltip strong {
+      color: #93c5fd;
+    }
+
+    .help-hint {
+      position: absolute;
+      bottom: 0.5rem;
+      left: 0.75rem;
+      background: rgba(255, 255, 255, 0.9);
+      backdrop-filter: blur(4px);
+      border: 1px solid var(--border);
+      border-radius: 0.25rem;
+      padding: 0.25rem 0.6rem;
+      font-size: 0.75rem;
+      color: var(--text-muted);
+      pointer-events: none;
+      z-index: 10;
+      box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="header-content">
+      <div class="title-nav">
+        <a href="index.html" class="nav-link">&larr; Overview</a>
+        <h1>Scenario {{ scenario_index }} Timeline</h1>
+        <div style="display: flex; gap: 0.25rem;">
+          {% if prev_scenario %}
+            <a href="{{ prev_scenario }}" class="nav-link">&larr; Prev</a>
+          {% endif %}
+          {% if next_scenario %}
+            <a href="{{ next_scenario }}" class="nav-link">Next &rarr;</a>
+          {% endif %}
+        </div>
+      </div>
+
+      <div class="controls-bar">
+        <div class="legend-bar">
+          <span style="font-weight: 600; color: var(--text-muted);">Operations:</span>
+          {% for op in timeline_data.operation_types %}
+            <div class="legend-chip">
+              <span class="legend-color-dot" style="background-color: {{ op.color }};"></span>
+              <span>{{ op.name }}</span>
+            </div>
+          {% endfor %}
+          <div class="legend-chip" style="border-left: 1px solid var(--border); padding-left: 0.5rem;">
+            <span style="display: inline-block; width: 8px; height: 3px; background: #27ae60;"></span>
+            <span>Success</span>
+            <span style="display: inline-block; width: 8px; height: 3px; background: #e74c3c; margin-left: 0.25rem;"></span>
+            <span>Fail</span>
+          </div>
+        </div>
+
+        <div class="btn-group">
+          <button id="btn-zoom-in" class="btn-sm" title="Zoom In (or Shift + Scroll Down)">Zoom In (+)</button>
+          <button id="btn-zoom-out" class="btn-sm" title="Zoom Out (or Shift + Scroll Up)">Zoom Out (-)</button>
+          <button id="btn-reset-view" class="btn-sm" title="Reset to Full Scenario View">Reset View</button>
+        </div>
+
+        <span class="badge">Duration: {{ "%.1f"|format(timeline_data.scenario_duration) }}s</span>
+        <span class="badge">{{ timeline_data.stats.total_steps }} Steps</span>
+        <span class="badge">{{ timeline_data.stats.total_origins }} Origins</span>
+        <span class="badge">{{ timeline_data.stats.total_operations }} Ops</span>
+      </div>
+    </div>
+  </header>
+
+  <div id="timeline-container">
+    <canvas id="timeline-canvas"></canvas>
+    <div id="tooltip"></div>
+    <div class="help-hint">
+      <strong>Controls:</strong> Left-drag or Mouse wheel to scroll &bull; Shift + Left-drag or Shift + Wheel to zoom
+    </div>
+  </div>
+
+  <script id="scenario-data" type="application/json">
+    {{ scenario_data_json|safe }}
+  </script>
+
+  <script>
+    (function() {
+      const rawDataElement = document.getElementById('scenario-data');
+      const data = JSON.parse(rawDataElement.textContent);
+
+      const container = document.getElementById('timeline-container');
+      const canvas = document.getElementById('timeline-canvas');
+      const ctx = canvas.getContext('2d');
+      const tooltip = document.getElementById('tooltip');
+
+      const scenarioStart = data.scenario_start;
+      const scenarioEnd = data.scenario_end;
+      const fullDuration = Math.max(0.1, scenarioEnd - scenarioStart);
+      const minDuration = 0.05; // 50ms min zoom window
+
+      // Visible time window [viewT0, viewT1]
+      let viewT0 = scenarioStart;
+      let viewT1 = scenarioEnd;
+
+      // Layout constants
+      const H_HEADER = 36;
+      const W_EVENTS = 130;
+      const W_TIME = 75;
+      const W_SCROLLBAR = 24;
+
+      let width = 0;
+      let height = 0;
+      let dpr = window.devicePixelRatio || 1;
+
+      let hoveredItem = null;
+
+      // Drag & Interaction state
+      let isDraggingMain = false;
+      let isDraggingScrollbar = false;
+      let dragAnchorY = 0;
+      let dragAnchorTime = 0;
+      let dragStartT0 = 0;
+      let dragStartT1 = 0;
+      let dragWithShift = false;
+
+      function clampView() {
+        let span = viewT1 - viewT0;
+        if (span >= fullDuration) {
+          viewT0 = scenarioStart;
+          viewT1 = scenarioEnd;
+          return;
+        }
+        if (span < minDuration) {
+          span = minDuration;
+        }
+        if (viewT0 < scenarioStart) {
+          viewT0 = scenarioStart;
+          viewT1 = viewT0 + span;
+        }
+        if (viewT1 > scenarioEnd) {
+          viewT1 = scenarioEnd;
+          viewT0 = viewT1 - span;
+        }
+        if (viewT0 < scenarioStart) {
+          viewT0 = scenarioStart;
+        }
+      }
+
+      function resizeCanvas() {
+        const rect = container.getBoundingClientRect();
+        width = rect.width;
+        height = rect.height;
+        dpr = window.devicePixelRatio || 1;
+
+        canvas.width = Math.floor(width * dpr);
+        canvas.height = Math.floor(height * dpr);
+        ctx.resetTransform();
+        ctx.scale(dpr, dpr);
+
+        draw();
+      }
+
+      window.addEventListener('resize', resizeCanvas);
+
+      function timeToY(t) {
+        const timelineH = Math.max(10, height - H_HEADER);
+        return H_HEADER + ((t - viewT0) / (viewT1 - viewT0)) * timelineH;
+      }
+
+      function yToTime(y) {
+        const timelineH = Math.max(10, height - H_HEADER);
+        return viewT0 + ((y - H_HEADER) / timelineH) * (viewT1 - viewT0);
+      }
+
+      function timeToScrollbarY(t) {
+        const timelineH = Math.max(10, height - H_HEADER);
+        return H_HEADER + ((t - scenarioStart) / fullDuration) * timelineH;
+      }
+
+      function scrollbarYToTime(y) {
+        const timelineH = Math.max(10, height - H_HEADER);
+        return scenarioStart + ((y - H_HEADER) / timelineH) * fullDuration;
+      }
+
+      function formatIsoTime(t) {
+        const d = new Date(t * 1000);
+        return d.toISOString().substr(11, 8); // HH:MM:SS
+      }
+
+      function formatIsoTimeMs(t) {
+        const d = new Date(t * 1000);
+        return d.toISOString().substr(11, 12); // HH:MM:SS.mmm
+      }
+
+      function formatDuration(sec) {
+        if (sec >= 1) {
+          return sec.toFixed(3) + 's';
+        } else {
+          return (sec * 1000).toFixed(1) + 'ms';
+        }
+      }
+
+      function drawArrow(startX, endX, y, color) {
+        ctx.strokeStyle = color;
+        ctx.fillStyle = color;
+        ctx.lineWidth = 1.5;
+        ctx.beginPath();
+        ctx.moveTo(startX, y);
+        ctx.lineTo(endX, y);
+        ctx.stroke();
+
+        // Arrow head
+        ctx.beginPath();
+        ctx.moveTo(endX, y);
+        ctx.lineTo(endX - 6, y - 3.5);
+        ctx.lineTo(endX - 6, y + 3.5);
+        ctx.closePath();
+        ctx.fill();
+      }
+
+      function draw() {
+        if (width <= 0 || height <= 0) return;
+
+        ctx.clearRect(0, 0, width, height);
+
+        const timelineH = Math.max(10, height - H_HEADER);
+        const totalOpLanes = Math.max(1, data.total_operation_lanes);
+        const xOpsStart = W_EVENTS + W_TIME;
+        const wOpsAvailable = Math.max(10, width - xOpsStart - W_SCROLLBAR);
+        const laneW = wOpsAvailable / totalOpLanes;
+
+        // 1. Column Backgrounds & Vertical Dividers
+        // Scenario Events Lane background
+        ctx.fillStyle = '#fafbfc';
+        ctx.fillRect(0, 0, W_EVENTS, height);
+
+        // Time Scale Lane background
+        ctx.fillStyle = '#f1f5f9';
+        ctx.fillRect(W_EVENTS, 0, W_TIME, height);
+
+        // Operations area background
+        ctx.fillStyle = '#ffffff';
+        ctx.fillRect(xOpsStart, 0, wOpsAvailable, height);
+
+        // Column Dividers
+        ctx.strokeStyle = '#e2e8f0';
+        ctx.lineWidth = 1;
+        ctx.beginPath();
+        ctx.moveTo(W_EVENTS, 0);
+        ctx.lineTo(W_EVENTS, height);
+        ctx.moveTo(xOpsStart, 0);
+        ctx.lineTo(xOpsStart, height);
+        ctx.moveTo(width - W_SCROLLBAR, 0);
+        ctx.lineTo(width - W_SCROLLBAR, height);
+        ctx.stroke();
+
+        // 2. Time Scale Ticks & Guidelines across lanes
+        const span = viewT1 - viewT0;
+        let tickInterval = 60; // 1 min default
+        if (span > 1800) tickInterval = 300; // 5 min
+        else if (span > 600) tickInterval = 120; // 2 min
+        else if (span > 120) tickInterval = 60; // 1 min
+        else if (span > 30) tickInterval = 10; // 10s
+        else if (span > 10) tickInterval = 5; // 5s
+        else tickInterval = 1; // 1s
+
+        const firstTick = Math.ceil(viewT0 / tickInterval) * tickInterval;
+        ctx.font = '10px -apple-system, BlinkMacSystemFont, sans-serif';
+        ctx.fillStyle = '#64748b';
+        ctx.textAlign = 'right';
+        ctx.textBaseline = 'middle';
+
+        for (let t = firstTick; t <= viewT1; t += tickInterval) {
+          const y = timeToY(t);
+          if (y >= H_HEADER && y <= height) {
+            // Horizontal guideline
+            ctx.strokeStyle = 'rgba(226, 232, 240, 0.8)';
+            ctx.lineWidth = 1;
+            ctx.beginPath();
+            ctx.moveTo(W_EVENTS, y);
+            ctx.lineTo(width - W_SCROLLBAR, y);
+            ctx.stroke();
+
+            // Tick in time column
+            ctx.strokeStyle = '#94a3b8';
+            ctx.beginPath();
+            ctx.moveTo(xOpsStart - 5, y);
+            ctx.lineTo(xOpsStart, y);
+            ctx.stroke();
+
+            // Time label
+            ctx.fillText(formatIsoTime(t), xOpsStart - 7, y);
+          }
+        }
+
+        // 3. Scenario Events Swim Lane (Leftmost)
+        data.steps.forEach((step) => {
+          // Event 1: Step Start (Yellow Arrow + Load Factor)
+          const yStart = timeToY(step.start_time);
+          if (yStart >= H_HEADER - 12 && yStart <= height + 12) {
+            ctx.fillStyle = '#b45309';
+            ctx.font = 'bold 10px -apple-system, BlinkMacSystemFont, sans-serif';
+            ctx.textAlign = 'left';
+            ctx.textBaseline = 'middle';
+            const label = `LF: ${step.load_factor}`;
+            ctx.fillText(label, 6, yStart);
+
+            const textWidth = ctx.measureText(label).width;
+            drawArrow(6 + textWidth + 4, xOpsStart, yStart, '#eab308');
+          }
+
+          // Event 2: Throughput Stability (Green Arrow + 👍)
+          if (step.throughput_stability_time !== null && step.throughput_stability_time !== undefined) {
+            const yStab = timeToY(step.throughput_stability_time);
+            if (yStab >= H_HEADER - 12 && yStab <= height + 12) {
+              ctx.fillStyle = '#15803d';
+              ctx.font = '11px -apple-system, BlinkMacSystemFont, sans-serif';
+              ctx.textAlign = 'left';
+              ctx.textBaseline = 'middle';
+              ctx.fillText('👍', 10, yStab);
+
+              drawArrow(28, xOpsStart, yStab, '#22c55e');
+            }
+          }
+
+          // Event 3: Step Termination (Red Arrow + Unicode Symbol)
+          const yEnd = timeToY(step.end_time);
+          if (yEnd >= H_HEADER - 12 && yEnd <= height + 12) {
+            ctx.fillStyle = '#b91c1c';
+            ctx.font = '12px -apple-system, BlinkMacSystemFont, sans-serif';
+            ctx.textAlign = 'left';
+            ctx.textBaseline = 'middle';
+            ctx.fillText(step.termination_symbol, 10, yEnd);
+
+            drawArrow(28, xOpsStart, yEnd, '#ef4444');
+          }
+        });
+
+        // 4. Origin Swim Lanes & Operation Rectangles
+        let currentLaneOffset = 0;
+
+        data.origins.forEach((origin) => {
+          const originX = xOpsStart + currentLaneOffset * laneW;
+          const originW = origin.num_lanes * laneW;
+
+          // Subtle divider between sublanes within origin
+          for (let l = 1; l < origin.num_lanes; l++) {
+            const subX = originX + l * laneW;
+            ctx.strokeStyle = '#f1f5f9';
+            ctx.lineWidth = 1;
+            ctx.beginPath();
+            ctx.moveTo(subX, H_HEADER);
+            ctx.lineTo(subX, height);
+            ctx.stroke();
+          }
+
+          // Origin column separator
+          ctx.strokeStyle = '#cbd5e1';
+          ctx.lineWidth = 1;
+          ctx.beginPath();
+          ctx.moveTo(originX + originW, 0);
+          ctx.lineTo(originX + originW, height);
+          ctx.stroke();
+
+          // Draw operations in each lane
+          origin.lanes.forEach((laneOps, laneIdx) => {
+            const laneX = originX + laneIdx * laneW;
+            laneOps.forEach((op) => {
+              if (op.t1 < viewT0 || op.t0 > viewT1) return;
+
+              const y0 = Math.max(H_HEADER, timeToY(op.t0));
+              const y1 = Math.min(height, timeToY(op.t1));
+              const rectH = Math.max(2, y1 - y0);
+
+              const rectX = laneX + 1;
+              const rectW = Math.max(2, laneW - 2);
+
+              // Operation rectangle
+              ctx.fillStyle = op.color;
+              ctx.fillRect(rectX, y0, rectW, rectH);
+
+              // Termination indicator line
+              const termY = timeToY(op.t1);
+              if (termY >= H_HEADER && termY <= height) {
+                const indH = Math.min(rectH, op.indicator_width || 2);
+                ctx.fillStyle = op.success ? '#22c55e' : '#ef4444';
+                ctx.fillRect(rectX, termY - indH, rectW, indH);
+              }
+
+              // Highlight if hovered
+              if (hoveredItem && hoveredItem.type === 'op' && hoveredItem.op === op) {
+                ctx.strokeStyle = '#0f172a';
+                ctx.lineWidth = 2;
+                ctx.strokeRect(rectX, y0, rectW, rectH);
+              }
+            });
+          });
+
+          currentLaneOffset += origin.num_lanes;
+        });
+
+        // 5. Header Row at Top (Origin Labels & Column Titles)
+        ctx.fillStyle = '#f8fafc';
+        ctx.fillRect(0, 0, width, H_HEADER);
+        ctx.strokeStyle = '#cbd5e1';
+        ctx.lineWidth = 1;
+        ctx.beginPath();
+        ctx.moveTo(0, H_HEADER);
+        ctx.lineTo(width, H_HEADER);
+        ctx.stroke();
+
+        ctx.font = 'bold 11px -apple-system, BlinkMacSystemFont, sans-serif';
+        ctx.fillStyle = '#475569';
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+
+        ctx.fillText('Scenario Events', W_EVENTS / 2, H_HEADER / 2);
+        ctx.fillText('Time', W_EVENTS + W_TIME / 2, H_HEADER / 2);
+
+        let headerOffset = 0;
+        data.origins.forEach((origin) => {
+          const originX = xOpsStart + headerOffset * laneW;
+          const originW = origin.num_lanes * laneW;
+
+          ctx.save();
+          ctx.beginPath();
+          ctx.rect(originX + 1, 0, originW - 2, H_HEADER);
+          ctx.clip();
+          ctx.fillText(origin.origin, originX + originW / 2, H_HEADER / 2);
+          ctx.restore();
+
+          headerOffset += origin.num_lanes;
+        });
+
+        // 6. Scroll Bar (Far Right)
+        const sbX = width - W_SCROLLBAR;
+        ctx.fillStyle = '#f1f5f9';
+        ctx.fillRect(sbX, H_HEADER, W_SCROLLBAR, timelineH);
+
+        // Scrollbar thumb
+        const thumbY0 = timeToScrollbarY(viewT0);
+        const thumbY1 = timeToScrollbarY(viewT1);
+        const thumbH = Math.max(8, thumbY1 - thumbY0);
+
+        ctx.fillStyle = 'rgba(59, 130, 246, 0.35)';
+        ctx.fillRect(sbX + 2, thumbY0, W_SCROLLBAR - 4, thumbH);
+        ctx.strokeStyle = '#2563eb';
+        ctx.lineWidth = 1.5;
+        ctx.strokeRect(sbX + 2, thumbY0, W_SCROLLBAR - 4, thumbH);
+
+        // Mini step markers on scrollbar
+        data.steps.forEach((step) => {
+          const sy = timeToScrollbarY(step.start_time);
+          ctx.strokeStyle = '#d97706';
+          ctx.lineWidth = 1;
+          ctx.beginPath();
+          ctx.moveTo(sbX, sy);
+          ctx.lineTo(sbX + 4, sy);
+          ctx.stroke();
+        });
+      }
+
+      // Hit-testing
+      function hitTest(x, y) {
+        if (y < H_HEADER) return null;
+
+        const xOpsStart = W_EVENTS + W_TIME;
+        const wOpsAvailable = Math.max(10, width - xOpsStart - W_SCROLLBAR);
+        const totalOpLanes = Math.max(1, data.total_operation_lanes);
+        const laneW = wOpsAvailable / totalOpLanes;
+
+        // Check if in events lane
+        if (x < xOpsStart) {
+          for (let step of data.steps) {
+            const yStart = timeToY(step.start_time);
+            if (Math.abs(y - yStart) < 7) {
+              return { type: 'event', eventType: 'start', step: step, y: yStart };
+            }
+            if (step.throughput_stability_time !== null && step.throughput_stability_time !== undefined) {
+              const yStab = timeToY(step.throughput_stability_time);
+              if (Math.abs(y - yStab) < 7) {
+                return { type: 'event', eventType: 'stability', step: step, y: yStab };
+              }
+            }
+            const yEnd = timeToY(step.end_time);
+            if (Math.abs(y - yEnd) < 7) {
+              return { type: 'event', eventType: 'end', step: step, y: yEnd };
+            }
+          }
+          return null;
+        }
+
+        // Check operations
+        if (x >= xOpsStart && x < width - W_SCROLLBAR) {
+          let currentLaneOffset = 0;
+          for (let origin of data.origins) {
+            const originX = xOpsStart + currentLaneOffset * laneW;
+            const originW = origin.num_lanes * laneW;
+
+            if (x >= originX && x < originX + originW) {
+              const laneIdx = Math.floor((x - originX) / laneW);
+              if (laneIdx >= 0 && laneIdx < origin.lanes.length) {
+                const laneOps = origin.lanes[laneIdx];
+                for (let op of laneOps) {
+                  const y0 = timeToY(op.t0);
+                  const y1 = timeToY(op.t1);
+                  const effectiveY0 = Math.min(y0, y1);
+                  const effectiveY1 = Math.max(y0, y1, effectiveY0 + 3);
+                  if (y >= effectiveY0 && y <= effectiveY1) {
+                    return { type: 'op', op: op, origin: origin.origin, lane: laneIdx };
+                  }
+                }
+              }
+            }
+            currentLaneOffset += origin.num_lanes;
+          }
+        }
+
+        return null;
+      }
+
+      function updateTooltip(e, item) {
+        if (!item) {
+          tooltip.style.display = 'none';
+          return;
+        }
+
+        let html = '';
+        if (item.type === 'op') {
+          const op = item.op;
+          html += `<div><strong>Operation:</strong> ${op.type}</div>`;
+          html += `<div><strong>Origin:</strong> ${item.origin} (Lane ${item.lane + 1})</div>`;
+          html += `<div><strong>Status:</strong> ${op.success ? '<span style="color:#4ade80">✔ Successful</span>' : '<span style="color:#f87171">✖ Unsuccessful</span>'}</div>`;
+          html += `<div><strong>Duration:</strong> ${formatDuration(op.duration)}</div>`;
+          html += `<div><strong>Start:</strong> ${formatIsoTimeMs(op.t0)}</div>`;
+          html += `<div><strong>End:</strong> ${formatIsoTimeMs(op.t1)}</div>`;
+          if (op.query) {
+            html += `<hr style="border-color: rgba(255,255,255,0.2); margin: 0.3rem 0;">`;
+            if (op.query.query_type) html += `<div><strong>Query Type:</strong> ${op.query.query_type}</div>`;
+            if (op.query.participant_id) html += `<div><strong>Participant:</strong> ${op.query.participant_id}</div>`;
+            if (op.query.method && op.query.url) html += `<div><strong>Request:</strong> ${op.query.method} ${op.query.url}</div>`;
+            if (op.query.status_code) html += `<div><strong>Response Code:</strong> ${op.query.status_code}</div>`;
+            if (op.query.elapsed_s) html += `<div><strong>Server Latency:</strong> ${formatDuration(op.query.elapsed_s)}</div>`;
+          }
+        } else if (item.type === 'event') {
+          const step = item.step;
+          html += `<div><strong>Step ${step.step_index} Event</strong></div>`;
+          html += `<div><strong>Load Factor:</strong> ${step.load_factor}</div>`;
+          if (item.eventType === 'start') {
+            html += `<div><strong>Event:</strong> Step Start (LF ${step.load_factor})</div>`;
+            html += `<div><strong>Time:</strong> ${formatIsoTimeMs(step.start_time)}</div>`;
+          } else if (item.eventType === 'stability') {
+            html += `<div><strong>Event:</strong> Throughput Stability Achieved 👍</div>`;
+            html += `<div><strong>Time:</strong> ${formatIsoTimeMs(step.throughput_stability_time)}</div>`;
+          } else if (item.eventType === 'end') {
+            html += `<div><strong>Event:</strong> Step Termination (${step.termination_reason} ${step.termination_symbol})</div>`;
+            html += `<div><strong>Time:</strong> ${formatIsoTimeMs(step.end_time)}</div>`;
+          }
+        }
+
+        tooltip.innerHTML = html;
+        tooltip.style.display = 'block';
+
+        const rect = container.getBoundingClientRect();
+        let posX = e.clientX - rect.left + 15;
+        let posY = e.clientY - rect.top + 15;
+
+        if (posX + tooltip.offsetWidth > width) {
+          posX = e.clientX - rect.left - tooltip.offsetWidth - 15;
+        }
+        if (posY + tooltip.offsetHeight > height) {
+          posY = e.clientY - rect.top - tooltip.offsetHeight - 15;
+        }
+
+        tooltip.style.left = Math.max(5, posX) + 'px';
+        tooltip.style.top = Math.max(5, posY) + 'px';
+      }
+
+      // Mouse Events
+      canvas.addEventListener('mousedown', (e) => {
+        if (e.button !== 0) return; // Left click only
+
+        const rect = canvas.getBoundingClientRect();
+        const x = e.clientX - rect.left;
+        const y = e.clientY - rect.top;
+
+        if (x >= width - W_SCROLLBAR) {
+          // Click on scrollbar
+          isDraggingScrollbar = true;
+          const targetTime = scrollbarYToTime(y);
+          const currentSpan = viewT1 - viewT0;
+          viewT0 = targetTime - currentSpan / 2;
+          viewT1 = targetTime + currentSpan / 2;
+          clampView();
+          draw();
+        } else {
+          // Click on main timeline
+          isDraggingMain = true;
+          dragAnchorY = y;
+          dragAnchorTime = yToTime(y);
+          dragStartT0 = viewT0;
+          dragStartT1 = viewT1;
+          dragWithShift = e.shiftKey;
+          canvas.style.cursor = 'grabbing';
+        }
+      });
+
+      window.addEventListener('mousemove', (e) => {
+        const rect = canvas.getBoundingClientRect();
+        const x = e.clientX - rect.left;
+        const y = e.clientY - rect.top;
+
+        if (isDraggingScrollbar) {
+          const targetTime = scrollbarYToTime(y);
+          const currentSpan = viewT1 - viewT0;
+          viewT0 = targetTime - currentSpan / 2;
+          viewT1 = targetTime + currentSpan / 2;
+          clampView();
+          draw();
+          return;
+        }
+
+        if (isDraggingMain) {
+          const timelineH = Math.max(10, height - H_HEADER);
+          if (e.shiftKey || dragWithShift) {
+            // Shift + Drag: Zoom centered at dragAnchorTime
+            const dy = y - dragAnchorY;
+            const zoomFactor = Math.exp(dy * 0.005);
+            const span = (dragStartT1 - dragStartT0) * zoomFactor;
+            const ratio = (dragAnchorTime - dragStartT0) / (dragStartT1 - dragStartT0);
+            viewT0 = dragAnchorTime - span * ratio;
+            viewT1 = dragAnchorTime + span * (1 - ratio);
+          } else {
+            // Left Drag: Pan view (keeping clicked time directly under cursor)
+            const dt = ((y - dragAnchorY) / timelineH) * (dragStartT1 - dragStartT0);
+            viewT0 = dragStartT0 - dt;
+            viewT1 = dragStartT1 - dt;
+          }
+          clampView();
+          draw();
+          return;
+        }
+
+        // Hover
+        if (x >= width - W_SCROLLBAR) {
+          canvas.style.cursor = 'pointer';
+        } else {
+          canvas.style.cursor = 'grab';
+        }
+
+        const item = hitTest(x, y);
+        if (item !== hoveredItem) {
+          hoveredItem = item;
+          draw();
+        }
+        updateTooltip(e, item);
+      });
+
+      window.addEventListener('mouseup', () => {
+        isDraggingMain = false;
+        isDraggingScrollbar = false;
+        canvas.style.cursor = 'grab';
+      });
+
+      canvas.addEventListener('wheel', (e) => {
+        e.preventDefault();
+
+        const rect = canvas.getBoundingClientRect();
+        const y = e.clientY - rect.top;
+        const cursorTime = yToTime(y);
+
+        if (e.shiftKey) {
+          // Shift + Wheel: Zoom centered at cursor
+          const zoomMultiplier = e.deltaY < 0 ? 0.8 : 1.25;
+          const currentSpan = viewT1 - viewT0;
+          const newSpan = currentSpan * zoomMultiplier;
+
+          const ratio = (cursorTime - viewT0) / currentSpan;
+          viewT0 = cursorTime - newSpan * ratio;
+          viewT1 = cursorTime + newSpan * (1 - ratio);
+        } else {
+          // Normal Wheel: Scroll view
+          const currentSpan = viewT1 - viewT0;
+          const dt = (e.deltaY / 120) * currentSpan * 0.15;
+          viewT0 += dt;
+          viewT1 += dt;
+        }
+
+        clampView();
+        draw();
+      }, { passive: false });
+
+      // Button controls
+      document.getElementById('btn-zoom-in').addEventListener('click', () => {
+        const center = (viewT0 + viewT1) / 2;
+        const newSpan = (viewT1 - viewT0) * 0.7;
+        viewT0 = center - newSpan / 2;
+        viewT1 = center + newSpan / 2;
+        clampView();
+        draw();
+      });
+
+      document.getElementById('btn-zoom-out').addEventListener('click', () => {
+        const center = (viewT0 + viewT1) / 2;
+        const newSpan = (viewT1 - viewT0) * 1.4;
+        viewT0 = center - newSpan / 2;
+        viewT1 = center + newSpan / 2;
+        clampView();
+        draw();
+      });
+
+      document.getElementById('btn-reset-view').addEventListener('click', () => {
+        viewT0 = scenarioStart;
+        viewT1 = scenarioEnd;
+        clampView();
+        draw();
+      });
+
+      // Initial layout
+      resizeCanvas();
+    })();
+  </script>
+</body>
+</html>

--- a/monitoring/benchmarker/artifacts/timeline/templates/scenario.html
+++ b/monitoring/benchmarker/artifacts/timeline/templates/scenario.html
@@ -188,7 +188,7 @@
       pointer-events: none;
       z-index: 1000;
       box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.2), 0 2px 4px -1px rgba(0, 0, 0, 0.1);
-      max-width: 400px;
+      max-width: 420px;
     }
 
     #tooltip strong {
@@ -263,7 +263,7 @@
     <canvas id="timeline-canvas"></canvas>
     <div id="tooltip"></div>
     <div class="help-hint">
-      <strong>Controls:</strong> Left-drag or Mouse wheel to scroll &bull; Shift + Left-drag or Shift + Wheel to zoom
+      <strong>Controls:</strong> Left-drag or Mouse wheel to scroll &bull; Shift + Left-drag or Shift + Wheel to zoom &bull; Hover Time column to inspect active operations
     </div>
   </div>
 
@@ -285,6 +285,27 @@
       const scenarioEnd = data.scenario_end;
       const fullDuration = Math.max(0.1, scenarioEnd - scenarioStart);
       const minDuration = 0.05; // 50ms min zoom window
+
+      // Flatten operations for fast time-based lookup
+      const allOperations = [];
+      data.origins.forEach((origin) => {
+        origin.lanes.forEach((laneOps) => {
+          laneOps.forEach((op) => {
+            allOperations.push(op);
+          });
+        });
+      });
+
+      function getActiveOperationsAt(t) {
+        const activeCounts = {};
+        for (let i = 0; i < allOperations.length; i++) {
+          const op = allOperations[i];
+          if (op.t0 <= t && t <= op.t1) {
+            activeCounts[op.type] = (activeCounts[op.type] || 0) + 1;
+          }
+        }
+        return activeCounts;
+      }
 
       // Visible time window [viewT0, viewT1]
       let viewT0 = scenarioStart;
@@ -579,7 +600,7 @@
               if (hoveredItem && hoveredItem.type === 'op' && hoveredItem.op === op) {
                 ctx.strokeStyle = '#0f172a';
                 ctx.lineWidth = 2;
-                ctx.strokeRect(rectX, y0, rectW, rectH);
+                ctx.strokeRect(rectX - 1, y0 - 1, rectW + 2, rectH + 2);
               }
             });
           });
@@ -620,7 +641,20 @@
           headerOffset += origin.num_lanes;
         });
 
-        // 6. Scroll Bar (Far Right)
+        // 6. Hovered Time Line (Dashed line across full width of display)
+        if (hoveredItem && hoveredItem.type === 'time' && hoveredItem.y >= H_HEADER && hoveredItem.y <= height) {
+          ctx.save();
+          ctx.strokeStyle = '#2563eb';
+          ctx.lineWidth = 1.5;
+          ctx.setLineDash([4, 4]);
+          ctx.beginPath();
+          ctx.moveTo(0, hoveredItem.y);
+          ctx.lineTo(width - W_SCROLLBAR, hoveredItem.y);
+          ctx.stroke();
+          ctx.restore();
+        }
+
+        // 7. Scroll Bar (Far Right)
         const sbX = width - W_SCROLLBAR;
         ctx.fillStyle = '#f1f5f9';
         ctx.fillRect(sbX, H_HEADER, W_SCROLLBAR, timelineH);
@@ -657,8 +691,8 @@
         const totalOpLanes = Math.max(1, data.total_operation_lanes);
         const laneW = wOpsAvailable / totalOpLanes;
 
-        // Check if in events lane
-        if (x < xOpsStart) {
+        // Check if in Scenario Events lane
+        if (x < W_EVENTS) {
           for (let step of data.steps) {
             const yStart = timeToY(step.start_time);
             if (Math.abs(y - yStart) < 7) {
@@ -678,7 +712,13 @@
           return null;
         }
 
-        // Check operations
+        // Check if in Time Scale swim lane
+        if (x >= W_EVENTS && x < xOpsStart) {
+          const hoveredTime = yToTime(y);
+          return { type: 'time', time: hoveredTime, y: y, activeCounts: getActiveOperationsAt(hoveredTime) };
+        }
+
+        // Check operations swim lanes
         if (x >= xOpsStart && x < width - W_SCROLLBAR) {
           let currentLaneOffset = 0;
           for (let origin of data.origins) {
@@ -692,13 +732,16 @@
                 for (let op of laneOps) {
                   const y0 = timeToY(op.t0);
                   const y1 = timeToY(op.t1);
-                  const effectiveY0 = Math.min(y0, y1);
-                  const effectiveY1 = Math.max(y0, y1, effectiveY0 + 3);
-                  if (y >= effectiveY0 && y <= effectiveY1) {
+                  const minY = Math.min(y0, y1) - 2;
+                  const maxY = Math.max(y0, y1, y0 + 3) + 2;
+                  if (y >= minY && y <= maxY) {
                     return { type: 'op', op: op, origin: origin.origin, lane: laneIdx };
                   }
                 }
               }
+              // Hovering on timeline lane background without hitting a specific operation
+              const hoveredTime = yToTime(y);
+              return { type: 'time', time: hoveredTime, y: y, activeCounts: getActiveOperationsAt(hoveredTime) };
             }
             currentLaneOffset += origin.num_lanes;
           }
@@ -743,6 +786,27 @@
           } else if (item.eventType === 'end') {
             html += `<div><strong>Event:</strong> Step Termination (${step.termination_reason} ${step.termination_symbol})</div>`;
             html += `<div><strong>Time:</strong> ${formatIsoTimeMs(step.end_time)}</div>`;
+          }
+        } else if (item.type === 'time') {
+          html += `<div><strong>Time:</strong> ${formatIsoTimeMs(item.time)}</div>`;
+          const entries = [];
+          data.operation_types.forEach((op) => {
+            const count = item.activeCounts[op.type];
+            if (count) {
+              entries.push(`${count}x ${op.type}`);
+            }
+          });
+          Object.keys(item.activeCounts).forEach((opType) => {
+            if (!data.operation_types.some((op) => op.type === opType)) {
+              entries.push(`${item.activeCounts[opType]}x ${opType}`);
+            }
+          });
+
+          if (entries.length > 0) {
+            html += `<hr style="border-color: rgba(255,255,255,0.2); margin: 0.3rem 0;">`;
+            html += entries.join('<br>');
+          } else {
+            html += `<div style="color: #94a3b8; margin-top: 0.25rem;">No operations in progress</div>`;
           }
         }
 
@@ -830,15 +894,26 @@
           return;
         }
 
-        // Hover
+        const item = hitTest(x, y);
+
+        // Cursor style
         if (x >= width - W_SCROLLBAR) {
           canvas.style.cursor = 'pointer';
+        } else if (item && (item.type === 'op' || item.type === 'event')) {
+          canvas.style.cursor = 'pointer';
+        } else if (item && item.type === 'time') {
+          canvas.style.cursor = 'crosshair';
         } else {
           canvas.style.cursor = 'grab';
         }
 
-        const item = hitTest(x, y);
-        if (item !== hoveredItem) {
+        const itemChanged = (
+          (item === null && hoveredItem !== null) ||
+          (item !== null && hoveredItem === null) ||
+          (item !== null && hoveredItem !== null && (item.type !== hoveredItem.type || (item.type === 'op' && item.op !== hoveredItem.op) || item.type === 'time'))
+        );
+
+        if (itemChanged) {
           hoveredItem = item;
           draw();
         }

--- a/monitoring/benchmarker/artifacts/timeline/templates/scenario.html
+++ b/monitoring/benchmarker/artifacts/timeline/templates/scenario.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Scenario {{ scenario_index }} Timeline - {{ spec.name }}</title>
+  <title>Scenario {{ scenario_index }} ({{ scenario_name }}) Timeline - {{ spec.name }}</title>
   <style>
     :root {
       --primary: #1976d2;
@@ -58,7 +58,7 @@
 
     h1 {
       margin: 0;
-      font-size: 1.25rem;
+      font-size: 1.15rem;
       font-weight: 700;
       color: var(--text);
       display: flex;
@@ -77,6 +77,7 @@
       padding: 0.25rem 0.5rem;
       border-radius: 0.25rem;
       border: 1px solid transparent;
+      white-space: nowrap;
     }
 
     .nav-link:hover {
@@ -110,6 +111,7 @@
       display: inline-flex;
       align-items: center;
       gap: 0.25rem;
+      white-space: nowrap;
     }
 
     .btn-sm:last-child {
@@ -136,6 +138,7 @@
       display: inline-flex;
       align-items: center;
       gap: 0.35rem;
+      white-space: nowrap;
     }
 
     .legend-color-dot {
@@ -155,6 +158,7 @@
       background-color: #f1f5f9;
       color: var(--text-muted);
       border: 1px solid var(--border);
+      white-space: nowrap;
     }
 
     #timeline-container {
@@ -213,7 +217,7 @@
     <div class="header-content">
       <div class="title-nav">
         <a href="index.html" class="nav-link">&larr; Overview</a>
-        <h1>Scenario {{ scenario_index }} Timeline</h1>
+        <h1>Scenario {{ scenario_index }} ({{ scenario_name }}) Timeline</h1>
         <div style="display: flex; gap: 0.25rem;">
           {% if prev_scenario %}
             <a href="{{ prev_scenario }}" class="nav-link">&larr; Prev</a>
@@ -242,12 +246,12 @@
         </div>
 
         <div class="btn-group">
-          <button id="btn-zoom-in" class="btn-sm" title="Zoom In (or Shift + Scroll Down)">Zoom In (+)</button>
-          <button id="btn-zoom-out" class="btn-sm" title="Zoom Out (or Shift + Scroll Up)">Zoom Out (-)</button>
+          <button id="btn-zoom-in" class="btn-sm" title="Zoom In (or Shift + Wheel Up)">Zoom In (+)</button>
+          <button id="btn-zoom-out" class="btn-sm" title="Zoom Out (or Shift + Wheel Down)">Zoom Out (-)</button>
           <button id="btn-reset-view" class="btn-sm" title="Reset to Full Scenario View">Reset View</button>
         </div>
 
-        <span class="badge">Duration: {{ "%.1f"|format(timeline_data.scenario_duration) }}s</span>
+        <span class="badge">Duration: {{ timeline_data.duration_shorthand }}</span>
         <span class="badge">{{ timeline_data.stats.total_steps }} Steps</span>
         <span class="badge">{{ timeline_data.stats.total_origins }} Origins</span>
         <span class="badge">{{ timeline_data.stats.total_operations }} Ops</span>
@@ -808,8 +812,9 @@
           const timelineH = Math.max(10, height - H_HEADER);
           if (e.shiftKey || dragWithShift) {
             // Shift + Drag: Zoom centered at dragAnchorTime
+            // Dragging down (dy > 0) zooms in (smaller span); dragging up (dy < 0) zooms out (larger span)
             const dy = y - dragAnchorY;
-            const zoomFactor = Math.exp(dy * 0.005);
+            const zoomFactor = Math.exp(-dy * 0.005);
             const span = (dragStartT1 - dragStartT0) * zoomFactor;
             const ratio = (dragAnchorTime - dragStartT0) / (dragStartT1 - dragStartT0);
             viewT0 = dragAnchorTime - span * ratio;
@@ -853,19 +858,25 @@
         const y = e.clientY - rect.top;
         const cursorTime = yToTime(y);
 
+        // Normalize delta across platforms where shiftKey may convert deltaY to deltaX
+        const delta = e.deltaY !== 0 ? e.deltaY : e.deltaX;
+        if (delta === 0) return;
+
         if (e.shiftKey) {
           // Shift + Wheel: Zoom centered at cursor
-          const zoomMultiplier = e.deltaY < 0 ? 0.8 : 1.25;
+          // delta < 0 (scrolling up / forward): zoom IN (factor < 1, span decreases)
+          // delta > 0 (scrolling down / backward): zoom OUT (factor > 1, span increases)
+          const zoomFactor = Math.max(0.5, Math.min(2.0, Math.exp((delta / 100) * 0.2)));
           const currentSpan = viewT1 - viewT0;
-          const newSpan = currentSpan * zoomMultiplier;
+          const newSpan = currentSpan * zoomFactor;
 
           const ratio = (cursorTime - viewT0) / currentSpan;
           viewT0 = cursorTime - newSpan * ratio;
           viewT1 = cursorTime + newSpan * (1 - ratio);
         } else {
-          // Normal Wheel: Scroll view
+          // Normal Wheel: Scroll view up / down
           const currentSpan = viewT1 - viewT0;
-          const dt = (e.deltaY / 120) * currentSpan * 0.15;
+          const dt = (delta / 100) * currentSpan * 0.15;
           viewT0 += dt;
           viewT1 += dt;
         }

--- a/monitoring/benchmarker/artifacts/timeline/timeline.py
+++ b/monitoring/benchmarker/artifacts/timeline/timeline.py
@@ -41,8 +41,7 @@ DEFAULT_PALETTE = [
 
 def natural_sort_key(s: str) -> list[int | str]:
     return [
-        int(text) if text.isdigit() else text.lower()
-        for text in re.split(r"(\d+)", s)
+        int(text) if text.isdigit() else text.lower() for text in re.split(r"(\d+)", s)
     ]
 
 
@@ -64,15 +63,14 @@ def _extract_query_summary(query: Query | None) -> dict[str, Any] | None:
         resp = query.response
         if "status_code" in resp and resp.status_code is not None:
             summary["status_code"] = resp.status_code
-        if (
-            "elapsed_s" in resp
-            and resp.elapsed_s is not None
-        ):
+        if "elapsed_s" in resp and resp.elapsed_s is not None:
             summary["elapsed_s"] = resp.elapsed_s
     return summary if summary else None
 
 
-def _assign_lanes_for_origin(operations: list[dict[str, Any]]) -> list[list[dict[str, Any]]]:
+def _assign_lanes_for_origin(
+    operations: list[dict[str, Any]],
+) -> list[list[dict[str, Any]]]:
     """Assign operations for a single origin into the minimum non-overlapping swim lanes,
     preferentially placing longer-running operations in lanes further to the left.
     """
@@ -338,10 +336,14 @@ def generate_timeline(
     for idx, scenario in enumerate(scenarios):
         scenario_name = (
             config_scenarios[idx].name
-            if idx < len(config_scenarios) and "name" in config_scenarios[idx] and config_scenarios[idx].name
+            if idx < len(config_scenarios)
+            and "name" in config_scenarios[idx]
+            and config_scenarios[idx].name
             else f"Scenario {idx}"
         )
-        timeline_data = compute_scenario_timeline_data(idx, scenario, spec, scenario_name)
+        timeline_data = compute_scenario_timeline_data(
+            idx, scenario, spec, scenario_name
+        )
         scenarios_timeline_data.append(timeline_data)
         scenarios_summary.append(
             {
@@ -353,8 +355,12 @@ def generate_timeline(
                 "steps_count": len(timeline_data["steps"]),
                 "origins_count": len(timeline_data["origins"]),
                 "operations_count": timeline_data["stats"]["total_operations"],
-                "successful_operations": timeline_data["stats"]["successful_operations"],
-                "unsuccessful_operations": timeline_data["stats"]["unsuccessful_operations"],
+                "successful_operations": timeline_data["stats"][
+                    "successful_operations"
+                ],
+                "unsuccessful_operations": timeline_data["stats"][
+                    "unsuccessful_operations"
+                ],
                 "steps": timeline_data["steps"],
             }
         )

--- a/monitoring/benchmarker/artifacts/timeline/timeline.py
+++ b/monitoring/benchmarker/artifacts/timeline/timeline.py
@@ -17,6 +17,7 @@ from monitoring.benchmarker.reports.report import (
     StepTerminationReason,
 )
 from monitoring.monitorlib.fetch import Query
+from monitoring.monitorlib.formatting import format_duration_shorthand
 
 DEFAULT_PALETTE = [
     "#32aced",
@@ -63,7 +64,10 @@ def _extract_query_summary(query: Query | None) -> dict[str, Any] | None:
         resp = query.response
         if "status_code" in resp and resp.status_code is not None:
             summary["status_code"] = resp.status_code
-        if "elapsed_s" in resp and resp.elapsed_s is not None:
+        if (
+            "elapsed_s" in resp
+            and resp.elapsed_s is not None
+        ):
             summary["elapsed_s"] = resp.elapsed_s
     return summary if summary else None
 
@@ -101,6 +105,7 @@ def compute_scenario_timeline_data(
     scenario_index: int,
     scenario: BenchmarkScenarioReport,
     spec: TimelineSpecification,
+    scenario_name: str | None = None,
 ) -> dict[str, Any]:
     # Operation specifications & colors
     spec_ops_map = {op_spec.type: op_spec for op_spec in spec.operations}
@@ -256,6 +261,9 @@ def compute_scenario_timeline_data(
     if scenario_end <= scenario_start:
         scenario_end = scenario_start + 1.0
 
+    duration = scenario_end - scenario_start
+    duration_shorthand = format_duration_shorthand(duration)
+
     # Sort origins and assign lanes
     sorted_origin_names = sorted(origin_ops.keys(), key=natural_sort_key)
     origins_data = []
@@ -286,9 +294,11 @@ def compute_scenario_timeline_data(
 
     return {
         "scenario_index": scenario_index,
+        "scenario_name": scenario_name or f"Scenario {scenario_index}",
         "scenario_start": scenario_start,
         "scenario_end": scenario_end,
-        "scenario_duration": scenario_end - scenario_start,
+        "scenario_duration": duration,
+        "duration_shorthand": duration_shorthand,
         "steps": steps_data,
         "origins": origins_data,
         "operation_types": operation_types_data,
@@ -313,17 +323,33 @@ def generate_timeline(
     logger.info(f"Generating timeline artifact in {timeline_dir}")
 
     scenarios = report.report.scenarios
+    config_scenarios = (
+        report.configuration.scenarios
+        if "configuration" in report
+        and report.configuration
+        and "scenarios" in report.configuration
+        and report.configuration.scenarios
+        else []
+    )
+
     scenarios_summary = []
     scenarios_timeline_data = []
 
     for idx, scenario in enumerate(scenarios):
-        timeline_data = compute_scenario_timeline_data(idx, scenario, spec)
+        scenario_name = (
+            config_scenarios[idx].name
+            if idx < len(config_scenarios) and "name" in config_scenarios[idx] and config_scenarios[idx].name
+            else f"Scenario {idx}"
+        )
+        timeline_data = compute_scenario_timeline_data(idx, scenario, spec, scenario_name)
         scenarios_timeline_data.append(timeline_data)
         scenarios_summary.append(
             {
                 "index": idx,
+                "name": scenario_name,
                 "filename": f"s{idx}.html",
                 "duration": timeline_data["scenario_duration"],
+                "duration_shorthand": timeline_data["duration_shorthand"],
                 "steps_count": len(timeline_data["steps"]),
                 "origins_count": len(timeline_data["origins"]),
                 "operations_count": timeline_data["stats"]["total_operations"],
@@ -344,6 +370,7 @@ def generate_timeline(
             f.write(
                 scenario_template.render(
                     scenario_index=idx,
+                    scenario_name=timeline_data["scenario_name"],
                     scenario_data_json=json.dumps(timeline_data),
                     timeline_data=timeline_data,
                     spec=spec,

--- a/monitoring/benchmarker/artifacts/timeline/timeline.py
+++ b/monitoring/benchmarker/artifacts/timeline/timeline.py
@@ -1,0 +1,371 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+from typing import Any
+
+from loguru import logger
+
+from monitoring.benchmarker.artifacts.timeline import jinja_env
+from monitoring.benchmarker.configurations.artifacts.timeline import (
+    TimelineSpecification,
+)
+from monitoring.benchmarker.reports.report import (
+    BenchmarkRunReport,
+    BenchmarkScenarioReport,
+    StepTerminationReason,
+)
+from monitoring.monitorlib.fetch import Query
+
+DEFAULT_PALETTE = [
+    "#32aced",
+    "#c7c46b",
+    "#70c76b",
+    "#c77f6b",
+    "#9b59b6",
+    "#e67e22",
+    "#1abc9c",
+    "#e74c3c",
+    "#34495e",
+    "#16a085",
+    "#27ae60",
+    "#2980b9",
+    "#8e44ad",
+    "#2c3e50",
+    "#f39c12",
+    "#d35400",
+]
+
+
+def natural_sort_key(s: str) -> list[int | str]:
+    return [
+        int(text) if text.isdigit() else text.lower()
+        for text in re.split(r"(\d+)", s)
+    ]
+
+
+def _extract_query_summary(query: Query | None) -> dict[str, Any] | None:
+    if query is None:
+        return None
+    summary: dict[str, Any] = {}
+    if "query_type" in query and query.query_type:
+        summary["query_type"] = query.query_type
+    if "participant_id" in query and query.participant_id:
+        summary["participant_id"] = query.participant_id
+    if "request" in query and query.request:
+        req = query.request
+        if "method" in req and req.method:
+            summary["method"] = req.method
+        if "url" in req and req.url:
+            summary["url"] = req.url
+    if "response" in query and query.response:
+        resp = query.response
+        if "status_code" in resp and resp.status_code is not None:
+            summary["status_code"] = resp.status_code
+        if "elapsed_s" in resp and resp.elapsed_s is not None:
+            summary["elapsed_s"] = resp.elapsed_s
+    return summary if summary else None
+
+
+def _assign_lanes_for_origin(operations: list[dict[str, Any]]) -> list[list[dict[str, Any]]]:
+    """Assign operations for a single origin into the minimum non-overlapping swim lanes,
+    preferentially placing longer-running operations in lanes further to the left.
+    """
+    if not operations:
+        return [[]]
+
+    # Sort by duration descending, tie-break by start time ascending
+    operations.sort(key=lambda op: (-op["duration"], op["t0"]))
+
+    lanes: list[list[dict[str, Any]]] = []
+    for op in operations:
+        placed = False
+        for lane in lanes:
+            # Check overlap with all operations currently in this lane
+            overlap = any(
+                max(op["t0"], placed_op["t0"]) < min(op["t1"], placed_op["t1"])
+                for placed_op in lane
+            )
+            if not overlap:
+                lane.append(op)
+                placed = True
+                break
+        if not placed:
+            lanes.append([op])
+
+    return lanes if lanes else [[]]
+
+
+def compute_scenario_timeline_data(
+    scenario_index: int,
+    scenario: BenchmarkScenarioReport,
+    spec: TimelineSpecification,
+) -> dict[str, Any]:
+    # Operation specifications & colors
+    spec_ops_map = {op_spec.type: op_spec for op_spec in spec.operations}
+    color_map: dict[str, str] = {}
+    indicator_width_map: dict[str, float] = {}
+    for idx, op_spec in enumerate(spec.operations):
+        color = (
+            op_spec.color
+            if "color" in op_spec and op_spec.color
+            else DEFAULT_PALETTE[idx % len(DEFAULT_PALETTE)]
+        )
+        color_map[op_spec.type] = color
+        indicator_width_map[op_spec.type] = (
+            float(op_spec.success_indicator_width)
+            if "success_indicator_width" in op_spec
+            and op_spec.success_indicator_width is not None
+            else 2.0
+        )
+
+    # Extract steps
+    steps_data = []
+    earliest_step_time = None
+    latest_step_time = None
+    for step_idx, step in enumerate(scenario.steps):
+        t_start = step.start_time.datetime.timestamp()
+        t_end = step.end_time.datetime.timestamp()
+        t_stab = (
+            step.throughput_stability_time.datetime.timestamp()
+            if "throughput_stability_time" in step
+            and step.throughput_stability_time is not None
+            else None
+        )
+
+        if earliest_step_time is None or t_start < earliest_step_time:
+            earliest_step_time = t_start
+        if latest_step_time is None or t_end > latest_step_time:
+            latest_step_time = t_end
+
+        term_reason = str(step.termination_reason)
+        # Identify symbol
+        if term_reason == StepTerminationReason.Completed:
+            term_symbol = "✔"
+        elif term_reason == StepTerminationReason.StabilityNotAchieved:
+            term_symbol = "👎"
+        elif term_reason == StepTerminationReason.Unstable:
+            term_symbol = "🛑"
+        else:
+            term_symbol = "✔" if "complete" in term_reason.lower() else "❓"
+
+        steps_data.append(
+            {
+                "step_index": step_idx,
+                "load_factor": step.load_factor,
+                "start_time": t_start,
+                "throughput_stability_time": t_stab,
+                "end_time": t_end,
+                "termination_reason": term_reason,
+                "termination_symbol": term_symbol,
+                "start_time_iso": str(step.start_time),
+                "stability_time_iso": str(step.throughput_stability_time)
+                if "throughput_stability_time" in step
+                and step.throughput_stability_time is not None
+                else None,
+                "end_time_iso": str(step.end_time),
+            }
+        )
+
+    # Collect operations of interest per origin
+    origin_ops: dict[str, list[dict[str, Any]]] = {}
+    earliest_op_time = None
+    latest_op_time = None
+    total_ops_count = 0
+    successful_ops_count = 0
+    unsuccessful_ops_count = 0
+
+    for op_group in scenario.operations:
+        op_type = op_group.type
+        if op_type not in spec_ops_map:
+            continue
+
+        color = color_map[op_type]
+        indicator_width = indicator_width_map[op_type]
+
+        for orig_group in op_group.origins:
+            origin = orig_group.origin
+            if origin not in origin_ops:
+                origin_ops[origin] = []
+
+            if "outcomes" in orig_group and orig_group.outcomes:
+                for outcome in orig_group.outcomes:
+                    if "successful" in outcome and outcome.successful:
+                        for op in outcome.successful:
+                            t0 = op.t0.datetime.timestamp()
+                            t1 = op.t1.datetime.timestamp()
+                            if earliest_op_time is None or t0 < earliest_op_time:
+                                earliest_op_time = t0
+                            if latest_op_time is None or t1 > latest_op_time:
+                                latest_op_time = t1
+
+                            origin_ops[origin].append(
+                                {
+                                    "type": op_type,
+                                    "t0": t0,
+                                    "t1": t1,
+                                    "duration": max(0.0, t1 - t0),
+                                    "t0_iso": str(op.t0),
+                                    "t1_iso": str(op.t1),
+                                    "success": True,
+                                    "color": color,
+                                    "indicator_width": indicator_width,
+                                    "query": _extract_query_summary(op.query)
+                                    if "query" in op and op.query is not None
+                                    else None,
+                                }
+                            )
+                            total_ops_count += 1
+                            successful_ops_count += 1
+
+                    if "unsuccessful" in outcome and outcome.unsuccessful:
+                        for op in outcome.unsuccessful:
+                            t0 = op.t0.datetime.timestamp()
+                            t1 = op.t1.datetime.timestamp()
+                            if earliest_op_time is None or t0 < earliest_op_time:
+                                earliest_op_time = t0
+                            if latest_op_time is None or t1 > latest_op_time:
+                                latest_op_time = t1
+
+                            origin_ops[origin].append(
+                                {
+                                    "type": op_type,
+                                    "t0": t0,
+                                    "t1": t1,
+                                    "duration": max(0.0, t1 - t0),
+                                    "t0_iso": str(op.t0),
+                                    "t1_iso": str(op.t1),
+                                    "success": False,
+                                    "color": color,
+                                    "indicator_width": indicator_width,
+                                    "query": _extract_query_summary(op.query)
+                                    if "query" in op and op.query is not None
+                                    else None,
+                                }
+                            )
+                            total_ops_count += 1
+                            unsuccessful_ops_count += 1
+
+    # Determine scenario start and end boundaries
+    all_starts = [t for t in (earliest_step_time, earliest_op_time) if t is not None]
+    all_ends = [t for t in (latest_step_time, latest_op_time) if t is not None]
+
+    scenario_start = min(all_starts) if all_starts else 0.0
+    scenario_end = max(all_ends) if all_ends else scenario_start + 60.0
+    if scenario_end <= scenario_start:
+        scenario_end = scenario_start + 1.0
+
+    # Sort origins and assign lanes
+    sorted_origin_names = sorted(origin_ops.keys(), key=natural_sort_key)
+    origins_data = []
+    total_operation_lanes = 0
+
+    for orig_name in sorted_origin_names:
+        lanes = _assign_lanes_for_origin(origin_ops[orig_name])
+        num_lanes = len(lanes)
+        total_operation_lanes += num_lanes
+        origins_data.append(
+            {
+                "origin": orig_name,
+                "num_lanes": num_lanes,
+                "lanes": lanes,
+            }
+        )
+
+    # Operation types list for legend and UI
+    operation_types_data = [
+        {
+            "type": op_spec.type,
+            "name": op_spec.type.split(".")[-1],
+            "color": color_map[op_spec.type],
+            "indicator_width": indicator_width_map[op_spec.type],
+        }
+        for op_spec in spec.operations
+    ]
+
+    return {
+        "scenario_index": scenario_index,
+        "scenario_start": scenario_start,
+        "scenario_end": scenario_end,
+        "scenario_duration": scenario_end - scenario_start,
+        "steps": steps_data,
+        "origins": origins_data,
+        "operation_types": operation_types_data,
+        "total_operation_lanes": total_operation_lanes,
+        "stats": {
+            "total_operations": total_ops_count,
+            "successful_operations": successful_ops_count,
+            "unsuccessful_operations": unsuccessful_ops_count,
+            "total_steps": len(steps_data),
+            "total_origins": len(origins_data),
+        },
+    }
+
+
+def generate_timeline(
+    report: BenchmarkRunReport,
+    spec: TimelineSpecification,
+    output_dir: str,
+) -> None:
+    timeline_dir = os.path.join(output_dir, spec.name)
+    os.makedirs(timeline_dir, exist_ok=True)
+    logger.info(f"Generating timeline artifact in {timeline_dir}")
+
+    scenarios = report.report.scenarios
+    scenarios_summary = []
+    scenarios_timeline_data = []
+
+    for idx, scenario in enumerate(scenarios):
+        timeline_data = compute_scenario_timeline_data(idx, scenario, spec)
+        scenarios_timeline_data.append(timeline_data)
+        scenarios_summary.append(
+            {
+                "index": idx,
+                "filename": f"s{idx}.html",
+                "duration": timeline_data["scenario_duration"],
+                "steps_count": len(timeline_data["steps"]),
+                "origins_count": len(timeline_data["origins"]),
+                "operations_count": timeline_data["stats"]["total_operations"],
+                "successful_operations": timeline_data["stats"]["successful_operations"],
+                "unsuccessful_operations": timeline_data["stats"]["unsuccessful_operations"],
+                "steps": timeline_data["steps"],
+            }
+        )
+
+    # Render scenario pages
+    scenario_template = jinja_env.get_template("scenario.html")
+    for idx, timeline_data in enumerate(scenarios_timeline_data):
+        scenario_file = os.path.join(timeline_dir, f"s{idx}.html")
+        prev_scenario = f"s{idx - 1}.html" if idx > 0 else None
+        next_scenario = f"s{idx + 1}.html" if idx < len(scenarios) - 1 else None
+
+        with open(scenario_file, "w") as f:
+            f.write(
+                scenario_template.render(
+                    scenario_index=idx,
+                    scenario_data_json=json.dumps(timeline_data),
+                    timeline_data=timeline_data,
+                    spec=spec,
+                    report=report,
+                    prev_scenario=prev_scenario,
+                    next_scenario=next_scenario,
+                    total_scenarios=len(scenarios),
+                )
+            )
+
+    # Render index overview page
+    index_template = jinja_env.get_template("index.html")
+    index_file = os.path.join(timeline_dir, "index.html")
+    with open(index_file, "w") as f:
+        f.write(
+            index_template.render(
+                report=report,
+                spec=spec,
+                scenarios_summary=scenarios_summary,
+            )
+        )
+
+    logger.info(
+        f"Timeline artifact successfully generated: {index_file} ({len(scenarios)} scenarios)"
+    )

--- a/monitoring/benchmarker/configurations/artifacts/artifact.py
+++ b/monitoring/benchmarker/configurations/artifacts/artifact.py
@@ -8,7 +8,9 @@ from monitoring.benchmarker.configurations.artifacts.matplotlib_figure import (
 from monitoring.benchmarker.configurations.artifacts.raw_report import (
     RawReportSpecification,
 )
-from monitoring.benchmarker.configurations.artifacts.timeline import TimelineSpecification
+from monitoring.benchmarker.configurations.artifacts.timeline import (
+    TimelineSpecification,
+)
 
 
 class ArtifactSpecification(ImplicitDict):

--- a/monitoring/benchmarker/configurations/artifacts/artifact.py
+++ b/monitoring/benchmarker/configurations/artifacts/artifact.py
@@ -8,8 +8,10 @@ from monitoring.benchmarker.configurations.artifacts.matplotlib_figure import (
 from monitoring.benchmarker.configurations.artifacts.raw_report import (
     RawReportSpecification,
 )
+from monitoring.benchmarker.configurations.artifacts.timeline import TimelineSpecification
 
 
 class ArtifactSpecification(ImplicitDict):
     raw_report: Optional[RawReportSpecification]
     matplotlib_figure: Optional[MatplotlibFigureSpecification]
+    timeline: Optional[TimelineSpecification]

--- a/monitoring/benchmarker/configurations/artifacts/timeline.py
+++ b/monitoring/benchmarker/configurations/artifacts/timeline.py
@@ -1,0 +1,24 @@
+from typing import Optional
+
+from implicitdict import ImplicitDict
+
+from monitoring.benchmarker.configurations.loads import OperationType
+
+
+class TimelineOperation(ImplicitDict):
+    type: OperationType
+
+    color: Optional[str]
+    """CSS color (e.g., #ff1122) for this operation.  Picked automatically if not specified."""
+
+    success_indicator_width: Optional[float]
+    """Width of the termination line indicating success or failure of each of these operations."""
+
+
+class TimelineSpecification(ImplicitDict):
+    name: str
+    """Machine-level name for this report.  Used as the output file name."""
+
+    operations: list[TimelineOperation]
+    """Operations to display on the timeline."""
+    

--- a/monitoring/benchmarker/configurations/artifacts/timeline.py
+++ b/monitoring/benchmarker/configurations/artifacts/timeline.py
@@ -21,4 +21,3 @@ class TimelineSpecification(ImplicitDict):
 
     operations: list[TimelineOperation]
     """Operations to display on the timeline."""
-    

--- a/monitoring/benchmarker/configurations/interuss/scd/single_s2_cell.jsonnet
+++ b/monitoring/benchmarker/configurations/interuss/scd/single_s2_cell.jsonnet
@@ -210,6 +210,29 @@ local shape = {
       },
     },
     {
+      timeline: {
+        name: 'timeline',
+        operations: [
+          {
+            type: "workflow.flight_planner.flight",
+            color: "#32aced",
+          },
+          {
+            type: "query.astm.f3548.v21.dss.createOperationalIntentReference",
+            color: "#c7c46b",
+          },
+          {
+            type: "query.astm.f3548.v21.dss.updateOperationalIntentReference",
+            color: "#70c76b",
+          },
+          {
+            type: "query.astm.f3548.v21.dss.deleteOperationalIntentReference",
+            color: "#c77f6b",
+          },
+        ],
+      }
+    },
+    {
       matplotlib_figure: {
         name: 'scalability_curve',
         title: test_name,

--- a/monitoring/benchmarker/configurations/interuss/scd/single_s2_cell.jsonnet
+++ b/monitoring/benchmarker/configurations/interuss/scd/single_s2_cell.jsonnet
@@ -81,8 +81,8 @@ local shape = {
         flight_generation: {
           independent_time_location_shape: {
             time: {
-              fixed_spacing: '29s',
-              uniform_random_spacing: '2s',
+              fixed_spacing: '36s',
+              uniform_random_spacing: '7.2s',
             },
             location: {
               fixed_location: location,
@@ -93,7 +93,7 @@ local shape = {
           },
         },
         flight_execution: {
-          end_flight_after_start: '10s',
+          end_flight_after_start: '5s',
         },
         scd_behavior: {
           dss_pool: ['uss%d_dss_pool' % uss],
@@ -227,7 +227,7 @@ local shape = {
           },
           {
             type: "query.astm.f3548.v21.dss.deleteOperationalIntentReference",
-            color: "#c77f6b",
+            color: "#c2c2c2",
           },
         ],
       }

--- a/monitoring/benchmarker/configurations/interuss/scd/single_s2_cell.jsonnet
+++ b/monitoring/benchmarker/configurations/interuss/scd/single_s2_cell.jsonnet
@@ -216,6 +216,7 @@ local shape = {
           {
             type: "workflow.flight_planner.flight",
             color: "#32aced",
+            success_indicator_width: 5,
           },
           {
             type: "query.astm.f3548.v21.dss.createOperationalIntentReference",

--- a/monitoring/monitorlib/formatting.py
+++ b/monitoring/monitorlib/formatting.py
@@ -145,3 +145,77 @@ def make_datetime(t) -> datetime.datetime:
 def limit_resolution(value: float, resolution: float) -> float:
     """Change resolution of a value"""
     return round(value / resolution) * resolution
+
+
+def format_duration_shorthand(duration: float | datetime.timedelta) -> str:
+    """Produce a smart shorthand string describing a duration.
+
+    Has a maximum of two significant units, and tenths of a second only for values <10s.
+    Examples:
+      - 3.8s (<10s)
+      - 48s (>=10s and <60s)
+      - 1m3s (60s <= d < 3600s)
+      - 12m42s
+      - 1h5m (3600s <= d < 86400s)
+      - 4h (if minutes == 0)
+      - 6m (if seconds == 0)
+      - 1d6h
+      - 3w4d
+    """
+    if isinstance(duration, datetime.timedelta):
+        seconds = duration.total_seconds()
+    else:
+        seconds = float(duration)
+
+    if seconds < 0:
+        return f"-{format_duration_shorthand(-seconds)}"
+
+    if seconds < 10.0:
+        rounded = round(seconds, 1)
+        if rounded >= 10.0:
+            return "10s"
+        return f"{rounded:.1f}s"
+
+    if seconds < 60.0:
+        rounded = round(seconds)
+        if rounded >= 60:
+            return "1m"
+        return f"{rounded}s"
+
+    if seconds < 3600.0:
+        total_sec = round(seconds)
+        mins = total_sec // 60
+        secs = total_sec % 60
+        if mins >= 60:
+            return "1h"
+        if secs == 0:
+            return f"{mins}m"
+        return f"{mins}m{secs}s"
+
+    if seconds < 86400.0:
+        total_min = round(seconds / 60.0)
+        hours = total_min // 60
+        mins = total_min % 60
+        if hours >= 24:
+            return "1d"
+        if mins == 0:
+            return f"{hours}h"
+        return f"{hours}h{mins}m"
+
+    if seconds < 604800.0:
+        total_hours = round(seconds / 3600.0)
+        days = total_hours // 24
+        hours = total_hours % 24
+        if days >= 7:
+            return "1w"
+        if hours == 0:
+            return f"{days}d"
+        return f"{days}d{hours}h"
+
+    total_days = round(seconds / 86400.0)
+    weeks = total_days // 7
+    days = total_days % 7
+    if days == 0:
+        return f"{weeks}w"
+    return f"{weeks}w{days}d"
+

--- a/monitoring/monitorlib/formatting.py
+++ b/monitoring/monitorlib/formatting.py
@@ -218,4 +218,3 @@ def format_duration_shorthand(duration: float | datetime.timedelta) -> str:
     if days == 0:
         return f"{weeks}w"
     return f"{weeks}w{days}d"
-

--- a/schemas/monitoring/benchmarker/configurations/artifacts/artifact/ArtifactSpecification.json
+++ b/schemas/monitoring/benchmarker/configurations/artifacts/artifact/ArtifactSpecification.json
@@ -26,6 +26,16 @@
           "$ref": "../raw_report/RawReportSpecification.json"
         }
       ]
+    },
+    "timeline": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "../timeline/TimelineSpecification.json"
+        }
+      ]
     }
   },
   "type": "object"

--- a/schemas/monitoring/benchmarker/configurations/artifacts/timeline/TimelineOperation.json
+++ b/schemas/monitoring/benchmarker/configurations/artifacts/timeline/TimelineOperation.json
@@ -1,0 +1,32 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/configurations/artifacts/timeline/TimelineOperation.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "monitoring.benchmarker.configurations.artifacts.timeline.TimelineOperation, as defined in monitoring/benchmarker/configurations/artifacts/timeline.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "color": {
+      "description": "CSS color (e.g., #ff1122) for this operation.  Picked automatically if not specified.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "success_indicator_width": {
+      "description": "Width of the termination line indicating success or failure of each of these operations.",
+      "type": [
+        "number",
+        "null"
+      ]
+    },
+    "type": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "type"
+  ],
+  "type": "object"
+}

--- a/schemas/monitoring/benchmarker/configurations/artifacts/timeline/TimelineSpecification.json
+++ b/schemas/monitoring/benchmarker/configurations/artifacts/timeline/TimelineSpecification.json
@@ -1,0 +1,27 @@
+{
+  "$id": "https://github.com/interuss/monitoring/blob/main/schemas/monitoring/benchmarker/configurations/artifacts/timeline/TimelineSpecification.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "monitoring.benchmarker.configurations.artifacts.timeline.TimelineSpecification, as defined in monitoring/benchmarker/configurations/artifacts/timeline.py",
+  "properties": {
+    "$ref": {
+      "description": "Path to content that replaces the $ref",
+      "type": "string"
+    },
+    "name": {
+      "description": "Machine-level name for this report.  Used as the output file name.",
+      "type": "string"
+    },
+    "operations": {
+      "description": "Operations to display on the timeline.",
+      "items": {
+        "$ref": "TimelineOperation.json"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "name",
+    "operations"
+  ],
+  "type": "object"
+}


### PR DESCRIPTION
This PR adds a timeline artifact to benchmarker which shows all the operations of interest happening in parallel visually:

<img width="1202" height="636" alt="Screenshot 2026-08-24 at 7 39 56 PM" src="https://github.com/user-attachments/assets/2ca4eef0-e6d6-4935-9e3d-4d2916451bda" />

Example generated from the changes to single_s2_cell.jsonnet:

[timeline.zip](https://github.com/user-attachments/files/31401080/timeline.zip)

I specified the configuration and "product spec", but nearly all the implementation is via Gemini.  I'm not too concerned about perfect architecture as I expect this to be "dead end" code only used for generating this artifact and not as a building block for anything else in the future.